### PR TITLE
install openshift-gitops-operator in own namespace with version

### DIFF
--- a/defaults/operators.yaml
+++ b/defaults/operators.yaml
@@ -35,11 +35,13 @@ operators:
     csvName: update-service-operator
 
   - name: openshift-gitops-operator
+    version: 1.19.1
     defaultChannel: gitops-1.19
     channels:
     - name: gitops-1.19
-    namespace: openshift-operators
+    namespace: openshift-gitops-operator
     source: cs-redhat-operator-index-v4-20
+    global: true
 
   - name: openshift-pipelines-operator-rh
     defaultChannel: pipelines-1.20


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated openshift-gitops-operator to version 1.19.1 and adjusted operator namespace configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->