### PR TITLE
package ansible collections in tarball

### DIFF
--- a/.github/workflows/build-push-tarball.yml
+++ b/.github/workflows/build-push-tarball.yml
@@ -35,6 +35,18 @@ jobs:
             echo "tag=${{ github.sha }}" >> $GITHUB_OUTPUT
           fi
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Download Ansible Collections
+        run: |
+          pip install ansible-core
+          mkdir -p collections
+          ansible-galaxy collection download --download-path ./collections --requirements-file ansible_collections.txt
+          cat ansible_collections.sha256 | sha256sum -c
+
       - name: Add version file
         run: |
           echo -n "${{ steps.meta.outputs.tag }}" > .version

--- a/.github/workflows/build-push-tarball.yml
+++ b/.github/workflows/build-push-tarball.yml
@@ -37,8 +37,6 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
 
       - name: Download Ansible Collections
         run: |


### PR DESCRIPTION
we've seen issues in the past with ansible galaxy not being available for download.

in this PR we are downloading ansible collections in build time to avoid the install time dependency when using the tarball.