### PR TITLE
Add retries to kubernetes.core.k8s calls

### DIFF
--- a/defaults/k8s.yaml
+++ b/defaults/k8s.yaml
@@ -1,0 +1,5 @@
+---
+# Retry settings for kubernetes.core.k8s state: present/absent/patched calls.
+# These are internal defaults and are not meant to be overridden by the user.
+k8s_retries: 6
+k8s_delay: 5

--- a/operators/advanced-cluster-management/acm_cis.yaml
+++ b/operators/advanced-cluster-management/acm_cis.yaml
@@ -25,6 +25,10 @@
   loop: "{{ r_cluster_image_set.resources }}"
   loop_control:
     loop_var: imageset
+  register: r_delete_clusterimageset
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_delete_clusterimageset is success
 
 - name: Create ClusterImageSet
   kubernetes.core.k8s:
@@ -39,3 +43,7 @@
   loop: "{{ openshift_versions }}"
   loop_control:
     loop_var: v
+  register: r_clusterimageset
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_clusterimageset is success

--- a/operators/advanced-cluster-management/tasks.yaml
+++ b/operators/advanced-cluster-management/tasks.yaml
@@ -38,6 +38,10 @@
       kind: Namespace
       metadata:
         name: openshift-acm-policies
+  register: r_namespace_acm_policies
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_namespace_acm_policies is success
 
 - name: Add ManagedClusterSetBinding
   kubernetes.core.k8s:
@@ -50,6 +54,10 @@
         namespace: openshift-acm-policies
       spec:
         clusterSet: default
+  register: r_managedclustersetbinding
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_managedclustersetbinding is success
 
 - name: Create Placement for policies
   kubernetes.core.k8s:
@@ -69,6 +77,10 @@
                     operator: In
                     values:
                       - local-cluster
+  register: r_placement_acm_policies
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_placement_acm_policies is success
 
 - name: ACM ClusterImageSet reconciliation
   ansible.builtin.include_tasks:

--- a/operators/cincinnati-operator/tasks.yaml
+++ b/operators/cincinnati-operator/tasks.yaml
@@ -14,6 +14,10 @@
         graphDataImage: registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/openshift/graph-image
         releases: registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/openshift/release-images
         replicas: 2
+  register: r_update_service
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_update_service is success
 
 - name: Create ACM Policy for Update Service
   environment:
@@ -53,6 +57,10 @@
                     name: version
                   spec:
                     upstream: "https://service-route-openshift-update-service.apps.{{ clusterName }}.{{ baseDomain }}/api/upgrades_info/v1/graph"
+  register: r_acm_policy_update_service
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_acm_policy_update_service is success
 
 - name: Create ACM PlacementRule for Update Service
   environment:
@@ -75,6 +83,10 @@
             - "account"
             - "default"
             - "platform"
+  register: r_acm_placementrule_update_service
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_acm_placementrule_update_service is success
 
 - name: Create ACM PlacementBinding for Update Service
   environment:
@@ -96,3 +108,7 @@
         - name: update-service
           kind: Policy
           apiGroup: policy.open-cluster-management.io
+  register: r_acm_placementbinding_update_service
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_acm_placementbinding_update_service is success

--- a/operators/lvms-operator/tasks.yaml
+++ b/operators/lvms-operator/tasks.yaml
@@ -21,6 +21,6 @@
       spec: "{{ _spec | from_yaml }}"
 
   register: r_lvmcluster_exists
-  retries: 6
-  delay: 5
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
   until: r_lvmcluster_exists is success

--- a/operators/multicluster-engine/tasks.yaml
+++ b/operators/multicluster-engine/tasks.yaml
@@ -277,6 +277,10 @@
             location = "quay.io/argoproj"
           [[registry.mirror]]
             location = "registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/argoproj"
+  register: r_configmap_disconnected
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_configmap_disconnected is success
 
 - name: Create assisted-service-user-config ConfigMap
   kubernetes.core.k8s:
@@ -290,6 +294,10 @@
       data:
         ALLOW_CONVERGED_FLOW: "false"
         PAUSE_PROVISIONED_BMHS: "false"
+  register: r_configmap_assisted_service
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_configmap_assisted_service is success
 
 - name: Create AgentServiceConfig for disconnected environment
   kubernetes.core.k8s:
@@ -323,3 +331,7 @@
           rootFSUrl: "http://{{ quayHostname }}/rhcos-4.20.0-x86_64-live-rootfs.x86_64.img"
           url: "http://{{ quayHostname }}/rhcos-4.20.0-x86_64-live-iso.x86_64.iso"
           version: 9.6.20251023-0
+  register: r_agentserviceconfig
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_agentserviceconfig is success

--- a/operators/odf-operator/tasks.yaml
+++ b/operators/odf-operator/tasks.yaml
@@ -10,6 +10,10 @@
       data:
         external_cluster_details: "{{ odfExternalConfig | b64encode }}"
       type: Opaque
+  register: r_odf_secret
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_odf_secret is success
 
 - name: Ensure StorageCluster is present
   kubernetes.core.k8s:

--- a/operators/openshift-pipelines-operator-rh/clair_import_pipeline.yaml
+++ b/operators/openshift-pipelines-operator-rh/clair_import_pipeline.yaml
@@ -19,6 +19,10 @@
       metadata:
         name: clair-import
         namespace: openshift-pipelines
+  register: r_clair_import_serviceaccount
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_clair_import_serviceaccount is success
 
 - name: Create Clair Import Task
   kubernetes.core.k8s:
@@ -54,6 +58,10 @@
                 fi
                 echo "$rc" > "$(results.exit-code.path)"
                 exit "$rc"
+  register: r_clair_import_task
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_clair_import_task is success
 
 - name: Create Clair Import Pipeline
   kubernetes.core.k8s:
@@ -75,3 +83,7 @@
           - name: status-report
             value: $(tasks.clair-import.results.status-report)
         timeout: "1h"
+  register: r_clair_import_pipeline
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_clair_import_pipeline is success

--- a/operators/openshift-pipelines-operator-rh/operator_update_pipeline.yaml
+++ b/operators/openshift-pipelines-operator-rh/operator_update_pipeline.yaml
@@ -19,6 +19,10 @@
       metadata:
         name: operator-update
         namespace: openshift-pipelines
+  register: r_operator_update_serviceaccount
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_operator_update_serviceaccount is success
 
 - name: Create Operator Update ClusterRole
   kubernetes.core.k8s:
@@ -32,6 +36,10 @@
         - apiGroups: ["operators.coreos.com"]
           resources: ["clusterserviceversions", "installplans"]
           verbs: ["get", "list", "patch", "update", "watch"]
+  register: r_operator_update_clusterrole
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_operator_update_clusterrole is success
 
 - name: Create Operator Update ClusterRoleBinding
   kubernetes.core.k8s:
@@ -49,6 +57,10 @@
         kind: ClusterRole
         name: operator-update
         apiGroup: rbac.authorization.k8s.io
+  register: r_operator_update_clusterrolebinding
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_operator_update_clusterrolebinding is success
 
 - name: Create Operator Update Task
   kubernetes.core.k8s:
@@ -92,6 +104,10 @@
                 rc=$?
                 echo -n "${rc}" > "$(results.exit-code.path)"
                 exit "${rc}"
+  register: r_operator_update_task
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_operator_update_task is success
 
 - name: Create Operator Update Pipeline
   kubernetes.core.k8s:
@@ -128,3 +144,7 @@
               - name: dry-run
                 value: $(params.dry-run)
             timeout: "2h"
+  register: r_operator_update_pipeline
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_operator_update_pipeline is success

--- a/operators/quay-operator/clair_disconnected.yaml
+++ b/operators/quay-operator/clair_disconnected.yaml
@@ -53,6 +53,10 @@
         - apiGroups: [""]
           resources: ["pods/exec"]
           verbs: ["create"]
