### PR TITLE
Mirror ose-cli image

### DIFF
--- a/playbooks/tasks/vmaas.yaml
+++ b/playbooks/tasks/vmaas.yaml
@@ -311,6 +311,13 @@
           data:
             "license.zip": "{{ __aap_b64_license.content }}"
 
+    - name: Get OpenShift CLI image from OpenShift release
+      ansible.builtin.command: >
+        {{ workingDir }}/bin/oc adm release info --registry-config={{ pullSecretPath }} --image-for cli
+        quay.io/openshift-release-dev/ocp-release:{{ mgmt_openshift_version }}-x86_64
+      register: __r_oc_cli_image
+      changed_when: false
+
     - name: "Create aap-bootstrap job"
       kubernetes.core.k8s:
         state: present

--- a/playbooks/templates/aap-bootstrap.yaml.j2
+++ b/playbooks/templates/aap-bootstrap.yaml.j2
@@ -8,7 +8,7 @@ spec:
     spec:
       initContainers:
       - name: wait-for-aap
-        image: registry.redhat.io/openshift4/ose-cli:latest
+        image: "{{ __r_oc_cli_image.stdout }}"
         command:
           - /bin/bash
           - -c


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenShift CLI image is now dynamically determined from the OpenShift release version instead of using a static hardcoded reference, enabling more flexible and version-aligned deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->