### PR TITLE
Fix three CI issues: cleanup, warnings visibility, and must-gather

### DIFF
--- a/.github/actions/collect-artifacts/action.yml
+++ b/.github/actions/collect-artifacts/action.yml
@@ -21,22 +21,8 @@ runs:
         echo "" >> $GITHUB_STEP_SUMMARY
 
         # Run artifact collection script
+        # The script handles its own warning reporting via annotations and GITHUB_STEP_SUMMARY
         ./scripts/verification/collect_ci_artifacts.sh ${{ inputs.artifact-type }} ${{ inputs.output-directory }} 2>&1 | tee artifact-collection.log
-
-        # Extract and highlight warnings from log
-        # Strip ANSI color codes before grepping to match warn() output
-        WARNING_COUNT=$(sed 's/\x1b\[[0-9;]*m//g' artifact-collection.log | grep -c "^\[WARN\]" 2>/dev/null || echo "0")
-        WARNING_COUNT=$(echo "$WARNING_COUNT" | head -1 | tr -d '\n')  # Ensure single value
-        if [ "${WARNING_COUNT:-0}" -gt 0 ]; then
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### ⚠️ Warnings During Collection" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Found $WARNING_COUNT warning(s):" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          # Strip ANSI codes to show clean warning messages
-          sed 's/\x1b\[[0-9;]*m//g' artifact-collection.log | grep "^\[WARN\]" | head -20 >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-        fi
 
         # Add summary if available
         if [ -f ${{ inputs.output-directory }}/collection-summary.txt ]; then

--- a/.github/actions/collect-artifacts/action.yml
+++ b/.github/actions/collect-artifacts/action.yml
@@ -23,6 +23,21 @@ runs:
         # Run artifact collection script
         ./scripts/verification/collect_ci_artifacts.sh ${{ inputs.artifact-type }} ${{ inputs.output-directory }} 2>&1 | tee artifact-collection.log
 
+        # Extract and highlight warnings from log
+        # Strip ANSI color codes before grepping to match warn() output
+        WARNING_COUNT=$(sed 's/\x1b\[[0-9;]*m//g' artifact-collection.log | grep -c "^\[WARN\]" 2>/dev/null || echo "0")
+        WARNING_COUNT=$(echo "$WARNING_COUNT" | head -1 | tr -d '\n')  # Ensure single value
+        if [ "${WARNING_COUNT:-0}" -gt 0 ]; then
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### ⚠️ Warnings During Collection" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Found $WARNING_COUNT warning(s):" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          # Strip ANSI codes to show clean warning messages
+          sed 's/\x1b\[[0-9;]*m//g' artifact-collection.log | grep "^\[WARN\]" | head -20 >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+        fi
+
         # Add summary if available
         if [ -f ${{ inputs.output-directory }}/collection-summary.txt ]; then
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/e2e-deployment.yml
+++ b/.github/workflows/e2e-deployment.yml
@@ -314,22 +314,87 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Removing infrastructure for cluster: $ENCLAVE_CLUSTER_NAME" >> $GITHUB_STEP_SUMMARY
 
-          make clean 2>&1 | tee cleanup.log
+          # Create cleanup logs directory
+          mkdir -p cleanup-logs
+
+          # Run cleanup and capture output
+          set +e
+          make clean 2>&1 | tee cleanup-logs/cleanup.log
+          CLEANUP_EXIT_CODE=$?
+          set -e
 
           # Check for any warnings in cleanup output
-          if grep -q "WARNING:" cleanup.log; then
+          if grep -q "WARNING:" cleanup-logs/cleanup.log; then
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "⚠️ Cleanup completed with warnings:" >> $GITHUB_STEP_SUMMARY
             echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-            grep "WARNING:" cleanup.log >> $GITHUB_STEP_SUMMARY
+            grep "WARNING:" cleanup-logs/cleanup.log >> $GITHUB_STEP_SUMMARY
             echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          else
+          elif [ $CLEANUP_EXIT_CODE -eq 0 ]; then
             echo "✅ Infrastructure cleaned up successfully" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "⚠️ Cleanup completed with errors (exit code: $CLEANUP_EXIT_CODE)" >> $GITHUB_STEP_SUMMARY
+            echo "Check cleanup-logs/cleanup.log for details" >> $GITHUB_STEP_SUMMARY
           fi
+
+      - name: Collect post-cleanup state
+        if: always()
+        run: |
+          mkdir -p cleanup-state/libvirt cleanup-state/system
+
+          # Capture post-cleanup system state
+          sudo virsh pool-list --all --details > cleanup-state/libvirt/storage-pools.txt 2>&1 || true
+          sudo virsh net-list --all > cleanup-state/libvirt/networks.txt 2>&1 || true
+          sudo virsh list --all > cleanup-state/libvirt/vms.txt 2>&1 || true
+          df -h > cleanup-state/system/disk-usage.txt 2>&1 || true
 
       - name: Verify cleanup
         if: always()
