### PR TITLE
MGMT-23352: Fix disconnected deployment with dev-scripts

### DIFF
--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -764,7 +764,7 @@ pullSecret: |
 
 **Example**:
 ```yaml
-pullSecretPath: "{{ workingDir }}/.config/pull-secret.json"
+pullSecretPath: "{{ workingDir }}/config/pull-secret.json"
 ```
 
 ## Storage Configuration

--- a/operators/advanced-cluster-management/acm_cis.yaml
+++ b/operators/advanced-cluster-management/acm_cis.yaml
@@ -2,6 +2,8 @@
 # ACM CIS tasks: ClusterImageSet reconciliation
 
 - name: Get current ClusterImageSet
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
   kubernetes.core.k8s_info:
     api_version: hive.openshift.io/v1
     kind: ClusterImageSet
@@ -12,6 +14,8 @@
     r_desired_image_set: "{{ openshift_versions | map(attribute='version') | map('regex_replace', '^(.*)$', 'openshift-v\\1-disconnected') | list }}"
 
 - name: Delete existing ClusterImageSet
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
   kubernetes.core.k8s:
     state: absent
     definition:
@@ -27,6 +31,8 @@
     loop_var: imageset
 
 - name: Create ClusterImageSet
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
   kubernetes.core.k8s:
     state: present
     definition:

--- a/operators/quay-operator/quay_disconnected.yaml
+++ b/operators/quay-operator/quay_disconnected.yaml
@@ -34,7 +34,7 @@
       --dest-tls-verify=false \
       --src-tls-verify=false \
       --parallel-images 10 \
-      --parallel-layers 10 \
+      --parallel-layers {{ 1 if quayBackend == 'LocalStorage' else 10 }} \
       --retry-times 10 \
       --retry-delay 0 \
       --image-timeout 40m0s \

