### PR TITLE
fix: Block 3scale images (tech preview) and update operators version

### DIFF
--- a/defaults/operators.yaml
+++ b/defaults/operators.yaml
@@ -62,7 +62,7 @@ operators:
     global: true
 
   - name: redhat-oadp-operator
-    version: 1.5.4
+    version: 1.5.5
     channel: stable
     namespace: openshift-oadp
     source: cs-redhat-operator-index-v4-20
@@ -97,7 +97,7 @@ operators:
     source: cs-redhat-operator-index-v4-20
 
   - name: metallb-operator
-    version: 4.20.0-202602091941
+    version: metallb-operator.v4.20.0-202602261925
     channel: stable
     namespace: metallb-system
     source: cs-redhat-operator-index-v4-20

--- a/templates/imagesetconfiguration.yaml.j2
+++ b/templates/imagesetconfiguration.yaml.j2
@@ -48,6 +48,9 @@ mirror:
     - name: {{ aap_bootstrap_job.image }}:{{ aap_bootstrap_job.tag }}
 
   blockedimages:
+    - name: registry.redhat.io/3scale-tech-preview/authorino-rhel9-operator
+    - name: registry.redhat.io/3scale-tech-preview/authorino-rhel9
+    - name: registry.redhat.io/3scale-tech-preview/authorino-operator-bundle
     - name: registry.redhat.io/rhoai/odh-dashboard-rhel8
     - name: registry.redhat.io/rhoai/odh-dashboard-rhel9
     - name: registry.redhat.io/rhoai/odh-codeflare-operator-rhel9


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added three Authorino-related container images to the blocked images list.
  * Updated operator versions for Red Hat OADP and MetalLB to newer releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->