### PR TITLE
mgmt-23171: Add support for an internal Datacenter Image Registry

### DIFF
--- a/defaults/catalogs.yaml
+++ b/defaults/catalogs.yaml
@@ -1,3 +1,7 @@
 ---
+certified_operator_catalog: "registry.redhat.io/redhat/certified-operator-index"
+certified_operator_catalog_version: "v4.20"
+rh_operator_catalog: "registry.redhat.io/redhat/redhat-operator-index"
+rh_operator_catalog_version: "v4.20"
 mirror_rh_operator_catalog: "mirror-redhat-operators"
 mirror_certified_rh_operator_catalog: "mirror-certified-operators"

--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -828,6 +828,92 @@ odfExternalConfig:
 **Notes**:
 - Only required when `blockStorageBackend` is set to `odf`
 
+### Datacenter Cache Configuration
+
+#### `dc_cache_address`
+
+**Description**: Address (host:port) for the Datacenter Cache registry.
+
+**Type**: String
+
+**Example**:
+```yaml
+dc_cache_address: "registry.cdn.nodns.in:443"
+```
+
+#### `dc_cache_user`
+
+**Description**: Administrator username for the Datacenter Cache registry.
+
+**Type**: String
+
+**Example**:
+```yaml
+dc_cache_user: registry-admin
+```
+
+#### `dc_cache_password`
+
+**Description**: Administrator password for the Datacenter Cache registry.
+
+**Type**: String
+
+**Example**:
+```yaml
+dc_cache_password: YourSecurePassword
+```
+
+**Note**: This is a placeholder - use a strong, unique password in your actual configuration.
+
+**Security Note**: Consider using Ansible Vault to encrypt this value.
+
+### Operator Catalog Configuration
+
+#### `certified_operator_catalog`
+
+**Description**: Address of the _certified-operator_ index.
+
+**Type**: String
+
+**Example**:
+```yaml
+certified_operator_catalog: "registry.redhat.io/redhat/certified-operator-index"
+```
+
+#### `certified_operator_catalog_version`
+
+**Description**: Version of the _certified-operator_ index.
+
+**Type**: String
+
+**Example**:
+```yaml
+certified_operator_catalog_version: "v4.20"
+```
+
+#### `rh_operator_catalog`
+
+**Description**: Address of the _redhat-operator_ index.
+
+**Type**: String
+
+**Example**:
+```yaml
+rh_operator_catalog: "registry.redhat.io/redhat/redhat-operator-index"
+
+```
+
+#### `rh_operator_catalog_version`
+
+**Description**: Version of the _redhat-operator_ index.
+
+**Type**: String
+
+**Example**:
+```yaml
+rh_operator_catalog_version: "v4.20"
+```
+
 ## SSL Certificate Configuration
 
 SSL certificates are stored in `config/certificates.yaml`, separated from the main configuration in `config/global.yaml`.

--- a/playbooks/02-mirror.yaml
+++ b/playbooks/02-mirror.yaml
@@ -7,11 +7,15 @@
 # - Generate combined pull secret
 # - Run oc-mirror to mirror OpenShift images and operator catalogs
 # - Mirror additional images (Vault, ArgoCD, etc.)
+# - Mirror images to datacenter cache (optional)
 #
 # IMPORTANT: This phase requires significant disk space (~150GB+) and time (~30+ minutes)
 #
 # Usage:
 #   ansible-playbook playbooks/02-mirror.yaml -e workingDir=/home/cloud-user
+#
+#   # Mirror images to datacenter cache
+#   ansible-playbook playbooks/02-mirror.yaml -e workingDir=/home/cloud-user --tags mirror-cache
 
 - name: Phase 2 - Mirror registry setup
   hosts: localhost
@@ -25,6 +29,15 @@
         apply:
           tags: always
       tags: always
+
+    - name: Include tasks for mirror-cache
+      ansible.builtin.include_tasks:
+        file: tasks/mirror_cache.yaml
+        apply:
+          tags: mirror-cache
+      tags:
+        - mirror-cache
+        - never
 
     - name: Verify disconnected mode
       ansible.builtin.assert:

