### PR TITLE
[openshift-cert-manager-operator] Set requests/limits for cert-manager

### DIFF
--- a/operators/openshift-cert-manager-operator/tasks.yaml
+++ b/operators/openshift-cert-manager-operator/tasks.yaml
@@ -1,3 +1,38 @@
 ---
-- ansible.builtin.debug: 
-    msg: "Operator configured properly, no further actions"
+- name: Patch CertManager to set resources
+  kubernetes.core.k8s:
+    state: patched
+    definition:
+      apiVersion: operator.openshift.io/v1alpha1
+      kind: CertManager
+      metadata:
+        name: cluster
+      spec:
+        cainjectorConfig:
+          overrideReplicas: 2
+          overrideResources:
+            limits:
+              cpu: 200m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 256Mi
+        controllerConfig:
+          overrideReplicas: 2
+          overrideResources:
+            limits:
+              cpu: 200m
+              memory: 128Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+        webhookConfig:
+          overrideReplicas: 3
+          overrideResources:
+            limits:
+              cpu: 20m
+              memory: 32Mi
+            requests:
+              cpu: 20m
+              memory: 32Mi
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CertManager resource configuration to properly apply patches instead of skipping operations. Now includes resource limits and replica settings for cainjector, controller, and webhook components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->