### PR TITLE
Simplify labeler: single job that never blocks PRs

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,4 +1,4 @@
-name: Auto Label
+name: 🏷️
 
 on:
   pull_request_target:
@@ -10,31 +10,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Area labels based on file paths
-  area-labels:
-    name: Area Labels
+  label:
+    name: 🏷️
     runs-on: [self-hosted, pr-validation]
     permissions:
       contents: read
       pull-requests: write
+    # Never fail or block PRs
+    continue-on-error: true
 
     steps:
-      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.2
+      # Area labels based on file paths
+      - name: Area labels
+        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.2
+        continue-on-error: true
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/labeler.yml
           sync-labels: true
 
-  # Size labels based on lines changed
-  size-labels:
-    name: Size Labels
-    runs-on: [self-hosted, pr-validation]
-    permissions:
-      contents: read
-      pull-requests: write
-
-    steps:
-      - uses: codelytv/pr-size-labeler@4ec67706cd878fbc1c8db0a5dcd28b6bb412e85a # v1.10.3
+      # Size labels based on lines changed
+      - name: Size labels
+        uses: codelytv/pr-size-labeler@4ec67706cd878fbc1c8db0a5dcd28b6bb412e85a # v1.10.3
+        continue-on-error: true
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           xs_label: 'size/XS'


### PR DESCRIPTION
Addresses feedback:
1. Minimized visibility with emoji-only name (🏷️)
2. Combined into single job instead of two separate jobs
3. Added continue-on-error to job and steps - can never fail or block PRs

Changes:
- Merged area-labels and size-labels into one 'label' job
- Added continue-on-error: true at job level and each step
- Shortened workflow name to just 🏷️ emoji for minimal UI presence
- Labels still applied automatically but failures are silent