### PR TITLE
Set defaults for RadosGW chunk size parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Operator version pinning.
+- Optional chunk size parameters support for RadosGW storage.
 
 ### Fixed
 

--- a/config/global.example.yaml
+++ b/config/global.example.yaml
@@ -45,6 +45,9 @@ quayBackendRGWConfiguration:
   secret_key: YOUR_S3_SECRET_KEY
   bucket_name: YOUR_S3_BUCKET_NAME
   hostname: YOUR_RADOSGW_ENDPOINT_HOSTNAME
+  # Uncomment only to override
+  # minimum_chunk_size_mb: YOUR_MIN_CHUNK_SIZE_MB  # Default: 100
+  # maximum_chunk_size_mb: YOUR_MAX_CHUNK_SIZE_MB  # Default: 500
 
 # Option 2: Local storage (NOT recommended for production)
 # quayBackend: LocalStorage

--- a/defaults/quay_operator.yaml
+++ b/defaults/quay_operator.yaml
@@ -11,3 +11,6 @@ quayBackendDefaults:
 quayBackendRGWDefaults:
   is_secure: true
   port: 443
+  minimum_chunk_size_mb: 100
+  maximum_chunk_size_mb: 500
+  server_side_assembly: true

--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -694,6 +694,9 @@ quayBackendRGWConfiguration:
   secret_key: YOUR_S3_SECRET_KEY_HERE
   bucket_name: quay-bucket-name
   hostname: ocs-storagecluster-cephobjectstore-openshift-storage.apps.store.enclave-test.nodns.in
+  # Uncomment only to override
+  # minimum_chunk_size_mb: YOUR_MIN_CHUNK_SIZE_MB  # Default: 100
+  # maximum_chunk_size_mb: YOUR_MAX_CHUNK_SIZE_MB  # Default: 500
 ```
 
 **Note**: Replace `YOUR_S3_ACCESS_KEY_HERE` and `YOUR_S3_SECRET_KEY_HERE` with your actual S3/RadosGW credentials.
@@ -709,12 +712,16 @@ quayBackendRGWConfiguration:
 | `is_secure` | Use HTTPS | `true` | `false` |
 | `port` | Port number | `443` | `8080` |
 | `storage_path` | Path prefix in bucket | `/datastorage/registry` | `/custom/path` |
+| `minimum_chunk_size_mb` | Minimum multipart upload chunk size (MB) | `100` | `50` |
+| `maximum_chunk_size_mb` | Maximum multipart upload chunk size (MB) | `500` | `800` |
 
 **Notes**:
 - Access and secret keys are created when setting up Ceph/RadosGW
 - Bucket must exist before Quay configuration
 - Hostname should be the OCP route for RadosGW service
 - `is_secure`, `port`, and `storage_path` have defaults in `defaults/quay_operator.yaml` and only need to be set here when overriding those defaults
+- `minimum_chunk_size_mb` and `maximum_chunk_size_mb` default to `100` and `500` respectively; override in `quayBackendRGWConfiguration` if needed
+- `server_side_assembly` is always enabled as it is included in the defaults alongside `maximum_chunk_size_mb`
 
 ### Pull Secrets
 

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -373,6 +373,9 @@ quayBackendRGWConfiguration:
   bucket_name: quay-bucket-name
   hostname: ocs-storagecluster-cephobjectstore-openshift-storage.apps.store.enclave-test.nodns.in
   # is_secure, port, and storage_path have defaults in defaults/quay_operator.yaml
+  # Uncomment only to override
+  # minimum_chunk_size_mb: YOUR_MIN_CHUNK_SIZE_MB  # Default: 100
+  # maximum_chunk_size_mb: YOUR_MAX_CHUNK_SIZE_MB  # Default: 500
 
 # Pull secret (combines public and internal registry secrets) - can be downloaded from https://console.redhat.com/openshift/downloads
 pullSecret: {"auths":{"cloud.openshift.com":{"auth":"...","email":"..."},"quay.io":{"auth":"...","email":"..."}}}

--- a/schemas/quay_operator.yaml
+++ b/schemas/quay_operator.yaml
@@ -35,9 +35,23 @@ properties:
         description: Port for backend storage endpoint
         minimum: 1
         maximum: 65535
+      minimum_chunk_size_mb:
+        type: integer
+        description: Minimum multipart upload chunk size in MB
+        minimum: 1
+      maximum_chunk_size_mb:
+        type: integer
+        description: Maximum multipart upload chunk size in MB
+        minimum: 1
+      server_side_assembly:
+        type: boolean
+        description: Enable server-side assembly for multipart uploads
     required:
       - is_secure
       - port
+      - minimum_chunk_size_mb
+      - maximum_chunk_size_mb
+      - server_side_assembly
 
 required:
   - quayFeatureProxyStorage

--- a/validations.sh
+++ b/validations.sh
@@ -286,6 +286,24 @@ if [[ "$quay_backend" == "RadosGWStorage" ]]; then
     fi
     s3_endpoint=${s3_protocol}://${s3_hostname}:${s3_port}
 
+    min_chunk=$(getValue .quayBackendRGWConfiguration.minimum_chunk_size_mb)
+    if [[ -n "$min_chunk" && "$min_chunk" != "null" ]]; then
+        if ! [[ "$min_chunk" =~ ^[0-9]+$ ]]; then
+            validation fail minimum_chunk_size_mb "minimum_chunk_size_mb must be an integer, got: $min_chunk"
+        else
+            validation pass minimum_chunk_size_mb "minimum_chunk_size_mb is a valid integer ($min_chunk)"
+        fi
+    fi
+
+    max_chunk=$(getValue .quayBackendRGWConfiguration.maximum_chunk_size_mb)
+    if [[ -n "$max_chunk" && "$max_chunk" != "null" ]]; then
+        if ! [[ "$max_chunk" =~ ^[0-9]+$ ]]; then
+            validation fail maximum_chunk_size_mb "maximum_chunk_size_mb must be an integer, got: $max_chunk"
+        else
+            validation pass maximum_chunk_size_mb "maximum_chunk_size_mb is a valid integer ($max_chunk)"
+        fi
+    fi
+
     s3_endpoint_curl_return=$(curl -o /dev/null -s -w '%{http_code}' $s3_endpoint)
     if [[ \
             $s3_endpoint_curl_return != 200 && \


### PR DESCRIPTION
Set `minimum_chunk_size_mb` (100) and `maximum_chunk_size_mb` (500) as defaults in `quayBackendRGWDefaults`, with `server_side_assembly` always enabled.

Integer validation for both parameters is added to `validations.sh` when the values are overridden in `config/global.yaml`.

References:
- https://docs.redhat.com/en/documentation/red_hat_quay/3/html-single/configure_red_hat_quay/index#config-fields-storage-rados
- https://docs.redhat.com/en/documentation/red_hat_quay/3/html/manage_red_hat_quay/preparing-registry-large-artifacts

MGMT-23416


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional chunk-size settings for RadosGW storage: minimum_chunk_size_mb (default 100 MB) and maximum_chunk_size_mb (default 500 MB).
  * Enabled server-side assembly for RadosGW operations.
  * Added runtime validations to ensure chunk-size parameters are integers when provided.

* **Documentation**
  * Updated configuration reference and deployment guidance with examples, defaults, and notes for the new RadosGW parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->