### PR TITLE
clair import support multiple clair pods

### DIFF
--- a/operators/openshift-pipelines-operator-rh/clair_import_pipeline.yaml
+++ b/operators/openshift-pipelines-operator-rh/clair_import_pipeline.yaml
@@ -46,7 +46,7 @@
                 #!/bin/bash
                 set -uo pipefail
 
-                clair_pod_name=$(oc get pods -n quay-enterprise -l quay-component=clair-app -o name | cut -d/ -f2)
+                clair_pod_name=$(oc get pods -n quay-enterprise -l quay-component=clair-app -o name | cut -d/ -f2 | head -1)
                 if oc exec -n quay-enterprise "$clair_pod_name" -- \
                 /bin/sh -c "
                   curl -L -o /tmp/updates.json.gz http://{{ quayHostname }}/clair/updates.json.gz


### PR DESCRIPTION
part of https://issues.redhat.com/browse/MGMT-23486

follow up on #60 to enable the clair import task to find a single pod where there may be multiple.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated pod selection logic to target the first available pod instead of the last, improving consistency in pod targeting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->