### PR TITLE
operator update retry on all errors

### DIFF
--- a/hack/operator_update.py
+++ b/hack/operator_update.py
@@ -31,10 +31,9 @@ def wait_for_resource_status(
         )
         if result.returncode != 0:
             stderr = (result.stderr or "").strip()
-            if "not found" not in stderr.lower():
-                raise RuntimeError(
-                    f"Failed to read {kind}/{name} in namespace {namespace}: {stderr}"
-                )
+            print(f"Failed to read {kind}/{name} in namespace {namespace}: {stderr}")
+            time.sleep(10)
+            continue
 
         current_state = parse_jsonpath_value(result.stdout or "")
         if current_state == desired_state:

--- a/hack/operator_update.py
+++ b/hack/operator_update.py
@@ -32,15 +32,15 @@ def wait_for_resource_status(
         if result.returncode != 0:
             stderr = (result.stderr or "").strip()
             print(f"Failed to read {kind}/{name} in namespace {namespace}: {stderr}")
-            time.sleep(10)
-            continue
 
-        current_state = parse_jsonpath_value(result.stdout or "")
-        if current_state == desired_state:
-            print(
-                f"{kind}/{name} in namespace {namespace} has reached status.{status_field}={desired_state}."
-            )
-            return
+        else:
+            current_state = parse_jsonpath_value(result.stdout or "")
+            if current_state == desired_state:
+                print(
+                    f"{kind}/{name} in namespace {namespace} has reached status.{status_field}={desired_state}."
+                )
+                return
+
         if time.time() > timeout:
             raise TimeoutError(
                 f"{kind}/{name} in namespace {namespace} did not reach status.{status_field}={desired_state} within {timeout_minutes} minutes (current state: {current_state})"

--- a/hack/operator_update.py
+++ b/hack/operator_update.py
@@ -33,14 +33,12 @@ def wait_for_resource_status(
             stderr = (result.stderr or "").strip()
             print(f"Failed to read {kind}/{name} in namespace {namespace}: {stderr}")
 
-        else:
-            current_state = parse_jsonpath_value(result.stdout or "")
-            if current_state == desired_state:
-                print(
-                    f"{kind}/{name} in namespace {namespace} has reached status.{status_field}={desired_state}."
-                )
-                return
-
+        current_state = parse_jsonpath_value(result.stdout or "")
+        if current_state == desired_state:
+            print(
+                f"{kind}/{name} in namespace {namespace} has reached status.{status_field}={desired_state}."
+            )
+            return
         if time.time() > timeout:
             raise TimeoutError(
                 f"{kind}/{name} in namespace {namespace} did not reach status.{status_field}={desired_state} within {timeout_minutes} minutes (current state: {current_state})"


### PR DESCRIPTION
one error that is not covered is a timeout from the server. there are likely more errors.

the optimization of checking "not found" is not worth the resiliency of singling out error by error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during resource status checks: subprocess errors are now logged and treated as non-fatal, allowing automatic retries instead of immediate termination. This reduces unexpected stops and improves reliability of monitoring operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->