--- a/operators/quay-operator/quay_lvms.yaml
+++ b/operators/quay-operator/quay_lvms.yaml
@@ -1,0 +1,143 @@
+---
+# LVMS-specific tasks for Quay: PVC, QuayRegistry, and deployment patch to mount registry storage.
+# Included from tasks.yaml only when blockStorageBackend == 'lvms'.
+
+- name: Ensure QuayRegistry is present (LVMS Backend)
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: quay.redhat.com/v1
+      kind: QuayRegistry
+      metadata:
+        name: registry
+        namespace: quay-enterprise
+      spec:
+        configBundleSecret: quay-config
+        components:
+        - kind: objectstorage
+          managed: false
+        - kind: quay
+          managed: true
+          overrides:
+            replicas: 1
+            resources:
+              limits:
+                cpu: "4"
+                memory: 12Gi
+              requests:
+                cpu: "{{ '2' if (disconnected | default(true)) else '1' }}"
+                memory: "{{ '6Gi' if (disconnected | default(true)) else '4Gi' }}"
+        - kind: horizontalpodautoscaler
+          managed: false
+  retries: 60
+  delay: 10
+  register: r_quay_lvms
+  until: r_quay_lvms is succeeded
+
+- name: Wait for Quay app deployment to exist (LVMS)
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    namespace: quay-enterprise
+    name: registry-quay-app
+  register: quay_app_deployment
+  retries: 30
+  delay: 10
+  until: quay_app_deployment.resources | length > 0
+
+- name: Set quay container index for LVMS patch (first container is the app)
+  ansible.builtin.set_fact:
+    quay_container_index: 0
+  when: quay_app_deployment.resources | default([]) | length > 0
+
+- name: Check if Quay app deployment already has registry-storage volume (LVMS)
+  ansible.builtin.set_fact:
+    quay_registry_storage_already_patched: "{{ quay_app_deployment.resources[0].spec.template.spec.volumes | selectattr('name', 'equalto', 'registry-storage') | list | length > 0 }}"
+  when: quay_app_deployment.resources | default([]) | length > 0
+
+- name: Patch Quay app deployment to mount registry storage PVC (LVMS)
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  ansible.builtin.shell: |
+    oc patch deployment registry-quay-app -n quay-enterprise --type=json -p='{{ quay_lvms_patch | to_json }}'
+  args:
+    executable: /bin/bash
+  vars:
+    quay_lvms_patch:
+      - op: add
+        path: /spec/template/spec/volumes/-
+        value:
+          name: registry-storage
+          persistentVolumeClaim:
+            claimName: quay-storage-pvc
+      - op: add
+        path: /spec/template/spec/containers/{{ quay_container_index }}/volumeMounts/-
+        value:
+          name: registry-storage
+          mountPath: /datastorage/registry
+  when:
+    - quay_app_deployment.resources | default([]) | length > 0
+    - quay_container_index is defined
+    - not (quay_registry_storage_already_patched | default(false))
+  register: quay_patch_result
+
+- name: Get last node name for Quay pinning (LVMS)
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  ansible.builtin.shell: |
+    oc get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | sort | tail -1
+  args:
+    executable: /bin/bash
+  register: quay_node_name_result
+  changed_when: false
+
+- name: Label node for Quay storage (LVMS)
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  ansible.builtin.shell: |
+    oc label node {{ quay_node_name_result.stdout }} storage-role=quay-node --overwrite
+  args:
+    executable: /bin/bash
+  when: quay_node_name_result.stdout | length > 0
+
+- name: Create LVMS PVC for Quay Storage
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: quay-storage-pvc
+        namespace: quay-enterprise
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 300Gi
+        storageClassName: lvms-vg1
+
+- name: Patch Quay app deployment with node affinity to Quay node (LVMS)
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  ansible.builtin.shell: |
+    oc patch deployment registry-quay-app -n quay-enterprise --type=merge -p '{{ quay_node_affinity_patch | to_json }}'
+  args:
+    executable: /bin/bash
+  vars:
+    quay_node_affinity_patch:
+      spec:
+        template:
+          spec:
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                  - matchExpressions:
+                    - key: storage-role
+                      operator: In
+                      values:
+                      - quay-node
+  when:
+    - quay_app_deployment.resources | default([]) | length > 0
+    - quay_node_name_result.stdout | default('') | length > 0

--- a/operators/quay-operator/tasks.yaml
+++ b/operators/quay-operator/tasks.yaml
@@ -26,6 +26,9 @@
                    | combine(quayBackendRGWDefaults)
                    | combine(quayBackendRGWConfiguration))
                    if quayBackend == 'RadosGWStorage'
+                   else (quayBackendDefaults
+                   | combine(quayBackendLocalStorageConfiguration | default({})))
+                   if quayBackend == 'LocalStorage'
                    else quayBackendDefaults)
                    | to_yaml }}
           DISTRIBUTED_STORAGE_DEFAULT_LOCATIONS:
@@ -57,7 +60,7 @@
           matcher:
             disable_updaters: true
 
-- name: Ensure QuayRegistry is present
+- name: Ensure QuayRegistry is present (ODF Backend)
   kubernetes.core.k8s:
     state: present
     definition:
@@ -70,7 +73,7 @@
         configBundleSecret: quay-config
         components:
         - kind: horizontalpodautoscaler
-          managed: "{{ true if blockStorageBackend == 'odf' else false }}"
+          managed: true
         - kind: quay
           managed: true
           overrides:
@@ -83,11 +86,15 @@
                 memory: "{{ '16Gi' if (disconnected | default(true)) else '2Gi' }}"
         - kind: objectstorage
           managed: false
+  when: blockStorageBackend == 'odf'
   retries: 60
   delay: 10
   register: r_quay
   until: r_quay is succeeded
 
+- name: Run LVMS-specific Quay tasks (PVC, QuayRegistry, deployment patch)
+  ansible.builtin.include_tasks: quay_lvms.yaml
+  when: blockStorageBackend == 'lvms'
 
 - name: Get router pod IP for Quay route access
   kubernetes.core.k8s_info:

