### PR TITLE
AAP version

### DIFF
--- a/defaults/operators.yaml
+++ b/defaults/operators.yaml
@@ -121,9 +121,9 @@ operators:
 
   # AAP is a dependency for osac-operator
   - name: ansible-automation-platform-operator
-    version: 2.5.0-0.1772612774
+    version: 2.5.0
     channel: stable-2.5-cluster-scoped
-    init_version: 2.5.0-0.1768928092
+    init_version: 2.5.0
     namespace: ansible-aap
     source: cs-redhat-operator-index-v4-20
     global: true


### PR DESCRIPTION
```
$ oc logs -n openshift-marketplace cs-redhat-operator-index-v4-20-7jn77                                                            
time="2026-03-12T13:45:15Z" level=info msg="starting pprof endpoint" address="localhost:6060"                                                                                                                                                                                                                                
time="2026-03-12T13:45:15Z" level=info msg="cache directory is empty, using preferred backend" backend=pogreb.v1 cache=/tmp/opm-serve-cache-2702672504 configs=/configs
time="2026-03-12T13:45:15Z" level=info msg="building cache" cache=/tmp/opm-serve-cache-2702672504 configs=/configs
time="2026-03-12T13:45:15Z" level=fatal msg="failed to load or rebuild cache: failed to rebuild cache: build package index: process package \"ansible-automation-platform-operator\": invalid index:\n└── invalid package \"ansible-automation-platform-operator\":\n    └── invalid channel \"stable-2.5-cluster-scoped\":\n
        └── channel must contain at least one bundle"
```