### PR TITLE
adding ansible-automation-platform-24 and ansible-automation-platform-26 to registries.conf

### DIFF
--- a/templates/registries.conf.j2
+++ b/templates/registries.conf.j2
@@ -274,9 +274,21 @@
 
 [[registry]]
   prefix = ""
+  location = "registry.redhat.io/ansible-automation-platform-24"
+[[registry.mirror]]
+  location = "{{ quayHostname }}:8443/ansible-automation-platform-24"
+
+[[registry]]
+  prefix = ""
   location = "registry.redhat.io/ansible-automation-platform-25"
 [[registry.mirror]]
   location = "{{ quayHostname }}:8443/ansible-automation-platform-25"
+
+[[registry]]
+  prefix = ""
+  location = "registry.redhat.io/ansible-automation-platform-26"
+[[registry.mirror]]
+  location = "{{ quayHostname }}:8443/ansible-automation-platform-26"
 
 [[registry]]
   prefix = ""


### PR DESCRIPTION
Adding all channels to the AAP, requires to synchronize 2.4 and 2.6