### PR TITLE
operator update remove openshift-operators exclusion

### DIFF
--- a/.github/workflows/e2e-deployment.yml
+++ b/.github/workflows/e2e-deployment.yml
@@ -71,6 +71,7 @@ jobs:
               - 'templates/**'
               - 'operators/**'
               - 'files/**'
+              - 'hack/**'
               - '.github/workflows/e2e-deployment.yml'
               - 'ansible.cfg'
               - 'requirements.yml'

--- a/hack/operator_update.py
+++ b/hack/operator_update.py
@@ -143,8 +143,6 @@ def init_ns_op_version_map(
         op_name = op["name"]
         op_version = op["version"]
         op_namespace = op["namespace"]
-        if op_namespace == "openshift-operators":
-            continue
         op_csv_name = op.get("csvName")
         ns_op_version_map.setdefault(op_namespace, {})[
             op_csv_name or op_name


### PR DESCRIPTION
after removing all operator installation from openshift-operators we do not need this exclusion anymore.

#44 #45 #46 #47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Operators from the previously omitted namespace are now included in evaluation and approval, ensuring all relevant operators are considered.

* **Chores**
  * CI trigger configuration updated to include additional tooling/scripts, causing end-to-end runs to consider changes in that area.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->