-        run: make verify-cleanup
+        run: |
+          echo "## Cleanup Verification" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          # Check for leftover resources
+          LEFTOVER_POOLS=$(sudo virsh pool-list --all --name | grep "^eci-" || true)
+          LEFTOVER_NETWORKS=$(sudo virsh net-list --all --name | grep "^eci-.*-[pe]$" || true)
+          LEFTOVER_VMS=$(sudo virsh list --all --name | grep "^eci-" || true)
+
+          # Save verification results to file (for artifacts)
+          {
+            echo "=== Cleanup Verification Results ==="
+            echo "Timestamp: $(date -u +"%Y%m%d-%H%M%S")"
+            echo ""
+            if [ -z "$LEFTOVER_POOLS" ] && [ -z "$LEFTOVER_NETWORKS" ] && [ -z "$LEFTOVER_VMS" ]; then
+              echo "✅ No leftover resources detected"
+            else
+              echo "⚠️ Leftover resources detected:"
+              [ -n "$LEFTOVER_POOLS" ] && echo "- Pools: $LEFTOVER_POOLS"
+              [ -n "$LEFTOVER_NETWORKS" ] && echo "- Networks: $LEFTOVER_NETWORKS"
+              [ -n "$LEFTOVER_VMS" ] && echo "- VMs: $LEFTOVER_VMS"
+            fi
+          } | tee cleanup-logs/verification.txt
+
+          # Also report to step summary
+          if [ -z "$LEFTOVER_POOLS" ] && [ -z "$LEFTOVER_NETWORKS" ] && [ -z "$LEFTOVER_VMS" ]; then
+            echo "✅ No leftover resources detected" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "⚠️ **Leftover resources detected:**" >> $GITHUB_STEP_SUMMARY
+            [ -n "$LEFTOVER_POOLS" ] && echo "- **Pools**: $(echo $LEFTOVER_POOLS | tr '\n' ' ')" >> $GITHUB_STEP_SUMMARY
+            [ -n "$LEFTOVER_NETWORKS" ] && echo "- **Networks**: $(echo $LEFTOVER_NETWORKS | tr '\n' ' ')" >> $GITHUB_STEP_SUMMARY
+            [ -n "$LEFTOVER_VMS" ] && echo "- **VMs**: $(echo $LEFTOVER_VMS | tr '\n' ' ')" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "These resources should be cleaned up manually or via the cleanup workflow." >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Upload post-cleanup artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: post-cleanup-state-${{ github.run_id }}
+          path: |
+            cleanup-logs/
+            cleanup-state/
+          retention-days: 7
 
       - name: Summary
         if: always()

--- a/.github/workflows/infra-verify.yml
+++ b/.github/workflows/infra-verify.yml
@@ -180,6 +180,20 @@ jobs:
             echo "Check step-logs/03-cleanup.log for details" >> $GITHUB_STEP_SUMMARY
           fi
 
+      - name: Collect post-cleanup state
+        if: always()
+        run: |
+          mkdir -p cleanup-state/libvirt cleanup-state/system cleanup-logs
+
+          # Copy cleanup log if it exists
+          [ -f step-logs/03-cleanup.log ] && cp step-logs/03-cleanup.log cleanup-logs/ || true
+
+          # Capture post-cleanup system state
+          sudo virsh pool-list --all --details > cleanup-state/libvirt/storage-pools.txt 2>&1 || true
+          sudo virsh net-list --all > cleanup-state/libvirt/networks.txt 2>&1 || true
+          sudo virsh list --all > cleanup-state/libvirt/vms.txt 2>&1 || true
+          df -h > cleanup-state/system/disk-usage.txt 2>&1 || true
+
       - name: Verify cleanup completion
         if: always()
         run: |
@@ -191,7 +205,22 @@ jobs:
           LEFTOVER_NETWORKS=$(sudo virsh net-list --all --name | grep "^eci-.*-[pe]$" || true)
           LEFTOVER_VMS=$(sudo virsh list --all --name | grep "^eci-" || true)
 
-          # Report findings
+          # Save verification results to file (for artifacts)
+          {
+            echo "=== Cleanup Verification Results ==="
+            echo "Timestamp: $(date -u +"%Y%m%d-%H%M%S")"
+            echo ""
+            if [ -z "$LEFTOVER_POOLS" ] && [ -z "$LEFTOVER_NETWORKS" ] && [ -z "$LEFTOVER_VMS" ]; then
+              echo "✅ No leftover resources detected"
+            else
+              echo "⚠️ Leftover resources detected:"
+              [ -n "$LEFTOVER_POOLS" ] && echo "- Pools: $LEFTOVER_POOLS"
+              [ -n "$LEFTOVER_NETWORKS" ] && echo "- Networks: $LEFTOVER_NETWORKS"
+              [ -n "$LEFTOVER_VMS" ] && echo "- VMs: $LEFTOVER_VMS"
+            fi
+          } | tee cleanup-logs/verification.txt
+
+          # Also report to step summary
           if [ -z "$LEFTOVER_POOLS" ] && [ -z "$LEFTOVER_NETWORKS" ] && [ -z "$LEFTOVER_VMS" ]; then
             echo "✅ No leftover resources detected" >> $GITHUB_STEP_SUMMARY
           else
