### PR TITLE
Move discovery cloud infra agents to runtime from crontab

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -189,6 +189,14 @@ printf '%b\n' "$(tail -3 ${workingDir}/ocp-cluster/.openshift_install.log \
   | sed -e 's/^"//' -e 's/"$//' -e 's/\\n/\
 /g' -e 's/\\"/"/g')"
 
+echo -p "Start discovering nodes.. " -n1 -s
+    if [ -f $cloud_infra_vars ]; then
+        if ! ansible-playbook -e @$global_vars -e @$certs_vars -e @$cloud_infra_vars playbooks/07-configure-discovery.yaml; then
+            echo -e "\\033[31m WARNING! \033[0m  Discovery hosts has failed, please check config and rerun: ansible-playbook -e @$global_vars -e @$certs_vars -e @$cloud_infra_vars playbooks/07-configure-discovery.yaml"
+        fi
+    fi
+echo -e "\e[38;5;10m Done...\033[0m"; date
+
 echo -p "Deploying Partner OverLay .. " -n1 -s
     if [ -f ./partner-install/start.sh ]; then
         bash ./partner-install/start.sh ${workingDir}/ocp-cluster/auth/kubeconfig ${global_vars} ${certs_vars} 2>&1 >> ${log}

--- a/playbooks/04-post-install.yaml
+++ b/playbooks/04-post-install.yaml
@@ -3,7 +3,6 @@
 # This phase is common to both modes
 #
 # Performs:
-# - Discovery crontab setup
 # - Namespace and secret creation
 # - TLS certificate configuration
 # - API server health checks

--- a/playbooks/tasks/post_install_config.yaml
+++ b/playbooks/tasks/post_install_config.yaml
@@ -1,10 +1,3 @@
-- name: Add discovery crontab task
-  ansible.builtin.cron:
-    name: "Cloud hardware - discovery and recycle"
-    minute: "0"
-    hour: "*"
-    job: "cd {{ playbook_dir }}/../ && /usr/bin/ansible-playbook -e @config/global.yaml -e @config/certificates.yaml -e @config/cloud_infra.yaml playbooks/07-configure-discovery.yaml"
-
 - name: "Ensure redhat-lz-admin Namespace exists"
   environment:
     KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added node discovery step during initial setup phase when cloud infrastructure variables are available.

* **Changes**
  * Removed automatic scheduled discovery process. Node discovery now occurs during bootstrap instead of periodically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->