### PR TITLE
execute clairctl export on landing zone itself and not within container

### DIFF
--- a/defaults/control_binaries.yaml
+++ b/defaults/control_binaries.yaml
@@ -12,3 +12,6 @@ control_binaries:
   oc_mirror:
     url: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.20.15/oc-mirror.tar.gz"
     checksum: "sha256:59791d2e6b84ee380bc6a180e4e5e2006590ca1e0f146b0176819386e11e26d1"
+  clairctl:
+    url: "https://github.com/quay/clair/releases/download/v4.8.0/clairctl-linux-amd64"
+    checksum: "sha256:eec1311f5e68165b49c8b4d024c83fc46285bdca2f37e756becf21d534551434"

--- a/operators/quay-operator/clair_disconnected.yaml
+++ b/operators/quay-operator/clair_disconnected.yaml
@@ -1,16 +1,3 @@
-- name: Get Clair Pod object from quay-enterprise
-  kubernetes.core.k8s_info:
-    kind: Pod
-    namespace: quay-enterprise
-    label_selectors:
-      - quay-component=clair-app
-  register: clair_pod_list
-
-- name: Set Pod fact and verify existence
-  ansible.builtin.set_fact:
-    clair_pod: "{{ clair_pod_list.resources[0] }}"
-  failed_when: clair_pod_list.resources | length == 0
-
 - name: Create local export directory
   ansible.builtin.file:
     path: "{{ workingDir }}/data/clair"
@@ -35,17 +22,8 @@
         delivery_interval: 1m
 
 - name: Export vulnerability data on Landing Zone
-  containers.podman.podman_container:
-    name: clair-exporter
-    image: "{{ clair_pod.spec.containers[0].image | regex_replace('^registry\\.redhat\\.io', quayHostname + ':8443') }}"
-    authfile: "{{ workingDir }}/config/pull-secret.quay.json"
-    tls_verify: no
-    rm: yes
-    volumes:
-      - "{{ workingDir }}/data/clair:/data:Z"
-    entrypoint: "/usr/bin/clairctl"
-    command: "--config /data/config.yaml export-updaters /data/updates.json.gz"
-    detach: false
+  ansible.builtin.shell: |
+    {{ workingDir }}/bin/clairctl --config {{ workingDir }}/data/clair/config.yaml export-updaters {{ workingDir }}/data/clair/updates.json.gz
 
 - name: Ensure directory /var/www/html/clair/
   become: true

--- a/playbooks/tasks/download_control_binaries.yaml
+++ b/playbooks/tasks/download_control_binaries.yaml
@@ -61,3 +61,10 @@
     src: "{{ workingDir }}/dist/oc-mirror.tar.gz"
     dest: "{{ workingDir }}/bin/"
     remote_src: true
+
+- name: Download clairctl
+  ansible.builtin.get_url:
+    url: "{{ control_binaries.clairctl.url }}"
+    dest: "{{ workingDir }}/bin/clairctl"
+    checksum: "{{ control_binaries.clairctl.checksum }}"
+    mode: "0750"

--- a/schemas/control_binaries.yaml
+++ b/schemas/control_binaries.yaml
@@ -65,6 +65,20 @@ properties:
         - url
         - checksum
         additionalProperties: false
+      clairctl:
+        type: object
+        properties:
+          url:
+            type: string
+            description: URL to download clairctl binary.
+          checksum:
+            type: string
+            description: SHA256 checksum for the binary.
+            pattern: "^sha256:[0-9a-f]{64}$"
+        required:
+        - url
+        - checksum
+        additionalProperties: false
     additionalProperties: false
 required:
 - control_binaries


### PR DESCRIPTION
running the command clairctl in the landing zone directly to avoid spinning up a container using podman.

this makes for a more consistent approach of obtaining control binaries and using them.

related to https://github.com/gori-project/GoRI/issues/818

this PR gets the same clairctl version as used in quay operator version 3.15: https://github.com/quay/clair/releases/tag/v4.8.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the clairctl tool with automatic download and checksum verification.

* **Improvements**
  * Simplified the vulnerability data export workflow to run the local clairctl tool directly instead of a container-based export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->