### PR TITLE
mirror all operator channels

### DIFF
--- a/defaults/model_operators.yaml
+++ b/defaults/model_operators.yaml
@@ -1,38 +1,20 @@
 ---
 model_operators:
   - name: nfd
-    defaultChannel: stable
-    channels:
-    - name: stable
+    channel: stable
   - name: gpu-operator-certified
-    defaultChannel: v25.10
-    channels:
-    - name: v25.10
+    channel: v25.10
   - name: limitador-operator
-    defaultChannel: stable
-    channels:
-    - name: stable
+    channel: stable
   - name: authorino-operator
-    defaultChannel: stable
-    channels:
-    - name: stable
+    channel: stable
   - name: dns-operator
-    defaultChannel: stable
-    channels:
-    - name: stable
+    channel: stable
   - name: rhcl-operator
-    defaultChannel: stable
-    channels:
-    - name: stable
+    channel: stable
   - name: leader-worker-set
-    defaultChannel: stable-v1.0
-    channels:
-    - name: stable-v1.0
+    channel: stable-v1.0
   - name: rhods-operator
-    defaultChannel: fast-3.x
-    channels:
-    - name: fast-3.x
+    channel: fast-3.x
   - name: servicemeshoperator3
-    defaultChannel: stable
-    channels:
-    - name: stable
+    channel: stable

--- a/defaults/operators.yaml
+++ b/defaults/operators.yaml
@@ -3,60 +3,46 @@ operators:
 
   - name: quay-operator
     version: 3.15.3
-    defaultChannel: stable-3.15
-    channels:
-    - name: stable-3.15
+    channel: stable-3.15
     namespace: quay-enterprise
     source: cs-redhat-operator-index-v4-20
 
   - name: multicluster-engine
     version: 2.10.1
-    defaultChannel: stable-2.10
-    channels:
-    - name: stable-2.10
+    channel: stable-2.10
     namespace: multicluster-engine
     source: cs-redhat-operator-index-v4-20
 
   - name: advanced-cluster-management
     version: 2.15.1
-    defaultChannel: release-2.15
-    channels:
-    - name: release-2.15
+    channel: release-2.15
     namespace: open-cluster-management
     source: cs-redhat-operator-index-v4-20
 
   - name: cincinnati-operator
     version: 5.0.3
-    defaultChannel: v1
-    channels:
-    - name: v1
+    channel: v1
     namespace: openshift-update-service
     source: cs-redhat-operator-index-v4-20
     csvName: update-service-operator
 
   - name: openshift-gitops-operator
     version: 1.19.2
-    defaultChannel: gitops-1.19
-    channels:
-    - name: gitops-1.19
+    channel: gitops-1.19
     namespace: openshift-gitops-operator
     source: cs-redhat-operator-index-v4-20
     global: true
 
   - name: openshift-pipelines-operator-rh
     version: 1.20.3
-    defaultChannel: pipelines-1.20
-    channels:
-    - name: pipelines-1.20
+    channel: pipelines-1.20
     namespace: openshift-pipelines
     source: cs-redhat-operator-index-v4-20
     global: true
 
   - name: netobserv-operator
     version: 1.11.0
-    defaultChannel: stable
-    channels:
-    - name: stable
+    channel: stable
     namespace: openshift-netobserv-operator
     source: cs-redhat-operator-index-v4-20
     global: true
@@ -64,54 +50,41 @@ operators:
 
   - name: cluster-logging
     version: 6.4.2
-    defaultChannel: stable-6.4
-    channels:
-    - name: stable-6.4
+    channel: stable-6.4
     namespace: openshift-logging
     source: cs-redhat-operator-index-v4-20
 
   - name: loki-operator
     version: 6.4.2
-    defaultChannel: stable-6.4
-    channels:
-    - name: stable-6.4
+    channel: stable-6.4
     namespace: openshift-operators-redhat
     source: cs-redhat-operator-index-v4-20
     global: true
 
   - name: redhat-oadp-operator
     version: 1.5.4
-    defaultChannel: stable
-    channels:
-    - name: stable
+    channel: stable
     namespace: openshift-oadp
     source: cs-redhat-operator-index-v4-20
     csvName: oadp-operator
 
   - name: openshift-cert-manager-operator
     version: 1.18.1