+  register: r_clair_import_role
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_clair_import_role is success
 
 - name: Create Clair Import RoleBinding
   kubernetes.core.k8s:
@@ -71,3 +75,7 @@
         kind: Role
         name: clair-import
         apiGroup: rbac.authorization.k8s.io
+  register: r_clair_import_rolebinding
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_clair_import_rolebinding is success

--- a/operators/quay-operator/tasks.yaml
+++ b/operators/quay-operator/tasks.yaml
@@ -56,6 +56,10 @@
                   name2repos_mapping_file: "/data/container-name-repos-map.json"
           matcher:
             disable_updaters: true
+  register: r_quay_config_secret
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_quay_config_secret is success
 
 - name: Ensure QuayRegistry is present
   kubernetes.core.k8s:
@@ -177,6 +181,10 @@
       stringData:
         .dockerconfigjson: "{{ pullSecretNew | to_json }}"
       type: kubernetes.io/dockerconfigjson
+  register: r_patch_cluster_pullsecret
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_patch_cluster_pullsecret is success
 
 - name: Create pull-secret file with the combination
   ansible.builtin.copy:

--- a/playbooks/07-configure-discovery.yaml
+++ b/playbooks/07-configure-discovery.yaml
@@ -25,6 +25,10 @@
           kind: Namespace
           metadata:
             name: infraenv
+      register: r_namespace_infraenv
+      retries: "{{ k8s_retries }}"
+      delay: "{{ k8s_delay }}"
+      until: r_namespace_infraenv is success
 
     - name: Read pull secret from file
       ansible.builtin.set_fact:
@@ -44,6 +48,10 @@
           stringData:
             .dockerconfigjson: "{{ pull_secret_content | to_json }}"
             type: kubernetes.io/dockerconfigjson
+      register: r_pullsecret_infraenv
+      retries: "{{ k8s_retries }}"
+      delay: "{{ k8s_delay }}"
+      until: r_pullsecret_infraenv is success
 
     - name: Create Infraenv
       environment:
@@ -70,6 +78,10 @@
               matchLabels:
                 infraenvs.agent-install.openshift.io: infraenv
             ignitionConfigOverride: '{"ignition":{"version":"3.2.0"},"storage":{"files":[{"path":"/etc/containers/policy.json","mode":420,"overwrite":true,"contents":{"source":"data:text/plain;charset=utf-8;base64,ewogICAgImRlZmF1bHQiOiBbCiAgICAgICAgewogICAgICAgICAgICAidHlwZSI6ICJpbnNlY3VyZUFjY2VwdEFueXRoaW5nIgogICAgICAgIH0KICAgIF0sCiAgICAidHJhbnNwb3J0cyI6CiAgICAgICAgewogICAgICAgICAgICAiZG9ja2VyLWRhZW1vbiI6CiAgICAgICAgICAgICAgICB7CiAgICAgICAgICAgICAgICAgICAgIiI6IFt7InR5cGUiOiJpbnNlY3VyZUFjY2VwdEFueXRoaW5nIn1dCiAgICAgICAgICAgICAgICB9CiAgICAgICAgfQp9"}}]}}'
+      register: r_infraenv
+      retries: "{{ k8s_retries }}"
+      delay: "{{ k8s_delay }}"
+      until: r_infraenv is success
 
     - name: Display discovery hosts status
       ansible.builtin.debug:

--- a/playbooks/common/load-vars.yaml
+++ b/playbooks/common/load-vars.yaml
@@ -26,5 +26,6 @@
     - mirror_registry.yaml
     - quay_operator.yaml
     - lvms_operator.yaml
+    - k8s.yaml
   loop_control:
     loop_var: config_file

--- a/playbooks/tasks/catalogsource.yaml
+++ b/playbooks/tasks/catalogsource.yaml
@@ -4,6 +4,10 @@
   kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('ansible.builtin.file', '../../files/catalogsource-configuration/00-namespace.yaml') | from_yaml }}"
