### PR TITLE
MGMT-23016: management cluster upgrade implementation

### DIFF
--- a/playbooks/06-day2.yaml
+++ b/playbooks/06-day2.yaml
@@ -96,5 +96,7 @@
         file: tasks/mgmt_cluster_upgrade.yaml
         apply:
           tags: mgmt-cluster-upgrade
+          environment:
+            KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
       tags:
         - mgmt-cluster-upgrade

--- a/playbooks/06-day2.yaml
+++ b/playbooks/06-day2.yaml
@@ -90,3 +90,11 @@
           environment:
             KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
       tags: vmaas
+
+    - name: Management cluster upgrade
+      ansible.builtin.include_tasks:
+        file: tasks/mgmt_cluster_upgrade.yaml
+        apply:
+          tags: mgmt-cluster-upgrade
+      tags:
+        - mgmt-cluster-upgrade

--- a/playbooks/tasks/mgmt_cluster_upgrade.yaml
+++ b/playbooks/tasks/mgmt_cluster_upgrade.yaml
@@ -28,7 +28,7 @@
 - name: Get available upgrades
   when: upgrade_required
   ansible.builtin.set_fact:
-    available_versions: "{{ cv_info.resources[0].status.availableUpdates | map(attribute='version') | list }}"
+    available_versions: "{{ (cv_info.resources[0].status.availableUpdates | default([])) | map(attribute='version') | list }}"
 
 - name: Determine if version is available (upgrade condition)
   when:
@@ -77,15 +77,20 @@
       }}
 
 - name: Determine if need to perform upgrade (aggregate upgrade conditions)
+  when: upgrade_required
   ansible.builtin.set_fact:
     perform_upgrade: >
       {{
-        upgrade_required
-        and upgrade_condition_version_mirrored
+       upgrade_condition_version_mirrored
         and upgrade_condition_version_available
         and upgrade_condition_co_healthy
         and upgrade_condition_co_upgradeable
       }}
+
+- name: Set perform_upgrade to false when upgrade not required
+  when: not upgrade_required
+  ansible.builtin.set_fact:
+    perform_upgrade: false
 
 - name: Trigger cluster upgrade
   when: perform_upgrade

--- a/playbooks/tasks/mgmt_cluster_upgrade.yaml
+++ b/playbooks/tasks/mgmt_cluster_upgrade.yaml
@@ -14,6 +14,14 @@
 - name: Determine if upgrade is required
   ansible.builtin.set_fact:
     upgrade_required: "{{ mgmt_openshift_version is ansible.builtin.version(cluster_version, '>') }}"
+    downgrade_requested: "{{ mgmt_openshift_version is ansible.builtin.version(cluster_version, '<') }}"
+
+- name: Fail when requested version is lower than current cluster version
+  when: downgrade_requested
+  ansible.builtin.fail:
+    msg: >-
+      Requested version {{ mgmt_openshift_version }} is lower than current cluster version {{ cluster_version }}.
+      Downgrades are not supported.
 
 - name: Get mirrored versions
   when: upgrade_required

--- a/playbooks/tasks/mgmt_cluster_upgrade.yaml
+++ b/playbooks/tasks/mgmt_cluster_upgrade.yaml
@@ -29,7 +29,9 @@
     mirrored_versions: "{{ openshift_versions | map(attribute='version') | list }}"
 
 - name: Fail when requested version is not mirrored
-  when: mgmt_openshift_version not in mirrored_versions
+  when:
+    - upgrade_required
+    - mgmt_openshift_version not in mirrored_versions
   ansible.builtin.fail:
     msg: >-
       Requested version {{ mgmt_openshift_version }} is not mirrored: {{ mirrored_versions }}.
@@ -120,6 +122,9 @@
     name: version
   register: cv_info
   until: >
+    cv_info is defined and
+    cv_info.resources is defined and
+    cv_info.resources | length > 0 and
     cv_info.resources[0].status.history[0].state == 'Completed' and
     cv_info.resources[0].status.history[0].version == mgmt_openshift_version
   retries: 120

--- a/playbooks/tasks/mgmt_cluster_upgrade.yaml
+++ b/playbooks/tasks/mgmt_cluster_upgrade.yaml
@@ -4,6 +4,9 @@
     kind: ClusterVersion
     name: version
   register: cv_info
+  until:
+    - cv_info.resources is defined
+    - cv_info.resources | length > 0
   retries: 120
   delay: 10
 
@@ -125,6 +128,9 @@
     cv_info is defined and
     cv_info.resources is defined and
     cv_info.resources | length > 0 and
+    cv_info.resources[0].status is defined and
+    cv_info.resources[0].status.history is defined and
+    cv_info.resources[0].status.history | length > 0 and
     cv_info.resources[0].status.history[0].state == 'Completed' and
     cv_info.resources[0].status.history[0].version == mgmt_openshift_version
   retries: 120