--- a/playbooks/tasks/configure_hardware_ironic_setup.yaml
+++ b/playbooks/tasks/configure_hardware_ironic_setup.yaml
@@ -37,7 +37,7 @@
   ansible.builtin.wait_for:
     port: "{{ http_server_port }}"
     host: localhost
-    timeout: 10
+    timeout: 30
 
 - name: Verify ISO is accessible via temporary HTTP server
   ansible.builtin.uri:

--- a/scripts/deployment/install_enclave.sh
+++ b/scripts/deployment/install_enclave.sh
@@ -265,8 +265,8 @@ if [ "$PULL_SECRET_FOUND" = true ]; then
     info "  Validated pull secret contains registry.redhat.io credentials"
 
     # Copy to Landing Zone
-    ssh $SSH_OPTS "$LZ_SSH" "mkdir -p ${LZ_ROOT_DIR}/.config"
-    scp $SSH_OPTS "$PULL_SECRET_SOURCE" "${LZ_SSH}:${LZ_ROOT_DIR}/.config/pull-secret.json"
+    ssh $SSH_OPTS "$LZ_SSH" "mkdir -p ${LZ_ROOT_DIR}/config"
+    scp $SSH_OPTS "$PULL_SECRET_SOURCE" "${LZ_SSH}:${LZ_ROOT_DIR}/config/pull-secret.json"
 
     success "Pull secret copied to Landing Zone"
 
@@ -281,7 +281,7 @@ import yaml
 import json
 
 # Read the pull secret
-with open('/home/cloud-user/.config/pull-secret.json', 'r') as f:
+with open('/home/cloud-user/config/pull-secret.json', 'r') as f:
     pull_secret = json.load(f)
 
 # Read config/global.yaml

--- a/scripts/infrastructure/generate_enclave_vars.sh
+++ b/scripts/infrastructure/generate_enclave_vars.sh
@@ -137,6 +137,8 @@ quayPassword: SuperPrivate123!
 # Option 1: External S3/RadosGW storage (RECOMMENDED for production)
 # Option 2: Local storage (NOT recommended for production)
 quayBackend: LocalStorage
+quayBackendLocalStorageConfiguration:
+  storage_path: /datastorage/registry
 
 # ============================================================================
 # Storage Backend
@@ -162,7 +164,7 @@ lvmsConfig: {}
 # Pull secret will be read from pullSecretPath
 pullSecret:
   auths: {}
-pullSecretPath: "{{ workingDir }}/.config/pull-secret.json"
+pullSecretPath: "{{ workingDir }}/config/pull-secret.json"
 
 # SSH public key path for cluster nodes
 sshPubPath: "{{ workingDir }}/.ssh/id_rsa.pub"
@@ -271,7 +273,7 @@ info "Generated configuration uses:"
 info "  - Worker IPs: ${WORKER_IP_START}-${WORKER_IP_END} (will be assigned during deployment)"
 info "  - Storage: LVMS with /dev/vda root disk"
 info "  - Registry: LocalStorage"
-info "  - Pull secret: Will use ~/.config/pull-secret.json on Landing Zone"
+info "  - Pull secret: Will use ~/config/pull-secret.json on Landing Zone"
 info "  - SSL certificates: Empty (self-signed will be generated)"
 echo ""
 info "Review config/global.yaml, config/certificates.yaml and config/cloud_infra.yaml"

--- a/scripts/infrastructure/provision_landing_zone.sh
+++ b/scripts/infrastructure/provision_landing_zone.sh
@@ -670,6 +670,18 @@ if [ "$BOOT_COMPLETE" = true ]; then
         exit 1
     fi
 
