### PR TITLE
MGMT-22814: export clair vulnerability data on tarball build

### DIFF
--- a/.github/workflows/build-push-tarball.yml
+++ b/.github/workflows/build-push-tarball.yml
@@ -46,7 +46,7 @@ jobs:
           retry_on: error
         run: |
           curl -L -o /tmp/clairctl https://github.com/quay/clair/releases/download/v4.9.0/clairctl-linux-amd64 && chmod +x /tmp/clairctl
-          /tmp/clairctl --config ./data/clair/minimal_config.yaml export-updaters --strict ./data/clair/updates.json.gz
+          /tmp/clairctl --config ./data/clair/minimal_config.yaml export-updaters ./data/clair/updates.json.gz
 
       - name: Install ORAS
         uses: oras-project/setup-oras@v1

--- a/.github/workflows/build-push-tarball.yml
+++ b/.github/workflows/build-push-tarball.yml
@@ -41,6 +41,9 @@ jobs:
 
       - name: Export Clair vulnerability data
         # if: github.event_name != 'pull_request'
+        with:
+          max_attempts: 3
+          retry_on: error
         run: |
           curl -L -o /tmp/clairctl https://github.com/quay/clair/releases/download/v4.9.0/clairctl-linux-amd64 && chmod +x /tmp/clairctl
           /tmp/clairctl --config ./data/clair/minimal_config.yaml export-updaters --strict ./data/clair/updates.json.gz

--- a/.github/workflows/build-push-tarball.yml
+++ b/.github/workflows/build-push-tarball.yml
@@ -41,9 +41,6 @@ jobs:
 
       - name: Export Clair vulnerability data
         # if: github.event_name != 'pull_request'
-        with:
-          max_attempts: 3
-          retry_on: error
         run: |
           curl -L -o /tmp/clairctl https://github.com/quay/clair/releases/download/v4.9.0/clairctl-linux-amd64 && chmod +x /tmp/clairctl
           /tmp/clairctl --config ./data/clair/minimal_config.yaml export-updaters ./data/clair/updates.json.gz

--- a/.github/workflows/build-push-tarball.yml
+++ b/.github/workflows/build-push-tarball.yml
@@ -40,7 +40,7 @@ jobs:
           echo -n "${{ steps.meta.outputs.tag }}" > .version
 
       - name: Export Clair vulnerability data
-        # if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         run: |
           curl -L -o /tmp/clairctl https://github.com/quay/clair/releases/download/v4.9.0/clairctl-linux-amd64 && chmod +x /tmp/clairctl
           /tmp/clairctl --config ./data/clair/minimal_config.yaml export-updaters ./data/clair/updates.json.gz

--- a/.github/workflows/build-push-tarball.yml
+++ b/.github/workflows/build-push-tarball.yml
@@ -39,6 +39,12 @@ jobs:
         run: |
           echo -n "${{ steps.meta.outputs.tag }}" > .version
 
+      - name: Export Clair vulnerability data
+        # if: github.event_name != 'pull_request'
+        run: |
+          curl -L -o /tmp/clairctl https://github.com/quay/clair/releases/download/v4.9.0/clairctl-linux-amd64 && chmod +x /tmp/clairctl
+          /tmp/clairctl --config ./data/clair/minimal_config.yaml export-updaters --strict ./data/clair/updates.json.gz
+
       - name: Install ORAS
         uses: oras-project/setup-oras@v1
         with:

--- a/operators/quay-operator/clair_disconnected.yaml
+++ b/operators/quay-operator/clair_disconnected.yaml
@@ -33,7 +33,7 @@
     volumes:
       - "{{ workingDir }}/data/clair:/data:Z"
     entrypoint: "/usr/bin/clairctl"
-    command: "--config /data/minimal_config.yaml export-updaters --strict /data/updates.json.gz"
+    command: "--config /data/minimal_config.yaml export-updaters /data/updates.json.gz"
     detach: false
 
 - name: Ensure directory /var/www/html/clair/

--- a/operators/quay-operator/clair_disconnected.yaml
+++ b/operators/quay-operator/clair_disconnected.yaml
@@ -17,24 +17,13 @@
     state: directory
     mode: '0777'
 
-- name: Create minimal Clair config for export
-  ansible.builtin.copy:
-    dest: "{{ workingDir }}/data/clair/config.yaml"
-    content: |
-      http_listen_addr: :8080
-      introspection_addr: :8081
-      indexer:
-        connstring: ""
-        scanlock_retry: 10
-        layer_scan_concurrency: 5
-      matcher:
-        connstring: ""
-        max_conn_pool: 100
-      notifier:
-        connstring: ""
-        delivery_interval: 1m
+- name: Check if Clair updates file exists
+  ansible.builtin.stat:
+    path: "{{ workingDir }}/data/clair/updates.json.gz"
+  register: clair_updates_stat_file
 
 - name: Export vulnerability data on Landing Zone
+  when: not clair_updates_stat_file.stat.exists
   containers.podman.podman_container:
     name: clair-exporter
     image: "{{ clair_pod.spec.containers[0].image | regex_replace('^registry\\.redhat\\.io', quayHostname + ':8443') }}"
@@ -44,7 +33,7 @@
     volumes:
       - "{{ workingDir }}/data/clair:/data:Z"
     entrypoint: "/usr/bin/clairctl"
-    command: "--config /data/config.yaml export-updaters /data/updates.json.gz"
+    command: "--config /data/minimal_config.yaml export-updaters --strict /data/updates.json.gz"
     detach: false
 
 - name: Ensure directory /var/www/html/clair/


### PR DESCRIPTION
part of https://issues.redhat.com/browse/MGMT-22814

related to https://github.com/gori-project/GoRI/issues/799

export clair updates on every push to main, and avoid exporting in the LZ if the updates file exists.

this approach will be compatible with anyone fetching the repository contents or fetching the tarball.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated export of vulnerability data into the build pipeline.
  * Improved disconnected deployment flow with a runtime check to skip export when updater data already exists.
  * Made export step conditional to reduce duplicate work and unnecessary processing.
  * Simplified configuration usage for offline vulnerability exports to streamline resource handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->