--- a/playbooks/tasks/mgmt_cluster_upgrade.yaml
+++ b/playbooks/tasks/mgmt_cluster_upgrade.yaml
@@ -1,0 +1,113 @@
+- name: Get current cluster version information
+  kubernetes.core.k8s_info:
+    api_version: config.openshift.io/v1
+    kind: ClusterVersion
+    name: version
+  register: cv_info
+  retries: 120
+  delay: 10
+
+- name: Get current desired cluster version
+  ansible.builtin.set_fact:
+    cluster_version: "{{ cv_info.resources[0].status.desired.version }}"
+
+- name: Determine if upgrade is required
+  ansible.builtin.set_fact:
+    upgrade_required: "{{ mgmt_openshift_version is ansible.builtin.version(cluster_version, '>') }}"
+
+- name: Get mirrored versions
+  when: upgrade_required
+  ansible.builtin.set_fact:
+    mirrored_versions: "{{ openshift_versions | map(attribute='version') | list }}"
+
+- name: Determine if version is mirrored (upgrade condition)
+  when: upgrade_required
+  ansible.builtin.set_fact:
+    upgrade_condition_version_mirrored: "{{ mgmt_openshift_version in mirrored_versions }}"
+
+- name: Get available upgrades
+  when: upgrade_required
+  ansible.builtin.set_fact:
+    available_versions: "{{ cv_info.resources[0].status.availableUpdates | map(attribute='version') | list }}"
+
+- name: Determine if version is available (upgrade condition)
+  when:
+    - upgrade_required
+  ansible.builtin.set_fact:
+    upgrade_condition_version_available: "{{ mgmt_openshift_version in available_versions }}"
+
+- name: Get cluster operators
+  when: upgrade_required
+  kubernetes.core.k8s_info:
+    api_version: config.openshift.io/v1
+    kind: ClusterOperator
+  register: cluster_operators
+
+- name: Get cluster operators status conditions
+  when: upgrade_required
+  ansible.builtin.set_fact:
+    cluster_operators_status_conditions: >
+      {{
+        cluster_operators.resources | 
+        selectattr('status.conditions', 'defined') | 
+        map(attribute='status.conditions') | 
+        flatten
+      }}
+
+- name: Determine if cluster operators are healthy (upgrade condition)
+  when: upgrade_required
+  ansible.builtin.set_fact:
+    upgrade_condition_co_healthy: >
+      {{
+        cluster_operators_status_conditions | 
+        selectattr('type', 'equalto', 'Degraded') | 
+        selectattr('status', 'equalto', 'True') | 
+        list | length == 0
+      }}
+
+- name: Determine if cluster operators are upgradeable (upgrade condition)
+  when: upgrade_required
+  ansible.builtin.set_fact:
+    upgrade_condition_co_upgradeable: >
+      {{
+        cluster_operators_status_conditions | 
+        selectattr('type', 'equalto', 'Upgradeable') | 
+        selectattr('status', 'equalto', 'False') | 
+        list | length == 0
+      }}
+
+- name: Determine if need to perform upgrade (aggregate upgrade conditions)
+  ansible.builtin.set_fact:
+    perform_upgrade: >
+      {{
+        upgrade_required
+        and upgrade_condition_version_mirrored
+        and upgrade_condition_version_available
+        and upgrade_condition_co_healthy
+        and upgrade_condition_co_upgradeable
+      }}
+
+- name: Trigger cluster upgrade
+  when: perform_upgrade
+  kubernetes.core.k8s:
+    state: patched
+    api_version: config.openshift.io/v1
+    kind: ClusterVersion
+    name: version
+    definition:
+      spec:
+        desiredUpdate:
+          version: "{{ mgmt_openshift_version }}"
+          force: false
+
+- name: Wait for cluster upgrade to complete
+  kubernetes.core.k8s_info:
+    api_version: config.openshift.io/v1
+    kind: ClusterVersion
+    name: version
+  register: cv_info
+  until: >
+    cv_info.resources[0].status.history[0].state == 'Completed' and
+    cv_info.resources[0].status.history[0].version == mgmt_openshift_version
+  retries: 120
+  delay: 60

--- a/playbooks/tasks/mgmt_cluster_upgrade.yaml
+++ b/playbooks/tasks/mgmt_cluster_upgrade.yaml
@@ -28,10 +28,11 @@
   ansible.builtin.set_fact:
     mirrored_versions: "{{ openshift_versions | map(attribute='version') | list }}"
 
-- name: Determine if version is mirrored (upgrade condition)
-  when: upgrade_required
-  ansible.builtin.set_fact:
-    upgrade_condition_version_mirrored: "{{ mgmt_openshift_version in mirrored_versions }}"
+- name: Fail when requested version is not mirrored
+  when: mgmt_openshift_version not in mirrored_versions
+  ansible.builtin.fail:
+    msg: >-
+      Requested version {{ mgmt_openshift_version }} is not mirrored: {{ mirrored_versions }}.
 
 - name: Get available upgrades
   when: upgrade_required
@@ -89,8 +90,7 @@
   ansible.builtin.set_fact:
     perform_upgrade: >
       {{
-       upgrade_condition_version_mirrored
-        and upgrade_condition_version_available
+        upgrade_condition_version_available
         and upgrade_condition_co_healthy
         and upgrade_condition_co_upgradeable
       }}


### PR DESCRIPTION
part of https://issues.redhat.com/browse/MGMT-23016

related to https://github.com/gori-project/GoRI/issues/797 (https://github.com/gori-project/GoRI/issues/605)

this PR adds tasks to perform an upgrade of the management cluster openshift version.
the tasks are executed as part of the day2 operations playbook, which is the expected MSP's interface for content update related tasks.

the cluster upgrade process is based on https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html-single/updating_clusters/index#updating-cluster-cli.

the tasks are resilient to the process being interrupted and restarted.

note: etcd backup is not included in this PR (pending input and/or may be implemented in a follow up PR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a management-cluster upgrade workflow for Day‑2 operations: automated OpenShift version upgrades with downgrade protection, validation of mirrored images and target availability, gating on operator health and upgradeability, conditional execution only when safe, and monitored completion with retries/polling for reliable, observable upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->