### PR TITLE
Fix size labeler: Switch from Docker to JavaScript action

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -30,18 +30,19 @@ jobs:
           sync-labels: true
 
       # Size labels based on lines changed
+      # Using pascalgn/size-label-action (JavaScript) instead of codelytv/pr-size-labeler (Docker)
+      # because Docker container actions don't work well with podman on self-hosted runners
       - name: Size labels
-        uses: codelytv/pr-size-labeler@4ec67706cd878fbc1c8db0a5dcd28b6bb412e85a # v1.10.3
+        uses: pascalgn/size-label-action@637b50d9ea6c2f84fc28ef5a9adbfac142f36670 # v0.5.4
         continue-on-error: true
-        with:
+        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          xs_label: 'size/XS'
-          xs_max_size: '9'
-          s_label: 'size/S'
-          s_max_size: '99'
-          m_label: 'size/M'
-          m_max_size: '499'
-          l_label: 'size/L'
-          l_max_size: '999'
-          xl_label: 'size/XL'
-          fail_if_xl: 'false'
+        with:
+          sizes: >
+            {
+              "0": "size/XS",
+              "10": "size/S",
+              "100": "size/M",
+              "500": "size/L",
+              "1000": "size/XL"
+            }


### PR DESCRIPTION
The codelytv/pr-size-labeler action is Docker-based and fails on self-hosted runners using podman with error:
```
  cannot resolve /github/home: lstat /github: no such file or directory
```

Switched to `pascalgn/size-label-action` which is JavaScript-based and works with both Docker and podman runners.

Size thresholds remain the same:
- 0-9 lines: size/XS
- 10-99 lines: size/S
- 100-499 lines: size/M
- 500-999 lines: size/L
- 1000+ lines: size/XL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automatic pull request size labeling process to use an improved labeling mechanism. PRs are now assigned size labels (XS, S, M, L, XL) based on the number of lines changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->