### PR TITLE
Allow parallel nightly workflow runs with unique concurrency groups

### DIFF
--- a/.github/workflows/nightly-e2e-connected.yml
+++ b/.github/workflows/nightly-e2e-connected.yml
@@ -21,9 +21,9 @@ on:
         type: boolean
         default: false
 
-# Prevent concurrent nightly runs
+# Allow parallel runs with unique concurrency groups per run
 concurrency:
-  group: nightly-connected
+  group: nightly-connected-${{ github.run_id }}
   cancel-in-progress: false
 
 jobs:
@@ -44,7 +44,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Generate cluster name
+      - name: Generate cluster name with hash
         uses: ./.github/actions/setup-cluster-name
         with:
           naming-strategy: hash

--- a/.github/workflows/nightly-e2e-disconnected.yml
+++ b/.github/workflows/nightly-e2e-disconnected.yml
@@ -21,9 +21,9 @@ on:
         type: boolean
         default: false
 
-# Prevent concurrent nightly runs
+# Allow parallel runs with unique concurrency groups per run
 concurrency:
-  group: nightly-disconnected
+  group: nightly-disconnected-${{ github.run_id }}
   cancel-in-progress: false
 
 jobs:
@@ -44,7 +44,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Generate cluster name
+      - name: Generate cluster name with hash
         uses: ./.github/actions/setup-cluster-name
         with:
           naming-strategy: hash


### PR DESCRIPTION
Updated both nightly E2E workflows (connected and disconnected) to use unique concurrency groups per run by incorporating github.run_id. This allows multiple manual runs to execute in parallel without blocking.

Changes:
- Concurrency group: nightly-connected -> nightly-connected-${{ github.run_id }}
- Concurrency group: nightly-disconnected -> nightly-disconnected-${{ github.run_id }}
- Updated comments to reflect parallel execution support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Nightly test workflows updated to allow parallel runs using per-run concurrency groups, improving test throughput.
  * Cluster naming for test runs changed from date-based to hash-based and now includes the run identifier for more reliable, unique test environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->