### PR TITLE
update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ Comprehensive documentation is available in the `docs/` folder:
 - **[Deployment Guide](docs/DEPLOYMENT_GUIDE.md)**: Complete guide on what gets deployed, prerequisites, and deployment workflow
 - **[Configuration Reference](docs/CONFIGURATION_REFERENCE.md)**: Detailed explanation of all configuration variables with examples
 
+> **Note on Host Discovery Management:** While Phase 7 allows you to configure hardware discovery through the Enclave configuration as a one-time convenience, **Red Hat Advanced Cluster Management (ACM) is the recommended approach for managing bare metal host discovery and lifecycle operations** in production. For adding, removing, or modifying nodes after initial deployment, use ACM. See the [Deployment Guide](docs/DEPLOYMENT_GUIDE.md#discovering-new-nodes) for details.
+
 ## Local Development & Testing
 
 ### Prerequisites

--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -499,6 +499,12 @@ curl -k -u user:pass https://<redfish-ip>/redfish/v1/Systems/1/EthernetInterface
 
 ## Discovery Hosts Configuration
 
+> **⚠️ Important: Use Red Hat ACM for Production Host Management**
+>
+> **Red Hat Advanced Cluster Management (ACM) is the recommended approach for managing bare metal host discovery and lifecycle operations.** The discovery hosts configuration in this file is provided as a convenience for initial one-time setup only.
+>
+> For ongoing operations such as adding nodes, removing nodes, changing configurations, or scaling the cluster, use Red Hat ACM instead. See the [Managing bare metal hosts documentation](https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#managing-bare-metal-hosts-console) for details.
+
 The discovery hosts configuration is defined in `config/global.yaml` for discovering new nodes after the initial cluster deployment. This configuration uses the same network settings (defaultDNS, defaultGateway, defaultPrefix, lzBmcIP) as the main cluster deployment.
 
 ### Discovery Hosts Settings

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -730,9 +730,35 @@ For diagnostic log collection, see the [Log Collection Tool](../lz-gather-logs/R
 
 ## Discovering New Nodes
 
-After the initial cluster deployment, you can discover and add new bare metal nodes to the cluster using the discovery process. This is useful for adding compute nodes or additional infrastructure nodes.
+After the initial cluster deployment, you can discover and add new bare metal nodes to the cluster.
 
-### Prerequisites
+### Recommended Approach: Red Hat Advanced Cluster Management (ACM)
+
+**Red Hat ACM is the recommended way to manage host discovery and bare metal infrastructure.** ACM provides a comprehensive interface for managing the complete lifecycle of bare metal hosts, including:
+
+- Adding new hosts to the cluster
+- Removing hosts from the cluster
+- Modifying host configurations
+- Monitoring host status and health
+- Managing host scaling operations
+
+For detailed information on managing bare metal hosts with ACM, refer to the official documentation:
+- [Managing bare metal hosts using Red Hat ACM](https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.15/html/clusters/cluster_mce_overview#cim-intro)
+
+### Alternative: Enclave Configuration (One-Time Convenience)
+
+As a convenience for initial setup, you can configure hosts in the Enclave configuration (`config/global.yaml`) and use the discovery playbook to boot them. **However, this is intended as a one-time operation.**
+
+**Important:** If you need to perform any of the following operations, you must use Red Hat ACM instead of the Enclave configuration:
+- Add more nodes after initial deployment
+- Remove nodes from the cluster
+- Change node configurations
+- Scale up or down the cluster
+- Perform day-2 operations on bare metal hosts
+
+The Enclave configuration method is provided only for initial convenience and is not suitable for ongoing infrastructure management.
+
+### Prerequisites for Enclave Configuration Method
 
 - The management cluster must be fully deployed and operational
 - You must have access to the cluster's kubeconfig file
@@ -778,7 +804,9 @@ Each node in `discovery_hosts` requires:
 | `redfishUser` | Redfish username | `admin` |
 | `redfishPassword` | Redfish password | `Password` |
 
-### Running Discovery
+### Running Discovery (One-Time Setup Only)
+
+> **⚠️ Warning:** This method is intended for initial setup only. For any subsequent host management operations, use Red Hat ACM instead.
 
 1. **Edit the configuration** in `config/global.yaml`:
    ```bash


### PR DESCRIPTION
As we are providing discovery only through ACM,
we update the documentation to explain the enclave approach is a one-time installation convenience. Any changes should be done via ACM. And in general it is recommended to configure all nodes via ACM to begin with.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance recommending Red Hat ACM as the preferred approach for production bare metal host discovery and lifecycle management.
  * Clarified that Enclave configuration is a one-time setup option unsuitable for ongoing host management.
  * Restructured deployment documentation with improved operational pathways and clearer prerequisites for discovery workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->