### PR TITLE
[resources tasks] Set limits openshift-external-secrets-operator

### DIFF
--- a/operators/openshift-external-secrets-operator/tasks.yaml
+++ b/operators/openshift-external-secrets-operator/tasks.yaml
@@ -4,7 +4,7 @@
     state: patched
     definition:
       apiVersion: operators.coreos.com/v1alpha1
-      kind: subscription
+      kind: Subscription
       metadata:
         name: openshift-external-secrets-operator
         namespace: external-secrets-operator
@@ -13,3 +13,7 @@
           resources:
             limits:
               cpu: 100m
+              memory: 1Gi
+            requests:
+              cpu: 100m
+              memory: 1Gi

--- a/operators/openshift-external-secrets-operator/tasks.yaml
+++ b/operators/openshift-external-secrets-operator/tasks.yaml
@@ -1,3 +1,15 @@
 ---
-- ansible.builtin.debug:
-    msg: "Operator configured properly, no further actions"
+- name: Patch Subscription openshift-external-secrets-operator to set resources
+  kubernetes.core.k8s:
+    state: patched
+    definition:
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: subscription
+      metadata:
+        name: openshift-external-secrets-operator
+        namespace: external-secrets-operator
+      spec:
+        config:
+          resources:
+            limits:
+              cpu: 100m


### PR DESCRIPTION
Task for https://github.com/gori-project/GoRI/issues/716

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resource limits and requests for CPU and memory are now applied to the external-secrets-operator.
  * Previous debug behavior removed; CPU limit set to 100m and corresponding memory values configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->