+  register: r_namespace_catalogsource
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_namespace_catalogsource is success
 
 - name: Create ACM Policy for mirrored catalogsource
   environment:
@@ -12,6 +16,10 @@
     state: present
     namespace: openshift-acm-policies
     definition: "{{ lookup('ansible.builtin.template', '../../files/catalogsource-configuration/10-policy.yaml.j2') | from_yaml }}"
+  register: r_acm_policy_catalogsource
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_acm_policy_catalogsource is success
 
 - name: Create ACM PlacementRule for mirrored catalogsource
   environment:
@@ -20,6 +28,10 @@
     state: present
     namespace: openshift-acm-policies
     definition: "{{ lookup('ansible.builtin.template', '../../files/catalogsource-configuration/20-placementrule.yaml.j2') | from_yaml }}"
+  register: r_acm_placementrule_catalogsource
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_acm_placementrule_catalogsource is success
 
 - name: Create ACM PlacementBinding for mirrored catalogsource
   environment:
@@ -28,3 +40,7 @@
     state: present
     namespace: openshift-acm-policies
     definition: "{{ lookup('ansible.builtin.template', '../../files/catalogsource-configuration/30-placementbinding.yaml.j2') | from_yaml }}"
+  register: r_acm_placementbinding_catalogsource
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_acm_placementbinding_catalogsource is success

--- a/playbooks/tasks/configure_certificates.yaml
+++ b/playbooks/tasks/configure_certificates.yaml
@@ -17,6 +17,10 @@
       data:
         tls.crt: "{{ sslIngressCertificateFullChain | b64encode }}"
         tls.key: "{{ sslIngressCertificateKey | b64encode }}"
+  register: r_tls_secret_ingress
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_tls_secret_ingress is success
 
 - name: Patch default IngressController to use the TLS secret
   environment:
@@ -31,6 +35,10 @@
       spec:
         defaultCertificate:
           name: cluster-ingress-domain
+  register: r_patch_ingress_controller
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_patch_ingress_controller is success
 
 - name: Create TLS secret for API server
   environment:
@@ -47,6 +55,10 @@
       data:
         tls.crt: "{{ sslAPICertificateFullChain | b64encode }}"
         tls.key: "{{ sslAPICertificateKey | b64encode }}"
+  register: r_tls_secret_api
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_tls_secret_api is success
 
 - name: Patch API server with named certificate
   environment:
@@ -64,6 +76,10 @@
                 - "api.{{ clusterName }}.{{ baseDomain }}"
               servingCertificate:
                 name: "api-certs"
+  register: r_patch_api_server
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_patch_api_server is success
 
 - name: Compute fingerprint for new API server certificate
   shell: echo "{{ sslAPICertificateFullChain }}" | openssl x509 -noout -fingerprint

--- a/playbooks/tasks/configure_discovery_host.yaml
+++ b/playbooks/tasks/configure_discovery_host.yaml
@@ -5,6 +5,10 @@
     validate_certs: false
     state: present
     definition: "{{ lookup('ansible.builtin.template', 'templates/nmstateconfig.yaml.j2') }}"
+  register: r_nmstateconfig
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_nmstateconfig is success
 
 - name: "Create BMC credentials secrets for [{{ discovery_host.name }}]"
   environment:
@@ -13,6 +17,10 @@
     validate_certs: false
     state: present
     definition: "{{ lookup('ansible.builtin.template', 'templates/bmc-secret.yaml.j2') }}"
+  register: r_bmc_credentials_secret
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_bmc_credentials_secret is success
 
 - name: "Check if BareMetalHost [{{ discovery_host.name }}] exists"
   environment:
@@ -34,3 +42,7 @@
     definition: "{{ lookup('ansible.builtin.template', 'templates/baremetalhost.yaml.j2') }}"
   vars:
     bmh_online: "{{ bmh_check.resources[0].spec.online if bmh_check.resources | length > 0 else false }}"
+  register: r_baremetalhost
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_baremetalhost is success