+    # Add mirror hostnames -> LZ cluster IP so master VMs can resolve both short and FQDN forms
+    MIRROR_SHORT_HOST="mirror"
+    MIRROR_FQDN="mirror.${BASE_DOMAIN:-lab}"
+    info "Adding DNS entry: ${MIRROR_SHORT_HOST}, ${MIRROR_FQDN} -> ${CLUSTER_IP} (Landing Zone) on network ${CLUSTER_NETWORK_NAME}..."
+    if ! sudo virsh net-update "${CLUSTER_NETWORK_NAME}" add dns-host \
+        "<host ip='${CLUSTER_IP}'><hostname>${MIRROR_SHORT_HOST}</hostname><hostname>${MIRROR_FQDN}</hostname></host>" \
+        --live --config 2>/dev/null; then
+        warning "Could not add mirror DNS entry (network may not support live update)"
+    else
+        info "✓ DNS entry added: ${MIRROR_SHORT_HOST}, ${MIRROR_FQDN} -> ${CLUSTER_IP}"
+    fi
+
     echo ""
     info "========================================="
     info "Landing Zone VM Provisioned Successfully"

--- a/scripts/setup/configure_devscripts.sh
+++ b/scripts/setup/configure_devscripts.sh
@@ -72,6 +72,16 @@ echo "Creating dev-scripts configuration at: $CONFIG_FILE"
 ENCLAVE_NUM_MASTERS="${ENCLAVE_NUM_MASTERS:-3}"
 ENCLAVE_NUM_LANDINGZONE="${ENCLAVE_NUM_LANDINGZONE:-1}"
 
+# VM extra disk size: 200G for disconnected (mirroring), 60G for connected
+DEPLOYMENT_MODE="${ENCLAVE_DEPLOYMENT_MODE:-disconnected}"
+if [ "$DEPLOYMENT_MODE" = "connected" ]; then
+    VM_EXTRADISKS_SIZE_VAL="60G"
+    MASTER_MEMORY_VAL=24576    # 24 GB for connected
+else
+    VM_EXTRADISKS_SIZE_VAL="300G"
+    MASTER_MEMORY_VAL=32768    # 32 GB for disconnected
+fi
+
 # Create configuration file
 cat > "$CONFIG_FILE" <<EOF
 #!/bin/bash
@@ -105,14 +115,14 @@ export NUM_EXTRA_WORKERS=0
 # =============================================================================
 
 # Master VMs need resources for OpenShift control plane nodes
-export MASTER_MEMORY=24576    # 24 GB RAM
-export MASTER_DISK=120        # 120 GB disk
-export MASTER_VCPU=12         # 12 vCPUs
+export MASTER_MEMORY=${MASTER_MEMORY_VAL}
+export MASTER_DISK=120  # 120 GB disk
+export MASTER_VCPU=12   # 12 vCPUs
 
 # Extra disks for storage (used by LVMS for PersistentVolumes)
 export VM_EXTRADISKS=true
 export VM_EXTRADISKS_LIST="vdb"
-export VM_EXTRADISKS_SIZE="60G"
+export VM_EXTRADISKS_SIZE="${VM_EXTRADISKS_SIZE_VAL}"
 
 # =============================================================================
 # Landing Zone VM Specs
@@ -159,6 +169,9 @@ export CLUSTER_NAME="${ENCLAVE_CLUSTER_NAME}"
 
 # Cluster domain (for DNS)
 export CLUSTER_DOMAIN="${ENCLAVE_CLUSTER_NAME}.lab"
+
+# Base domain (so dev-scripts uses .lab not test.metalkube.org for CLUSTER_DOMAIN)
+export BASE_DOMAIN="lab"
 
 # Working directory (where VMs and configs are stored)
 # Must be set explicitly for dev-scripts to use cluster-specific paths

--- a/scripts/verification/verify_enclave_installation.sh
+++ b/scripts/verification/verify_enclave_installation.sh
@@ -244,10 +244,10 @@ fi
 
 # Test 8: Pull secret
 info "Test 8: Checking pull secret..."
-if ssh $SSH_OPTS "$LZ_SSH" "test -f ~/.config/pull-secret.json"; then
-    success "Pull secret exists at ~/.config/pull-secret.json"
+if ssh $SSH_OPTS "$LZ_SSH" "test -f ~/config/pull-secret.json"; then
+    success "Pull secret exists at ~/config/pull-secret.json"
 else
