### PR TITLE
MGMT-23352: handle LocalStorage tasks for LVMS

### DIFF
--- a/operators/quay-operator/quay_lvms.yaml
+++ b/operators/quay-operator/quay_lvms.yaml
@@ -14,6 +14,8 @@
       spec:
         configBundleSecret: quay-config
         components:
+        - kind: horizontalpodautoscaler
+          managed: "{{ quayBackend != 'LocalStorage' }}"
         - kind: objectstorage
           managed: false
         - kind: quay
@@ -27,73 +29,92 @@
               requests:
                 cpu: "{{ '2' if (disconnected | default(true)) else '1' }}"
                 memory: "{{ '6Gi' if (disconnected | default(true)) else '4Gi' }}"
-        - kind: horizontalpodautoscaler
-          managed: false
+        - kind: postgres
+          managed: true
+          overrides:
+            resources:
+              limits:
+                cpu: 500m
+                memory: 2Gi
+              requests:
+                cpu: 500m
+                memory: 2Gi
+        - kind: clairpostgres
+          managed: true
+          overrides:
+            resources:
+              limits:
+                cpu: 500m
+                memory: 2Gi
+              requests:
+                cpu: 500m
+                memory: 2Gi
   retries: 60
   delay: 10
   register: r_quay_lvms
   until: r_quay_lvms is succeeded
 
-- name: Wait for Quay app deployment to exist (LVMS)
-  kubernetes.core.k8s_info:
-    api_version: apps/v1
-    kind: Deployment
-    namespace: quay-enterprise
-    name: registry-quay-app
-  register: quay_app_deployment
-  retries: 30
-  delay: 10
-  until: quay_app_deployment.resources | length > 0
+- name: Quay LVMS storage (PVC and deployment patch)
+  when: quayBackend == 'LocalStorage'
+  block:
+  - name: Wait for Quay app deployment to exist (LVMS)
+    kubernetes.core.k8s_info:
+      api_version: apps/v1
+      kind: Deployment
+      namespace: quay-enterprise
+      name: registry-quay-app
+    register: quay_app_deployment
+    retries: 30
+    delay: 10
+    until: quay_app_deployment.resources | length > 0
 
-- name: Set quay container index for LVMS patch (first container is the app)
-  ansible.builtin.set_fact:
-    quay_container_index: 0
-  when: quay_app_deployment.resources | default([]) | length > 0
+  - name: Set quay container index for LVMS patch (first container is the app)
+    ansible.builtin.set_fact:
+      quay_container_index: 0
+    when: quay_app_deployment.resources | default([]) | length > 0
 
-- name: Check if Quay app deployment already has registry-storage volume (LVMS)
-  ansible.builtin.set_fact:
-    quay_registry_storage_already_patched: "{{ quay_app_deployment.resources[0].spec.template.spec.volumes | selectattr('name', 'equalto', 'registry-storage') | list | length > 0 }}"
-  when: quay_app_deployment.resources | default([]) | length > 0
+  - name: Check if Quay app deployment already has registry-storage volume (LVMS)
+    ansible.builtin.set_fact:
+      quay_registry_storage_already_patched: "{{ quay_app_deployment.resources[0].spec.template.spec.volumes | selectattr('name', 'equalto', 'registry-storage') | list | length > 0 }}"
+    when: quay_app_deployment.resources | default([]) | length > 0
 
-- name: Create LVMS PVC for Quay Storage
-  kubernetes.core.k8s:
-    state: present
-    definition:
-      apiVersion: v1
-      kind: PersistentVolumeClaim
-      metadata:
-        name: quay-storage-pvc
-        namespace: quay-enterprise
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 300Gi
-        storageClassName: lvms-vg1
+  - name: Create LVMS PVC for Quay Storage
+    kubernetes.core.k8s:
+      state: present
+      definition:
+        apiVersion: v1
+        kind: PersistentVolumeClaim
+        metadata:
+          name: quay-storage-pvc
+          namespace: quay-enterprise
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 300Gi
+          storageClassName: lvms-vg1
 
-- name: Patch Quay app deployment to mount registry storage PVC (LVMS)
-  environment:
-    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
-  ansible.builtin.shell: |
-    oc patch deployment registry-quay-app -n quay-enterprise --type=json -p='{{ quay_lvms_patch | to_json }}'
-  args:
-    executable: /bin/bash
-  vars:
-    quay_lvms_patch:
-      - op: add
-        path: /spec/template/spec/volumes/-
-        value:
-          name: registry-storage
-          persistentVolumeClaim:
-            claimName: quay-storage-pvc
-      - op: add
-        path: /spec/template/spec/containers/{{ quay_container_index }}/volumeMounts/-
-        value:
-          name: registry-storage
-          mountPath: /datastorage/registry
-  when:
-    - quay_app_deployment.resources | default([]) | length > 0
-    - quay_container_index is defined
-    - not (quay_registry_storage_already_patched | default(false))
-  register: quay_patch_result
+  - name: Patch Quay app deployment to mount registry storage PVC (LVMS)
+    environment:
+      KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+    ansible.builtin.shell: |
+      {{ workingDir }}/bin/oc patch deployment registry-quay-app -n quay-enterprise --type=json -p='{{ quay_lvms_patch | to_json }}'
+    vars:
+      quay_lvms_patch:
+        - op: add
+          path: /spec/template/spec/volumes/-
+          value:
+            name: registry-storage
+            persistentVolumeClaim:
+              claimName: quay-storage-pvc
+        - op: add
+          path: /spec/template/spec/containers/{{ quay_container_index }}/volumeMounts/-
+          value:
+            name: registry-storage
+            mountPath: /datastorage/registry
+    when:
+      - quay_app_deployment.resources | default([]) | length > 0
+      - quay_container_index is defined
+      - not (quay_registry_storage_already_patched | default(false))
+    register: quay_patch_result

--- a/operators/quay-operator/tasks.yaml
+++ b/operators/quay-operator/tasks.yaml
@@ -118,7 +118,7 @@
 
 - name: Run LVMS-specific Quay tasks (PVC, QuayRegistry, deployment patch)
   ansible.builtin.include_tasks: quay_lvms.yaml
-  when: blockStorageBackend == 'lvms' and quayBackend == 'LocalStorage'
+  when: blockStorageBackend == 'lvms'
 
 - name: Get router pod IP for Quay route access
   kubernetes.core.k8s_info:


### PR DESCRIPTION
quay_lvms.yaml (LVMS QuayRegistry):
- Add horizontalpodautoscaler with managed true only when quayBackend is not LocalStorage.
- Add postgres and clairpostgres limits.
- LVMS storage tasks (PVC, deployment patch) in a block that runs only when quayBackend == 'LocalStorage'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conditional horizontal pod autoscaler management based on backend type.
  * Dedicated LVMS storage flow for local-storage backends, including PVC creation and deployment patching.

* **Refactor**
  * Reorganized LVMS tasks into a guarded, stepwise workflow with clearer execution conditions.
  * Expanded resource override support for backend databases (postgres/clairpostgres).
  * Simplified LVMS activation condition for broader compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->