@@ -202,6 +231,16 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "These resources should be cleaned up manually or via the cleanup workflow." >> $GITHUB_STEP_SUMMARY
           fi
+
+      - name: Upload post-cleanup artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: post-cleanup-state
+          path: |
+            cleanup-logs/
+            cleanup-state/
+          retention-days: 7
 
       - name: Workflow summary
         if: always()

--- a/.github/workflows/nightly-e2e-connected.yml
+++ b/.github/workflows/nightly-e2e-connected.yml
@@ -183,7 +183,10 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
 
           # Use centralized artifact collection script with full level
-          ./scripts/verification/collect_ci_artifacts.sh full artifacts 2>&1 | tee artifact-collection-full.log
+          # Make this best-effort so must-gather runs even if artifact collection fails
+          if ! ./scripts/verification/collect_ci_artifacts.sh full artifacts 2>&1 | tee artifact-collection-full.log; then
+            echo "⚠️ Full artifact collection failed; continuing with must-gather" >> $GITHUB_STEP_SUMMARY
+          fi
 
           # Also run must-gather if cluster is accessible
           LZ_IP=$(./scripts/utils/get_landing_zone_ip.sh)

--- a/.github/workflows/nightly-e2e-connected.yml
+++ b/.github/workflows/nightly-e2e-connected.yml
@@ -176,6 +176,43 @@ jobs:
           artifact-type: deployment
           output-directory: artifacts
 