--- a/playbooks/tasks/configure_operator.yaml
+++ b/playbooks/tasks/configure_operator.yaml
@@ -6,8 +6,8 @@
     kind: Namespace
     name: "{{ operator.namespace }}"
   register: r_namespace_exists
-  retries: 6
-  delay: 5
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
   until: r_namespace_exists is success
 
 - name: "Ensure OperatorGroup exists (with target namespace)"
@@ -26,8 +26,8 @@
         targetNamespaces:
           - "{{ operator.namespace }}"
   register: r_operatorgroup_exists
-  retries: 6
-  delay: 5
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
   until: r_operatorgroup_exists is success
 
 - name: "Ensure OperatorGroup exists (global - without target namespace)"
@@ -44,8 +44,8 @@
         namespace: "{{ operator.namespace }}"
       spec: {}
   register: r_operatorgroup_exists
-  retries: 6
-  delay: 5
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
   until: r_operatorgroup_exists is success
 
 - name: "Check if Subscription already exists"
@@ -75,8 +75,8 @@
         source: "{{ operator.source if (disconnected | default(true)) else 'redhat-operators' }}"
         sourceNamespace: openshift-marketplace
   register: r_sub_exists
-  retries: 6
-  delay: 5
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
   until: r_sub_exists is success
 
 - name: "Ensure Subscription exists (Manual)"
@@ -99,8 +99,8 @@
         sourceNamespace: openshift-marketplace
         startingCSV: "{{ operator.csvName | default(operator.name) }}.v{{ operator.version }}"
   register: r_sub_exists
-  retries: 6
-  delay: 5
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
   until: r_sub_exists is success
 
 - name: "Wait for Install Plan ({{ operator.name }})"

--- a/playbooks/tasks/model_config.yaml
+++ b/playbooks/tasks/model_config.yaml
@@ -4,6 +4,10 @@
   kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('ansible.builtin.file', '../../files/model-configuration/00-namespace.yaml') | from_yaml }}"
+  register: r_namespace_model_config
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_namespace_model_config is success
 
 - name: Create ACM Policy for Model configuration
   environment:
@@ -12,7 +16,10 @@
     state: present
     namespace: openshift-acm-policies
     definition: "{{ lookup('ansible.builtin.template', '../../files/model-configuration/10-policy.yaml.j2') | from_yaml }}"
-
+  register: r_acm_policy_model_config
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_acm_policy_model_config is success
 
 - name: Create ACM PlacementRule for Model configuration
   environment:
@@ -21,6 +28,10 @@
     state: present
     namespace: openshift-acm-policies
     definition: "{{ lookup('ansible.builtin.file', '../../files/model-configuration/20-placementrule.yaml') | from_yaml }}"
+  register: r_acm_placementrule_model_config
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_acm_placementrule_model_config is success
 
 - name: Create ACM PlacementBinding for Model configuration
   environment:
@@ -29,3 +40,7 @@
     state: present
     namespace: openshift-acm-policies
     definition: "{{ lookup('ansible.builtin.file', '../../files/model-configuration/30-placementbinding.yaml') | from_yaml }}"
+  register: r_acm_placementbinding_model_config
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_acm_placementbinding_model_config is success

--- a/playbooks/tasks/post_install_config.yaml
+++ b/playbooks/tasks/post_install_config.yaml
@@ -14,8 +14,8 @@
     kind: Namespace
     name: redhat-lz-admin
   register: r_namespace_creds_exists
-  retries: 6
-  delay: 5
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
   until: r_namespace_creds_exists is success
 
 - name: Create quay-credentials Secret
@@ -33,6 +33,10 @@
       stringData:
         username: "{{ quayUser }}"
         password: "{{ quayPassword }}"
+  register: r_quay_credentials_secret
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_quay_credentials_secret is success
 
 - name: Configure custom TLS certificates
   ansible.builtin.include_tasks: configure_certificates.yaml

