### PR TITLE
[quay-operator] Set requests/limits for postgres and enable always HPA

### DIFF
--- a/operators/quay-operator/tasks.yaml
+++ b/operators/quay-operator/tasks.yaml
@@ -70,7 +70,7 @@
         configBundleSecret: quay-config
         components:
         - kind: horizontalpodautoscaler
-          managed: "{{ true if blockStorageBackend == 'odf' else false }}"
+          managed: true
         - kind: quay
           managed: true
           overrides:
@@ -83,6 +83,27 @@
                 memory: "{{ '16Gi' if (disconnected | default(true)) else '2Gi' }}"
         - kind: objectstorage
           managed: false
+        - kind: postgres
+          managed: true
+          overrides:
+            resources:
+              limits:
+                cpu: 500m
+                memory: 2Gi
+              requests:
+                cpu: 500m
+                memory: 2Gi
+        - kind: clairpostgres
+          managed: true
+          overrides:
+            resources:
+              limits:
+                cpu: 500m
+                memory: 2Gi
+              requests:
+                cpu: 500m
+                memory: 2Gi
+
   retries: 60
   delay: 10
   register: r_quay


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated horizontal pod autoscaler configuration for QuayRegistry component.
  * Added postgres and clairpostgres components with resource allocation specifications (500m CPU and 2Gi memory limits/requests).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->