### PR TITLE
install openshift-pipelines-operator in own namespace with version

### DIFF
--- a/defaults/operators.yaml
+++ b/defaults/operators.yaml
@@ -42,11 +42,13 @@ operators:
     source: cs-redhat-operator-index-v4-20
 
   - name: openshift-pipelines-operator-rh
+    version: 1.20.2
     defaultChannel: pipelines-1.20
     channels:
     - name: pipelines-1.20
-    namespace: openshift-operators
+    namespace: openshift-pipelines
     source: cs-redhat-operator-index-v4-20
+    global: true
 
   - name: netobserv-operator
     defaultChannel: stable


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * OpenShift Pipelines Operator upgraded to version 1.20.2 with the latest features and improvements
  * Operator deployment namespace reconfigured to improve resource organization
  * Target namespace isolation setting enabled to enhance operational control and flexibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->