### PR TITLE
operators rename disableTargetNamespace to global

### DIFF
--- a/defaults/operators.yaml
+++ b/defaults/operators.yaml
@@ -71,7 +71,7 @@ operators:
     - name: stable-6.4
     namespace: openshift-operators-redhat
     source: cs-redhat-operator-index-v4-20
-    disableTargetNamespace: true
+    global: true
 
   - name: redhat-oadp-operator
     version: 1.5.3
@@ -106,7 +106,7 @@ operators:
     - name: stable-v1.0
     namespace: external-secrets-operator
     source: cs-redhat-operator-index-v4-20
-    disableTargetNamespace: true
+    global: true
     csvName: external-secrets-operator
 
   - name: compliance-operator
@@ -124,7 +124,7 @@ operators:
     - name: stable
     namespace: metallb-system
     source: cs-redhat-operator-index-v4-20
-    disableTargetNamespace: true
+    global: true
 
   # AAP is a dependency for osac-operator
   - name: ansible-automation-platform-operator
@@ -134,5 +134,5 @@ operators:
     - name: stable-2.5-cluster-scoped
     namespace: ansible-aap
     source: cs-redhat-operator-index-v4-20
-    disableTargetNamespace: true
+    global: true
     csvName: aap-operator

--- a/playbooks/tasks/configure_operator.yaml
+++ b/playbooks/tasks/configure_operator.yaml
@@ -10,10 +10,10 @@
   delay: 5
   until: r_namespace_exists is success
 
-- name: "Ensure OperatorGroup exists"
+- name: "Ensure OperatorGroup exists (with target namespace)"
   when:
     - operator.namespace != "openshift-operators"
-    - operator.disableTargetNamespace | default(false) | bool != true
+    - not (operator.global | default(false))
   kubernetes.core.k8s:
     state: present
     definition:
@@ -30,10 +30,10 @@
   delay: 5
   until: r_operatorgroup_exists is success
 
-- name: "Ensure OperatorGroup exists (without targetNamespace)"
+- name: "Ensure OperatorGroup exists (global - without target namespace)"
   when:
     - operator.namespace != "openshift-operators"
-    - operator.disableTargetNamespace | default(false) | bool
+    - operator.global | default(false)
   kubernetes.core.k8s:
     state: present
     definition:
@@ -42,7 +42,7 @@
       metadata:
         name: "{{ operator.name }}-og"
         namespace: "{{ operator.namespace }}"
-      spec:
+      spec: {}
   register: r_operatorgroup_exists
   retries: 6
   delay: 5

--- a/schemas/operators.yaml
+++ b/schemas/operators.yaml
@@ -37,9 +37,9 @@ definitions:
       csvName:
         type: string
         description: ClusterServiceVersion name for the operator.
-      disableTargetNamespace:
+      global:
         type: boolean
-        description: configure operator to watch a specific namespace or to watch the entire cluster
+        description: Configure operator to watch the entire cluster.
     required:
     - name
     - defaultChannel


### PR DESCRIPTION
changing the abstraction from negative to ease understanding. also changing from detail oriented to functionality oriented - these operators are installed globally, regardless of how it is done.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated operator scope configuration. Four operators have been reconfigured: loki-operator, external-secrets-operator, metallb-operator, and ansible-automation-platform-operator. All are now configured to operate globally across the entire cluster infrastructure. These operators actively manage and monitor all resources across all namespaces rather than being restricted to specific individual namespace scopes. Configuration applies across the cluster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->