--- a/playbooks/tasks/vmaas.yaml
+++ b/playbooks/tasks/vmaas.yaml
@@ -15,6 +15,10 @@
   loop: "{{ acm_addons }}"
   loop_control:
     loop_var: addon
+  register: r_acm_addons_vmaas
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_acm_addons_vmaas is success
 
 - name: ACM policy for VMaaS
   environment:
@@ -25,21 +29,37 @@
       kubernetes.core.k8s:
         state: present
         definition: "{{ lookup('ansible.builtin.file', '../files/vmaas/00-namespace.yaml') | from_yaml }}"
+      register: r_namespace_acm_vmaas
+      retries: "{{ k8s_retries }}"
+      delay: "{{ k8s_delay }}"
+      until: r_namespace_acm_vmaas is success
 
     - name: Create ACM Policy for VMaaS
       kubernetes.core.k8s:
         state: present
         definition: "{{ lookup('ansible.builtin.template', '../files/vmaas/10-policy.yaml.j2') | from_yaml }}"
+      register: r_acm_policy_vmaas
+      retries: "{{ k8s_retries }}"
+      delay: "{{ k8s_delay }}"
+      until: r_acm_policy_vmaas is success
 
     - name: Create ACM PlacementRule for VMaaS
       kubernetes.core.k8s:
         state: present
         definition: "{{ lookup('ansible.builtin.file', '../files/vmaas/20-placementrule.yaml') | from_yaml }}"
+      register: r_acm_placementrule_vmaas
+      retries: "{{ k8s_retries }}"
+      delay: "{{ k8s_delay }}"
+      until: r_acm_placementrule_vmaas is success
 
     - name: Create ACM PlacementBinding for VMaaS
       kubernetes.core.k8s:
         state: present
         definition: "{{ lookup('ansible.builtin.file', '../files/vmaas/30-placementbinding.yaml') | from_yaml }}"
+      register: r_acm_placementbinding_vmaas
+      retries: "{{ k8s_retries }}"
+      delay: "{{ k8s_delay }}"
+      until: r_acm_placementbinding_vmaas is success
 
 - name: ACM policy for NMState
   environment:
@@ -50,21 +70,37 @@
       kubernetes.core.k8s:
         state: present
         definition: "{{ lookup('ansible.builtin.file', '../files/nmstate/00-namespace.yaml') | from_yaml }}"
+      register: r_namespace_acm_nmstate
+      retries: "{{ k8s_retries }}"
+      delay: "{{ k8s_delay }}"
+      until: r_namespace_acm_nmstate is success
 
     - name: Create ACM Policy for NMState
       kubernetes.core.k8s:
         state: present
         definition: "{{ lookup('ansible.builtin.template', '../files/nmstate/10-policy.yaml.j2') | from_yaml }}"
+      register: r_acm_policy_nmstate
+      retries: "{{ k8s_retries }}"
+      delay: "{{ k8s_delay }}"
+      until: r_acm_policy_nmstate is success
 
     - name: Create ACM PlacementRule for NMState
       kubernetes.core.k8s:
         state: present
         definition: "{{ lookup('ansible.builtin.file', '../files/nmstate/20-placementrule.yaml') | from_yaml }}"
+      register: r_acm_placementrule_nmstate
+      retries: "{{ k8s_retries }}"
+      delay: "{{ k8s_delay }}"
+      until: r_acm_placementrule_nmstate is success
 
     - name: Create ACM PlacementBinding for NMState
       kubernetes.core.k8s:
         state: present
         definition: "{{ lookup('ansible.builtin.file', '../files/nmstate/30-placementbinding.yaml') | from_yaml }}"
+      register: r_acm_placementbinding_nmstate
+      retries: "{{ k8s_retries }}"
+      delay: "{{ k8s_delay }}"
+      until: r_acm_placementbinding_nmstate is success
 
 - name: "Fetch the kubeconfig for the VMaaS cluster"
   environment:
@@ -103,6 +139,10 @@
           kind: Namespace
           metadata:
             name: "{{ aap_ns }}"
