### PR TITLE
Add automatic PR labeling system

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,6 @@
+self-hosted-runner:
+  # Custom runner labels for enclave CI infrastructure
+  labels:
+    - pr-validation   # Fast validation jobs
+    - enclave-small   # Medium jobs like infra-verify
+    - enclave-large   # Long-running E2E jobs

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,43 @@
+# Area labels - no prefix, based on file paths
+
+deployment:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'playbooks/0[1-7]-*.yaml'
+      - 'playbooks/main.yaml'
+      - 'scripts/generate_*.sh'
+      - 'Makefile'
+      - 'defaults/**/*'
+      - 'config/**/*'
+
+ci-cd:
+  - changed-files:
+    - any-glob-to-any-file:
+      - '.github/**/*'
+      - 'scripts/runners/**/*'
+
+infrastructure:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'scripts/create_*.sh'
+      - 'scripts/configure_*.sh'
+      - 'scripts/provision_*.sh'
+      - 'scripts/cleanup.sh'
+      - 'playbooks/tasks/create_*.yaml'
+      - 'playbooks/tasks/configure_*.yaml'
+      - 'playbooks/tasks/provision_*.yaml'
+
+validation:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'schemas/**/*'
+      - 'validations.sh'
+      - 'playbooks/tasks/validate_*.yaml'
+
+operators:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'operators/**/*'
+      - 'playbooks/05-operators.yaml'
+      - 'playbooks/tasks/*operator*.yaml'
+      - 'playbooks/tasks/deploy_operator*.yaml'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,49 @@
+name: Auto Label
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+# Only one labeler run per PR
+concurrency:
+  group: labeler-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  # Area labels based on file paths
+  area-labels:
+    name: Area Labels
+    runs-on: [self-hosted, pr-validation]
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.2
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: .github/labeler.yml
+          sync-labels: true
+
+  # Size labels based on lines changed
+  size-labels:
+    name: Size Labels
+    runs-on: [self-hosted, pr-validation]
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: codelytv/pr-size-labeler@4ec67706cd878fbc1c8db0a5dcd28b6bb412e85a # v1.10.3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          xs_label: 'size/XS'
+          xs_max_size: '9'
+          s_label: 'size/S'
+          s_max_size: '99'
+          m_label: 'size/M'
+          m_max_size: '499'
+          l_label: 'size/L'
+          l_max_size: '999'
+          xl_label: 'size/XL'
+          fail_if_xl: 'false'


### PR DESCRIPTION
Implements transparent auto-labeling for pull requests:

Area labels (file-based):
- deployment: Deployment-related changes
- ci-cd: CI/CD infrastructure
- infrastructure: Infrastructure setup (VMs, networks)
- validation: Validation and testing
- operators: Operator installation/config

Size labels (lines-based):
- size/XS: < 10 lines
- size/S: 10-99 lines
- size/M: 100-499 lines
- size/L: 500-999 lines
- size/XL: 1000+ lines

Uses standard GitHub Actions:
- actions/labeler@v5: For area labels based on file paths
- codelytv/pr-size-labeler@v1: For size labels based on lines changed

Jobs run on self-hosted pr-validation runners and are transparent to users (no notification spam). Labels are applied/removed automatically when PR is opened, synchronized, or reopened.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Implemented automated PR labeling: area labels (deployment, CI/CD, infrastructure, validation, operators) and size labels (XS–XL) are now applied based on changed files and lines changed.
  * Added configuration for CI runner labels to support staged validation and varying job durations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->