### PR TITLE
mirror single operator channel with min and max version

### DIFF
--- a/defaults/model_operators.yaml
+++ b/defaults/model_operators.yaml
@@ -1,20 +1,34 @@
 ---
 model_operators:
   - name: nfd
+    version: 4.20.0-202602261925
     channel: stable
-  - name: gpu-operator-certified
-    channel: v25.10
+    init_version: 4.20.0-202509262039
   - name: limitador-operator
+    version: 1.3.0
     channel: stable
+    init_version: 1.3.0
   - name: authorino-operator
+    version: 1.3.0
     channel: stable
+    init_version: 1.3.0
   - name: dns-operator
+    version: 1.3.0
     channel: stable
+    init_version: 1.3.0
   - name: rhcl-operator
+    version: 1.3.0
     channel: stable
+    init_version: 1.3.0
   - name: leader-worker-set
+    version: 1.0.0
     channel: stable-v1.0
+    init_version: 1.0.0
   - name: rhods-operator
+    version: 3.3.0
     channel: fast-3.x
+    init_version: 3.0.0
   - name: servicemeshoperator3
+    version: 3.2.2
     channel: stable
+    init_version: 3.0.0

--- a/defaults/operators.yaml
+++ b/defaults/operators.yaml
@@ -4,24 +4,28 @@ operators:
   - name: quay-operator
     version: 3.15.3
     channel: stable-3.15
+    init_version: 3.15.0
     namespace: quay-enterprise
     source: cs-redhat-operator-index-v4-20
 
   - name: multicluster-engine
     version: 2.10.1
     channel: stable-2.10
+    init_version: 2.10.0
     namespace: multicluster-engine
     source: cs-redhat-operator-index-v4-20
 
   - name: advanced-cluster-management
     version: 2.15.1
     channel: release-2.15
+    init_version: 2.15.0
     namespace: open-cluster-management
     source: cs-redhat-operator-index-v4-20
 
   - name: cincinnati-operator
     version: 5.0.3
     channel: v1
+    init_version: 5.0.3
     namespace: openshift-update-service
     source: cs-redhat-operator-index-v4-20
     csvName: update-service-operator
@@ -29,6 +33,7 @@ operators:
   - name: openshift-gitops-operator
     version: 1.19.2
     channel: gitops-1.19
+    init_version: 1.19.0
     namespace: openshift-gitops-operator
     source: cs-redhat-operator-index-v4-20
     global: true
@@ -36,6 +41,7 @@ operators:
   - name: openshift-pipelines-operator-rh
     version: 1.20.3
     channel: pipelines-1.20
+    init_version: 1.20.0
     namespace: openshift-pipelines
     source: cs-redhat-operator-index-v4-20
     global: true
@@ -43,6 +49,7 @@ operators:
   - name: netobserv-operator
     version: 1.11.0
     channel: stable
+    init_version: 1.11.0
     namespace: openshift-netobserv-operator
     source: cs-redhat-operator-index-v4-20
     global: true
@@ -51,12 +58,14 @@ operators:
   - name: cluster-logging
     version: 6.4.2
     channel: stable-6.4
+    init_version: 6.4.0
     namespace: openshift-logging
     source: cs-redhat-operator-index-v4-20
 
   - name: loki-operator
     version: 6.4.2
     channel: stable-6.4
+    init_version: 6.4.0
     namespace: openshift-operators-redhat
     source: cs-redhat-operator-index-v4-20
     global: true
@@ -64,6 +73,7 @@ operators:
   - name: redhat-oadp-operator
     version: 1.5.5
     channel: stable
+    init_version: 1.5.0
     namespace: openshift-oadp
     source: cs-redhat-operator-index-v4-20
     csvName: oadp-operator
@@ -71,6 +81,7 @@ operators:
   - name: openshift-cert-manager-operator
     version: 1.18.1
     channel: stable-v1
