### PR TITLE
MGMT-23352: Fix disconnected deployment with dev-scripts

### DIFF
--- a/operators/quay-operator/quay_lvms.yaml
+++ b/operators/quay-operator/quay_lvms.yaml
@@ -1,0 +1,97 @@
+---
+# LVMS-specific tasks for Quay: PVC, QuayRegistry, and deployment patch to mount registry storage.
+# Included from tasks.yaml only when blockStorageBackend == 'lvms'.
+
+- name: Create LVMS PVC for Quay Storage
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: quay-storage-pvc
+        namespace: quay-enterprise
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 250Gi
+        storageClassName: lvms-vg1
+
+- name: Ensure QuayRegistry is present (LVMS Backend)
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: quay.redhat.com/v1
+      kind: QuayRegistry
+      metadata:
+        name: registry
+        namespace: quay-enterprise
+      spec:
+        configBundleSecret: quay-config
+        components:
+        - kind: objectstorage
+          managed: false
+        - kind: quay
+          managed: true
+          overrides:
+            replicas: 1
+            resources:
+              limits:
+                cpu: "8"
+                memory: 32Gi
+              requests:
+                cpu: "{{ '4' if (disconnected | default(true)) else '2' }}"
+                memory: "{{ '3Gi' if (disconnected | default(true)) else '2Gi' }}"
+        - kind: horizontalpodautoscaler
+          managed: false
+  retries: 1
+  delay: 10
+  register: r_quay_lvms
+  until: r_quay_lvms is succeeded
+
+- name: Wait for Quay app deployment to exist (LVMS)
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    namespace: quay-enterprise
+    name: registry-quay-app
+  register: quay_app_deployment
+  retries: 30
+  delay: 10
+  until: quay_app_deployment.resources | length > 0
+
+- name: Set quay container index for LVMS patch (first container is the app)
+  ansible.builtin.set_fact:
+    quay_container_index: 0
+  when: quay_app_deployment.resources | default([]) | length > 0
+
+- name: Check if Quay app deployment already has registry-storage volume (LVMS)
+  ansible.builtin.set_fact:
+    quay_registry_storage_already_patched: "{{ quay_app_deployment.resources[0].spec.template.spec.volumes | selectattr('name', 'equalto', 'registry-storage') | list | length > 0 }}"
+  when: quay_app_deployment.resources | default([]) | length > 0
+
+- name: Patch Quay app deployment to mount registry storage PVC (LVMS)
+  ansible.builtin.shell: |
+    oc patch deployment registry-quay-app -n quay-enterprise --type=json -p='{{ quay_lvms_patch | to_json }}'
+  args:
+    executable: /bin/bash
+  vars:
+    quay_lvms_patch:
+      - op: add
+        path: /spec/template/spec/volumes/-
+        value:
+          name: registry-storage
+          persistentVolumeClaim:
+            claimName: quay-storage-pvc
+      - op: add
+        path: /spec/template/spec/containers/{{ quay_container_index }}/volumeMounts/-
+        value:
+          name: registry-storage
+          mountPath: /datastorage/registry
+  when:
+    - quay_app_deployment.resources | default([]) | length > 0
+    - quay_container_index is defined
+    - not (quay_registry_storage_already_patched | default(false))
+  register: quay_patch_result

--- a/operators/quay-operator/tasks.yaml
+++ b/operators/quay-operator/tasks.yaml
@@ -26,6 +26,9 @@
                    | combine(quayBackendRGWDefaults)
                    | combine(quayBackendRGWConfiguration))
                    if quayBackend == 'RadosGWStorage'
+                   else (quayBackendDefaults 
+                   | combine(quayBackendLocalStorageConfiguration))
+                   if quayBackend == 'LocalStorage'
                    else quayBackendDefaults)
                    | to_yaml }}
           DISTRIBUTED_STORAGE_DEFAULT_LOCATIONS:
@@ -57,7 +60,7 @@
           matcher:
             disable_updaters: true
 
-- name: Ensure QuayRegistry is present
+- name: Ensure QuayRegistry is present (ODF Backend)
   kubernetes.core.k8s:
     state: present
     definition:
@@ -70,7 +73,7 @@
         configBundleSecret: quay-config
         components:
         - kind: horizontalpodautoscaler
-          managed: "{{ true if blockStorageBackend == 'odf' else false }}"
+          managed: true
         - kind: quay
           managed: true
           overrides:
@@ -83,11 +86,15 @@
                 memory: "{{ '16Gi' if (disconnected | default(true)) else '2Gi' }}"
         - kind: objectstorage
           managed: false
+  when: blockStorageBackend == 'odf'
   retries: 60
   delay: 10
   register: r_quay
   until: r_quay is succeeded
 
