### PR TITLE
Add failed step detection and artifact links to Slack notifications

### DIFF
--- a/.github/actions/notify-slack/action.yml
+++ b/.github/actions/notify-slack/action.yml
@@ -34,327 +34,92 @@ runs:
   steps:
     - name: Send Slack notification
       shell: bash
+      env:
+        INPUT_STATUS: ${{ inputs.status }}
+        INPUT_WORKFLOW_NAME: ${{ inputs.workflow-name }}
+        INPUT_CLUSTER_NAME: ${{ inputs.cluster-name }}
+        INPUT_BRANCH_NAME: ${{ inputs.branch-name }}
+        INPUT_WORKFLOW_URL: ${{ inputs.workflow-url }}
+        INPUT_FAILED_STEP: ${{ inputs.failed-step }}
+        INPUT_ARTIFACT_URL: ${{ inputs.artifact-url }}
+        INPUT_SLACK_WEBHOOKS: ${{ inputs.slack-webhook-urls }}
       run: |
-        if [ "${{ inputs.status }}" = "success" ]; then
+        # Set status-specific values
+        if [ "$INPUT_STATUS" = "success" ]; then
           ICON=":green_jenkins_circle:"
           STATUS_TEXT="PASSED"
           COLOR="#36a64f"
-          MESSAGE_TEXT="${ICON} ${{ inputs.workflow-name }} ${STATUS_TEXT}"
         else
           ICON=":red_jenkins_circle:"
           STATUS_TEXT="FAILED"
           COLOR="#ff0000"
-          if [ -n "${{ inputs.failed-step }}" ]; then
-            MESSAGE_TEXT="${ICON} ${{ inputs.workflow-name }} ${STATUS_TEXT} at ${{ inputs.failed-step }}"
-          else
-            MESSAGE_TEXT="${ICON} ${{ inputs.workflow-name }} ${STATUS_TEXT}"
-          fi
         fi
 
