### PR TITLE
Fix nightly workflow naming to prevent conflicts on manual runs

### DIFF
--- a/.github/workflows/nightly-e2e-connected.yml
+++ b/.github/workflows/nightly-e2e-connected.yml
@@ -39,11 +39,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Generate cluster name with date
+      - name: Generate cluster name
         uses: ./.github/actions/setup-cluster-name
         with:
-          naming-strategy: date
+          naming-strategy: hash
           prefix: nc
+          run-id: ${{ github.run_id }}
 
       - name: Setup cluster-specific working directory
         run: |

--- a/.github/workflows/nightly-e2e-disconnected.yml
+++ b/.github/workflows/nightly-e2e-disconnected.yml
@@ -39,11 +39,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Generate cluster name with date
+      - name: Generate cluster name
         uses: ./.github/actions/setup-cluster-name
         with:
-          naming-strategy: date
+          naming-strategy: hash
           prefix: nd
+          run-id: ${{ github.run_id }}
 
       - name: Setup cluster-specific working directory
         run: |


### PR DESCRIPTION
Change nightly workflows from date-based to hash-based naming strategy to prevent conflicts when manually triggering workflows multiple times in the same day.

Changes:
- Switch from naming-strategy: date to naming-strategy: hash
- Add run-id parameter for unique hash generation per workflow run
- Ensures unique cluster names for both scheduled and manual runs

Before: nd-20260312 (conflicts on multiple manual runs same day)
After: nd-a1b2c3d4 (unique hash per run, no conflicts)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nightly E2E test infrastructure to use hash-based cluster naming instead of date-based naming and improved run identification tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->