### PR TITLE
Move discovery_hosts to cloud_infra.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@ Check [Topo.png](docs/Topo.png) for expected hardware setup and [ArchMap.png](do
 ```bash
 cp config/global.example.yaml config/global.yaml
 cp config/certificates.example.yaml config/certificates.yaml
+cp config/cloud_infra.example.yaml config/cloud_infra.yaml
 vim config/global.yaml        # Fill in your cluster, network, and hardware settings
 vim config/certificates.yaml  # Fill in your SSL certificates
+vim config/cloud_infra.yaml   # Fill in your discovery hosts (or leave discovery_hosts: [])
 ```
 
 2. Run the bootstrap script:
@@ -347,6 +349,7 @@ ssh cloud-user@<landing-zone-ip>
 ls -la /home/cloud-user/enclave
 cat /home/cloud-user/enclave/config/global.yaml
 cat /home/cloud-user/enclave/config/certificates.yaml
+cat /home/cloud-user/enclave/config/cloud_infra.yaml
 ```
 
 #### Test Only Cluster Deployment

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2,27 +2,78 @@
 set -o pipefail
 set -e
 
+usage() {
+    echo "Usage: $0 [OPTIONS]"
+    echo ""
+    echo "Options:"
+    echo "  --global-vars FILE    Path to global vars file (default: config/global.yaml)"
+    echo "  --certs-vars FILE     Path to certificates vars file (default: config/certificates.yaml)"
+    echo "  -h, --help            Show this help message"
+    exit "${1:-0}"
+}
+
+global_vars=config/global.yaml
+certs_vars=config/certificates.yaml
+cloud_infra_vars=config/cloud_infra.yaml
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --global-vars)
+            global_vars="$2"
+            shift 2
+            ;;
+        --certs-vars)
+            certs_vars="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Error: Unknown option '$1'"
+            usage 1
+            ;;
+    esac
+done
+
+echo " "
+echo " ██████╗░███████╗██████╗░  ██╗░░██╗░█████╗░████████╗"
+echo " ██╔══██╗██╔════╝██╔══██╗  ██║░░██║██╔══██╗╚══██╔══╝"
+echo " ██████╔╝█████╗░░██║░░██║  ███████║███████║░░░██║░░░"
+echo " ██╔══██╗██╔══╝░░██║░░██║  ██╔══██║██╔══██║░░░██║░░░"
+echo " ██║░░██║███████╗██████╔╝  ██║░░██║██║░░██║░░░██║░░░"
+echo " ╚═╝░░╚═╝╚══════╝╚═════╝░  ╚═╝░░╚═╝╚═╝░░╚═╝░░░╚═╝░░░"
+echo " "
+echo "This script is designed to be re-run on demand "
+echo "NOTE: Every run will destroy the entire cloud  "
+echo "      Some functions will reuse local caches   "
+echo ""
+echo "Config files:"
+echo "  Global vars:  $global_vars"
+echo "  Certificates: $certs_vars"
+echo "  Cloud infra:  $cloud_infra_vars"
+echo ""
+
 getValue(){
     python -c 'import sys, yaml, json; print(json.dumps(yaml.safe_load(sys.stdin)))' < $global_vars \
         | jq -r $1
 }
 
-global_vars=${1:-config/global.yaml}
-certs_vars=${2:-config/certificates.yaml}
-
 if [ ! -f "$global_vars" ]; then
     echo "Error: $global_vars not found."
-    if [ -z "$1" ]; then
-        echo "Copy config/global.example.yaml to $global_vars and fill in your values."
-    fi
+    echo "Copy config/global.example.yaml to $global_vars and fill in your values."
     exit 1
 fi
 
 if [ ! -f "$certs_vars" ]; then
     echo "Error: $certs_vars not found."
-    if [ -z "$2" ]; then
-        echo "Copy config/certificates.example.yaml to $certs_vars and fill in your values."
-    fi
+    echo "Copy config/certificates.example.yaml to $certs_vars and fill in your values."
+    exit 1
+fi
+
+if [ ! -f "$cloud_infra_vars" ]; then
+    echo "Error: $cloud_infra_vars not found."
+    echo "Copy config/cloud_infra.example.yaml to $cloud_infra_vars and fill in your values."
     exit 1
 fi
 
@@ -35,19 +86,6 @@ log="$logdir/${DSTAMP}"
 _cleanup(){
     rm -fr "${lck}"
 }
-
-
-echo " "
-echo " ██████╗░███████╗██████╗░  ██╗░░██╗░█████╗░████████╗"
-echo " ██╔══██╗██╔════╝██╔══██╗  ██║░░██║██╔══██╗╚══██╔══╝"
-echo " ██████╔╝█████╗░░██║░░██║  ███████║███████║░░░██║░░░"
-echo " ██╔══██╗██╔══╝░░██║░░██║  ██╔══██║██╔══██║░░░██║░░░"
-echo " ██║░░██║███████╗██████╔╝  ██║░░██║██║░░██║░░░██║░░░"
-echo " ╚═╝░░╚═╝╚══════╝╚═════╝░  ╚═╝░░╚═╝╚═╝░░╚═╝░░░╚═╝░░░"
-echo " "
-echo "This script is designed to be re-run on demand "
-echo "NOTE: Every run will destroy the entire cloud  "
-echo "      Some functions will reuse local caches   "
 
 read -rp "Press Enter to start .. " -n1 -s
 
@@ -72,7 +110,7 @@ date > "$log"
 
 echo -p "Check Config .. " -n1 -s | tee -a ${log}
 FList="ansible.cfg  bootstrap.sh  playbooks/main.yaml  playbooks/  \
-        setup_ansible.sh  setup_env.sh $global_vars $certs_vars"
+        setup_ansible.sh  setup_env.sh $global_vars $certs_vars $cloud_infra_vars"
 for x in $FList; do
     if [ -e $x ]; then
         echo "file check passed ..." $x   | tee -a ${log}
@@ -90,7 +128,7 @@ echo -e "\e[38;5;10m Done...\033[0m"; date
 
 echo -p "Validating Config .. " -n1 -s  | tee -a ${log}
     ansible-playbook playbooks/validate-schema.yaml -e@$global_vars -e@$certs_vars --tags schema-validation 2>&1 | tee -a ${log}
-    bash ./validations.sh $global_vars $certs_vars 2>&1 | tee -a ${log}
+    bash ./validations.sh --global-vars $global_vars --certs-vars $certs_vars 2>&1 | tee -a ${log}
 echo -e "\e[38;5;10m Done...\033[0m"; date
 
 echo -p "Downloading Deps Content .. " -n1 -s

--- a/config/README.md
+++ b/config/README.md
@@ -9,10 +9,12 @@ This directory contains the configuration files needed for your enclave deployme
    cd config/
    cp global.example.yaml global.yaml
    cp certificates.example.yaml certificates.yaml
+   cp cloud_infra.example.yaml cloud_infra.yaml
    ```
 
 2. **Fill in `global.yaml` with your environment details**
 3. **Fill in `certificates.yaml` with your SSL certificates**
+4. **Fill in `cloud_infra.yaml` with your discovery hosts (or leave `discovery_hosts: []` if not needed)**
 
 ## Configuration Files
 
@@ -22,8 +24,11 @@ Contains all cluster and infrastructure configuration.
 ### `certificates.yaml` (required)
 Contains SSL certificates for the cluster.
 
+### `cloud_infra.yaml` (required)
+Contains cloud infrastructure configuration, including the list of worker nodes to be discovered and added to the cluster. Set `discovery_hosts: []` if no discovery hosts are needed.
+
 ## Security
-- **Never commit `global.yaml` or `certificates.yaml` to version control**
+- **Never commit `global.yaml`, `certificates.yaml` or `cloud_infra.yaml` to version control**
 - These files contain sensitive credentials and private keys
 - The `.gitignore` is configured to exclude them
 

--- a/config/cloud_infra.example.yaml
+++ b/config/cloud_infra.example.yaml
@@ -1,0 +1,23 @@
+##############################################################################
+# CLOUD INFRASTRUCTURE CONFIGURATION TEMPLATE
+# Instructions: Copy this file to 'cloud_infra.yaml' and fill in your values
+##############################################################################
+
+# ============================================================================
+# Discovery Hosts Configuration
+# ============================================================================
+# Discovery hosts for cloud infrastructure (CaaS)
+# These are worker nodes that will be discovered and added to the cluster
+# Set to an empty list if no discovery hosts are needed:
+# discovery_hosts: []
+#
+# Or add hosts to discover:
+discovery_hosts:
+  - name: YOUR_NODE_NAME              # Example: node01
+    macAddress: YOUR_MAC_ADDRESS      # Example: 0c:c4:7a:62:fe:ec
+    ipAddress: YOUR_IP_ADDRESS        # Should be in machineNetwork
+    redfish: YOUR_REDFISH_IP          # IPMI/Redfish management IP
+    rootDisk: YOUR_ROOT_DISK_PATH     # Example: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: YOUR_REDFISH_USER
+    redfishPassword: YOUR_REDFISH_PASSWORD
+  # Add more hosts as needed

--- a/config/global.example.yaml
+++ b/config/global.example.yaml
@@ -120,17 +120,3 @@ agent_hosts:
 # instead of the macAddress and ipAddress parameters
 # See docs/CONFIGURATION_REFERENCE.md for reference
 
-# ============================================================================
-# Discovery Hosts Configuration
-# ============================================================================
-# Discovery hosts for cloud infrastructure (CaaS)
-# These are worker nodes that will be discovered and added to the cluster
-discovery_hosts:
-  - name: YOUR_NODE_NAME              # Example: node01
-    macAddress: YOUR_MAC_ADDRESS      # Example: 0c:c4:7a:62:fe:ec
-    ipAddress: YOUR_IP_ADDRESS        # Shoul be in machineNetwork
-    redfish: YOUR_REDFISH_IP          # IPMI/Redfish management IP
-    rootDisk: YOUR_ROOT_DISK_PATH     # Example: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
-    redfishUser: YOUR_REDFISH_USER
-    redfishPassword: YOUR_REDFISH_PASSWORD
-  # Add more hosts as needed

--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -10,6 +10,7 @@ Configuration is split across multiple files for better organization and maintai
 |------|-------------|
 | `config/global.yaml` | Main configuration file with cluster, network, hardware, registry, and pull secret settings |
 | `config/certificates.yaml` | SSL certificates for the API server and Ingress |
+| `config/cloud_infra.yaml` | Cloud infrastructure configuration, including discovery hosts for bare metal node discovery |
 | `defaults/operators.yaml` | General cluster operators configuration |
 | `defaults/platforms.yaml` | Available OpenShift versions |
 | `defaults/storage_operators.yaml` | Storage operators (ODF, LVMS) configuration |
@@ -26,6 +27,7 @@ Copy the example files to get started:
 ```bash
 cp config/global.example.yaml config/global.yaml
 cp config/certificates.example.yaml config/certificates.yaml
+cp config/cloud_infra.example.yaml config/cloud_infra.yaml
 ```
 
 All configuration files in the `defaults/` directory are automatically loaded by the phase playbooks at runtime via `playbooks/common/load-vars.yaml`.
@@ -505,7 +507,7 @@ curl -k -u user:pass https://<redfish-ip>/redfish/v1/Systems/1/EthernetInterface
 >
 > For ongoing operations such as adding nodes, removing nodes, changing configurations, or scaling the cluster, use Red Hat ACM instead. See the [Managing bare metal hosts documentation](https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#managing-bare-metal-hosts-console) for details.
 
-The discovery hosts configuration is defined in `config/global.yaml` for discovering new nodes after the initial cluster deployment. This configuration uses the same network settings (defaultDNS, defaultGateway, defaultPrefix, lzBmcIP) as the main cluster deployment.
+The discovery hosts configuration is defined in `config/cloud_infra.yaml` for discovering new nodes after the initial cluster deployment. This configuration uses the same network settings (defaultDNS, defaultGateway, defaultPrefix, lzBmcIP) as the main cluster deployment.
 
 ### Discovery Hosts Settings
 
@@ -1246,7 +1248,7 @@ sslCACertificate: |
 
 1. **Restrict file permissions**:
    ```bash
-   chmod 600 config/global.yaml config/certificates.yaml
+   chmod 600 config/global.yaml config/certificates.yaml config/cloud_infra.yaml
    ```
 
 2. **Use strong passwords** for:

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -585,8 +585,10 @@ Certificates are stored in `config/certificates.yaml` and must be provided in PE
    ```bash
    cp config/global.example.yaml config/global.yaml
    cp config/certificates.example.yaml config/certificates.yaml
+   cp config/cloud_infra.example.yaml config/cloud_infra.yaml
    vim config/global.yaml       # Edit cluster, network, hardware and registry settings
    vim config/certificates.yaml # Add SSL certificates
+   vim config/cloud_infra.yaml  # Add discovery hosts (leave discovery_hosts: [] if none)
    ```
 
 3. **Run bootstrap**:
@@ -747,7 +749,7 @@ For detailed information on managing bare metal hosts with ACM, refer to the off
 
 ### Alternative: Enclave Configuration (One-Time Convenience)
 
-As a convenience for initial setup, you can configure hosts in the Enclave configuration (`config/global.yaml`) and use the discovery playbook to boot them. **However, this is intended as a one-time operation.**
+As a convenience for initial setup, you can configure hosts in the Enclave configuration (`config/cloud_infra.yaml`) and use the discovery playbook to boot them. **However, this is intended as a one-time operation.**
 
 **Important:** If you need to perform any of the following operations, you must use Red Hat ACM instead of the Enclave configuration:
 - Add more nodes after initial deployment
@@ -767,7 +769,13 @@ The Enclave configuration method is provided only for initial convenience and is
 
 ### Configuration
 
-Add or edit the `discovery_hosts` section in `config/global.yaml` with the details of the nodes you want to discover:
+If you have not created `config/cloud_infra.yaml` yet, copy the example file first:
+
+```bash
+cp config/cloud_infra.example.yaml config/cloud_infra.yaml
+```
+
+Then add or edit the `discovery_hosts` section with the details of the nodes you want to discover:
 
 ```yaml
 # Discovery hosts for cloud infrastructure (CaaS)
@@ -808,21 +816,21 @@ Each node in `discovery_hosts` requires:
 
 > **⚠️ Warning:** This method is intended for initial setup only. For any subsequent host management operations, use Red Hat ACM instead.
 
-1. **Edit the configuration** in `config/global.yaml`:
+1. **Edit the configuration** in `config/cloud_infra.yaml`:
    ```bash
-   vim config/global.yaml
+   vim config/cloud_infra.yaml
    # Add or update the discovery_hosts section
    ```
 
 2. **Run the discovery playbook**:
    ```bash
-   ansible-playbook -e @config/global.yaml playbooks/05-configure-discovery.yaml
+   ansible-playbook -e @config/global.yaml -e @config/certificates.yaml -e @config/cloud_infra.yaml playbooks/07-configure-discovery.yaml
    ```
 
    Or if you're on the Landing Zone and Enclave is installed:
    ```bash
-   cd /home/enclave
-   ansible-playbook -e @config/global.yaml playbooks/05-configure-discovery.yaml
+   cd /home/cloud-user/enclave
+   ansible-playbook -e @config/global.yaml -e @config/certificates.yaml -e @config/cloud_infra.yaml playbooks/07-configure-discovery.yaml
    ```
 
 ### What the Discovery Process Does
@@ -838,7 +846,7 @@ The discovery process performs the following steps:
    - BMC connection details
    - bootMACAddress field set to the node's MAC address
    - Reference to the InfraEnv for the discovery ISO
-8. **Monitors for Host discovery**:
+7. **Monitors for Host discovery**:
    - Each host boots from the discovery ISO and registers as an Agent
 
 ### Discovery ISO and Metal3 Provisioning

--- a/docs/LOCAL_TESTING.md
+++ b/docs/LOCAL_TESTING.md
@@ -717,7 +717,7 @@ bash -x ./scripts/provision_landing_zone.sh
 # For Ansible (on Landing Zone)
 ssh cloud-user@$LZ_IP
 cd /home/cloud-user/enclave
-ansible-playbook -vvv -e@config/global.yaml playbooks/main.yaml
+ansible-playbook -vvv -e@config/global.yaml -e@config/certificates.yaml -e@config/cloud_infra.yaml playbooks/main.yaml
 ```
 
 **Collect logs for troubleshooting:**

--- a/docs/features/clair-in-disconnected-environments.md
+++ b/docs/features/clair-in-disconnected-environments.md
@@ -8,7 +8,7 @@ This feature enables image scanning using Clair in a disconnected environment by
     1. Update `defaults/operators.yaml` quay-operator channel to `stable-3.15`.
     1. Execute the mirror phase:
         ```sh
-        $ ansible-playbook -e @config/global.yaml playbooks/02-mirror.yaml
+        $ ansible-playbook -e @config/global.yaml -e @config/certificates.yaml -e @config/cloud_infra.yaml playbooks/02-mirror.yaml
         ```
     1. Uninstall the existing instance:
         ```sh
@@ -45,7 +45,7 @@ This feature enables image scanning using Clair in a disconnected environment by
 
 1. Execute the post-install phase (or just run the operators task directly):
     ```sh
-    $ ansible-playbook -e @config/global.yaml playbooks/04-post-install.yaml
+    $ ansible-playbook -e @config/global.yaml -e @config/certificates.yaml -e @config/cloud_infra.yaml playbooks/04-post-install.yaml
     # Or run operators task directly:
-    $ ansible-playbook -e @config/global.yaml playbooks/tasks/configure_operators.yaml
+    $ ansible-playbook -e @config/global.yaml -e @config/certificates.yaml -e @config/cloud_infra.yaml playbooks/tasks/configure_operators.yaml
     ```

--- a/must-gather/gather_lz.sh
+++ b/must-gather/gather_lz.sh
@@ -175,3 +175,32 @@ PYTHON_SCRIPT
 
     log_info "  OK Collected configuration (sanitized)"
 fi
+
+CLOUD_INFRA_FILE="${ENCLAVE_DIR}/config/cloud_infra.yaml"
+if [ -f "${CLOUD_INFRA_FILE}" ]; then
+    python3 <<PYTHON_SCRIPT > "${COLLECTION_DIR}/config/cloud_infra.yaml" 2>/dev/null || true
+import sys
+import yaml
+
+with open('${CLOUD_INFRA_FILE}', 'r') as f:
+    data = yaml.safe_load(f)
+
+if 'discovery_hosts' in data and isinstance(data['discovery_hosts'], list):
+    for host in data['discovery_hosts']:
+        if isinstance(host, dict):
+            if 'redfishPassword' in host:
+                host['redfishPassword'] = 'REDACTED'
+            if 'password' in host:
+                host['password'] = 'REDACTED'
+
+yaml.dump(data, sys.stdout, default_flow_style=False, sort_keys=False)
+PYTHON_SCRIPT
+
+    if [ ! -s "${COLLECTION_DIR}/config/cloud_infra.yaml" ]; then
+        log_warning "Python sanitization failed for cloud_infra.yaml, using sed fallback"
+        sed -e 's/\(redfishPassword:\).*/\1 REDACTED/' \
+            "${CLOUD_INFRA_FILE}" > "${COLLECTION_DIR}/config/cloud_infra.yaml" 2>/dev/null || true
+    fi
+
+    log_info "  OK Collected cloud infra configuration (sanitized)"
+fi

--- a/playbooks/07-configure-discovery.yaml
+++ b/playbooks/07-configure-discovery.yaml
@@ -6,11 +6,6 @@
     - name: Load common variables
       ansible.builtin.include_tasks: common/load-vars.yaml
 
-    - name: Set discovery_hosts default
-      ansible.builtin.set_fact:
-        discovery_hosts: []
-      when: discovery_hosts is not defined
-
     - name: Deploy Metal3 common resources
       ansible.builtin.include_tasks: "../playbooks/tasks/deploy_metal3_common.yaml"
 

--- a/playbooks/common/load-vars.yaml
+++ b/playbooks/common/load-vars.yaml
@@ -9,6 +9,9 @@
 - name: Include certificate vars
   ansible.builtin.include_vars: ../../config/certificates.yaml
 
+- name: Include cloud infra vars
+  ansible.builtin.include_vars: ../../config/cloud_infra.yaml
+
 - name: Include common configuration
   ansible.builtin.include_vars: "../../defaults/{{ config_file }}"
   loop:

--- a/playbooks/tasks/post_install_config.yaml
+++ b/playbooks/tasks/post_install_config.yaml
@@ -3,7 +3,7 @@
     name: "Cloud hardware - discovery and recycle"
     minute: "0"
     hour: "*"
-    job: "cd {{ playbook_dir }}/../ && /usr/bin/ansible-playbook -e @config/global.yaml -e @config/certificates.yaml playbooks/07-configure-discovery.yaml"
+    job: "cd {{ playbook_dir }}/../ && /usr/bin/ansible-playbook -e @config/global.yaml -e @config/certificates.yaml -e @config/cloud_infra.yaml playbooks/07-configure-discovery.yaml"
 
 - name: "Ensure redhat-lz-admin Namespace exists"
   environment:

--- a/scripts/generate_enclave_vars.sh
+++ b/scripts/generate_enclave_vars.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-# Generate Enclave Lab config/global.yaml and config/certificates.yaml from
-# infrastructure metadata
+# Generate Enclave Lab config/global.yaml, config/certificates.yaml and
+# config/cloud_infra.yaml from infrastructure metadata
 #
 # This script reads environment.json (created in Task 1) and generates
-# config/global.yaml and config/certificates.yaml configuration files for Enclave
-# Lab deployment.
+# config/global.yaml, config/certificates.yaml and config/cloud_infra.yaml
+# configuration files for Enclave Lab deployment.
 
 set -euo pipefail
 
@@ -58,6 +58,7 @@ fi
 
 GLOBAL_VARS_OUTPUT="${WORKING_DIR}/config/global.yaml"
 CERTS_VARS_OUTPUT="${WORKING_DIR}/config/certificates.yaml"
+CLOUD_INFRA_VARS_OUTPUT="${WORKING_DIR}/config/cloud_infra.yaml"
 
 info "Generating Enclave Lab configuration from infrastructure metadata..."
 
@@ -195,12 +196,6 @@ pullSecretPath: "{{ workingDir }}/.config/pull-secret.json"
 sshPubPath: "{{ workingDir }}/.ssh/id_rsa.pub"
 
 # ============================================================================
-# Discovery Hosts Configuration
-# ============================================================================
-# Add hosts here if you want to use the discovery feature
-discovery_hosts: []
-
-# ============================================================================
 # Cluster Hosts Configuration (Agent Hosts)
 # ============================================================================
 agent_hosts:
@@ -248,9 +243,8 @@ for i in $(seq 0 $((MASTER_COUNT - 1))); do
 EOF
 done
 
-
 # Generate config/certificates.yaml file
-cat > "$CERTS_VARS_OUTPUT" <<'EOF'
+cat > "$CERTS_VARS_OUTPUT" <<EOF
 ---
 # SSL Certificates Configuration
 # Auto-generated from infrastructure metadata
@@ -269,12 +263,28 @@ sslIngressCertificateFullChain: ""
 sslCACertificate: ""
 EOF
 
+# Generate config/cloud_infra.yaml file
+cat > "$CLOUD_INFRA_VARS_OUTPUT" <<EOF
+---
+# Cloud Infrastructure Configuration
+# Auto-generated from infrastructure metadata
+# Generated: $(date -Iseconds)
 
-info "✓ Configuration files generated: $GLOBAL_VARS_OUTPUT and $CERTS_VARS_OUTPUT"
+# ============================================================================
+# Discovery Hosts Configuration
+# ============================================================================
+# Discovery hosts for cloud infrastructure (CaaS)
+# These are worker nodes that will be discovered and added to the cluster
+# Set to an empty list if no discovery hosts are needed:
+discovery_hosts: []
+EOF
+
+info "✓ Configuration files generated: $GLOBAL_VARS_OUTPUT, $CERTS_VARS_OUTPUT and $CLOUD_INFRA_VARS_OUTPUT"
 echo ""
 info "Configuration summary:"
 info "  Global vars file: $GLOBAL_VARS_OUTPUT"
 info "  Certificates vars file: $CERTS_VARS_OUTPUT"
+info "  Cloud infra vars file: $CLOUD_INFRA_VARS_OUTPUT"
 info "  Cluster: $CLUSTER_NAME.$BASE_DOMAIN"
 info "  Network: $CLUSTER_CIDR"
 info "  Masters: $MASTER_COUNT nodes"
@@ -292,5 +302,6 @@ info "  - Registry: LocalStorage"
 info "  - Pull secret: Will use ~/.config/pull-secret.json on Landing Zone"
 info "  - SSL certificates: Empty (self-signed will be generated)"
 echo ""
-info "Review config/global.yaml and config/certificates.yaml and adjust if needed before running Enclave Lab"
+info "Review config/global.yaml, config/certificates.yaml and config/cloud_infra.yaml"
+info "and adjust if needed before running Enclave Lab"
 echo ""

--- a/scripts/install_enclave.sh
+++ b/scripts/install_enclave.sh
@@ -3,7 +3,7 @@
 #
 # This script:
 # 1. Copies Enclave Lab repository to Landing Zone VM
-# 2. Generates config/global.yaml and config/certificates.yaml configuration
+# 2. Generates config/global.yaml, config/certificates.yaml and config/cloud_infra.yaml configuration
 #    from infrastructure
 # 3. Installs any missing dependencies
 # 4. Verifies installation
@@ -223,16 +223,17 @@ EOSSH
 
 success "Dependencies installed"
 
-# Step 5: Generate config/global.yaml and config/certificates.yaml configuration
-info "Step 5: Generating Enclave Lab configuration (config/global.yaml and config/certificates.yaml)..."
+# Step 5: Generate config/global.yaml, config/certificates.yaml and config/cloud_infra.yaml configuration
+info "Step 5: Generating Enclave Lab configuration (config/global.yaml, config/certificates.yaml and config/cloud_infra.yaml)..."
 
-# Generate config/global.yaml and config/certificates.yaml using helper script
+# Generate config files using helper script
 "${ENCLAVE_DIR}/scripts/generate_enclave_vars.sh"
 
 # Copy vars files to Landing Zone
 ssh $SSH_OPTS "$LZ_SSH" "mkdir -p ${LZ_ENCLAVE_DIR}/config"
 scp $SSH_OPTS "${WORKING_DIR}/config/global.yaml" "${LZ_SSH}:${LZ_ENCLAVE_DIR}/config/global.yaml"
 scp $SSH_OPTS "${WORKING_DIR}/config/certificates.yaml" "${LZ_SSH}:${LZ_ENCLAVE_DIR}/config/certificates.yaml"
+scp $SSH_OPTS "${WORKING_DIR}/config/cloud_infra.yaml" "${LZ_SSH}:${LZ_ENCLAVE_DIR}/config/cloud_infra.yaml"
 
 success "Configuration generated and copied to Landing Zone"
 
@@ -361,6 +362,7 @@ info "Enclave Lab Installation Summary:"
 info "  Enclave Lab Directory: $LZ_ENCLAVE_DIR"
 info "  Configuration: $LZ_ENCLAVE_DIR/config/global.yaml"
 info "  Certificates: $LZ_ENCLAVE_DIR/config/certificates.yaml"
+info "  Cloud Infra: $LZ_ENCLAVE_DIR/config/cloud_infra.yaml"
 info "  Working Directory: $LZ_ROOT_DIR"
 echo ""
 
@@ -375,7 +377,7 @@ echo ""
 info "Next steps:"
 info "  1. SSH to Landing Zone: ssh $LZ_SSH"
 info "  2. Review configuration: cat $LZ_ENCLAVE_DIR/config/global.yaml"
-info "  3. Edit config/global.yaml and config/certificates.yaml as needed (pull secret, SSL certs, etc.)"
+info "  3. Edit config/global.yaml, config/certificates.yaml and config/cloud_infra.yaml as needed"
 info "  4. Run Enclave Lab: cd $LZ_ENCLAVE_DIR && ansible-playbook playbooks/main.yaml"
 echo ""
 info "To verify installation:"

--- a/scripts/verify_enclave_installation.sh
+++ b/scripts/verify_enclave_installation.sh
@@ -3,7 +3,7 @@
 #
 # This script verifies that:
 # - Enclave Lab repository is copied to Landing Zone
-# - Configuration files config/global.yaml and config/certificates.yaml exist and are valid
+# - Configuration files config/global.yaml, config/certificates.yaml and config/cloud_infra.yaml exist and are valid
 # - Required dependencies are installed
 # - Directory structure is correct
 
@@ -115,10 +115,11 @@ else
     exit 1
 fi
 
-# Test 3: Configuration files config/global.yaml and config/certificates.yaml exist
+# Test 3: Configuration files config/global.yaml, config/certificates.yaml and config/cloud_infra.yaml exist
 info "Test 3: Checking vars configuration..."
 GLOBAL_YAML="$LZ_ENCLAVE_DIR/config/global.yaml"
 CERTS_YAML="$LZ_ENCLAVE_DIR/config/certificates.yaml"
+CLOUD_INFRA_YAML="$LZ_ENCLAVE_DIR/config/cloud_infra.yaml"
 
 if ssh $SSH_OPTS "$LZ_SSH" "test -f $GLOBAL_YAML"; then
     success "config/global.yaml configuration file exists"
@@ -167,6 +168,20 @@ if ssh $SSH_OPTS "$LZ_SSH" "test -f $CERTS_YAML"; then
     fi
 else
     fail "config/certificates.yaml not found"
+    info "Run 'make install-enclave' to generate configuration"
+fi
+
+if ssh $SSH_OPTS "$LZ_SSH" "test -f $CLOUD_INFRA_YAML"; then
+    success "config/cloud_infra.yaml configuration file exists"
+
+    # Validate YAML syntax
+    if ssh $SSH_OPTS "$LZ_SSH" "python3 -c 'import yaml; yaml.safe_load(open(\"$CLOUD_INFRA_YAML\"))'" 2>/dev/null; then
+        success "  config/cloud_infra.yaml has valid YAML syntax"
+    else
+        warning "  config/cloud_infra.yaml may have syntax errors"
+    fi
+else
+    fail "config/cloud_infra.yaml not found"
     info "Run 'make install-enclave' to generate configuration"
 fi
 
@@ -327,17 +342,18 @@ info "Installation Details:"
 info "  Location: $LZ_SSH:$LZ_ENCLAVE_DIR"
 info "  Configuration vars: $LZ_ENCLAVE_DIR/config/global.yaml"
 info "  Certificates vars: $LZ_ENCLAVE_DIR/config/certificates.yaml"
+info "  Cloud infra vars:  $LZ_ENCLAVE_DIR/config/cloud_infra.yaml"
 info "  SSH Access: ssh $LZ_SSH"
 echo ""
 info "Before running Enclave Lab:"
 info "  1. Review configuration vars: ssh $LZ_SSH 'cat $LZ_ENCLAVE_DIR/config/global.yaml'"
 info "  2. Update pull secret: ssh $LZ_SSH 'vi ~/.config/pull-secret.json'"
-info "  3. Adjust any other settings in config/global.yaml and config/certificates.yaml as needed"
+info "  3. Adjust any other settings in config/global.yaml, config/certificates.yaml and config/cloud_infra.yaml as needed"
 echo ""
 info "To run Enclave Lab:"
 info "  ssh $LZ_SSH"
 info "  cd $LZ_ENCLAVE_DIR"
-info "  ansible-playbook -e@config/global.yaml playbooks/main.yaml"
+info "  ansible-playbook -e@config/global.yaml -e@config/certificates.yaml -e@config/cloud_infra.yaml playbooks/main.yaml"
 echo ""
 
 # Exit with failure if any tests failed

--- a/validations.sh
+++ b/validations.sh
@@ -1,7 +1,38 @@
 #!/bin/bash
 
-global_vars=${1:-config/global.yaml}
-certs_vars=${2:-config/certificates.yaml}
+usage() {
+    echo "Usage: $0 [OPTIONS]"
+    echo ""
+    echo "Options:"
+    echo "  --global-vars FILE    Path to global vars file (default: config/global.yaml)"
+    echo "  --certs-vars FILE     Path to certificates vars file (default: config/certificates.yaml)"
+    echo "  -h, --help            Show this help message"
+    exit "${1:-0}"
+}
+
+global_vars=config/global.yaml
+certs_vars=config/certificates.yaml
+cloud_infra_vars=config/cloud_infra.yaml
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --global-vars)
+            global_vars="$2"
+            shift 2
+            ;;
+        --certs-vars)
+            certs_vars="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Error: Unknown option '$1'"
+            usage 1
+            ;;
+    esac
+done
 
 getValue(){
     python -c 'import sys, yaml, json; print(json.dumps(yaml.safe_load(sys.stdin)))' < $vars_rendered \
@@ -128,7 +159,7 @@ validation_section "syntax"
 # Render a vars.yaml file. This allows variable interpolation in vars.yaml
 vars_rendered=$(mktemp)
 trap 'rm -f "$vars_rendered"' exit
-if ! vars_rendering=$(ansible localhost -e "@$global_vars" -e "@$certs_vars" -m copy -a "content={{ hostvars['localhost'] | to_yaml }} dest=${vars_rendered}" 2>&1); then
+if ! vars_rendering=$(ansible localhost -e "@$global_vars" -e "@$certs_vars" -e "@$cloud_infra_vars" -m copy -a "content={{ hostvars['localhost'] | to_yaml }} dest=${vars_rendered}" 2>&1); then
     validation fail vars_yaml "Configuration files could not be parsed" "$vars_rendering"
 fi
 validation pass vars_yaml "Configuration syntax OK"


### PR DESCRIPTION
- Introduce `config/cloud_infra.yaml` as a mandatory config file for `discovery_hosts`, separating it from `global.yaml`
- Add `config/cloud_infra.example.yaml` template
- Remove `discovery_hosts` from `config/global.example.yaml`
- Add named `--global-vars` `--certs-vars` params to `bootstrap.sh` and `validations.sh`, replacing positional arguments

Depends on #15 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated cloud infrastructure configuration file for discovery hosts and generation/sanitization support.

* **Documentation**
  * Updated Quick Start, deployment, configuration, testing, and local-testing docs to include creating, editing, and verifying the new cloud infra config and examples.

* **Refactor**
  * Moved discovery-hosts settings out of the global config; updated install, bootstrap, validation, and runtime flows to accept and validate the new cloud infra config.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->