### PR TITLE
MGMT-22814: day 2 sync of clair vulnerability data (import execution in tekton)

### DIFF
--- a/operators/openshift-pipelines-operator-rh/clair_import_pipeline.yaml
+++ b/operators/openshift-pipelines-operator-rh/clair_import_pipeline.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Get OpenShift CLI image from OpenShift release
   ansible.builtin.command: >
-    {{ workingDir }}/bin/oc adm release info --registry-config={{ workingDir }}/config/pull-secret.json --image-for cli
+    {{ workingDir }}/bin/oc adm release info --registry-config={{ pullSecretPath }} --image-for cli
     quay.io/openshift-release-dev/ocp-release:{{ mgmt_openshift_version }}-x86_64
   register: r_oc_cli_image
   changed_when: false

--- a/operators/openshift-pipelines-operator-rh/clair_import_pipeline.yaml
+++ b/operators/openshift-pipelines-operator-rh/clair_import_pipeline.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Get OpenShift CLI image from OpenShift release
   ansible.builtin.command: >
-    {{ rootDir }}/bin/oc adm release info --registry-config={{ rootDir }}/config/pull-secret.json --image-for cli
+    {{ workingDir }}/bin/oc adm release info --registry-config={{ workingDir }}/config/pull-secret.json --image-for cli
     quay.io/openshift-release-dev/ocp-release:{{ mgmt_openshift_version }}-x86_64
   register: r_oc_cli_image
   changed_when: false

--- a/operators/openshift-pipelines-operator-rh/clair_import_pipeline.yaml
+++ b/operators/openshift-pipelines-operator-rh/clair_import_pipeline.yaml
@@ -40,14 +40,20 @@
             image: "{{ oc_cli_image }}"
             script: |
                 #!/bin/bash
+                set -uo pipefail
 
                 clair_pod_name=$(oc get pods -n quay-enterprise -l quay-component=clair-app -o name | cut -d/ -f2)
-                oc exec -n quay-enterprise $clair_pod_name -- \
+                if oc exec -n quay-enterprise "$clair_pod_name" -- \
                 /bin/sh -c "
                   curl -L -o /tmp/updates.json.gz http://{{ quayHostname }}/clair/updates.json.gz
                   /usr/bin/clairctl --config /clair/config.yaml import-updaters /tmp/updates.json.gz
-                " > $(results.status-report.path)
-                echo $? > $(results.exit-code.path)
+                " > "$(results.status-report.path)" 2>&1; then
+                  rc=0
+                else
+                  rc=$?
+                fi
+                echo "$rc" > "$(results.exit-code.path)"
+                exit "$rc"
 
 - name: Create Clair Import Pipeline
   kubernetes.core.k8s:
@@ -63,9 +69,9 @@
           - name: clair-import
             taskRef:
               name: clair-import
-            results:
-              - name: exit-code
-                value: $(tasks.clair-import.results.exit-code)
-              - name: status-report
-                value: $(tasks.clair-import.results.status-report)
+        results:
+          - name: exit-code
+            value: $(tasks.clair-import.results.exit-code)
+          - name: status-report
+            value: $(tasks.clair-import.results.status-report)
         timeout: "1h"

--- a/operators/openshift-pipelines-operator-rh/clair_import_pipeline.yaml
+++ b/operators/openshift-pipelines-operator-rh/clair_import_pipeline.yaml
@@ -1,0 +1,71 @@
+---
+- name: Get OpenShift CLI image from OpenShift release
+  ansible.builtin.command: >
+    {{ rootDir }}/bin/oc adm release info --registry-config={{ rootDir }}/config/pull-secret.json --image-for cli
+    quay.io/openshift-release-dev/ocp-release:{{ mgmt_openshift_version }}-x86_64
+  register: r_oc_cli_image
+  changed_when: false
+
+- name: Set image facts
+  ansible.builtin.set_fact:
+    oc_cli_image: "{{ r_oc_cli_image.stdout }}"
+
+- name: Create Clair Import ServiceAccount
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: clair-import
+        namespace: openshift-pipelines
+
+- name: Create Clair Import Task
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: tekton.dev/v1
+      kind: Task
+      metadata:
+        name: clair-import
+        namespace: openshift-pipelines
+      spec:
+        results:
+          - name: exit-code
+            description: "Success of clair import (exit code)"
+          - name: status-report
+            description: "Report of clair import"
+        steps:
+          - name: clair-import
+            image: "{{ oc_cli_image }}"
+            script: |
+                #!/bin/bash
+
+                clair_pod_name=$(oc get pods -n quay-enterprise -l quay-component=clair-app -o name | cut -d/ -f2)
+                oc exec -n quay-enterprise $clair_pod_name -- \
+                /bin/sh -c "
+                  curl -L -o /tmp/updates.json.gz http://{{ quayHostname }}/clair/updates.json.gz
+                  /usr/bin/clairctl --config /clair/config.yaml import-updaters /tmp/updates.json.gz
+                " > $(results.status-report.path)
+                echo $? > $(results.exit-code.path)
+
+- name: Create Clair Import Pipeline
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: tekton.dev/v1
+      kind: Pipeline
+      metadata:
+        name: clair-import
+        namespace: openshift-pipelines
+      spec:
+        tasks:
+          - name: clair-import
+            taskRef:
+              name: clair-import
+            results:
+              - name: exit-code
+                value: $(tasks.clair-import.results.exit-code)
+              - name: status-report
+                value: $(tasks.clair-import.results.status-report)
+        timeout: "1h"

