### PR TITLE
ansible-automation-platform-operator versioning fix attempt

### DIFF
--- a/defaults/operators.yaml
+++ b/defaults/operators.yaml
@@ -121,9 +121,9 @@ operators:
 
   # AAP is a dependency for osac-operator
   - name: ansible-automation-platform-operator
-    version: 2.5.0
+    version: 2.5.0+0.1772612774
     channel: stable-2.5-cluster-scoped
-    init_version: 2.5.0
+    init_version: 2.5.0+0.1768928092
     namespace: ansible-aap
     source: cs-redhat-operator-index-v4-20
     global: true

--- a/hack/operator_update.py
+++ b/hack/operator_update.py
@@ -143,7 +143,7 @@ def init_ns_op_version_map(
         op_csv_name = op.get("csvName")
         ns_op_version_map.setdefault(op_namespace, {})[
             op_csv_name or op_name
-        ] = op_version
+        ] = op_version.replace("+", "-")
 
     return ns_op_version_map
 

--- a/playbooks/tasks/configure_operator.yaml
+++ b/playbooks/tasks/configure_operator.yaml
@@ -97,7 +97,7 @@
         name: "{{ operator.name }}"
         source: "{{ operator.source if (disconnected | default(true)) else 'redhat-operators' }}"
         sourceNamespace: openshift-marketplace
-        startingCSV: "{{ operator.csvName | default(operator.name) }}.v{{ operator.version }}"
+        startingCSV: "{{ operator.csvName | default(operator.name) }}.v{{ operator.version | replace('+', '-') }}"
   register: r_sub_exists
   retries: "{{ k8s_retries }}"
   delay: "{{ k8s_delay }}"


### PR DESCRIPTION
<img width="1397" height="397" alt="image" src="https://github.com/user-attachments/assets/f9f9065b-fbda-417e-8df5-15f69c87f588" />

<img width="556" height="432" alt="image" src="https://github.com/user-attachments/assets/e3cce824-ec44-49af-8e30-3c41c76b309e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Operator entries now use build-specific version identifiers, so operator versions will reflect build-specific suffixes.
  * Version string handling improved: plus signs in versions are normalized to hyphens when forming CSV names and internal mappings, ensuring consistent observable version names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->