### PR TITLE
nightly-e2e-disconnected: dedicated runner, larger disks, more retries

### DIFF
--- a/.github/workflows/nightly-e2e-disconnected.yml
+++ b/.github/workflows/nightly-e2e-disconnected.yml
@@ -29,8 +29,8 @@ concurrency:
 jobs:
   nightly-disconnected-deployment:
     name: Nightly Disconnected Deployment
-    runs-on: [self-hosted, enclave-large]
-    timeout-minutes: 270  # 4.5 hours
+    runs-on: [self-hosted, enclave-disconnected]
+    timeout-minutes: 480  # 8 hours
 
     env:
       DEV_SCRIPTS_PATH: ${{ vars.DEV_SCRIPTS_PATH }}

--- a/operators/quay-operator/quay_disconnected.yaml
+++ b/operators/quay-operator/quay_disconnected.yaml
@@ -40,7 +40,7 @@
       --image-timeout 40m0s \
       > {{ workingDir }}/logs/oc-mirror.progress.quay.$(date +%s).log 2>&1
 
-  retries: 5
+  retries: 10
   delay: 10
   register: r_oc_mirror_quay
   until: r_oc_mirror_quay is succeeded

--- a/operators/quay-operator/quay_lvms.yaml
+++ b/operators/quay-operator/quay_lvms.yaml
@@ -55,7 +55,9 @@
   until: r_quay_lvms is succeeded
 
 - name: Quay LVMS storage (PVC and deployment patch)
-  when: quayBackend == 'LocalStorage'
+  when:
+    - quayBackend == 'LocalStorage'
+    - disconnected | default(true)
   block:
   - name: Wait for Quay app deployment to exist (LVMS)
     kubernetes.core.k8s_info:
@@ -92,7 +94,7 @@
             - ReadWriteOnce
           resources:
             requests:
-              storage: 300Gi
+              storage: 600Gi
           storageClassName: lvms-vg1
 
   - name: Patch Quay app deployment to mount registry storage PVC (LVMS)

--- a/playbooks/tasks/mirror_registry.yaml
+++ b/playbooks/tasks/mirror_registry.yaml
@@ -42,7 +42,7 @@
 - name: Start oc-mirror process
   ansible.builtin.shell: |
     {{ workingDir }}/bin/oc-mirror --v2 --log-level {{ ocMirrorLogLevel }} --authfile "{{ pullSecretPath }}" -c {{ workingDir }}/config/imagesetconfiguration.yaml --workspace file://{{ workingDir }}/config/oc-mirror-workspace docker://{{ quayHostname }}:8443 --dest-tls-verify=false --parallel-images 10 --parallel-layers 10 --retry-times 10 --retry-delay 0 > {{ workingDir }}/logs/oc-mirror.progress.$(date +%s).log 2>&1
-  retries: 5
+  retries: 10
   delay: 10
   register: r_oc_mirror
   until: r_oc_mirror is success

--- a/scripts/infrastructure/provision_landing_zone.sh
+++ b/scripts/infrastructure/provision_landing_zone.sh
@@ -272,11 +272,11 @@ sudo qemu-img convert -f qcow2 -O qcow2 \
     "${LZ_WORKING_DIR}/${CLOUD_IMAGE_NAME}" \
     "${POOL_PATH}/${LZ_VM_NAME}.qcow2"
 
-# Resize to 600GB (needed for OpenShift image mirroring)
+# Resize to 700GB (needed for OpenShift image mirroring)
 # Provides ample space for: Quay storage ~130GB, oc-mirror workspace ~7GB,
 # ISO files ~3GB, binaries ~3GB, OS and other ~7GB, plus large buffer
-info "Resizing disk to 600GB..."
-sudo qemu-img resize "${POOL_PATH}/${LZ_VM_NAME}.qcow2" 600G
+info "Resizing disk to 700GB..."
+sudo qemu-img resize "${POOL_PATH}/${LZ_VM_NAME}.qcow2" 700G
 
 # Refresh pool so libvirt sees the new volume
 info "Refreshing libvirt pool..."

--- a/scripts/setup/configure_devscripts.sh
+++ b/scripts/setup/configure_devscripts.sh
@@ -74,13 +74,13 @@ echo "Creating dev-scripts configuration at: $CONFIG_FILE"
 ENCLAVE_NUM_MASTERS="${ENCLAVE_NUM_MASTERS:-3}"
 ENCLAVE_NUM_LANDINGZONE="${ENCLAVE_NUM_LANDINGZONE:-1}"
 
-# VM extra disk size: 500G for disconnected (mirroring), 60G for connected
+# VM extra disk size: 800G for disconnected (mirroring), 60G for connected
 DEPLOYMENT_MODE="${ENCLAVE_DEPLOYMENT_MODE:-disconnected}"
 if [ "$DEPLOYMENT_MODE" = "connected" ]; then
     VM_EXTRADISKS_SIZE_VAL="60G"
     MASTER_MEMORY_VAL=24576    # 24 GB for connected
 else
-    VM_EXTRADISKS_SIZE_VAL="500G"
+    VM_EXTRADISKS_SIZE_VAL="800G"
     MASTER_MEMORY_VAL=32768    # 32 GB for disconnected
 fi
 


### PR DESCRIPTION
Workflow
- Use enclave-disconnected runner (was enclave-large)
- Job timeout: 270m → 480m (8h)

Disks & storage
- Required for mirror size: 1269 images, ~523G in container storage.
- Landing zone VM: 600GB → 700GB (provision_landing_zone.sh)
- Disconnected VM extra disk: 500G → 800G (configure_devscripts.sh)
- Quay registry PVC (LVMS): 300Gi → 600Gi (quay_lvms.yaml)

Resilience
- oc-mirror retries: 5 → 10 (mirror_registry.yaml, quay_disconnected.yaml)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased retry attempts for mirror operations to improve reliability.
  * Expanded LVMS storage capacity (300Gi → 600Gi) for disconnected deployments.
  * Increased disk allocation for provisioning (600G → 700G) and VM extra disk size for disconnected setups (500G → 800G).
  * Extended timeout for nightly disconnected deployment testing to accommodate longer runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->