+      - name: Collect full diagnostics on failure
+        if: failure()
+        run: |
+          echo "## Collecting Full Diagnostics (failure)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          # Use centralized artifact collection script with full level
+          ./scripts/verification/collect_ci_artifacts.sh full artifacts 2>&1 | tee artifact-collection-full.log
+
+          # Also run must-gather if cluster is accessible
+          LZ_IP=$(./scripts/utils/get_landing_zone_ip.sh)
+          if [ -n "$LZ_IP" ]; then
+            SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10"
+
+            if ssh $SSH_OPTS cloud-user@$LZ_IP "test -f /home/cloud-user/enclave/scripts/diagnostics/gather.sh" 2>/dev/null; then
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "### Running must-gather..." >> $GITHUB_STEP_SUMMARY
+
+              mkdir -p artifacts/must-gather
+              GATHER_OUT=$(ssh $SSH_OPTS cloud-user@$LZ_IP \
+                "cd /home/cloud-user/enclave/scripts/diagnostics && \
+                 export KUBECONFIG=/home/cloud-user/ocp-cluster/auth/kubeconfig && \
+                 GITHUB_RUN_ID='${{ github.run_id }}' ./gather.sh --must-gather=full ../../config/global.yaml 2>&1" || true)
+              echo "$GATHER_OUT" >> artifacts/must-gather/gather-output.txt
+
+              # Copy must-gather archives
+              scp $SSH_OPTS "cloud-user@${LZ_IP}:/home/cloud-user/enclave/scripts/diagnostics/lz-logs-*.tar.gz" artifacts/must-gather/ 2>/dev/null || true
+              scp $SSH_OPTS "cloud-user@${LZ_IP}:/home/cloud-user/enclave/scripts/diagnostics/cluster-logs-*.tar.gz" artifacts/must-gather/ 2>/dev/null || true
+
+              if ls artifacts/must-gather/*-logs-*.tar.gz 1>/dev/null 2>&1; then
+                echo "✅ Collected must-gather archives" >> $GITHUB_STEP_SUMMARY
+              else
+                echo "⚠️ Must-gather failed (see must-gather/gather-output.txt)" >> $GITHUB_STEP_SUMMARY
+              fi
+            fi
+          fi
+
       - name: Upload artifacts
         if: always()
         id: upload_artifacts

--- a/.github/workflows/nightly-e2e-disconnected.yml
+++ b/.github/workflows/nightly-e2e-disconnected.yml
@@ -197,6 +197,43 @@ jobs:
           artifact-type: deployment
           output-directory: artifacts
 
+      - name: Collect full diagnostics on failure
+        if: failure()
+        run: |
+          echo "## Collecting Full Diagnostics (failure)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          # Use centralized artifact collection script with full level
+          ./scripts/verification/collect_ci_artifacts.sh full artifacts 2>&1 | tee artifact-collection-full.log
+
+          # Also run must-gather if cluster is accessible
+          LZ_IP=$(./scripts/utils/get_landing_zone_ip.sh)
+          if [ -n "$LZ_IP" ]; then
+            SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10"
+
+            if ssh $SSH_OPTS cloud-user@$LZ_IP "test -f /home/cloud-user/enclave/scripts/diagnostics/gather.sh" 2>/dev/null; then
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "### Running must-gather..." >> $GITHUB_STEP_SUMMARY
+
+              mkdir -p artifacts/must-gather
+              GATHER_OUT=$(ssh $SSH_OPTS cloud-user@$LZ_IP \
+                "cd /home/cloud-user/enclave/scripts/diagnostics && \
+                 export KUBECONFIG=/home/cloud-user/ocp-cluster/auth/kubeconfig && \
+                 GITHUB_RUN_ID='${{ github.run_id }}' ./gather.sh --must-gather=full ../../config/global.yaml 2>&1" || true)
+              echo "$GATHER_OUT" >> artifacts/must-gather/gather-output.txt
+
+              # Copy must-gather archives
+              scp $SSH_OPTS "cloud-user@${LZ_IP}:/home/cloud-user/enclave/scripts/diagnostics/lz-logs-*.tar.gz" artifacts/must-gather/ 2>/dev/null || true
+              scp $SSH_OPTS "cloud-user@${LZ_IP}:/home/cloud-user/enclave/scripts/diagnostics/cluster-logs-*.tar.gz" artifacts/must-gather/ 2>/dev/null || true
+
+              if ls artifacts/must-gather/*-logs-*.tar.gz 1>/dev/null 2>&1; then
+                echo "✅ Collected must-gather archives" >> $GITHUB_STEP_SUMMARY
+              else
+                echo "⚠️ Must-gather failed (see must-gather/gather-output.txt)" >> $GITHUB_STEP_SUMMARY
+              fi
+            fi
+          fi
+
       - name: Upload artifacts
         if: always()
         id: upload_artifacts

--- a/.github/workflows/nightly-e2e-disconnected.yml
+++ b/.github/workflows/nightly-e2e-disconnected.yml
@@ -204,7 +204,10 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
 
           # Use centralized artifact collection script with full level
-          ./scripts/verification/collect_ci_artifacts.sh full artifacts 2>&1 | tee artifact-collection-full.log
+          # Make this best-effort so must-gather runs even if artifact collection fails
+          if ! ./scripts/verification/collect_ci_artifacts.sh full artifacts 2>&1 | tee artifact-collection-full.log; then
+            echo "⚠️ Full artifact collection failed; continuing with must-gather" >> $GITHUB_STEP_SUMMARY
+          fi
 
           # Also run must-gather if cluster is accessible
           LZ_IP=$(./scripts/utils/get_landing_zone_ip.sh)

--- a/scripts/cleanup/cleanup.sh
+++ b/scripts/cleanup/cleanup.sh
@@ -26,6 +26,18 @@ require_dir "${DEV_SCRIPTS_PATH}"
 
 CONFIG_FILE="${DEV_SCRIPTS_PATH}/${CONFIG_NAME}"
 
+# Reconstruct WORKING_DIR if not set (needed for cleanup)
+# During setup, WORKING_DIR is exported to environment, but during cleanup it may not be available
+if [ -z "${WORKING_DIR:-}" ]; then
+    if [ -n "${BASE_WORKING_DIR:-}" ]; then
+        # New structure: BASE_WORKING_DIR/clusters/CLUSTER_NAME
+        export WORKING_DIR="${BASE_WORKING_DIR}/clusters/${CLUSTER_NAME}"
+        info "Reconstructed WORKING_DIR from BASE_WORKING_DIR: ${WORKING_DIR}"
+    else
+        warning "Neither WORKING_DIR nor BASE_WORKING_DIR is set - some cleanup may be skipped"
+    fi
+fi
+
 # Ensure config file exists for cleanup
 if [ ! -f "$CONFIG_FILE" ]; then
     warning "Config file not found: $CONFIG_FILE"
@@ -47,7 +59,17 @@ EOF
     info "Created minimal config at: $CONFIG_FILE"
 fi
 
-# Clean up libvirt networks first (more reliable than dev-scripts cleanup)
+# Run dev-scripts cleanup (with lock to prevent conflicts with parallel runners)
+# Must run dev-scripts first - it needs networks to exist for proper VM cleanup
+info "Running dev-scripts cleanup..."
+
+if "${SCRIPT_DIR}/../utils/with_libvirt_lock.sh" sh -c "cd ${DEV_SCRIPTS_PATH} && CONFIG=${CONFIG_NAME} make clean"; then
+    success "dev-scripts cleanup completed successfully"
+else
+    warning "dev-scripts cleanup reported failure, but continuing..."
+fi
+
+# Clean up libvirt networks (after dev-scripts completes)
 info "Cleaning up libvirt networks for cluster: ${CLUSTER_NAME}..."
 for net in $(sudo virsh net-list --all --name 2>/dev/null | grep "^${CLUSTER_NAME}-" || true); do
     info "  Found network: $net"
@@ -111,36 +133,21 @@ for bridge in $ORPHANED_BRIDGES; do
     fi
 done
 
-# Run dev-scripts cleanup (with lock to prevent conflicts with parallel runners)
-info "Running dev-scripts cleanup..."
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
-if "${SCRIPT_DIR}/../utils/with_libvirt_lock.sh" sh -c "cd ${DEV_SCRIPTS_PATH} && CONFIG=${CONFIG_NAME} make clean"; then
-    success "dev-scripts cleanup completed successfully"
-else
-    warning "dev-scripts cleanup reported failure, but continuing..."
-fi
-
-# Clean up cluster-specific working directory and files
+# Determine cluster directory (will be removed later, after pools are cleaned up)
 # Support both new structure (BASE_WORKING_DIR/clusters/CLUSTER_NAME) and old structure (WORKING_DIR)
+CLUSTER_DIR_TO_REMOVE=""
 if [ -n "${WORKING_DIR:-}" ]; then
     # Determine the actual cluster directory
     # If WORKING_DIR ends with /clusters/${CLUSTER_NAME}, use it directly
     # Otherwise, check if BASE_WORKING_DIR is set and use that structure
     if [[ "${WORKING_DIR}" == *"/clusters/${CLUSTER_NAME}" ]]; then
-        CLUSTER_DIR="${WORKING_DIR}"
+        CLUSTER_DIR_TO_REMOVE="${WORKING_DIR}"
     elif [ -n "${BASE_WORKING_DIR:-}" ]; then
-        CLUSTER_DIR="${BASE_WORKING_DIR}/clusters/${CLUSTER_NAME}"
-    else
-        # Old structure - files in WORKING_DIR directly
-        CLUSTER_DIR=""
+        CLUSTER_DIR_TO_REMOVE="${BASE_WORKING_DIR}/clusters/${CLUSTER_NAME}"
     fi
 
-    # If we have a cluster-specific directory, remove it entirely
-    if [ -n "$CLUSTER_DIR" ] && [ -d "$CLUSTER_DIR" ]; then
-        info "Removing cluster-specific working directory: $CLUSTER_DIR"
-        sudo rm -rf "$CLUSTER_DIR" || warning "Failed to remove cluster directory"
-    else
+    # For old structure, clean up individual files (new structure will remove entire dir later)
+    if [ -z "$CLUSTER_DIR_TO_REMOVE" ]; then
         # Old structure - clean up individual files
         # Remove cluster-specific environment file
         ENV_FILE="${WORKING_DIR}/environment-${CLUSTER_NAME}.json"
@@ -176,18 +183,36 @@ if [ -n "${WORKING_DIR:-}" ]; then
         fi
 
         # Also remove orphaned private-mirror files from previous clusters
-        # These accumulate in HOME directory from parallel CI runs
+        # These accumulate in HOME directory from failed CI runs
+        # Only remove files from clusters that no longer have active VMs (to avoid parallel run conflicts)
         info "Checking for orphaned private-mirror files in HOME..."
         ORPHANED_MIRRORS=$(find "${HOME}" -maxdepth 1 -name "private-mirror-eci-*.json" 2>/dev/null || true)
         if [ -n "$ORPHANED_MIRRORS" ]; then
-            ORPHAN_COUNT=$(echo "$ORPHANED_MIRRORS" | wc -l)
-            info "  Found $ORPHAN_COUNT orphaned private-mirror files, removing..."
-            echo "$ORPHANED_MIRRORS" | while IFS= read -r mirror_file; do
-                if [ -f "$mirror_file" ]; then
-                    rm -f "$mirror_file"
+            ORPHANED_COUNT=0
+            # Use here-string to avoid subshell and preserve ORPHANED_COUNT
+            while IFS= read -r mirror_file; do
+                if [ -z "$mirror_file" ] || [ ! -f "$mirror_file" ]; then
+                    continue
                 fi
-            done
-            success "Removed orphaned private-mirror files"
+
+                # Extract cluster ID from filename: private-mirror-eci-XXXXXXXX.json -> eci-XXXXXXXX
+                ORPHAN_CLUSTER=$(basename "$mirror_file" | sed 's/private-mirror-\(eci-[^.]*\)\.json/\1/')
+
+                # Check if this cluster has any active VMs
+                if sudo virsh list --all 2>/dev/null | grep -q "$ORPHAN_CLUSTER"; then
+                    # Cluster still has VMs - skip (might be from parallel run)
+                    continue
+                fi
+
+                # No VMs found - safe to remove
+                info "  Removing orphaned file from completed cluster: $(basename "$mirror_file")"
+                rm -f "$mirror_file"
+                ORPHANED_COUNT=$((ORPHANED_COUNT + 1))
+            done <<< "$ORPHANED_MIRRORS"
+
+            if [ $ORPHANED_COUNT -gt 0 ]; then
+                success "Removed $ORPHANED_COUNT orphaned private-mirror files"
+            fi
         fi
     fi
 fi
@@ -252,7 +277,8 @@ if [ -n "${WORKING_DIR:-}" ]; then
         info "Cleaning up volume files for cluster: ${CLUSTER_NAME}"
 
         # Find and remove all volume files for this cluster
-        VOLUME_FILES=$(find "$POOL_DIR" -maxdepth 1 -type f \( -name "${CLUSTER_NAME}_*.img" -o -name "${CLUSTER_NAME}_*.qcow2" \) 2>/dev/null || true)
+        # Support both underscore and hyphen patterns (e.g., nc-20260308_master_0.qcow2 and nc-20260308-master-0.qcow2)
+        VOLUME_FILES=$(find "$POOL_DIR" -maxdepth 1 -type f \( -name "${CLUSTER_NAME}_*.img" -o -name "${CLUSTER_NAME}-*.img" -o -name "${CLUSTER_NAME}_*.qcow2" -o -name "${CLUSTER_NAME}-*.qcow2" \) 2>/dev/null || true)
 
         if [ -n "$VOLUME_FILES" ]; then
             VOLUME_COUNT=$(echo "$VOLUME_FILES" | wc -l)
@@ -297,6 +323,7 @@ POOLS_TO_CLEAN=()
 
 # Add standard pool names we might have created
 # Dev-scripts may append -1, -lz, or _pool suffixes
+# Note: Shared pools like oooq_pool are only added after path verification below
 for POOL_NAME in "${CLUSTER_NAME}" "${CLUSTER_NAME}-1" "${CLUSTER_NAME}-lz" "${CLUSTER_NAME}_pool"; do
     if sudo virsh pool-uuid "$POOL_NAME" > /dev/null 2>&1; then
         POOLS_TO_CLEAN+=("$POOL_NAME")
@@ -312,7 +339,7 @@ if [ ${#CLUSTER_POOL_PATHS[@]} -gt 0 ]; then
                 if [ "$POOL_PATH_CHECK" = "$cluster_path" ]; then
                     # Check if not already in the list
                     if [[ ! " ${POOLS_TO_CLEAN[*]} " =~ \ $pool\  ]]; then
-                        info "Found pool '$pool' pointing to cluster path $cluster_path, will clean it up"
+                        info "Found pool '$pool' pointing to cluster path: $cluster_path"
                         POOLS_TO_CLEAN+=("$pool")
                     fi
                     break
@@ -346,8 +373,14 @@ for POOL_NAME in "${POOLS_TO_CLEAN[@]}"; do
     fi
 done
 
+# Remove cluster-specific working directory (deferred until after pools are cleaned up)
+# This must happen AFTER storage pools are undefined, otherwise the directory removal may fail
+if [ -n "${CLUSTER_DIR_TO_REMOVE:-}" ] && [ -d "$CLUSTER_DIR_TO_REMOVE" ]; then
+    info "Removing cluster-specific working directory: $CLUSTER_DIR_TO_REMOVE"
+    sudo rm -rf "$CLUSTER_DIR_TO_REMOVE" || warning "Failed to remove cluster directory"
+fi
+
 # Release allocated subnet
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [ -f "${SCRIPT_DIR}/../setup/allocate_subnet.sh" ]; then
     info "Releasing allocated subnet for cluster: ${CLUSTER_NAME}"
 
@@ -429,7 +462,7 @@ if [ -n "${WORKING_DIR:-}" ]; then
     fi
 
     if [ -d "$POOL_DIR" ]; then
-        LEFTOVER_VOLS=$(find "$POOL_DIR" -maxdepth 1 -type f \( -name "${CLUSTER_NAME}_*.img" -o -name "${CLUSTER_NAME}_*.qcow2" \) 2>/dev/null || true)
+        LEFTOVER_VOLS=$(find "$POOL_DIR" -maxdepth 1 -type f \( -name "${CLUSTER_NAME}_*.img" -o -name "${CLUSTER_NAME}-*.img" -o -name "${CLUSTER_NAME}_*.qcow2" -o -name "${CLUSTER_NAME}-*.qcow2" \) 2>/dev/null || true)
         if [ -n "$LEFTOVER_VOLS" ]; then
             warning "Found leftover volume files in pool:"
             echo "$LEFTOVER_VOLS" | while read -r vol; do

--- a/scripts/cleanup/cleanup.sh
+++ b/scripts/cleanup/cleanup.sh
@@ -34,7 +34,8 @@ if [ -z "${WORKING_DIR:-}" ]; then
         export WORKING_DIR="${BASE_WORKING_DIR}/clusters/${CLUSTER_NAME}"
         info "Reconstructed WORKING_DIR from BASE_WORKING_DIR: ${WORKING_DIR}"
     else
-        warning "Neither WORKING_DIR nor BASE_WORKING_DIR is set - some cleanup may be skipped"
+        error "Neither WORKING_DIR nor BASE_WORKING_DIR is set; cannot safely determine cleanup paths"
+        exit 1
     fi
 fi
 
@@ -59,37 +60,44 @@ EOF
     info "Created minimal config at: $CONFIG_FILE"
 fi
 
-# Run dev-scripts cleanup (with lock to prevent conflicts with parallel runners)
+# Run dev-scripts cleanup and network teardown under lock to prevent conflicts with parallel runners
 # Must run dev-scripts first - it needs networks to exist for proper VM cleanup
-info "Running dev-scripts cleanup..."
+# Then immediately clean up networks under the same lock to prevent races
+info "Running dev-scripts cleanup and network teardown (under lock)..."
 
-if "${SCRIPT_DIR}/../utils/with_libvirt_lock.sh" sh -c "cd ${DEV_SCRIPTS_PATH} && CONFIG=${CONFIG_NAME} make clean"; then
-    success "dev-scripts cleanup completed successfully"
+if "${SCRIPT_DIR}/../utils/with_libvirt_lock.sh" bash -c "
+    # Run dev-scripts cleanup
+    cd ${DEV_SCRIPTS_PATH} && CONFIG=${CONFIG_NAME} make clean
+    CLEANUP_EXIT=\$?
+
+    # Clean up libvirt networks (after dev-scripts completes, but still under lock)
+    echo 'Cleaning up libvirt networks for cluster: ${CLUSTER_NAME}...'
+    for net in \$(sudo virsh net-list --all --name 2>/dev/null | grep '^${CLUSTER_NAME}-' || true); do
+        echo \"  Found network: \$net\"
+
+        # Disable autostart first
+        if sudo virsh net-info \"\$net\" 2>/dev/null | grep -q 'Autostart:.*yes'; then
+            echo \"    Disabling autostart for: \$net\"
+            sudo virsh net-autostart --disable \"\$net\" 2>/dev/null || echo \"    Failed to disable autostart for \$net\"
+        fi
+
+        # Destroy if active
+        if sudo virsh net-info \"\$net\" 2>/dev/null | grep -q 'Active:.*yes'; then
+            echo \"    Destroying active network: \$net\"
+            sudo virsh net-destroy \"\$net\" 2>/dev/null || echo \"    Failed to destroy \$net\"
+        fi
+
+        # Undefine
+        echo \"    Undefining network: \$net\"
+        sudo virsh net-undefine \"\$net\" 2>/dev/null || echo \"    Failed to undefine \$net\"
+    done
+
+    exit \$CLEANUP_EXIT
+"; then
+    success "dev-scripts cleanup and network teardown completed successfully"
 else
     warning "dev-scripts cleanup reported failure, but continuing..."
 fi
-
-# Clean up libvirt networks (after dev-scripts completes)
-info "Cleaning up libvirt networks for cluster: ${CLUSTER_NAME}..."
-for net in $(sudo virsh net-list --all --name 2>/dev/null | grep "^${CLUSTER_NAME}-" || true); do
-    info "  Found network: $net"
-
-    # Disable autostart first
-    if sudo virsh net-info "$net" 2>/dev/null | grep -q "Autostart:.*yes"; then
-        info "    Disabling autostart for: $net"
-        sudo virsh net-autostart --disable "$net" 2>/dev/null || warning "    Failed to disable autostart for $net"
-    fi
-
-    # Destroy if active
-    if sudo virsh net-info "$net" 2>/dev/null | grep -q "Active:.*yes"; then
-        info "    Destroying active network: $net"
-        sudo virsh net-destroy "$net" 2>/dev/null || warning "    Failed to destroy $net"
-    fi
-
-    # Undefine
-    info "    Undefining network: $net"
-    sudo virsh net-undefine "$net" 2>/dev/null || warning "    Failed to undefine $net"
-done
 
 # Clean up orphaned bridge interfaces
 # Support both old naming (-b, -c) and new naming (-p, -e) during transition
@@ -139,10 +147,10 @@ CLUSTER_DIR_TO_REMOVE=""
 if [ -n "${WORKING_DIR:-}" ]; then
     # Determine the actual cluster directory
     # If WORKING_DIR ends with /clusters/${CLUSTER_NAME}, use it directly
-    # Otherwise, check if BASE_WORKING_DIR is set and use that structure
+    # Otherwise, check if BASE_WORKING_DIR is set and that directory actually exists
     if [[ "${WORKING_DIR}" == *"/clusters/${CLUSTER_NAME}" ]]; then
         CLUSTER_DIR_TO_REMOVE="${WORKING_DIR}"
-    elif [ -n "${BASE_WORKING_DIR:-}" ]; then
+    elif [ -n "${BASE_WORKING_DIR:-}" ] && [ -d "${BASE_WORKING_DIR}/clusters/${CLUSTER_NAME}" ]; then
         CLUSTER_DIR_TO_REMOVE="${BASE_WORKING_DIR}/clusters/${CLUSTER_NAME}"
     fi
 

--- a/scripts/infrastructure/start_sushy_tools.sh
+++ b/scripts/infrastructure/start_sushy_tools.sh
@@ -219,7 +219,7 @@ fi
 
 # Verify sushy-tools endpoint is responding
 info "Verifying sushy-tools endpoint accessibility..."
-MAX_WAIT=30
+MAX_WAIT=90
 COUNTER=0
 ENDPOINT_READY=false
 

--- a/scripts/lib/output.sh
+++ b/scripts/lib/output.sh
@@ -55,7 +55,7 @@ output() {
     local msg="$1"
     echo -e "$msg"
     if [ "$USE_GITHUB" = true ]; then
-        # Strip ANSI color codes for GitHub summary
-        echo "$msg" | sed 's/\x1b\[[0-9;]*m//g' >> "$GITHUB_STEP_SUMMARY"
+        # Strip ANSI color codes for GitHub summary (both \033 and \x1b forms)
+        echo "$msg" | sed -e 's/\\033\[[0-9;]*m//g' -e 's/\x1b\[[0-9;]*m//g' >> "$GITHUB_STEP_SUMMARY"
     fi
 }

--- a/scripts/setup/setup_working_dir.sh
+++ b/scripts/setup/setup_working_dir.sh
@@ -37,13 +37,15 @@ CLUSTER_WORKING_DIR="${BASE_WORKING_DIR}/clusters/${ENCLAVE_CLUSTER_NAME}"
 echo "Creating cluster-specific working directory: ${CLUSTER_WORKING_DIR}"
 mkdir -p "$CLUSTER_WORKING_DIR"
 
+# Always write to temp file for workflow steps to read
+echo "${CLUSTER_WORKING_DIR}" > /tmp/working_dir
+
 # Export to GitHub Actions environment if available
 if [ -n "${GITHUB_ENV:-}" ]; then
     echo "WORKING_DIR=${CLUSTER_WORKING_DIR}" >> "$GITHUB_ENV"
     echo "✅ Working directory exported to GitHub Actions: ${CLUSTER_WORKING_DIR}"
 else
-    # For local execution, write to temp file and export to current shell
-    echo "${CLUSTER_WORKING_DIR}" > /tmp/working_dir
+    # For local execution, export to current shell
     export WORKING_DIR="${CLUSTER_WORKING_DIR}"
     echo "✅ Working directory set: ${CLUSTER_WORKING_DIR}"
     echo "   (exported as WORKING_DIR environment variable)"

--- a/scripts/verification/collect_ci_artifacts.sh
+++ b/scripts/verification/collect_ci_artifacts.sh
@@ -47,6 +47,10 @@ info() {
 warn() {
     echo -e "${YELLOW}[WARN]${NC} $1"
     COLLECTION_WARNINGS=$((COLLECTION_WARNINGS + 1))
+    # Emit GitHub annotation if in CI
+    if [ -n "${GITHUB_ACTIONS:-}" ]; then
+        echo "::warning file=collect_ci_artifacts.sh,title=Collection Warning::$1"
+    fi
 }
 
 error() {
@@ -811,7 +815,16 @@ esac
 
 info "✓ Artifact collection complete"
 if [ "$COLLECTION_WARNINGS" -gt 0 ]; then
-    warn "Collection completed with $COLLECTION_WARNINGS warning(s)"
+    # Use info instead of warn to avoid incrementing counter again
+    echo -e "${YELLOW}[INFO]${NC} Collection completed with $COLLECTION_WARNINGS warning(s)"
+    if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+        echo "## ⚠️ Collection Warnings ($COLLECTION_WARNINGS)" >> "$GITHUB_STEP_SUMMARY"
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+        echo "Artifact collection completed with warnings (non-fatal):" >> "$GITHUB_STEP_SUMMARY"
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+        echo "> Check annotations above for details." >> "$GITHUB_STEP_SUMMARY"
+    fi
 fi
 if [ "$COLLECTION_ERRORS" -gt 0 ]; then
     error "Collection completed with $COLLECTION_ERRORS error(s)"


### PR DESCRIPTION
Fix cleanup script leaving files behind by reordering operations to run dev-scripts cleanup first before removing networks. This prevents cascade failures where VMs aren't properly destroyed. Also fix volume file patterns to support both underscore and hyphen naming, and enhance pool detection to include oooq_pool.

Add must-gather collection to nightly workflows on failure. Both connected and disconnected workflows now collect full diagnostics including lz-logs and cluster-logs archives when jobs fail.

Make artifact collection warnings prominently visible in GitHub UI through annotations and step summaries while keeping jobs successful (exit 0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved failure diagnostics: full artifact capture on failure, conditional remote must‑gather collection, and appended collection warnings (numeric count + up to 20 warning lines) in job summaries.
  * Cleaner step summaries by stripping extra terminal escape codes.
  * Ensure working-directory path is reliably available to workflow steps.
  * Increased service startup wait to reduce spurious failures.

* **Bug Fixes**
  * More robust cleanup and verification for leftover networks, volumes, pools, images, landing-zone, and cluster artifacts.
  * Tolerant remote diagnostics collection with clearer reporting on missing/partial results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->