--- a/operators/openshift-pipelines-operator-rh/tasks.yaml
+++ b/operators/openshift-pipelines-operator-rh/tasks.yaml
@@ -14,3 +14,7 @@
   until: r_tekton_config_info is success
   retries: 120
   delay: 30
+
+- name: Create Clair Import Pipeline
+  ansible.builtin.include_tasks:
+    file: clair_import_pipeline.yaml

--- a/operators/quay-operator/clair_disconnected.yaml
+++ b/operators/quay-operator/clair_disconnected.yaml
@@ -37,25 +37,34 @@
     src: "{{ workingDir }}/data/clair/updates.json.gz"
     dest: "/var/www/html/clair/updates.json.gz"
 
-- name: Get Clair Pod object from quay-enterprise
-  kubernetes.core.k8s_info:
-    kind: Pod
-    namespace: quay-enterprise
-    label_selectors:
-      - quay-component=clair-app
-  register: clair_pod_list
+- name: Create Clair Import Role
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: clair-import
+        namespace: quay-enterprise
+      rules:
+        - apiGroups: [""]
+          resources: ["pods"]
+          verbs: ["get", "list", "exec"]
 
-- name: Set Pod fact and verify existence
-  ansible.builtin.set_fact:
-    clair_pod: "{{ clair_pod_list.resources[0] }}"
-  failed_when: clair_pod_list.resources | length == 0
-
-- name: Execute Import inside the Clair Pod
-  ansible.builtin.shell: |
-    {{ workingDir }}/bin/oc exec -n quay-enterprise {{ clair_pod.metadata.name }} -- \
-    /bin/sh -c "
-      set -e
-      curl -L -o /tmp/updates.json.gz http://{{ quayHostname }}/clair/updates.json.gz
-      /usr/bin/clairctl --config /clair/config.yaml import-updaters /tmp/updates.json.gz
-    "
-  register: import_output
+- name: Create Clair Import RoleBinding
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: clair-import
+        namespace: quay-enterprise
+      subjects:
+        - kind: ServiceAccount
+          name: clair-import
+          namespace: openshift-pipelines
+      roleRef:
+        kind: Role
+        name: clair-import
+        apiGroup: rbac.authorization.k8s.io

--- a/operators/quay-operator/clair_disconnected.yaml
+++ b/operators/quay-operator/clair_disconnected.yaml
@@ -49,7 +49,10 @@
       rules:
         - apiGroups: [""]
           resources: ["pods"]
-          verbs: ["get", "list", "exec"]
+          verbs: ["get", "list"]
+        - apiGroups: [""]
+          resources: ["pods/exec"]
+          verbs: ["create"]
 
 - name: Create Clair Import RoleBinding
   kubernetes.core.k8s:

--- a/sync.sh
+++ b/sync.sh
@@ -76,6 +76,10 @@ echo -p "Quay disconnected .." -n1 -s
     ansible-playbook playbooks/06-day2.yaml -e@$global_vars -e@$certs_vars --tags quay-disconnected 2>&1 | tee -a ${log}
 echo -e "\e[38;5;10m Done...\033[0m"; date
 
+echo -p "Clair disconnected .." -n1 -s
+    ansible-playbook playbooks/06-day2.yaml -e@$global_vars -e@$certs_vars --tags clair-disconnected 2>&1 | tee -a ${log}
+echo -e "\e[38;5;10m Done...\033[0m"; date
+
 echo -p "ACM ClusterImageSets .." -n1 -s
     ansible-playbook playbooks/06-day2.yaml -e@$global_vars -e@$certs_vars --tags acm-cis 2>&1 | tee -a ${log}
 echo -e "\e[38;5;10m Done...\033[0m"; date


### PR DESCRIPTION
part of https://issues.redhat.com/browse/MGMT-22814

related to https://github.com/gori-project/GoRI/issues/799

keep vulnerability export in LZ as part of bootstrap. in this PR we also add this to sync, which is an activity performed prior to content update, such as mirroring.

we are also adding a tekton pipeline to perform the vulnerability data import within the management cluster instead of as part of bootstrap. this is to enable multiple executions of this operations in case of failure.

the import operation is also more fragile, and removing it from the e2e bootstrap makes the initial bootstrap more resilient.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated Clair import workflow with status reporting and a 1-hour timeout.
  * Introduced RBAC-based Clair access for disconnected environments, replacing direct in‑pod execution.

* **Chores**
  * Updated deployment automation to create and wire the Clair import pipeline.
  * Added a sync step to run Clair-disconnected tasks during automated deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->