### PR TITLE
fix(ssl): Check every 30 seconds, 30 times if the SSL is available

### DIFF
--- a/playbooks/tasks/configure_certificates.yaml
+++ b/playbooks/tasks/configure_certificates.yaml
@@ -90,8 +90,8 @@
     echo | openssl s_client -connect api.{{ clusterName }}.{{ baseDomain }}:6443 2>/dev/null \
       | openssl x509 -noout -fingerprint
   register: remote_fp
-  retries: 100
-  delay: 5
+  retries: 30
+  delay: 30
   until: remote_fp.stdout == local_fp.stdout
 
 - name: Remove certificate-authority-data from the kubeconfig

--- a/playbooks/tasks/post_install_config.yaml
+++ b/playbooks/tasks/post_install_config.yaml
@@ -51,8 +51,8 @@
     kind: ClusterOperator
     name: kube-apiserver
   register: co_info
-  retries: 100
-  delay: 5
+  retries: 30
+  delay: 30
   until: >
     (
       (


### PR DESCRIPTION
Allow more time for the apiservers to get the new certificate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized API server configuration wait behavior by reducing retry attempts while increasing delays between retries during certificate configuration and post-installation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->