### PR TITLE
disable quay feature quota management

### DIFF
--- a/defaults/quay_operator.yaml
+++ b/defaults/quay_operator.yaml
@@ -1,7 +1,7 @@
 ---
 # Quay features
 quayFeatureProxyStorage: true
-quayFeatureQuotaManagement: true
+quayFeatureQuotaManagement: false
 
 # Default storage configuration for all Quay backends
 quayBackendDefaults:


### PR DESCRIPTION
test mirror speed without quota management.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default configuration for the quota management feature. Quota management is now disabled by default, enabling more flexible deployments and simplified setup for users who don't require this capability. Administrators and operators can enable quota management through their configuration settings as needed for their specific deployment requirements and use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->