-    defaultChannel: stable-v1
-    channels:
-    - name: stable-v1
-    - name: stable-v1.18
+    channel: stable-v1
     namespace: cert-manager-operator
     source: cs-redhat-operator-index-v4-20
     csvName: cert-manager-operator
 
   - name: cluster-observability-operator
     version: 1.3.1
-    defaultChannel: stable
-    channels:
-    - name: stable
+    channel: stable
     namespace: openshift-cluster-observability-operator
     source: cs-redhat-operator-index-v4-20
     global: true
 
   - name: openshift-external-secrets-operator
     version: 1.0.0
-    defaultChannel: stable-v1.0
-    channels:
-    - name: stable-v1.0
+    channel: stable-v1.0
     namespace: external-secrets-operator
     source: cs-redhat-operator-index-v4-20
     global: true
@@ -119,17 +92,13 @@ operators:
 
   - name: compliance-operator
     version: 1.8.2
-    defaultChannel: stable
-    channels:
-    - name: stable
+    channel: stable
     namespace: openshift-compliance
     source: cs-redhat-operator-index-v4-20
 
   - name: metallb-operator
     version: 4.20.0-202602091941
-    defaultChannel: stable
-    channels:
-    - name: stable
+    channel: stable
     namespace: metallb-system
     source: cs-redhat-operator-index-v4-20
     global: true
@@ -137,9 +106,7 @@ operators:
   # AAP is a dependency for osac-operator
   - name: ansible-automation-platform-operator
     version: 2.5.0-0.1772612774
-    defaultChannel: stable-2.5-cluster-scoped
-    channels:
-    - name: stable-2.5-cluster-scoped
+    channel: stable-2.5-cluster-scoped
     namespace: ansible-aap
     source: cs-redhat-operator-index-v4-20
     global: true

--- a/defaults/storage_operators.yaml
+++ b/defaults/storage_operators.yaml
@@ -2,16 +2,12 @@ storage_operators:  # Install operator depending blockStorageBackend variable
   odf:
     name: odf-operator
     version: 4.20.7-rhodf
-    defaultChannel: stable-4.20
-    channels:
-    - name: stable-4.20
+    channel: stable-4.20
     namespace: openshift-storage
     source: cs-redhat-operator-index-v4-20
   lvms:
     name: lvms-operator
     version: 4.20.0
-    defaultChannel: stable-4.20
-    channels:
-    - name: stable-4.20
+    channel: stable-4.20
     namespace: openshift-storage
     source: cs-redhat-operator-index-v4-20

