### PR TITLE
Revert "include specific tasks for the operators after all operators are installed"

### DIFF
--- a/operators/ansible-automation-platform-operator/tasks.yaml
+++ b/operators/ansible-automation-platform-operator/tasks.yaml
@@ -1,3 +1,0 @@
----
-- ansible.builtin.debug:
-    msg: "Operator configured properly, no further actions"

--- a/operators/metallb-operator/tasks.yaml
+++ b/operators/metallb-operator/tasks.yaml
@@ -1,3 +1,0 @@
----
-- ansible.builtin.debug:
-    msg: "Operator configured properly, no further actions"

--- a/playbooks/tasks/configure_operator.yaml
+++ b/playbooks/tasks/configure_operator.yaml
@@ -105,3 +105,11 @@
   - r_csv.resources[0].status.phase is defined
   - r_csv.resources[0].status.phase | length > 0
   - r_csv.resources[0].status.phase == "Succeeded"
+
+
+- name: Include specific tasks for the operator
+  ansible.builtin.include_tasks: "{{ item }}"
+  with_first_found:
+    - files:
+        - "../../operators/{{ operator.name }}/tasks.yaml"
+      skip: true

--- a/playbooks/tasks/configure_operators.yaml
+++ b/playbooks/tasks/configure_operators.yaml
@@ -13,11 +13,5 @@
       loop_control:
         loop_var: operator
 
-    - name: Include specific tasks for the operators
-      ansible.builtin.include_tasks: "../../operators/{{ operator.name }}/tasks.yaml"
-      loop: "{{ [storage_operators[blockStorageBackend]] + operators }}"
-      loop_control:
-        loop_var: operator
-
   environment:
     KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"


### PR DESCRIPTION
Reverts rh-ecosystem-edge/enclave#14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured operator configuration task inclusion workflow for improved organization.
  
* **Chores**
  * Removed debug output messages from operator configuration tasks, reducing verbose logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->