### PR TITLE
install netobserv-operator in own namespace with version

### DIFF
--- a/defaults/operators.yaml
+++ b/defaults/operators.yaml
@@ -49,11 +49,13 @@ operators:
     source: cs-redhat-operator-index-v4-20
 
   - name: netobserv-operator
+    version: 1.10.1
     defaultChannel: stable
     channels:
     - name: stable
-    namespace: openshift-operators
+    namespace: openshift-netobserv-operator
     source: cs-redhat-operator-index-v4-20
+    global: true
     csvName: network-observability-operator
 
   - name: cluster-logging


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated netobserv-operator to version 1.10.1
  * Changed deployment namespace to openshift-netobserv-operator

<!-- end of auto-generated comment: release notes by coderabbit.ai -->