--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -953,9 +953,7 @@ Operator configuration is stored in the `defaults/` directory:
 ```yaml
 operators:
   - name: operator-name
-    defaultChannel: channel-name
-    channels:
-    - name: channel-name
+    channel: channel-name
     namespace: target-namespace
     source: catalog-source-name
     config:  # Optional operator-specific configuration
@@ -979,27 +977,9 @@ name: lvms-operator
 - Must match the package name in the operator catalog
 - Case-sensitive
 
-#### `defaultChannel`
+#### `channel`
 
-**Description**: Default update channel for the operator.
-
-**Type**: String
-
-**Examples**:
-```yaml
-defaultChannel: stable-4.19    # Stable channel for OCP 4.19
-defaultChannel: latest         # Latest available version
-defaultChannel: release-2.15   # Specific release channel
-```
-
-**Notes**:
-- Different operators use different channel naming
-- Check operator documentation for available channels
-- `latest` may not be stable - prefer versioned channels
-
-#### `channels`
-
-**Description**: Available update channels for the operator.
+**Description**: Update channel for the operator.
 
 **Type**: String
 

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -386,49 +386,37 @@ Operators are configured in `defaults/operators.yaml`:
 operators:
   # Advanced Cluster Management
   - name: advanced-cluster-management
-    defaultChannel: release-2.15
-    channels:
-      - name: release-2.15
+    channel: release-2.15
     namespace: open-cluster-management
     source: cs-redhat-operator-index-v4-19
 
   # OpenShift GitOps (ArgoCD)
   - name: openshift-gitops-operator
-    defaultChannel: latest
-    channels:
-      - name: latest
+    channel: latest
     namespace: openshift-operators
     source: cs-redhat-operator-index-v4-19
 
   # OpenShift Pipelines (Tekton)
   - name: openshift-pipelines-operator-rh
-    defaultChannel: latest
-    channels:
-      - name: latest
+    channel: latest
     namespace: openshift-operators
     source: cs-redhat-operator-index-v4-19
 
   # Network Observability
   - name: netobserv-operator
-    defaultChannel: stable
-    channels:
-      - name: stable
+    channel: stable
     namespace: openshift-operators
     source: cs-redhat-operator-index-v4-19
 
   # Backup and Restore
   - name: redhat-oadp-operator
-    defaultChannel: stable
-    channels:
-      - name: stable
+    channel: stable
     namespace: openshift-oadp
     source: cs-redhat-operator-index-v4-19
 
   # Certificate Manager
   - name: openshift-cert-manager-operator
-    defaultChannel: stable-v1
-    channels:
-      - name: stable-v1
+    channel: stable-v1
     namespace: cert-manager-operator
     source: cs-redhat-operator-index-v4-19
   [...]

--- a/playbooks/tasks/configure_operator.yaml
+++ b/playbooks/tasks/configure_operator.yaml
@@ -70,7 +70,7 @@
         namespace: "{{ operator.namespace }}"
       spec:
         installPlanApproval: Automatic
-        channel: "{{ operator.defaultChannel }}"
+        channel: "{{ operator.channel }}"
         name: "{{ operator.name }}"
         source: "{{ operator.source if (disconnected | default(true)) else 'redhat-operators' }}"
         sourceNamespace: openshift-marketplace
@@ -93,7 +93,7 @@
         namespace: "{{ operator.namespace }}"
       spec:
         installPlanApproval: Manual
-        channel: "{{ operator.defaultChannel }}"
+        channel: "{{ operator.channel }}"
         name: "{{ operator.name }}"
         source: "{{ operator.source if (disconnected | default(true)) else 'redhat-operators' }}"
         sourceNamespace: openshift-marketplace

--- a/schemas/operators.yaml
+++ b/schemas/operators.yaml
@@ -14,17 +14,8 @@ definitions:
         type: string
         description: Operator version.
       channel:
-        type: array
+        type: string
         description: Update channel for the operator.
-        items:
-          type: object
-          additionalProperties: false
-          properties:
-            name:
-              type: string
-              description: Update channel name for the operator.
-          required:
-          - name
       namespace:
         type: string
         description: Target namespace where the operator will be installed.

--- a/schemas/operators.yaml
+++ b/schemas/operators.yaml
@@ -13,12 +13,9 @@ definitions:
       version:
         type: string
         description: Operator version.
-      defaultChannel:
-        type: string
-        description: Default update channel for the operator.
-      channels:
+      channel:
         type: array
-        description: Update channels for the operator.
+        description: Update channel for the operator.
         items:
           type: object
           additionalProperties: false
@@ -42,8 +39,7 @@ definitions:
         description: Configure operator to watch the entire cluster.
     required:
     - name
-    - defaultChannel
-    - channels
+    - channel
 
 additionalProperties: false
 properties:

--- a/templates/imagesetconfiguration.yaml.j2
+++ b/templates/imagesetconfiguration.yaml.j2
@@ -14,17 +14,12 @@ mirror:
     - catalog: registry.redhat.io/redhat/certified-operator-index:v4.20
       packages:
         - name: gpu-operator-certified
-          defaultChannel: v25.10
-          channels:
-          - name: v25.10
     - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.20
       packages:
         - name: kubevirt-hyperconverged
         - name: kubernetes-nmstate-operator
 {% for operator in operators + model_operators %}
         - name: {{ operator.name }}
-          defaultChannel: {{ operator.defaultChannel }}
-          channels: {{ operator.channels }}
 {% endfor %}
         - name: "{{ storage_operators[blockStorageBackend].name }}"
 {% if blockStorageBackend == "odf" %}


### PR DESCRIPTION
following experiment in #70

seems mirroring specific channels causes package manifests to not reflect all versions in the channel and only the head of the channel.

we will mirror more content, but we increase stability and gain the ability to pin older operator versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated per-operator multi-channel settings into a single channel field across all operator configurations, simplifying operator manifests and templates.

* **Documentation**
  * Updated configuration reference and deployment guide to reflect the new single-channel format and examples.

* **Schema**
  * Operator schema updated to require the new channel field and remove previous multi-channel entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->