### PR TITLE
exclude scripts from tarball

### DIFF
--- a/.github/workflows/build-push-tarball.yml
+++ b/.github/workflows/build-push-tarball.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Build tarball
         run: |
-          tar --exclude='.git' --exclude='.gitignore' --exclude='.github' \
+          tar --exclude='.git' --exclude='.gitignore' --exclude='.github' --exclude='scripts' \
             -czvf /tmp/enclave.tar.gz .
           mv /tmp/enclave.tar.gz .
           ls -lh enclave.tar.gz


### PR DESCRIPTION
these scripts are not required for our customers and just like the .github dir, this can be excluded as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for tarball creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->