+    init_version: 1.18.0
     namespace: cert-manager-operator
     source: cs-redhat-operator-index-v4-20
     csvName: cert-manager-operator
@@ -78,6 +89,7 @@ operators:
   - name: cluster-observability-operator
     version: 1.3.1
     channel: stable
+    init_version: 1.3.0
     namespace: openshift-cluster-observability-operator
     source: cs-redhat-operator-index-v4-20
     global: true
@@ -85,6 +97,7 @@ operators:
   - name: openshift-external-secrets-operator
     version: 1.0.0
     channel: stable-v1.0
+    init_version: 1.0.0
     namespace: external-secrets-operator
     source: cs-redhat-operator-index-v4-20
     global: true
@@ -93,12 +106,14 @@ operators:
   - name: compliance-operator
     version: 1.8.2
     channel: stable
+    init_version: 1.8.0
     namespace: openshift-compliance
     source: cs-redhat-operator-index-v4-20
 
   - name: metallb-operator
     version: 4.20.0-202602261925
     channel: stable
+    init_version: 4.20.0-202602091941
     namespace: metallb-system
     source: cs-redhat-operator-index-v4-20
     global: true
@@ -108,6 +123,7 @@ operators:
   - name: ansible-automation-platform-operator
     version: 2.5.0-0.1772612774
     channel: stable-2.5-cluster-scoped
+    init_version: 2.5.0-0.1768928092
     namespace: ansible-aap
     source: cs-redhat-operator-index-v4-20
     global: true

--- a/defaults/storage_operators.yaml
+++ b/defaults/storage_operators.yaml
@@ -3,11 +3,13 @@ storage_operators:  # Install operator depending blockStorageBackend variable
     name: odf-operator
     version: 4.20.7-rhodf
     channel: stable-4.20
+    init_version: 4.20.7-rhodf
     namespace: openshift-storage
     source: cs-redhat-operator-index-v4-20
   lvms:
     name: lvms-operator
     version: 4.20.0
     channel: stable-4.20
+    init_version: 4.20.0
     namespace: openshift-storage
     source: cs-redhat-operator-index-v4-20

--- a/defaults/storage_operators.yaml
+++ b/defaults/storage_operators.yaml
@@ -1,15 +1,15 @@
 storage_operators:  # Install operator depending blockStorageBackend variable
   odf:
-    name: odf-operator
-    version: 4.20.7-rhodf
-    channel: stable-4.20
-    init_version: 4.20.7-rhodf
-    namespace: openshift-storage
-    source: cs-redhat-operator-index-v4-20
+    - name: odf-operator
+      version: 4.20.7-rhodf
+      channel: stable-4.20
+      init_version: 4.20.7-rhodf
+      namespace: openshift-storage
+      source: cs-redhat-operator-index-v4-20
   lvms:
-    name: lvms-operator
-    version: 4.20.0
-    channel: stable-4.20
-    init_version: 4.20.0
-    namespace: openshift-storage
-    source: cs-redhat-operator-index-v4-20
+    - name: lvms-operator
+      version: 4.20.0
+      channel: stable-4.20
+      init_version: 4.20.0
+      namespace: openshift-storage
+      source: cs-redhat-operator-index-v4-20

--- a/operators/openshift-pipelines-operator-rh/operator_update_pipeline.yaml
+++ b/operators/openshift-pipelines-operator-rh/operator_update_pipeline.yaml
@@ -100,7 +100,7 @@
             script: |
                 #!/bin/bash
 
-                python ./operator_update.py "{{ [storage_operators[blockStorageBackend]] + operators }}" "$(params.dry-run)" > "$(results.status-report.path)"
+                python ./operator_update.py "{{ storage_operators[blockStorageBackend] + operators }}" "$(params.dry-run)" > "$(results.status-report.path)"
                 rc=$?
                 echo -n "${rc}" > "$(results.exit-code.path)"
                 exit "${rc}"