-        # Build the Slack payload using a heredoc to avoid shell interpretation issues
-        if [ "${{ inputs.status }}" = "success" ]; then
-          # Success message
-          if [ -n "${{ inputs.artifact-url }}" ]; then
-            # With artifacts
-            PAYLOAD=$(cat <<'EOFPAYLOAD'
-        {
-          "text": "MESSAGE_TEXT_PLACEHOLDER",
-          "attachments": [
-            {
-              "color": "COLOR_PLACEHOLDER",
-              "blocks": [
-                {
-                  "type": "header",
-                  "text": {
-                    "type": "plain_text",
-                    "text": "MESSAGE_TEXT_PLACEHOLDER",
-                    "emoji": true
-                  }
-                },
-                {
-                  "type": "section",
-                  "fields": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Cluster:*\nCLUSTER_PLACEHOLDER"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Branch:*\nBRANCH_PLACEHOLDER"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Workflow:*\n<WORKFLOW_URL_PLACEHOLDER|View Run>"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Status:*\nSTATUS_PLACEHOLDER"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Artifacts:*\n<ARTIFACT_URL_PLACEHOLDER|Download>"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-        EOFPAYLOAD
-            )
-          else
-            # Without artifacts
-            PAYLOAD=$(cat <<'EOFPAYLOAD'
-        {
-          "text": "MESSAGE_TEXT_PLACEHOLDER",
-          "attachments": [
-            {
-              "color": "COLOR_PLACEHOLDER",
-              "blocks": [
-                {
-                  "type": "header",
-                  "text": {
-                    "type": "plain_text",
-                    "text": "MESSAGE_TEXT_PLACEHOLDER",
-                    "emoji": true
-                  }
-                },
-                {
-                  "type": "section",
-                  "fields": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Cluster:*\nCLUSTER_PLACEHOLDER"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Branch:*\nBRANCH_PLACEHOLDER"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Workflow:*\n<WORKFLOW_URL_PLACEHOLDER|View Run>"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Status:*\nSTATUS_PLACEHOLDER"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-        EOFPAYLOAD
-            )
-          fi
+        # Build message text
+        if [ "$INPUT_STATUS" = "success" ]; then
+          MESSAGE_TEXT="${ICON} ${INPUT_WORKFLOW_NAME} ${STATUS_TEXT}"
         else
-          # Failure message
-          if [ -n "${{ inputs.failed-step }}" ]; then
-            # With failed step info
-            if [ -n "${{ inputs.artifact-url }}" ]; then
-              # With artifacts
-              PAYLOAD=$(cat <<'EOFPAYLOAD'
-        {
-          "text": "MESSAGE_TEXT_PLACEHOLDER",
-          "attachments": [
-            {
-              "color": "COLOR_PLACEHOLDER",
-              "blocks": [
-                {
-                  "type": "header",
-                  "text": {
-                    "type": "plain_text",
-                    "text": "MESSAGE_TEXT_PLACEHOLDER",
-                    "emoji": true
-                  }
-                },
-                {
-                  "type": "section",
-                  "fields": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Cluster:*\nCLUSTER_PLACEHOLDER"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Branch:*\nBRANCH_PLACEHOLDER"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Workflow:*\n<WORKFLOW_URL_PLACEHOLDER|View Run>"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Failed at:*\nFAILED_STEP_PLACEHOLDER"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Artifacts:*\n<ARTIFACT_URL_PLACEHOLDER|Download>"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-        EOFPAYLOAD
-              )
-            else
-              # Without artifacts
-              PAYLOAD=$(cat <<'EOFPAYLOAD'
-        {
-          "text": "MESSAGE_TEXT_PLACEHOLDER",
-          "attachments": [
-            {
-              "color": "COLOR_PLACEHOLDER",
-              "blocks": [
-                {
-                  "type": "header",
-                  "text": {
-                    "type": "plain_text",
-                    "text": "MESSAGE_TEXT_PLACEHOLDER",
-                    "emoji": true
-                  }
-                },
-                {
-                  "type": "section",
-                  "fields": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Cluster:*\nCLUSTER_PLACEHOLDER"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Branch:*\nBRANCH_PLACEHOLDER"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Workflow:*\n<WORKFLOW_URL_PLACEHOLDER|View Run>"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Failed at:*\nFAILED_STEP_PLACEHOLDER"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-        EOFPAYLOAD
-              )
-            fi
+          if [ -n "$INPUT_FAILED_STEP" ]; then
+            MESSAGE_TEXT="${ICON} ${INPUT_WORKFLOW_NAME} ${STATUS_TEXT} at ${INPUT_FAILED_STEP}"
           else
-            # Without failed step info
-            if [ -n "${{ inputs.artifact-url }}" ]; then
-              # With artifacts
-              PAYLOAD=$(cat <<'EOFPAYLOAD'
-        {
-          "text": "MESSAGE_TEXT_PLACEHOLDER",
-          "attachments": [
-            {
-              "color": "COLOR_PLACEHOLDER",
-              "blocks": [
-                {
-                  "type": "header",
-                  "text": {
-                    "type": "plain_text",
-                    "text": "MESSAGE_TEXT_PLACEHOLDER",
-                    "emoji": true
-                  }
-                },
-                {
-                  "type": "section",
-                  "fields": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Cluster:*\nCLUSTER_PLACEHOLDER"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Branch:*\nBRANCH_PLACEHOLDER"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Workflow:*\n<WORKFLOW_URL_PLACEHOLDER|View Run>"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Status:*\nSTATUS_PLACEHOLDER"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Artifacts:*\n<ARTIFACT_URL_PLACEHOLDER|Download>"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-        EOFPAYLOAD
-              )
-            else
-              # Without artifacts
-              PAYLOAD=$(cat <<'EOFPAYLOAD'
-        {
-          "text": "MESSAGE_TEXT_PLACEHOLDER",
-          "attachments": [
-            {
-              "color": "COLOR_PLACEHOLDER",
-              "blocks": [
-                {
-                  "type": "header",
-                  "text": {
-                    "type": "plain_text",
-                    "text": "MESSAGE_TEXT_PLACEHOLDER",
-                    "emoji": true
-                  }
-                },
-                {
-                  "type": "section",
-                  "fields": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Cluster:*\nCLUSTER_PLACEHOLDER"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Branch:*\nBRANCH_PLACEHOLDER"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Workflow:*\n<WORKFLOW_URL_PLACEHOLDER|View Run>"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Status:*\nSTATUS_PLACEHOLDER"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-        EOFPAYLOAD
-              )
-            fi
+            MESSAGE_TEXT="${ICON} ${INPUT_WORKFLOW_NAME} ${STATUS_TEXT}"
           fi
         fi
 
-        # Replace placeholders with actual values using sed
-        PAYLOAD=$(echo "$PAYLOAD" | sed \
-          -e "s|MESSAGE_TEXT_PLACEHOLDER|${MESSAGE_TEXT}|g" \
-          -e "s|COLOR_PLACEHOLDER|${COLOR}|g" \
-          -e "s|CLUSTER_PLACEHOLDER|${{ inputs.cluster-name }}|g" \
-          -e "s|BRANCH_PLACEHOLDER|${{ inputs.branch-name }}|g" \
-          -e "s|WORKFLOW_URL_PLACEHOLDER|${{ inputs.workflow-url }}|g" \
-          -e "s|STATUS_PLACEHOLDER|${STATUS_TEXT}|g" \
-          -e "s|FAILED_STEP_PLACEHOLDER|${{ inputs.failed-step }}|g" \
-          -e "s|ARTIFACT_URL_PLACEHOLDER|${{ inputs.artifact-url }}|g")
+        # Build fields array using jq for safe JSON construction
+        FIELDS=$(jq -n \
+          --arg cluster "$INPUT_CLUSTER_NAME" \
+          --arg branch "$INPUT_BRANCH_NAME" \
+          --arg workflow_url "$INPUT_WORKFLOW_URL" \
+          --arg status "$STATUS_TEXT" \
+          --arg failed_step "$INPUT_FAILED_STEP" \
+          --arg artifact_url "$INPUT_ARTIFACT_URL" \
+          '[
+            {"type": "mrkdwn", "text": ("*Cluster:*\n" + $cluster)},
+            {"type": "mrkdwn", "text": ("*Branch:*\n" + $branch)},
+            {"type": "mrkdwn", "text": ("*Workflow:*\n<" + $workflow_url + "|View Run>")},
+            (if ($failed_step != "") then
+              {"type": "mrkdwn", "text": ("*Failed at:*\n" + $failed_step)}
+            else
+              {"type": "mrkdwn", "text": ("*Status:*\n" + $status)}
+            end),
+            (if ($artifact_url != "") then
+              {"type": "mrkdwn", "text": ("*Artifacts:*\n<" + $artifact_url + "|Download>")}
+            else
+              empty
+            end)
+          ]')
+
+        # Build complete Slack payload using jq
+        PAYLOAD=$(jq -n \
+          --arg text "$MESSAGE_TEXT" \
+          --arg color "$COLOR" \
+          --argjson fields "$FIELDS" \
+          '{
+            "text": $text,
+            "attachments": [
+              {
+                "color": $color,
+                "blocks": [
+                  {
+                    "type": "header",
+                    "text": {
+                      "type": "plain_text",
+                      "text": $text,
+                      "emoji": true
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "fields": $fields
+                  }
+                ]
+              }
+            ]
+          }')
 
         # Send to all webhook URLs
-        for WEBHOOK_URL in ${{ inputs.slack-webhook-urls }}; do
+        for WEBHOOK_URL in $INPUT_SLACK_WEBHOOKS; do
           echo "Sending notification to Slack..."
           curl -X POST -H 'Content-type: application/json' --data "$PAYLOAD" "$WEBHOOK_URL"
         done

--- a/.github/actions/notify-slack/action.yml
+++ b/.github/actions/notify-slack/action.yml
@@ -20,6 +20,14 @@ inputs:
   branch-name:
     description: 'Git branch name'
     required: true
+  failed-step:
+    description: 'Name of the failed step (optional, for failure notifications)'
+    required: false
+    default: ''
+  artifact-url:
+    description: 'URL to download artifacts (optional)'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -31,24 +39,35 @@ runs:
           ICON=":green_jenkins_circle:"
           STATUS_TEXT="PASSED"
           COLOR="#36a64f"
+          MESSAGE_TEXT="${ICON} ${{ inputs.workflow-name }} ${STATUS_TEXT}"
         else
           ICON=":red_jenkins_circle:"
           STATUS_TEXT="FAILED"
           COLOR="#ff0000"
+          if [ -n "${{ inputs.failed-step }}" ]; then
+            MESSAGE_TEXT="${ICON} ${{ inputs.workflow-name }} ${STATUS_TEXT} at ${{ inputs.failed-step }}"
+          else
+            MESSAGE_TEXT="${ICON} ${{ inputs.workflow-name }} ${STATUS_TEXT}"
+          fi
         fi
 
-        PAYLOAD=$(cat <<EOF
+        # Build the Slack payload using a heredoc to avoid shell interpretation issues
+        if [ "${{ inputs.status }}" = "success" ]; then
+          # Success message
+          if [ -n "${{ inputs.artifact-url }}" ]; then
+            # With artifacts
+            PAYLOAD=$(cat <<'EOFPAYLOAD'
         {
-          "text": "${ICON} ${{ inputs.workflow-name }} ${STATUS_TEXT}",
+          "text": "MESSAGE_TEXT_PLACEHOLDER",
           "attachments": [
             {
-              "color": "${COLOR}",
+              "color": "COLOR_PLACEHOLDER",
               "blocks": [
                 {
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "${ICON} ${{ inputs.workflow-name }} - ${STATUS_TEXT}",
+                    "text": "MESSAGE_TEXT_PLACEHOLDER",
                     "emoji": true
                   }
                 },
@@ -57,19 +76,23 @@ runs:
                   "fields": [
                     {
                       "type": "mrkdwn",
-                      "text": "*Cluster:*\n${{ inputs.cluster-name }}"
+                      "text": "*Cluster:*\nCLUSTER_PLACEHOLDER"
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "*Branch:*\n${{ inputs.branch-name }}"
+                      "text": "*Branch:*\nBRANCH_PLACEHOLDER"
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "*Workflow:*\n<${{ inputs.workflow-url }}|View Run>"
+                      "text": "*Workflow:*\n<WORKFLOW_URL_PLACEHOLDER|View Run>"
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "*Status:*\n${STATUS_TEXT}"
+                      "text": "*Status:*\nSTATUS_PLACEHOLDER"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Artifacts:*\n<ARTIFACT_URL_PLACEHOLDER|Download>"
                     }
                   ]
                 }
@@ -77,8 +100,258 @@ runs:
             }
           ]
         }
-        EOF
-        )
+        EOFPAYLOAD
+            )
+          else
+            # Without artifacts
+            PAYLOAD=$(cat <<'EOFPAYLOAD'
+        {
+          "text": "MESSAGE_TEXT_PLACEHOLDER",
+          "attachments": [
+            {
+              "color": "COLOR_PLACEHOLDER",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "MESSAGE_TEXT_PLACEHOLDER",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Cluster:*\nCLUSTER_PLACEHOLDER"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Branch:*\nBRANCH_PLACEHOLDER"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Workflow:*\n<WORKFLOW_URL_PLACEHOLDER|View Run>"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Status:*\nSTATUS_PLACEHOLDER"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+        EOFPAYLOAD
+            )
+          fi
+        else
+          # Failure message
+          if [ -n "${{ inputs.failed-step }}" ]; then
+            # With failed step info
+            if [ -n "${{ inputs.artifact-url }}" ]; then
+              # With artifacts
+              PAYLOAD=$(cat <<'EOFPAYLOAD'
+        {
+          "text": "MESSAGE_TEXT_PLACEHOLDER",
+          "attachments": [
+            {
+              "color": "COLOR_PLACEHOLDER",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "MESSAGE_TEXT_PLACEHOLDER",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Cluster:*\nCLUSTER_PLACEHOLDER"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Branch:*\nBRANCH_PLACEHOLDER"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Workflow:*\n<WORKFLOW_URL_PLACEHOLDER|View Run>"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Failed at:*\nFAILED_STEP_PLACEHOLDER"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Artifacts:*\n<ARTIFACT_URL_PLACEHOLDER|Download>"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+        EOFPAYLOAD
+              )
+            else
+              # Without artifacts
+              PAYLOAD=$(cat <<'EOFPAYLOAD'
+        {
+          "text": "MESSAGE_TEXT_PLACEHOLDER",
+          "attachments": [
+            {
+              "color": "COLOR_PLACEHOLDER",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "MESSAGE_TEXT_PLACEHOLDER",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Cluster:*\nCLUSTER_PLACEHOLDER"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Branch:*\nBRANCH_PLACEHOLDER"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Workflow:*\n<WORKFLOW_URL_PLACEHOLDER|View Run>"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Failed at:*\nFAILED_STEP_PLACEHOLDER"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+        EOFPAYLOAD
+              )
+            fi
+          else
+            # Without failed step info
+            if [ -n "${{ inputs.artifact-url }}" ]; then
+              # With artifacts
+              PAYLOAD=$(cat <<'EOFPAYLOAD'
+        {
+          "text": "MESSAGE_TEXT_PLACEHOLDER",
+          "attachments": [
+            {
+              "color": "COLOR_PLACEHOLDER",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "MESSAGE_TEXT_PLACEHOLDER",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Cluster:*\nCLUSTER_PLACEHOLDER"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Branch:*\nBRANCH_PLACEHOLDER"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Workflow:*\n<WORKFLOW_URL_PLACEHOLDER|View Run>"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Status:*\nSTATUS_PLACEHOLDER"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Artifacts:*\n<ARTIFACT_URL_PLACEHOLDER|Download>"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+        EOFPAYLOAD
+              )
+            else
+              # Without artifacts
+              PAYLOAD=$(cat <<'EOFPAYLOAD'
+        {
+          "text": "MESSAGE_TEXT_PLACEHOLDER",
+          "attachments": [
+            {
+              "color": "COLOR_PLACEHOLDER",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "MESSAGE_TEXT_PLACEHOLDER",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Cluster:*\nCLUSTER_PLACEHOLDER"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Branch:*\nBRANCH_PLACEHOLDER"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Workflow:*\n<WORKFLOW_URL_PLACEHOLDER|View Run>"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Status:*\nSTATUS_PLACEHOLDER"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+        EOFPAYLOAD
+              )
+            fi
+          fi
+        fi
+
+        # Replace placeholders with actual values using sed
+        PAYLOAD=$(echo "$PAYLOAD" | sed \
+          -e "s|MESSAGE_TEXT_PLACEHOLDER|${MESSAGE_TEXT}|g" \
+          -e "s|COLOR_PLACEHOLDER|${COLOR}|g" \
+          -e "s|CLUSTER_PLACEHOLDER|${{ inputs.cluster-name }}|g" \
+          -e "s|BRANCH_PLACEHOLDER|${{ inputs.branch-name }}|g" \
+          -e "s|WORKFLOW_URL_PLACEHOLDER|${{ inputs.workflow-url }}|g" \
+          -e "s|STATUS_PLACEHOLDER|${STATUS_TEXT}|g" \
+          -e "s|FAILED_STEP_PLACEHOLDER|${{ inputs.failed-step }}|g" \
+          -e "s|ARTIFACT_URL_PLACEHOLDER|${{ inputs.artifact-url }}|g")
 
         # Send to all webhook URLs
         for WEBHOOK_URL in ${{ inputs.slack-webhook-urls }}; do

--- a/.github/workflows/nightly-e2e-connected.yml
+++ b/.github/workflows/nightly-e2e-connected.yml
@@ -207,6 +207,33 @@ jobs:
           echo "- **Completed at**: $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_STEP_SUMMARY
           echo "- **Status**: ${{ job.status }}" >> $GITHUB_STEP_SUMMARY
 
+      - name: Determine failed step
+        if: failure()
+        id: failed_step
+        run: |
+          # Map of step IDs to human-readable names
+          declare -A step_names=(
+            ["deploy_prepare"]="Phase 1: Prepare binaries and content"
+            ["deploy_install"]="Phase 2: Deploy OpenShift cluster"
+            ["deploy_post_install"]="Phase 3: Post-install configuration"
+            ["deploy_operators"]="Phase 4: Install operators"
+            ["deploy_day2"]="Phase 5: Day-2 operations"
+            ["deploy_discovery"]="Phase 6: Configure hardware discovery"
+            ["verify_cluster"]="Verify cluster deployment"
+          )
+
+          # Check each step outcome from the JSON context
+          FAILED_STEP="Unknown"
+          for step_id in "${!step_names[@]}"; do
+            outcome=$(echo '${{ toJSON(steps) }}' | jq -r --arg id "$step_id" '.[$id].outcome // "skipped"')
+            if [ "$outcome" == "failure" ]; then
+              FAILED_STEP="${step_names[$step_id]}"
+              break
+            fi
+          done
+
+          echo "FAILED_STEP=$FAILED_STEP" >> $GITHUB_OUTPUT
+
       - name: Notify Slack
         if: always() && (github.event_name == 'schedule' || inputs.send-slack-notification == true)
         uses: ./.github/actions/notify-slack
@@ -217,3 +244,5 @@ jobs:
           slack-webhook-urls: ${{ secrets.SLACK_WEBHOOK_URLS }}
           workflow-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           branch-name: ${{ github.ref_name }}
+          failed-step: ${{ steps.failed_step.outputs.FAILED_STEP }}
+          artifact-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts

--- a/.github/workflows/nightly-e2e-connected.yml
+++ b/.github/workflows/nightly-e2e-connected.yml
@@ -178,12 +178,33 @@ jobs:
 
       - name: Upload artifacts
         if: always()
+        id: upload_artifacts
         uses: actions/upload-artifact@v4
         with:
           name: nightly-connected-${{ env.ENCLAVE_CLUSTER_NAME }}
           path: artifacts/
           retention-days: 7
           if-no-files-found: warn
+
+      - name: Get artifact download URL
+        if: always()
+        id: artifact_url
+        run: |
+          # Wait a moment for artifact to be registered
+          sleep 2
+
+          # Get the artifact ID for this run
+          ARTIFACT_ID=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts \
+            --jq '.artifacts[] | select(.name == "nightly-connected-${{ env.ENCLAVE_CLUSTER_NAME }}") | .id')
+
+          if [ -n "$ARTIFACT_ID" ]; then
+            ARTIFACT_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${ARTIFACT_ID}"
+            echo "ARTIFACT_URL=${ARTIFACT_URL}" >> $GITHUB_OUTPUT
+          else
+            echo "ARTIFACT_URL=" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Cleanup infrastructure
         if: always()
@@ -222,9 +243,20 @@ jobs:
             ["verify_cluster"]="Verify cluster deployment"
           )
 
-          # Check each step outcome from the JSON context
-          FAILED_STEP="Unknown"
-          for step_id in "${!step_names[@]}"; do
+          # Ordered list of step IDs to check (ensures deterministic order)
+          step_order=(
+            deploy_prepare
+            deploy_install
+            deploy_post_install
+            deploy_operators
+            deploy_day2
+            deploy_discovery
+            verify_cluster
+          )
+
+          # Check each step outcome in order from the JSON context
+          FAILED_STEP=""
+          for step_id in "${step_order[@]}"; do
             outcome=$(echo '${{ toJSON(steps) }}' | jq -r --arg id "$step_id" '.[$id].outcome // "skipped"')
             if [ "$outcome" == "failure" ]; then
               FAILED_STEP="${step_names[$step_id]}"
@@ -232,7 +264,10 @@ jobs:
             fi
           done
 
-          echo "FAILED_STEP=$FAILED_STEP" >> $GITHUB_OUTPUT
+          # Only output if we found a failed step
+          if [ -n "$FAILED_STEP" ]; then
+            echo "FAILED_STEP=$FAILED_STEP" >> $GITHUB_OUTPUT
+          fi
 
       - name: Notify Slack
         if: always() && (github.event_name == 'schedule' || inputs.send-slack-notification == true)
@@ -245,4 +280,4 @@ jobs:
           workflow-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           branch-name: ${{ github.ref_name }}
           failed-step: ${{ steps.failed_step.outputs.FAILED_STEP }}
-          artifact-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts
+          artifact-url: ${{ steps.artifact_url.outputs.ARTIFACT_URL }}

--- a/.github/workflows/nightly-e2e-disconnected.yml
+++ b/.github/workflows/nightly-e2e-disconnected.yml
@@ -199,12 +199,33 @@ jobs:
 
       - name: Upload artifacts
         if: always()
+        id: upload_artifacts
         uses: actions/upload-artifact@v4
         with:
           name: nightly-disconnected-${{ env.ENCLAVE_CLUSTER_NAME }}
           path: artifacts/
           retention-days: 7
           if-no-files-found: warn
+
+      - name: Get artifact download URL
+        if: always()
+        id: artifact_url
+        run: |
+          # Wait a moment for artifact to be registered
+          sleep 2
+
+          # Get the artifact ID for this run
+          ARTIFACT_ID=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts \
+            --jq '.artifacts[] | select(.name == "nightly-disconnected-${{ env.ENCLAVE_CLUSTER_NAME }}") | .id')
+
+          if [ -n "$ARTIFACT_ID" ]; then
+            ARTIFACT_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${ARTIFACT_ID}"
+            echo "ARTIFACT_URL=${ARTIFACT_URL}" >> $GITHUB_OUTPUT
+          else
+            echo "ARTIFACT_URL=" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Cleanup infrastructure
         if: always()
@@ -244,9 +265,21 @@ jobs:
             ["verify_cluster"]="Verify cluster deployment"
           )
 
-          # Check each step outcome from the JSON context
-          FAILED_STEP="Unknown"
-          for step_id in "${!step_names[@]}"; do
+          # Ordered list of step IDs to check (ensures deterministic order)
+          step_order=(
+            deploy_prepare
+            deploy_mirror
+            deploy_install
+            deploy_post_install
+            deploy_operators
+            deploy_day2
+            deploy_discovery
+            verify_cluster
+          )
+
+          # Check each step outcome in order from the JSON context
+          FAILED_STEP=""
+          for step_id in "${step_order[@]}"; do
             outcome=$(echo '${{ toJSON(steps) }}' | jq -r --arg id "$step_id" '.[$id].outcome // "skipped"')
             if [ "$outcome" == "failure" ]; then
               FAILED_STEP="${step_names[$step_id]}"
@@ -254,7 +287,10 @@ jobs:
             fi
           done
 
-          echo "FAILED_STEP=$FAILED_STEP" >> $GITHUB_OUTPUT
+          # Only output if we found a failed step
+          if [ -n "$FAILED_STEP" ]; then
+            echo "FAILED_STEP=$FAILED_STEP" >> $GITHUB_OUTPUT
+          fi
 
       - name: Notify Slack
         if: always() && (github.event_name == 'schedule' || inputs.send-slack-notification == true)
@@ -267,4 +303,4 @@ jobs:
           workflow-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           branch-name: ${{ github.ref_name }}
           failed-step: ${{ steps.failed_step.outputs.FAILED_STEP }}
-          artifact-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts
+          artifact-url: ${{ steps.artifact_url.outputs.ARTIFACT_URL }}

--- a/.github/workflows/nightly-e2e-disconnected.yml
+++ b/.github/workflows/nightly-e2e-disconnected.yml
@@ -228,6 +228,34 @@ jobs:
           echo "- **Completed at**: $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_STEP_SUMMARY
           echo "- **Status**: ${{ job.status }}" >> $GITHUB_STEP_SUMMARY
 
+      - name: Determine failed step
+        if: failure()
+        id: failed_step
+        run: |
+          # Map of step IDs to human-readable names
+          declare -A step_names=(
+            ["deploy_prepare"]="Phase 1: Prepare binaries and content"
+            ["deploy_mirror"]="Phase 2: Setup mirror registry"
+            ["deploy_install"]="Phase 3: Deploy OpenShift cluster"
+            ["deploy_post_install"]="Phase 4: Post-install configuration"
+            ["deploy_operators"]="Phase 5: Install operators"
+            ["deploy_day2"]="Phase 6: Day-2 operations"
+            ["deploy_discovery"]="Phase 7: Configure hardware discovery"
+            ["verify_cluster"]="Verify cluster deployment"
+          )
+
+          # Check each step outcome from the JSON context
+          FAILED_STEP="Unknown"
+          for step_id in "${!step_names[@]}"; do
+            outcome=$(echo '${{ toJSON(steps) }}' | jq -r --arg id "$step_id" '.[$id].outcome // "skipped"')
+            if [ "$outcome" == "failure" ]; then
+              FAILED_STEP="${step_names[$step_id]}"
+              break
+            fi
+          done
+
+          echo "FAILED_STEP=$FAILED_STEP" >> $GITHUB_OUTPUT
+
       - name: Notify Slack
         if: always() && (github.event_name == 'schedule' || inputs.send-slack-notification == true)
         uses: ./.github/actions/notify-slack
@@ -238,3 +266,5 @@ jobs:
           slack-webhook-urls: ${{ secrets.SLACK_WEBHOOK_URLS }}
           workflow-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           branch-name: ${{ github.ref_name }}
+          failed-step: ${{ steps.failed_step.outputs.FAILED_STEP }}
+          artifact-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts


### PR DESCRIPTION
Enhances E2E workflow Slack notifications to identify which deployment phase failed and provide direct artifact download links:
- Add failed step detection in nightly-e2e-connected workflow (7 phases)
- Add failed step detection in nightly-e2e-disconnected workflow (8 phases)
- Extend notify-slack action with failed-step and artifact-url parameters
- Display "FAILED at Phase X" in Slack message when workflow fails
- Include artifact download link in both success and failure notifications

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slack notifications now show which pipeline step failed, can include an artifact download link for diagnostics, and send richer success/failure messages to multiple webhook destinations.

* **Chores**
  * Notification interface expanded with optional failed-step and artifact-url so CI workflows can provide richer, contextual reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->