### PR TITLE
random ironic pod name

### DIFF
--- a/playbooks/tasks/deploy_ironic.yaml
+++ b/playbooks/tasks/deploy_ironic.yaml
@@ -109,7 +109,6 @@
 - name: Run ironic container
   containers.podman.podman_container:
     name: ironic
-    pod: metal3-ironic
     image: "{{ metal3_ironic_image }}"
     authfile: "{{ pullSecretPath }}"
     restart_policy: always
@@ -125,11 +124,16 @@
     command:
       - /bin/runironic
     state: started
+  register: ironic_info
+
+- name: Set ironic container facts
+  ansible.builtin.set_fact:
+    ironic_pod_name: "{{ ironic_info.pod.Name }}"
 
 - name: Run httpd container
   containers.podman.podman_container:
     name: httpd
-    pod: metal3-ironic
+    pod: "{{ ironic_pod_name }}"
     image: "{{ metal3_ironic_image }}"
     authfile: "{{ pullSecretPath }}"
     restart_policy: always
@@ -150,7 +154,7 @@
 
 - name: Wait for metal3-ironic pod and containers to be running
   containers.podman.podman_pod_info:
-    name: metal3-ironic
+    name: "{{ ironic_pod_name }}"
   register: r_pod_ready
   retries: 60
   delay: 5

--- a/playbooks/tasks/deploy_metal3_stack.yaml
+++ b/playbooks/tasks/deploy_metal3_stack.yaml
@@ -64,7 +64,6 @@
 - name: Run ironic container
   containers.podman.podman_container:
     name: ironic
-    pod: metal3-ironic
     image: "{{ metal3_ironic_image }}"
     authfile: "{{ pullSecretPath }}"
     restart_policy: always
@@ -91,11 +90,16 @@
     command:
       - /bin/runironic
     state: started
+  register: ironic_info
+
+- name: Set ironic container facts
+  ansible.builtin.set_fact:
+    ironic_pod_name: "{{ ironic_info.pod.Name }}"
 
 - name: Run httpd container
   containers.podman.podman_container:
     name: httpd
-    pod: metal3-ironic
+    pod: "{{ ironic_pod_name }}"
     image: "{{ metal3_ironic_image }}"
     authfile: "{{ pullSecretPath }}"
     restart_policy: always
@@ -116,7 +120,7 @@
 
 - name: Wait for metal3-ironic pod and containers to be running
   containers.podman.podman_pod_info:
-    name: metal3-ironic
+    name: "{{ ironic_pod_name }}"
   register: r_pod_ready
   retries: 60
   delay: 5


### PR DESCRIPTION
perhaps due to the fixed pod name we are unable to parallelize tests?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Container deployment tasks now use dynamically obtained pod names instead of hard-coded pod references.
  * Pod readiness checks and container startup wait conditions updated to reference dynamic pod identifiers.
  * Changes applied to ironic and httpd container deployment sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->