--- a/playbooks/tasks/configure_operators.yaml
+++ b/playbooks/tasks/configure_operators.yaml
@@ -9,7 +9,7 @@
 
     - name: Include configure_operator
       ansible.builtin.include_tasks: configure_operator.yaml
-      loop: "{{ [storage_operators[blockStorageBackend]] + operators }}"
+      loop: "{{ storage_operators[blockStorageBackend] + operators }}"
       loop_control:
         loop_var: operator
 

--- a/schemas/operators.yaml
+++ b/schemas/operators.yaml
@@ -54,6 +54,12 @@ properties:
     additionalProperties: false
     properties:
       odf:
-        $ref: "#/definitions/operator"
+        type: array
+        description: List of operators to install and configure.
+        items:
+          $ref: "#/definitions/operator"
       lvms:
-        $ref: "#/definitions/operator"
+        type: array
+        description: List of operators to install and configure.
+        items:
+          $ref: "#/definitions/operator"

--- a/schemas/operators.yaml
+++ b/schemas/operators.yaml
@@ -16,6 +16,9 @@ definitions:
       channel:
         type: string
         description: Update channel for the operator.
+      init_version:
+        type: string
+        description: Initial operator version.
       namespace:
         type: string
         description: Target namespace where the operator will be installed.
@@ -30,7 +33,9 @@ definitions:
         description: Configure operator to watch the entire cluster.
     required:
     - name
+    - version
     - channel
+    - init_version
 
 additionalProperties: false
 properties:

--- a/templates/imagesetconfiguration.yaml.j2
+++ b/templates/imagesetconfiguration.yaml.j2
@@ -14,12 +14,22 @@ mirror:
     - catalog: registry.redhat.io/redhat/certified-operator-index:v4.20
       packages:
         - name: gpu-operator-certified
+          defaultChannel: v25.10
+          channels:
+            - name: v25.10
+              minVersion: 25.10.0
+              maxVersion: 25.10.1
     - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.20
       packages:
         - name: kubevirt-hyperconverged
         - name: kubernetes-nmstate-operator
 {% for operator in operators + model_operators %}
         - name: {{ operator.name }}
+          defaultChannel: {{ operator.channel }}
+          channels:
+            - name: {{ operator.channel }}
+              minVersion: {{ operator.init_version }}
+              maxVersion: {{ operator.version }}
 {% endfor %}
         - name: "{{ storage_operators[blockStorageBackend].name }}"
 {% if blockStorageBackend == "odf" %}

--- a/templates/imagesetconfiguration.yaml.j2
+++ b/templates/imagesetconfiguration.yaml.j2
@@ -23,7 +23,7 @@ mirror:
       packages:
         - name: kubevirt-hyperconverged
         - name: kubernetes-nmstate-operator
-{% for operator in operators + model_operators %}
+{% for operator in operators + model_operators + storage_operators[blockStorageBackend] %}
         - name: {{ operator.name }}
           defaultChannel: {{ operator.channel }}
           channels:
@@ -31,7 +31,6 @@ mirror:
               minVersion: {{ operator.init_version }}
               maxVersion: {{ operator.version }}
 {% endfor %}
-        - name: "{{ storage_operators[blockStorageBackend].name }}"
 {% if blockStorageBackend == "odf" %}
         - name: mcg-operator
         - name: odf-csi-addons-operator


### PR DESCRIPTION
following up on #72

this PR reverts the above to mirror a single channel per operator, and adds a minVersion to start mirroring from. we also add maxVersion to mirror to.

this should limit the size of the content mirrored while explicitly defining the desired content to mirror without relying to oc-mirro defaults which are not functioning as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Operators now record an explicit initial-install version to improve install/version resolution.
  * Image set templates now include per-operator default channel and channel ranges for more precise version selection.

* **Configuration Updates**
  * Added initial-version entries for many operators (including storage and model operators) and aligned channel/version metadata.
  * Network observability operator package name configured for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->