--- a/playbooks/tasks/mirror_cache.yaml
+++ b/playbooks/tasks/mirror_cache.yaml
@@ -1,0 +1,54 @@
+---
+- name: Validate dc_cache mandatory variables
+  ansible.builtin.fail:
+    msg: "Variables dc_cache_address, dc_cache_user and dc_cache_password are mandatory"
+  when: >
+    dc_cache_address | default('') | length == 0 or
+    dc_cache_user | default('') | length == 0 or
+    dc_cache_password | default('') | length == 0
+
+- name: Generate pull secret for datacenter cache
+  ansible.builtin.set_fact:
+    __pull_secret_dc:
+      auths:
+        "{{ dc_cache_address }}":
+          auth: "{{ (dc_cache_user + ':' + dc_cache_password) | ansible.builtin.b64encode }}"
+  no_log: true
+
+- name: Combine pull secrets
+  ansible.builtin.set_fact:
+    __pull_secret_cache: "{{ pullSecret | from_json | ansible.builtin.combine(__pull_secret_dc, recursive=true) }}"
+  no_log: true
+
+- name: Create pull-secret-cache file with the combination
+  ansible.builtin.copy:
+    content: "{{ __pull_secret_cache | to_json }}"
+    dest: "{{ workingDir }}/config/pull-secret-cache.json"
+  no_log: true
+
+- name: Create imagesetconfiguration-cache.yaml for datacenter cache
+  ansible.builtin.template:
+    src: ../../templates/imagesetconfiguration.yaml.j2
+    dest: "{{ workingDir }}/config/imagesetconfiguration-cache.yaml"
+
+- name: Change oc-mirror permissions
+  ansible.builtin.file:
+    path: "{{ workingDir }}/bin/oc-mirror"
+    mode: "0755"
+
+- name: Start oc-mirror process
+  ansible.builtin.shell: >
+    {{ workingDir }}/bin/oc-mirror --v2
+    --log-level {{ ocMirrorLogLevel }}
+    --authfile {{ workingDir }}/config/pull-secret-cache.json
+    --dest-tls-verify=false
+    -c {{ workingDir }}/config/imagesetconfiguration-cache.yaml
+    --workspace file://{{ workingDir }}/config/oc-mirror-cache-workspace
+    --parallel-images 10 --parallel-layers 10
+    --retry-times 10 --retry-delay 0
+    docker://{{ dc_cache_address }}
+    > {{ workingDir }}/logs/oc-mirror-cache.progress.$(date +%s).log 2>&1
+  retries: 5
+  delay: 10
+  register: __r_oc_mirror_cache
+  until: __r_oc_mirror_cache is success

--- a/playbooks/tasks/mirror_registry.yaml
+++ b/playbooks/tasks/mirror_registry.yaml
@@ -36,12 +36,23 @@
     src: ../../templates/imagesetconfiguration.yaml.j2
     dest: "{{ workingDir }}/config/imagesetconfiguration.yaml"
 
-- name: Change permissions  # FIXME
-  command: chmod u+x {{ workingDir }}/bin/oc-mirror
+- name: Change oc-mirror permissions
+  ansible.builtin.file:
+    path: "{{ workingDir }}/bin/oc-mirror"
+    mode: "0755"
 
 - name: Start oc-mirror process
-  ansible.builtin.shell: |
-    {{ workingDir }}/bin/oc-mirror --v2 --log-level {{ ocMirrorLogLevel }} --authfile "{{ pullSecretPath }}" -c {{ workingDir }}/config/imagesetconfiguration.yaml --workspace file://{{ workingDir }}/config/oc-mirror-workspace docker://{{ quayHostname }}:8443 --dest-tls-verify=false --parallel-images 10 --parallel-layers 10 --retry-times 10 --retry-delay 0 > {{ workingDir }}/logs/oc-mirror.progress.$(date +%s).log 2>&1
+  ansible.builtin.shell: >
+    {{ workingDir }}/bin/oc-mirror --v2
+    --log-level {{ ocMirrorLogLevel }}
+    --authfile {{ pullSecretPath }}
+    --dest-tls-verify=false
+    -c {{ workingDir }}/config/imagesetconfiguration.yaml
+    --workspace file://{{ workingDir }}/config/oc-mirror-workspace
+    --parallel-images 10 --parallel-layers 10
+    --retry-times 10 --retry-delay 0
+    docker://{{ quayHostname }}:8443
+    > {{ workingDir }}/logs/oc-mirror.progress.$(date +%s).log 2>&1
   retries: 10
   delay: 10
   register: r_oc_mirror

--- a/schemas/catalogs.yaml
+++ b/schemas/catalogs.yaml
@@ -5,6 +5,18 @@ type: object
 
 additionalProperties: false
 properties:
+  certified_operator_catalog:
+    type: string
+    description: Certified Operator Catalog address
+  certified_operator_catalog_version:
+    type: string
+    description: Certified Operator Catalog version
+  rh_operator_catalog:
+    type: string
+    description: Red Hat Operator Catalog address
+  rh_operator_catalog_version:
+    type: string
+    description: Red Hat Operator Catalog version
   mirror_rh_operator_catalog:
     type: string
     description: Mirror Red Hat Operator Catalog name

--- a/templates/imagesetconfiguration.yaml.j2
+++ b/templates/imagesetconfiguration.yaml.j2
@@ -26,7 +26,7 @@ mirror:
 {% endfor %}
     graph: true
   operators:
-    - catalog: registry.redhat.io/redhat/certified-operator-index:v4.20
+    - catalog: {{ certified_operator_catalog }}:{{ certified_operator_catalog_version }}
       packages:
         - name: gpu-operator-certified
           defaultChannel: v25.10
@@ -34,7 +34,7 @@ mirror:
             - name: v25.10
               minVersion: 25.10.0
               maxVersion: 25.10.1
-    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.20
+    - catalog: {{ rh_operator_catalog }}:{{ rh_operator_catalog_version }}
       packages:
         - name: kubevirt-hyperconverged
         - name: kubernetes-nmstate-operator


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable Certified and Red Hat operator catalogs with version control
  * Optional datacenter cache mirroring workflow with authenticated pull-secret support

* **Bug Fixes / Reliability**
  * Improved mirror execution reliability with retries and idempotent permission handling
  * More robust mirror command formatting

* **Documentation**
  * Added configuration reference for operator catalog and datacenter cache settings with examples and notes

* **Chores**
  * Schema updated to include new operator catalog fields
<!-- end of auto-generated comment: release notes by coderabbit.ai -->