### PR TITLE
operator mirroring: optional version pinning (pinVersion)

### DIFF
--- a/defaults/operators.yaml
+++ b/defaults/operators.yaml
@@ -2,7 +2,7 @@
 operators:
 
   - name: quay-operator
-    version: 3.15.3
+    version: 3.15.2
     defaultChannel: stable-3.15
     channels:
     - name: stable-3.15
@@ -35,7 +35,7 @@ operators:
     csvName: update-service-operator
 
   - name: openshift-gitops-operator
-    version: 1.19.2
+    version: 1.19.1
     defaultChannel: gitops-1.19
     channels:
     - name: gitops-1.19
@@ -44,7 +44,7 @@ operators:
     global: true
 
   - name: openshift-pipelines-operator-rh
-    version: 1.20.3
+    version: 1.20.2
     defaultChannel: pipelines-1.20
     channels:
     - name: pipelines-1.20
@@ -53,7 +53,7 @@ operators:
     global: true
 
   - name: netobserv-operator
-    version: 1.11.0
+    version: 1.10.1
     defaultChannel: stable
     channels:
     - name: stable
@@ -63,7 +63,7 @@ operators:
     csvName: network-observability-operator
 
   - name: cluster-logging
-    version: 6.4.2
+    version: 6.4.1
     defaultChannel: stable-6.4
     channels:
     - name: stable-6.4
@@ -71,7 +71,7 @@ operators:
     source: cs-redhat-operator-index-v4-20
 
   - name: loki-operator
-    version: 6.4.2
+    version: 6.4.1
     defaultChannel: stable-6.4
     channels:
     - name: stable-6.4
@@ -80,7 +80,7 @@ operators:
     global: true
 
   - name: redhat-oadp-operator
-    version: 1.5.4
+    version: 1.5.3
     defaultChannel: stable
     channels:
     - name: stable
@@ -127,6 +127,7 @@ operators:
 
   - name: metallb-operator
     version: 4.20.0-202602091941
+    pinVersion: false
     defaultChannel: stable
     channels:
     - name: stable
@@ -134,9 +135,10 @@ operators:
     source: cs-redhat-operator-index-v4-20
     global: true
 
-  # AAP is a dependency for osac-operator
+  # AAP is a dependency for osac-operator (pinVersion: false - build not always in catalog)
   - name: ansible-automation-platform-operator
     version: 2.5.0-0.1772612774
+    pinVersion: false
     defaultChannel: stable-2.5-cluster-scoped
     channels:
     - name: stable-2.5-cluster-scoped

--- a/playbooks/tasks/configure_operator.yaml
+++ b/playbooks/tasks/configure_operator.yaml
@@ -79,10 +79,12 @@
   delay: "{{ k8s_delay }}"
   until: r_sub_exists is success
 
-- name: "Ensure Subscription exists (Manual)"
+- name: "Ensure Subscription exists (Manual, version pinned)"
   when:
     - r_sub_check.resources | length == 0
     - operator.namespace != "openshift-operators"
+    - operator.version is defined
+    - operator.pinVersion | default(true) | bool
   kubernetes.core.k8s:
     state: present
     definition:
@@ -98,6 +100,30 @@
         source: "{{ operator.source if (disconnected | default(true)) else 'redhat-operators' }}"
         sourceNamespace: openshift-marketplace
         startingCSV: "{{ operator.csvName | default(operator.name) }}.v{{ operator.version }}"
+  register: r_sub_exists
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_sub_exists is success
+
+- name: "Ensure Subscription exists (Manual, channel latest)"
+  when:
+    - r_sub_check.resources | length == 0
+    - operator.namespace != "openshift-operators"
+    - not (operator.version is defined and operator.pinVersion | default(true) | bool)
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: "{{ operator.name }}"
+        namespace: "{{ operator.namespace }}"
+      spec:
+        installPlanApproval: Manual
+        channel: "{{ operator.defaultChannel }}"
+        name: "{{ operator.name }}"
+        source: "{{ operator.source if (disconnected | default(true)) else 'redhat-operators' }}"
+        sourceNamespace: openshift-marketplace
   register: r_sub_exists
   retries: "{{ k8s_retries }}"
   delay: "{{ k8s_delay }}"

--- a/schemas/operators.yaml
+++ b/schemas/operators.yaml
@@ -13,6 +13,9 @@ definitions:
       version:
         type: string
         description: Operator version.
+      pinVersion:
+        type: boolean
+        description: If true (default when version is set), emit minVersion/maxVersion in ImageSetConfiguration to mirror only this version. Set false when the exact bundle may not exist in the catalog (e.g. build number changes).
       defaultChannel:
         type: string
         description: Default update channel for the operator.

--- a/templates/imagesetconfiguration.yaml.j2
+++ b/templates/imagesetconfiguration.yaml.j2
@@ -25,6 +25,10 @@ mirror:
         - name: {{ operator.name }}
           defaultChannel: {{ operator.defaultChannel }}
           channels: {{ operator.channels }}
+{% if operator.version is defined and operator.pinVersion | default(true) %}
+          minVersion: "{{ operator.version }}"
+          maxVersion: "{{ operator.version }}"
+{% endif %}
 {% endfor %}
         - name: "{{ storage_operators[blockStorageBackend].name }}"
 {% if blockStorageBackend == "odf" %}


### PR DESCRIPTION
- templates/imagesetconfiguration.yaml.j2: emit minVersion/maxVersion only when operator has version and pinVersion is not false (default true).
- schemas/operators.yaml: add optional pinVersion (boolean) to operator schema.
- defaults/operators.yaml: set pinVersion: false for ansible-automation-platform-operator and metallb-operator so oc-mirror uses channel head instead of exact build (avoids 'specific version not found in bundles' when build not in catalog).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new pinVersion option for operators to control whether an operator's exact bundle version is strictly pinned in image set configurations.

* **Updates**
  * Several operators had their version/pinning settings adjusted.
  * Subscription creation now distinguishes pinned installs (starts a specific CSV) from unpinned installs (uses channel/latest).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->