### PR TITLE
Add skip cleanup option to nightly workflows

### DIFF
--- a/.github/workflows/nightly-e2e-connected.yml
+++ b/.github/workflows/nightly-e2e-connected.yml
@@ -15,6 +15,11 @@ on:
         required: false
         type: boolean
         default: false
+      skip-cleanup:
+        description: 'Skip cleanup after deployment (leave infrastructure running)'
+        required: false
+        type: boolean
+        default: false
 
 # Prevent concurrent nightly runs
 concurrency:
@@ -247,7 +252,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Cleanup infrastructure
-        if: always()
+        if: always() && (github.event_name == 'schedule' || inputs.skip-cleanup != true)
         run: |
           echo "## Cleanup Infrastructure" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -255,6 +260,20 @@ jobs:
           make clean
 
           echo "✅ Infrastructure cleaned up" >> $GITHUB_STEP_SUMMARY
+
+      - name: Cleanup skipped notice
+        if: always() && github.event_name == 'workflow_dispatch' && inputs.skip-cleanup == true
+        run: |
+          echo "## ⚠️ Cleanup Skipped" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Infrastructure cleanup was skipped as requested." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**⚠️ IMPORTANT**: Remember to manually clean up the infrastructure:" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+          echo "make clean" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Cluster name**: $ENCLAVE_CLUSTER_NAME" >> $GITHUB_STEP_SUMMARY
 
       - name: Summary
         if: always()

--- a/.github/workflows/nightly-e2e-disconnected.yml
+++ b/.github/workflows/nightly-e2e-disconnected.yml
@@ -15,6 +15,11 @@ on:
         required: false
         type: boolean
         default: false
+      skip-cleanup:
+        description: 'Skip cleanup after deployment (leave infrastructure running)'
+        required: false
+        type: boolean
+        default: false
 
 # Prevent concurrent nightly runs
 concurrency:
@@ -268,7 +273,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Cleanup infrastructure
-        if: always()
+        if: always() && (github.event_name == 'schedule' || inputs.skip-cleanup != true)
         run: |
           echo "## Cleanup Infrastructure" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -276,6 +281,20 @@ jobs:
           make clean
 
           echo "✅ Infrastructure cleaned up" >> $GITHUB_STEP_SUMMARY
+
+      - name: Cleanup skipped notice
+        if: always() && github.event_name == 'workflow_dispatch' && inputs.skip-cleanup == true
+        run: |
+          echo "## ⚠️ Cleanup Skipped" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Infrastructure cleanup was skipped as requested." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**⚠️ IMPORTANT**: Remember to manually clean up the infrastructure:" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+          echo "make clean" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Cluster name**: $ENCLAVE_CLUSTER_NAME" >> $GITHUB_STEP_SUMMARY
 
       - name: Summary
         if: always()


### PR DESCRIPTION
Add optional skip-cleanup checkbox when running nightly workflows manually. This allows keeping infrastructure running after deployment for debugging or manual testing.

Changes:
- Add skip-cleanup input parameter to both nightly workflows
- Cleanup step now checks if skip-cleanup is enabled
- Add warning notice when cleanup is skipped with cleanup instructions
- Scheduled runs always clean up regardless of setting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a skip-cleanup option to nightly E2E workflows. When run manually, users can skip automatic infrastructure cleanup; scheduled runs still clean up automatically.
  * When cleanup is skipped, the workflow now posts a clear notice with manual cleanup instructions and the cluster identifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->