### PR TITLE
Fail playbook when Ironic node reaches deploy failed state

### DIFF
--- a/playbooks/tasks/configure_hardware_ironic_node.yaml
+++ b/playbooks/tasks/configure_hardware_ironic_node.yaml
@@ -189,6 +189,7 @@
     status_code: [200]
   register: node_state
   until: node_state.json.provision_state in ["active", "deploy failed"]
+  failed_when: node_state.json.provision_state == "deploy failed"
   retries: 60
   delay: 10
   when: current_provision_state == "available"


### PR DESCRIPTION
Stop silently accepting 'deploy failed' as a successful deployment outcome.
Add `failed_when` so the task fails immediately when the node reaches that state, while still exiting the retry loop early.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved failure detection during hardware node provisioning: the wait step now aborts immediately if a node enters a "deploy failed" state, preventing further retries.
  * Preserves the existing until/retries/delay retry loop while providing faster failure feedback and clearer error behavior during provisioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->