+- name: Run LVMS-specific Quay tasks (PVC, QuayRegistry, deployment patch)
+  ansible.builtin.include_tasks: quay_lvms.yaml
+  when: blockStorageBackend == 'lvms'
 
 - name: Get router pod IP for Quay route access
   kubernetes.core.k8s_info:

--- a/scripts/configure_devscripts.sh
+++ b/scripts/configure_devscripts.sh
@@ -99,7 +99,7 @@ export MASTER_VCPU=12         # 12 vCPUs
 # Extra disks for storage (used by LVMS for PersistentVolumes)
 export VM_EXTRADISKS=true
 export VM_EXTRADISKS_LIST="vdb"
-export VM_EXTRADISKS_SIZE="60G"
+export VM_EXTRADISKS_SIZE="120G"
 
 # =============================================================================
 # Landing Zone VM Specs
@@ -146,6 +146,9 @@ export CLUSTER_NAME="${ENCLAVE_CLUSTER_NAME}"
 
 # Cluster domain (for DNS)
 export CLUSTER_DOMAIN="${ENCLAVE_CLUSTER_NAME}.lab"
+
+# Base domain (so dev-scripts uses .lab not test.metalkube.org for CLUSTER_DOMAIN)
+export BASE_DOMAIN="lab"
 
 # Working directory (where VMs and configs are stored)
 export WORKING_DIR="/opt/dev-scripts"

--- a/scripts/generate_enclave_vars.sh
+++ b/scripts/generate_enclave_vars.sh
@@ -164,6 +164,8 @@ quayPassword: SuperPrivate123!
 # Option 1: External S3/RadosGW storage (RECOMMENDED for production)
 # Option 2: Local storage (NOT recommended for production)
 quayBackend: LocalStorage
+quayBackendLocalStorageConfiguration:
+  storage_path: /datastorage/registry
 
 # ============================================================================
 # Storage Backend
@@ -202,7 +204,7 @@ defaultNtpServers: []
 # Pull secret will be read from pullSecretPath
 pullSecret:
   auths: {}
-pullSecretPath: "{{ workingDir }}/.config/pull-secret.json"
+pullSecretPath: "{{ workingDir }}/config/pull-secret.json"
 
 # Discovery hosts for hardware discovery (optional)
 # Add hosts here if you want to use the discovery feature

--- a/scripts/provision_landing_zone.sh
+++ b/scripts/provision_landing_zone.sh
@@ -341,6 +341,14 @@ if [ "$BOOT_COMPLETE" = true ]; then
         info "✓ BMC network already configured: enp1s0 (${BMC_IP}/${BMC_PREFIX})"
     fi
 
+    # Add mirror -> LZ cluster IP to virsh network DNS so master VMs can resolve mirror.<domain>
+    info "Adding DNS entry: mirror -> ${CLUSTER_IP} (Landing Zone) on network ${CLUSTER_NETWORK_NAME}..."
+    if ! sudo virsh net-update "${CLUSTER_NETWORK_NAME}" add dns-host "<host ip='${CLUSTER_IP}'><hostname>mirror</hostname></host>" --live --config 2>/dev/null; then
+        warning "Could not add mirror DNS entry (network may not support live update)"
+    else
+        info "✓ DNS entry added: mirror -> ${CLUSTER_IP}"
+    fi
+
     echo ""
     info "========================================="
     info "Landing Zone VM Provisioned Successfully"


### PR DESCRIPTION
Fix disconnected deployment, enclave DNS/config, and Quay LVMS support

Disconnected and enclave:
- Add BASE_DOMAIN=lab in dev-scripts config so CLUSTER_DOMAIN is enclave-test.lab
- Add mirror -> LZ IP to virsh network DNS after provisioning (mirror.<domain> resolution)
- Fix pullSecretPath to config/pull-secret.json (was .config/) for install-config.yaml
- Quay backend storage_path: /var/quaydata -> /datastorage/registry
- Increase VM extra disk size to 120G (configure_devscripts.sh)

Quay operator:
- Add quay_lvms.yaml: LVMS PVC, QuayRegistry, and deployment patch for registry storage
- Split tasks.yaml: ODF backend (existing QuayRegistry) vs LVMS (include quay_lvms.yaml)
- ODF branch: HPA managed true, task conditional on blockStorageBackend == 'odf'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for LVMS as a local storage backend option for Quay deployments
  * Added automatic DNS configuration for Landing Zone cluster connectivity

* **Chores**
  * Increased default storage disk allocation for virtual machines
  * Updated pull secret configuration path reference

<!-- end of auto-generated comment: release notes by coderabbit.ai -->