-    warning "Pull secret not found at ~/.config/pull-secret.json"
+    warning "Pull secret not found at ~/config/pull-secret.json"
     info "  You will need to provide a valid OpenShift pull secret before running Enclave Lab"
 fi
 
@@ -322,7 +322,7 @@ info "  SSH Access: ssh $LZ_SSH"
 echo ""
 info "Before running Enclave Lab:"
 info "  1. Review configuration vars: ssh $LZ_SSH 'cat $LZ_ENCLAVE_DIR/config/global.yaml'"
-info "  2. Update pull secret: ssh $LZ_SSH 'vi ~/.config/pull-secret.json'"
+info "  2. Update pull secret: ssh $LZ_SSH 'vi ~/config/pull-secret.json'"
 info "  3. Adjust any other settings in config/global.yaml, config/certificates.yaml and config/cloud_infra.yaml as needed"
 echo ""
 info "To run Enclave Lab:"

--- a/templates/registries.conf.j2
+++ b/templates/registries.conf.j2
@@ -63,6 +63,12 @@
 
 [[registry]]
   prefix = ""
+  location = "registry.redhat.io/ubi9-minimal"
+[[registry.mirror]]
+  location = "{{ quayHostname }}:8443/ubi9-minimal"
+
+[[registry]]
+  prefix = ""
   location = "registry.redhat.io/multicluster-engine"
 [[registry.mirror]]
   location = "{{ quayHostname }}:8443/multicluster-engine"
@@ -277,3 +283,9 @@
   location = "registry.redhat.io/ansible-automation-platform"
 [[registry.mirror]]
   location = "{{ quayHostname }}:8443/ansible-automation-platform"
+
+[[registry]]
+  prefix = ""
+  location = "registry.redhat.io/ansible-automation-platform-tech-preview"
+[[registry.mirror]]
+  location = "{{ quayHostname }}:8443/ansible-automation-platform-tech-preview"


### PR DESCRIPTION
Fix disconnected deployment, enclave DNS/config, and Quay LVMS support.

Disconnected and enclave:
- configure_devscripts.sh: Add BASE_DOMAIN=lab so CLUSTER_DOMAIN is <cluster>.lab
- configure_devscripts.sh: VM_EXTRADISKS_SIZE and MASTER_MEMORY by mode (disconnected: 300G/32GB, connected: 60G/24GB)
- provision_landing_zone.sh: Add mirror + mirror.<domain> -> LZ IP to virsh network DNS after provisioning
- Pull secret path: .config/pull-secret.json -> config/pull-secret.json (install_enclave.sh, generate_enclave_vars.sh, verify_enclave_installation.sh, docs)
- generate_enclave_vars.sh: quayBackendLocalStorageConfiguration.storage_path = /datastorage/registry
- configure_hardware_ironic_setup.yaml: Increase HTTP server wait timeout 10 -> 30s

Quay operator:
- Add quay_lvms.yaml: LVMS PVC, QuayRegistry, and deployment patch for registry storage
- Split tasks.yaml: ODF backend (existing QuayRegistry) vs LVMS (include quay_lvms.yaml)
- ODF branch: HPA managed true, task conditional on blockStorageBackend == 'odf'

Operator tasks (cluster API):
- acm_cis.yaml: Add KUBECONFIG to ClusterImageSet tasks (Get current, Delete, Create)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LVMS backend support for Quay deployments
  * Improved Clair pod handling for disconnected imports
  * Added DNS mirror entry for Landing Zone cluster

* **Improvements**
  * Deployment-mode-based resource tuning (connected vs disconnected)
  * Increased HTTP readiness timeout to 30s
  * Conditional mirroring parallelism for local storage

* **Configuration Updates**
  * Standardized pull secret path to ./config/pull-secret.json
  * Added local storage config for Quay registry

<!-- end of auto-generated comment: release notes by coderabbit.ai -->