### PR TITLE
Simplify configuration vars follow-up

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -9,6 +9,23 @@ getValue(){
 
 global_vars=${1:-config/global.yaml}
 certs_vars=${2:-config/certificates.yaml}
+
+if [ ! -f "$global_vars" ]; then
+    echo "Error: $global_vars not found."
+    if [ -z "$1" ]; then
+        echo "Copy config/global.example.yaml to $global_vars and fill in your values."
+    fi
+    exit 1
+fi
+
+if [ ! -f "$certs_vars" ]; then
+    echo "Error: $certs_vars not found."
+    if [ -z "$2" ]; then
+        echo "Copy config/certificates.example.yaml to $certs_vars and fill in your values."
+    fi
+    exit 1
+fi
+
 workingDir=$(getValue .workingDir)
 lck=~/.lck-rh-lz
 DSTAMP=$(date +%Y%m%d_%H%M%S)

--- a/config/global.example.yaml
+++ b/config/global.example.yaml
@@ -77,31 +77,31 @@ blockStorageBackend: lvms
 #     "kind": "ConfigMap", "data": ..}]'
 
 # ============================================================================
-# OpenShift Configuration
+# OpenShift Deployment Configuration (optional)
+# All settings below have defaults. Uncomment only to override.
 # ============================================================================
-# Disconnected mode
-disconnected: true
+# Disconnected mode (default: true, set to false for connected deployments)
+# disconnected: false
 
-# Encrypt installation partition with TPM v2
-diskEncryption: false
+# Encrypt installation partition with TPM v2 (default: false, set to true to enable)
+# diskEncryption: true
 
-# SSH public key path for cluster nodes
-sshPubPath: "YOUR_SSH_PUB_KEY_PATH"
+# Log level for oc-mirror (default: info, options: trace, debug, info, error)
+# ocMirrorLogLevel: debug
 
-# Variables for oc-mirror
-ocMirrorLogLevel: debug
-
-# Additional NTP sources for cluster nodes (optional)
+# Additional NTP sources for cluster nodes (no additional servers by default)
 # defaultNtpServers:
 #  - YOUR_NTP_SERVER_1
 #  - YOUR_NTP_SERVER_2
 
 # ============================================================================
-# Pull Secret Configuration
+# Pull Secret and SSH Public Key Configuration
 # ============================================================================
 # Obtain from: https://console.redhat.com/openshift/install/pull-secret
 pullSecret: '{"auths":{"YOUR_PULL_SECRET"}}'
-pullSecretPath: "{{ workingDir }}/config/pull-secret.json"
+
+# SSH public key path for cluster nodes
+sshPubPath: "YOUR_SSH_PUB_KEY_PATH"
 
 # ============================================================================
 # Cluster Hosts Configuration (Agent Hosts)

--- a/defaults/deployment.yaml
+++ b/defaults/deployment.yaml
@@ -1,0 +1,12 @@
+---
+# Default deployment mode. Override in config/global.yaml to deploy in connected mode.
+disconnected: true
+
+# Default disk encryption setting. Override in config/global.yaml to enable TPM v2 encryption.
+diskEncryption: false
+
+# Default oc-mirror log level. Override in config/global.yaml for more verbosity.
+ocMirrorLogLevel: info
+
+# Default pull secret path. Override in config/global.yaml if stored elsewhere.
+pullSecretPath: "{{ workingDir }}/config/pull-secret.json"

--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -748,13 +748,15 @@ pullSecret: |
 
 #### `pullSecretPath`
 
-**Description**: Path to pull secret file (alternative to inline `pullSecret`).
+**Description**: Path to pull secret JSON file. Defaults to `{{ workingDir }}/config/pull-secret.json`. Override in `config/global.yaml` if your pull secret is stored elsewhere.
 
 **Type**: String (file path)
 
+**Default**: `{{ workingDir }}/config/pull-secret.json`
+
 **Example**:
 ```yaml
-pullSecretPath: "{{ workingDir }}/config/pull-secret.json"
+pullSecretPath: "{{ workingDir }}/.config/pull-secret.json"
 ```
 
 ## Storage Configuration
@@ -1144,11 +1146,18 @@ defaultPrefix: 24
 rendezvousIP: 192.168.2.24
 lzBmcIP: 100.64.1.10
 
-# OpenShift Configuration
-disconnected: true
-diskEncryption: false
+# OpenShift Deployment Configuration (optional — uncomment only to override defaults)
+# disconnected: false  # Default: true (set to false for connected deployments)
+# diskEncryption: true  # Default: false (set to true to enable TPM v2 encryption)
+# ocMirrorLogLevel: debug  # Default: info
+# defaultNtpServers:  # No additional servers by default
+#  - YOUR_NTP_SERVER_1
+#  - YOUR_NTP_SERVER_2
+
+# Pull Secret and SSH Public Key
+pullSecret: '{"auths":{"cloud.openshift.com":{...},"quay.io":{...}}}'
+# pullSecretPath: "{{ workingDir }}/config/pull-secret.json"  # Default
 sshPubPath: "{{ workingDir }}/.ssh/id_rsa.pub"
-ocMirrorLogLevel: debug
 
 # Storage Backend
 blockStorageBackend: lvms
@@ -1187,9 +1196,6 @@ quayBackendRGWConfiguration:
   bucket_name: quay-bucket-name
   hostname: ocs-storagecluster-cephobjectstore-openshift-storage.apps.store.enclave-test.nodns.in
 
-# Pull Secret
-pullSecret: '{"auths":{"cloud.openshift.com":{...},"quay.io":{...}}}'
-pullSecretPath: "{{ workingDir }}/config/pull-secret.json"
 ```
 
 ### `config/certificates.yaml`

--- a/playbooks/common/load-vars.yaml
+++ b/playbooks/common/load-vars.yaml
@@ -1,5 +1,8 @@
 ---
 
+- name: Include deployment defaults
+  ansible.builtin.include_vars: ../../defaults/deployment.yaml
+
 - name: Include global deployment vars
   ansible.builtin.include_vars: "{{ vars_file | default('../../config/global.yaml') }}"
 

--- a/playbooks/tasks/configure_ocp_abi.yaml
+++ b/playbooks/tasks/configure_ocp_abi.yaml
@@ -13,13 +13,6 @@
     backend: cryptography
     private_key_format: ssh
 
-- name: Copy pull secret to config directory for Ironic (connected mode)
-  when: not (disconnected | default(true))
-  ansible.builtin.copy:
-    src: "{{ pullSecretPath }}"
-    dest: "{{ workingDir }}/config/pull-secret.json"
-    remote_src: true
-
 - name: Extract openshift-install binary
   ansible.builtin.command: |
     {{ workingDir }}/bin/oc adm release extract --registry-config={{ pullSecretPath }} --command=openshift-install --to {{ workingDir }}/bin/

--- a/playbooks/tasks/deploy_bmo.yaml
+++ b/playbooks/tasks/deploy_bmo.yaml
@@ -3,7 +3,7 @@
 
 - name: Get baremetal-operator image from OpenShift release
   ansible.builtin.command: >
-    {{ workingDir }}/bin/oc adm release info --registry-config={{ workingDir }}/config/pull-secret.json --image-for baremetal-operator
+    {{ workingDir }}/bin/oc adm release info --registry-config={{ pullSecretPath }} --image-for baremetal-operator
     quay.io/openshift-release-dev/ocp-release:{{ mgmt_openshift_version }}-x86_64
   register: r_baremetal_operator_image
   changed_when: false
@@ -38,7 +38,7 @@
   containers.podman.podman_container:
     name: baremetal-operator
     image: "{{ metal3_baremetal_operator_image }}"
-    authfile: "{{ workingDir }}/config/pull-secret.json"
+    authfile: "{{ pullSecretPath }}"
     user: "65532:65532"
     cap_drop:
       - ALL

--- a/playbooks/tasks/deploy_ironic.yaml
+++ b/playbooks/tasks/deploy_ironic.yaml
@@ -3,7 +3,7 @@
 
 - name: Get ironic image from OpenShift release
   ansible.builtin.command: >
-    {{ workingDir }}/bin/oc adm release info --registry-config={{ workingDir }}/config/pull-secret.json --image-for ironic
+    {{ workingDir }}/bin/oc adm release info --registry-config={{ pullSecretPath }} --image-for ironic
     quay.io/openshift-release-dev/ocp-release:{{ mgmt_openshift_version }}-x86_64
   register: r_ironic_image
   changed_when: false
@@ -111,7 +111,7 @@
     name: ironic
     pod: metal3-ironic
     image: "{{ metal3_ironic_image }}"
-    authfile: "{{ workingDir }}/config/pull-secret.json"
+    authfile: "{{ pullSecretPath }}"
     restart_policy: always
     user: "1002:1003"
     cap_drop:
@@ -131,7 +131,7 @@
     name: httpd
     pod: metal3-ironic
     image: "{{ metal3_ironic_image }}"
-    authfile: "{{ workingDir }}/config/pull-secret.json"
+    authfile: "{{ pullSecretPath }}"
     restart_policy: always
     user: "1002:1003"
     cap_drop:

--- a/playbooks/tasks/deploy_metal3_stack.yaml
+++ b/playbooks/tasks/deploy_metal3_stack.yaml
@@ -3,7 +3,7 @@
 
 - name: Get ironic image from OpenShift release
   ansible.builtin.command: >
-    {{ workingDir }}/bin/oc adm release info --registry-config={{ workingDir }}/config/pull-secret.json --image-for ironic
+    {{ workingDir }}/bin/oc adm release info --registry-config={{ pullSecretPath }} --image-for ironic
     quay.io/openshift-release-dev/ocp-release:{{ mgmt_openshift_version }}-x86_64
   register: r_ironic_image
   changed_when: false
@@ -66,7 +66,7 @@
     name: ironic
     pod: metal3-ironic
     image: "{{ metal3_ironic_image }}"
-    authfile: "{{ workingDir }}/config/pull-secret.json"
+    authfile: "{{ pullSecretPath }}"
     restart_policy: always
     user: "1002:1003"
     cap_drop:
@@ -97,7 +97,7 @@
     name: httpd
     pod: metal3-ironic
     image: "{{ metal3_ironic_image }}"
-    authfile: "{{ workingDir }}/config/pull-secret.json"
+    authfile: "{{ pullSecretPath }}"
     restart_policy: always
     user: "1002:1003"
     cap_drop:

--- a/playbooks/tasks/mirror_registry.yaml
+++ b/playbooks/tasks/mirror_registry.yaml
@@ -13,7 +13,6 @@
         {{ workingDir }}/bin/mirror-registry  install --quayHostname "{{ quayHostname }}" --quayRoot {{ workingDir }}/data --initPassword "{{ quayPassword }}" --initUser "{{ quayUser }}"
       register: r_mirror_registry
 
-
 - name: Generate pull secret for internal mirror
   ansible.builtin.set_fact:
     pullSecretInternal: '{"auths":{"{{ quayHostname }}:8443":{"auth":"{{ (quayUser + ":" + quayPassword) | ansible.builtin.b64encode }}"}}}'
@@ -25,7 +24,7 @@
 - name: Create pull-secret file with the combination
   ansible.builtin.copy:
     content: "{{ pullSecretNew }}"
-    dest: "{{ workingDir }}/config/pull-secret.json"
+    dest: "{{ pullSecretPath }}"
 
 - name: Create pull-secret internal file with the combination
   ansible.builtin.copy:
@@ -42,7 +41,7 @@
 
 - name: Start oc-mirror process
   ansible.builtin.shell: |
-    {{ workingDir }}/bin/oc-mirror --v2 --log-level {{ ocMirrorLogLevel }} --authfile {{ workingDir }}/config/pull-secret.json -c {{ workingDir }}/config/imagesetconfiguration.yaml --workspace file://{{ workingDir }}/config/oc-mirror-workspace docker://{{ quayHostname }}:8443 --dest-tls-verify=false --parallel-images 10 --parallel-layers 10 --retry-times 10 --retry-delay 0 > {{ workingDir }}/logs/oc-mirror.progress.$(date +%s).log 2>&1
+    {{ workingDir }}/bin/oc-mirror --v2 --log-level {{ ocMirrorLogLevel }} --authfile "{{ pullSecretPath }}" -c {{ workingDir }}/config/imagesetconfiguration.yaml --workspace file://{{ workingDir }}/config/oc-mirror-workspace docker://{{ quayHostname }}:8443 --dest-tls-verify=false --parallel-images 10 --parallel-layers 10 --retry-times 10 --retry-delay 0 > {{ workingDir }}/logs/oc-mirror.progress.$(date +%s).log 2>&1
   retries: 5
   delay: 10
   register: r_oc_mirror

--- a/playbooks/tasks/schema_validation.yaml
+++ b/playbooks/tasks/schema_validation.yaml
@@ -1,3 +1,9 @@
+- name: validate defaults/deployment.yaml schema
+  ansible.utils.validate:
+    data: "{{ lookup('ansible.builtin.file', '../../defaults/deployment.yaml') | from_yaml | to_json }}"
+    criteria: "{{ lookup('ansible.builtin.file', '../../schemas/deployment.yaml') | from_yaml | to_json }}"
+    engine: ansible.utils.jsonschema
+
 - name: validate defaults/catalogs.yaml schema
   ansible.utils.validate:
     data: "{{ lookup('ansible.builtin.file', '../../defaults/catalogs.yaml') | from_yaml | to_json }}"

--- a/schemas/deployment.yaml
+++ b/schemas/deployment.yaml
@@ -1,0 +1,32 @@
+---
+"$schema": "http://json-schema.org/draft-07/schema"
+version: "1.0"
+type: object
+
+additionalProperties: false
+properties:
+  disconnected:
+    type: boolean
+    description: >-
+      Whether the deployment is disconnected (air-gapped). Default: true.
+      Set to false for connected deployments.
+  diskEncryption:
+    type: boolean
+    description: >-
+      Whether to enable disk encryption using TPM v2. Default: false.
+      Set to true to encrypt the installation partition on all nodes.
+  ocMirrorLogLevel:
+    type: string
+    enum: [trace, debug, info, error]
+    description: >-
+      Log level for oc-mirror. Default: info.
+  pullSecretPath:
+    type: string
+    description: >-
+      Path to the pull secret JSON file. Default: {{ workingDir }}/config/pull-secret.json.
+
+required:
+  - disconnected
+  - diskEncryption
+  - ocMirrorLogLevel
+  - pullSecretPath

--- a/scripts/generate_enclave_vars.sh
+++ b/scripts/generate_enclave_vars.sh
@@ -178,25 +178,12 @@ blockStorageBackend: lvms
 lvmsConfig: {}
 
 # ============================================================================
-# OpenShift Configuration
+# OpenShift Deployment Configuration (optional)
 # ============================================================================
-# Disconnected mode
-disconnected: true
-
-# Encrypt installation partition with TPM v2
-diskEncryption: false
-
-# SSH public key path for cluster nodes
-sshPubPath: "{{ workingDir }}/.ssh/id_rsa.pub"
-
-# Variables for oc-mirror
-ocMirrorLogLevel: info
-
-# Additional NTP sources for cluster nodes (optional)
-defaultNtpServers: []
+# Leaving default values
 
 # ============================================================================
-# Pull Secret Configuration
+# Pull Secret and SSH Public Key Configuration
 # ============================================================================
 # Obtain from: https://console.redhat.com/openshift/install/pull-secret
 # Pull secret will be read from pullSecretPath
@@ -204,7 +191,12 @@ pullSecret:
   auths: {}
 pullSecretPath: "{{ workingDir }}/.config/pull-secret.json"
 
-# Discovery hosts for hardware discovery (optional)
+# SSH public key path for cluster nodes
+sshPubPath: "{{ workingDir }}/.ssh/id_rsa.pub"
+
+# ============================================================================
+# Discovery Hosts Configuration
+# ============================================================================
 # Add hosts here if you want to use the discovery feature
 discovery_hosts: []
 

--- a/templates/agent-config.yaml.j2
+++ b/templates/agent-config.yaml.j2
@@ -10,7 +10,7 @@ rendezvousIP:  {{ rendezvousIP }}
 # If defaultNtpServers are defined, add it to the configuration
 {% if defaultNtpServers | default("") | length > 0  %}
 additionalNTPSources:
-{{ defaultNtpServers | to_nice_yaml }}  
+{{ defaultNtpServers | to_nice_yaml }}
 {% endif %}
 
 # And we add the network configuration of each host, in nmstate format


### PR DESCRIPTION
Simplify configuration vars follow-up changes after testing and suggestions:

The `bootstrap.sh` script validates now both config files before attempting to read them and exits with a clear message.
Before this change, running `bootstrap.sh` without `config/global.yaml` produced the "No such file or directory" bash error.

Add default values (in `defaults/deployment.yaml`) for:
  - `disconnected: true`
  - `diskEncryption: false`
  - `ocMirrorLogLevel: info`
  - `pullSecretPath: "{{ workingDir }}/config/pull-secret.json"`

The variables have been removed from `config/global.example.yaml` but the defaults values can be overridden in `config/global.yaml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Consolidated "OpenShift Deployment Configuration (optional)" with updated pull-secret and SSH key guidance and example paths; updated configuration reference.

* **Chores**
  * Added default deployment settings and a schema for validation; playbooks now load deployment defaults and use a centralized pull-secret path.

* **Bug Fixes / Behavior**
  * Added preflight checks with clear errors for missing config files and removed automatic pull-secret copying; deployments use the configured pull-secret path.

* **Style**
  * Minor template formatting cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->