### PR TITLE
cleanup mirroring definitions after single channel

### DIFF
--- a/templates/imagesetconfiguration.yaml.j2
+++ b/templates/imagesetconfiguration.yaml.j2
@@ -57,9 +57,6 @@ mirror:
     - name: {{ aap_bootstrap_job.image }}:{{ aap_bootstrap_job.tag }}
 
   blockedimages:
-    - name: registry.redhat.io/3scale-tech-preview/authorino-rhel9-operator
-    - name: registry.redhat.io/3scale-tech-preview/authorino-rhel9
-    - name: registry.redhat.io/3scale-tech-preview/authorino-operator-bundle
     - name: registry.redhat.io/rhoai/odh-dashboard-rhel8
     - name: registry.redhat.io/rhoai/odh-dashboard-rhel9
     - name: registry.redhat.io/rhoai/odh-codeflare-operator-rhel9
@@ -146,4 +143,3 @@ mirror:
     - name: registry.redhat.io/rhoai/odh-ml-pipelines-driver-rhel9
     - name: registry.redhat.io/rhoai/odh-ml-pipelines-launcher-rhel9
     - name: registry.redhat.io/rhoai/odh-ml-pipelines-runtime-generic-rhel9
-    - name: nvcr.io/nvidia/gpu-feature-discovery

--- a/templates/registries.conf.j2
+++ b/templates/registries.conf.j2
@@ -274,30 +274,12 @@
 
 [[registry]]
   prefix = ""
-  location = "registry.redhat.io/ansible-automation-platform-24"
-[[registry.mirror]]
-  location = "{{ quayHostname }}:8443/ansible-automation-platform-24"
-
-[[registry]]
-  prefix = ""
   location = "registry.redhat.io/ansible-automation-platform-25"
 [[registry.mirror]]
   location = "{{ quayHostname }}:8443/ansible-automation-platform-25"
 
 [[registry]]
   prefix = ""
-  location = "registry.redhat.io/ansible-automation-platform-26"
-[[registry.mirror]]
-  location = "{{ quayHostname }}:8443/ansible-automation-platform-26"
-
-[[registry]]
-  prefix = ""
   location = "registry.redhat.io/ansible-automation-platform"
 [[registry.mirror]]
   location = "{{ quayHostname }}:8443/ansible-automation-platform"
-
-[[registry]]
-  prefix = ""
-  location = "registry.redhat.io/ansible-automation-platform-tech-preview"
-[[registry.mirror]]
-  location = "{{ quayHostname }}:8443/ansible-automation-platform-tech-preview"


### PR DESCRIPTION
cleanup after #86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed image restrictions for Authorino and NVIDIA GPU Feature Discovery components from the blocklist
  * Removed registry configurations for Ansible Automation Platform versions 24, 26, and tech-preview

<!-- end of auto-generated comment: release notes by coderabbit.ai -->