### PR TITLE
add commit sha to e2e connected/disconnected slack notification

### DIFF
--- a/.github/actions/notify-slack/action.yml
+++ b/.github/actions/notify-slack/action.yml
@@ -20,6 +20,9 @@ inputs:
   branch-name:
     description: 'Git branch name'
     required: true
+  commit-sha:
+    description: 'Git commit sha'
+    required: true
   failed-step:
     description: 'Name of the failed step (optional, for failure notifications)'
     required: false
@@ -39,6 +42,7 @@ runs:
         INPUT_WORKFLOW_NAME: ${{ inputs.workflow-name }}
         INPUT_CLUSTER_NAME: ${{ inputs.cluster-name }}
         INPUT_BRANCH_NAME: ${{ inputs.branch-name }}
+        INPUT_COMMIT_SHA: ${{ inputs.commit-sha }}
         INPUT_WORKFLOW_URL: ${{ inputs.workflow-url }}
         INPUT_FAILED_STEP: ${{ inputs.failed-step }}
         INPUT_ARTIFACT_URL: ${{ inputs.artifact-url }}
@@ -70,13 +74,14 @@ runs:
         FIELDS=$(jq -n \
           --arg cluster "$INPUT_CLUSTER_NAME" \
           --arg branch "$INPUT_BRANCH_NAME" \
+          --arg commit "$INPUT_COMMIT_SHA" \
           --arg workflow_url "$INPUT_WORKFLOW_URL" \
           --arg status "$STATUS_TEXT" \
           --arg failed_step "$INPUT_FAILED_STEP" \
           --arg artifact_url "$INPUT_ARTIFACT_URL" \
           '[
             {"type": "mrkdwn", "text": ("*Cluster:*\n" + $cluster)},
-            {"type": "mrkdwn", "text": ("*Branch:*\n" + $branch)},
+            {"type": "mrkdwn", "text": ("*Branch:*\n" + $branch + "(Commit: " + $commit + ")")},
             {"type": "mrkdwn", "text": ("*Workflow:*\n<" + $workflow_url + "|View Run>")},
             (if ($failed_step != "") then
               {"type": "mrkdwn", "text": ("*Failed at:*\n" + $failed_step)}

--- a/.github/actions/notify-slack/action.yml
+++ b/.github/actions/notify-slack/action.yml
@@ -81,7 +81,7 @@ runs:
           --arg artifact_url "$INPUT_ARTIFACT_URL" \
           '[
             {"type": "mrkdwn", "text": ("*Cluster:*\n" + $cluster)},
-            {"type": "mrkdwn", "text": ("*Branch:*\n" + $branch + "(Commit: " + $commit + ")")},
+            {"type": "mrkdwn", "text": ("*Branch:*\n" + $branch + " (Commit: " + $commit + ")")},
             {"type": "mrkdwn", "text": ("*Workflow:*\n<" + $workflow_url + "|View Run>")},
             (if ($failed_step != "") then
               {"type": "mrkdwn", "text": ("*Failed at:*\n" + $failed_step)}

--- a/.github/workflows/nightly-e2e-connected.yml
+++ b/.github/workflows/nightly-e2e-connected.yml
@@ -339,5 +339,6 @@ jobs:
           slack-webhook-urls: ${{ secrets.SLACK_WEBHOOK_URLS }}
           workflow-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           branch-name: ${{ github.ref_name }}
+          commit-sha: ${{ github.sha }}
           failed-step: ${{ steps.failed_step.outputs.FAILED_STEP }}
           artifact-url: ${{ steps.artifact_url.outputs.ARTIFACT_URL }}

--- a/.github/workflows/nightly-e2e-disconnected.yml
+++ b/.github/workflows/nightly-e2e-disconnected.yml
@@ -362,5 +362,6 @@ jobs:
           slack-webhook-urls: ${{ secrets.SLACK_WEBHOOK_URLS }}
           workflow-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           branch-name: ${{ github.ref_name }}
+          commit-sha: ${{ github.sha }}
           failed-step: ${{ steps.failed_step.outputs.FAILED_STEP }}
           artifact-url: ${{ steps.artifact_url.outputs.ARTIFACT_URL }}


### PR DESCRIPTION
to distinguish between runs based on commit sha right from the slack notification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slack notifications now display the commit SHA alongside branch information for better traceability of deployments and CI runs.
  * Nightly workflows updated to send commit SHA with notification messages, improving observability of which commit triggered each alert.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->