### PR TITLE
Add optional Slack notifications for manual e2e workflow runs

### DIFF
--- a/.github/workflows/nightly-e2e-connected.yml
+++ b/.github/workflows/nightly-e2e-connected.yml
@@ -9,6 +9,12 @@ on:
     - cron: '0 3 * * *'
   workflow_dispatch:
     # Allow manual triggering for testing
+    inputs:
+      send-slack-notification:
+        description: 'Send Slack notification on completion'
+        required: false
+        type: boolean
+        default: false
 
 # Prevent concurrent nightly runs
 concurrency:
@@ -134,7 +140,7 @@ jobs:
           echo "- **Status**: ${{ job.status }}" >> $GITHUB_STEP_SUMMARY
 
       - name: Notify Slack
-        if: always()
+        if: always() && (github.event_name == 'schedule' || inputs.send-slack-notification == true)
         uses: ./.github/actions/notify-slack
         with:
           status: ${{ job.status }}

--- a/.github/workflows/nightly-e2e-disconnected.yml
+++ b/.github/workflows/nightly-e2e-disconnected.yml
@@ -9,6 +9,12 @@ on:
     - cron: '0 3 * * *'
   workflow_dispatch:
     # Allow manual triggering for testing
+    inputs:
+      send-slack-notification:
+        description: 'Send Slack notification on completion'
+        required: false
+        type: boolean
+        default: false
 
 # Prevent concurrent nightly runs
 concurrency:
@@ -153,7 +159,7 @@ jobs:
           echo "- **Status**: ${{ job.status }}" >> $GITHUB_STEP_SUMMARY
 
       - name: Notify Slack
-        if: always()
+        if: always() && (github.event_name == 'schedule' || inputs.send-slack-notification == true)
         uses: ./.github/actions/notify-slack
         with:
           status: ${{ job.status }}


### PR DESCRIPTION
Add interactive input to control Slack notifications when manually triggering nightly e2e workflows via workflow_dispatch.

Changes:
- Add 'send-slack-notification' boolean input to workflow_dispatch
- Update Slack notification condition to check event type
- Scheduled runs: Always send notifications (default behavior)
- Manual runs: Optional checkbox in GitHub UI (default: off)

This allows developers to test workflows interactively without spamming Slack channels, while preserving automatic notifications for scheduled nightly runs.

Workflows updated:
- nightly-e2e-connected.yml
- nightly-e2e-disconnected.yml