### PR TITLE
fix: Enable Partner Overlay deployment

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -134,10 +134,10 @@ printf '%b\n' "$(tail -3 ${workingDir}/ocp-cluster/.openshift_install.log \
   | sed -e 's/^"//' -e 's/"$//' -e 's/\\n/\
 /g' -e 's/\\"/"/g')"
 
-#echo -p "Deploying Partner OverLay .. " -n1 -s
-#    ./partner-install/start.sh ${workingDir}/ocp-cluster/auth/kubeconfig ${global_vars} ${certs_vars} 2>&1 >> ${log}
-#echo -e "\e[38;5;10m Done...\033[0m"; date
-#
+echo -p "Deploying Partner OverLay .. " -n1 -s
+    ./partner-install/start.sh ${workingDir}/ocp-cluster/auth/kubeconfig ${global_vars} ${certs_vars} 2>&1 >> ${log}
+echo -e "\e[38;5;10m Done...\033[0m"; date
+
 #echo -p "Service Validation and HealthCheck ..TBD " -n1 -s  | tee -a ${log}
 #echo -e "\e[38;5;10m Done...\033[0m"; date
 


### PR DESCRIPTION
The `bootstrap.sh` has disabled partner overlay install script call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Partner Overlay deployment is now enabled and active during system deployment. The installation and startup routines will execute as part of the standard deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->