### PR TITLE
add option to enable/disable openshift-ai and nvidia-gpu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,5 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - User input variables restructure under `config`.
+- OpenShift AI and Nvidia GPU functionality feature flags.
 
 ### Removed

--- a/config/global.example.yaml
+++ b/config/global.example.yaml
@@ -120,3 +120,8 @@ agent_hosts:
 # instead of the macAddress and ipAddress parameters
 # See docs/CONFIGURATION_REFERENCE.md for reference
 
+# Enable OpenShift AI support
+enable_openshift_ai: false
+
+# Enable NVIDIA GPU support
+enable_nvidia_gpu: false

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -537,6 +537,13 @@ Each operator in the `operators` list requires:
 - `source`: Catalog source name (from oc-mirror)
 - `config`: (Optional) Operator-specific configuration
 
+### Additional Functionality Configuration
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `enable_openshift_ai` | Enable OpenShift AI features | `true` |
+| `enable_nvidia_gpu` | Enable Nvidia GPU functionality | `true` |
+
 ### SSL Certificates
 
 Certificates are stored in `config/certificates.yaml` and must be provided in PEM format:

--- a/files/model-configuration/10-policy.yaml.j2
+++ b/files/model-configuration/10-policy.yaml.j2
@@ -175,6 +175,7 @@ spec:
               operand:
                 imagePullPolicy: IfNotPresent
                 servicePort: 12000
+{% if enable_nvidia_gpu | default(false) %}
         # Install NVIDIA GPU Operator
         - complianceType: mustonlyhave
           metadataComplianceType: musthave
@@ -300,6 +301,7 @@ spec:
                 enabled: false
               gdrcopy:
                 enabled: false
+{% endif %}
         # Install cert-manager for Red Hat OpenShift
         - complianceType: mustonlyhave
           metadataComplianceType: musthave

--- a/playbooks/06-day2.yaml
+++ b/playbooks/06-day2.yaml
@@ -74,6 +74,7 @@
       tags: acm-policy-catalogsources
 
     - name: Model configurations
+      when: enable_openshift_ai | default(false)
       ansible.builtin.include_tasks:
         file: tasks/model_config.yaml
         apply:

--- a/sync.sh
+++ b/sync.sh
@@ -83,3 +83,7 @@ echo -e "\e[38;5;10m Done...\033[0m"; date
 echo -p "ACM ClusterImageSets .." -n1 -s
     ansible-playbook playbooks/06-day2.yaml -e@$global_vars -e@$certs_vars --tags acm-cis 2>&1 | tee -a ${log}
 echo -e "\e[38;5;10m Done...\033[0m"; date
+
+echo -p "Model config.. " -n1 -s
+    ansible-playbook playbooks/06-day2.yaml -e@$global_vars -e@$certs_vars --tags model-config 2>&1 | tee -a ${log}
+echo -e "\e[38;5;10m Done...\033[0m"; date

--- a/templates/imagesetconfiguration.yaml.j2
+++ b/templates/imagesetconfiguration.yaml.j2
@@ -11,6 +11,7 @@ mirror:
 {% endfor %}
     graph: true
   operators:
+{% if enable_nvidia_gpu | default(false) %}
     - catalog: registry.redhat.io/redhat/certified-operator-index:v4.20
       packages:
         - name: gpu-operator-certified
@@ -19,11 +20,12 @@ mirror:
             - name: v25.10
               minVersion: 25.10.0
               maxVersion: 25.10.1
+{% endif %}
     - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.20
       packages:
         - name: kubevirt-hyperconverged
         - name: kubernetes-nmstate-operator
-{% for operator in operators + model_operators + storage_operators[blockStorageBackend] %}
+{% for operator in operators + (model_operators if (enable_openshift_ai | default(false)) else []) + storage_operators[blockStorageBackend] %}
         - name: {{ operator.name }}
           defaultChannel: {{ operator.channel }}
           channels:
@@ -56,6 +58,7 @@ mirror:
     - name: {{ osac_operator.image }}:{{ osac_operator.tag }}
     - name: {{ aap_bootstrap_job.image }}:{{ aap_bootstrap_job.tag }}
 
+{% if enable_openshift_ai | default(false) %}
   blockedimages:
     - name: registry.redhat.io/rhoai/odh-dashboard-rhel8
     - name: registry.redhat.io/rhoai/odh-dashboard-rhel9
@@ -143,3 +146,4 @@ mirror:
     - name: registry.redhat.io/rhoai/odh-ml-pipelines-driver-rhel9
     - name: registry.redhat.io/rhoai/odh-ml-pipelines-launcher-rhel9
     - name: registry.redhat.io/rhoai/odh-ml-pipelines-runtime-generic-rhel9
+{% endif %}


### PR DESCRIPTION
part of:
- https://issues.redhat.com/browse/MGMT-23443
- https://issues.redhat.com/browse/MGMT-23442

in this PR we are adding 2 variables to the global configuration file:
- `enable_openShift_ai` - boolean, false by default
- `enable_nvidia_gpu` - boolean, false by default

the bootstrap process will include or not the required controls that implement these functionalities:
- mirror nvidia content
- apply acm policies

these functionalities may be enabled in day2 by updating the variables in the global configuration file and running `sync.sh`, which is the already established day2 entrypoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enable_openshift_ai and enable_nvidia_gpu flags to toggle OpenShift AI and NVIDIA GPU components (both default to disabled).
  * AI/GPU-related components and image entries are included only when their flags are enabled.

* **Documentation**
  * Deployment guide updated with the new configuration options and certificate formatting guidance.

* **Changed**
  * Changelog updated to reference the new feature flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->