### PR TITLE
check that all ansible collections exist to avoid failing on a directory with partial content

### DIFF
--- a/setup_ansible.sh
+++ b/setup_ansible.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 # Download Ansible Collections to check the checksum
 # Check if the 'collections' directory exists and has files in it
-if [ -d "collections" ] && [ "$(ls -A collections)" ]; then
+if [ -d "collections" ] && [ "$(ls -A collections)" ] && sha256sum --status -c ansible_collections.sha256; then
     echo "Collections already exist. Skipping download."
 else
     echo "Collections not found or empty. Downloading..."


### PR DESCRIPTION
without this change, a directory called `collections` that contains any files will cause the script to skip downloading ansible collections.

in this PR we explicitly check that all ansible collections exist and match the requirements to decide on skipping download.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced download validation to verify checksum integrity during setup initialization, ensuring collection files are not corrupted or incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->