+      register: r_aap_namespace
+      retries: "{{ k8s_retries }}"
+      delay: "{{ k8s_delay }}"
+      until: r_aap_namespace is success
 
     - name: "Create kubeconfig secret for the VMaaS cluster (aap namespace)"
       kubernetes.core.k8s:
@@ -116,6 +156,10 @@
           type: Opaque
           data:
             kubeconfig: "{{ __vmaas_cluster_kubeconfig.resources[0].data.kubeconfig }}"
+      register: r_kubeconfig_secret_aap
+      retries: "{{ k8s_retries }}"
+      delay: "{{ k8s_delay }}"
+      until: r_kubeconfig_secret_aap is success
 
     - name: "Create AAP config secret for Config as Code"
       kubernetes.core.k8s:
@@ -138,6 +182,10 @@
             name: "cluster-fulfillment-ig"
             namespace: "{{ aap_ns }}"
           type: Opaque
+      register: r_cluster_fulfillment_secret
+      retries: "{{ k8s_retries }}"
+      delay: "{{ k8s_delay }}"
+      until: r_cluster_fulfillment_secret is success
 
     - name: "Create osac-sa Service Account in AAP namespace"
       kubernetes.core.k8s:
@@ -310,6 +358,10 @@
           type: Opaque
           data:
             "license.zip": "{{ __aap_b64_license.content }}"
+      register: r_config_as_code_secret
+      retries: "{{ k8s_retries }}"
+      delay: "{{ k8s_delay }}"
+      until: r_config_as_code_secret is success
 
     - name: "Create aap-bootstrap job"
       kubernetes.core.k8s:
@@ -335,6 +387,10 @@
           kind: Namespace
           metadata:
             name: "{{ osac_operator_ns | default('osac-operator-system') }}"
+      register: r_osac_namespace
+      retries: "{{ k8s_retries }}"
+      delay: "{{ k8s_delay }}"
+      until: r_osac_namespace is success
 
     # If the AAP token is NOT defined, and it happens if the token was previously
     # created on an earlier run, we avoid creating the osac config secret
@@ -360,6 +416,10 @@
           type: Opaque
           data:
             kubeconfig: "{{ __vmaas_cluster_kubeconfig.resources[0].data.kubeconfig }}"
+      register: r_kubeconfig_secret_osac
+      retries: "{{ k8s_retries }}"
+      delay: "{{ k8s_delay }}"
+      until: r_kubeconfig_secret_osac is success
 
     - name: "Pull OSAC operator container image"
       containers.podman.podman_image:
@@ -391,8 +451,8 @@
         state: present
         src: "/tmp/osac-install.yaml"
       register: __r_apply_manifests
-      retries: 6
-      delay: 5
+      retries: "{{ k8s_retries }}"
+      delay: "{{ k8s_delay }}"
       until: __r_apply_manifests is success
 
     - name: "Remove OSAC installation manifest"
@@ -436,6 +496,10 @@
                   - name: "vmaas-cluster-kubeconfig"
                     secret:
                       secretName: "{{ osac_kubeconfig_secret_name | default('vmaas-cluster-kubeconfig') }}"
+      register: r_patch_osac_deployment
+      retries: "{{ k8s_retries }}"
+      delay: "{{ k8s_delay }}"
+      until: r_patch_osac_deployment is success
       when: __osac_deploy.resources | length > 0
 
   always:


### PR DESCRIPTION
Add a retry mechanism to `kubernetes.core.k8s` `present`, `absent`, and `patched` calls to make them more robust against transient API or network issues.

Define default retries and delay values in `defaults/k8s.yaml`:
 - `k8s_retries: 6`
 - `k8s_delay: 5`

MGMT-23221

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable Kubernetes retry settings with new `k8s_retries` (default: 6) and `k8s_delay` (default: 5) configuration parameters.
  
* **Improvements**
  * Enhanced reliability across multiple operators and playbooks by implementing retry logic and success verification for Kubernetes operations, ensuring tasks complete successfully before proceeding to the next step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->