### PR TITLE
Landing zone: increase disk size in disconnected mode

### DIFF
--- a/scripts/infrastructure/provision_landing_zone.sh
+++ b/scripts/infrastructure/provision_landing_zone.sh
@@ -272,11 +272,16 @@ sudo qemu-img convert -f qcow2 -O qcow2 \
     "${LZ_WORKING_DIR}/${CLOUD_IMAGE_NAME}" \
     "${POOL_PATH}/${LZ_VM_NAME}.qcow2"
 
-# Resize to 700GB (needed for OpenShift image mirroring)
-# Provides ample space for: Quay storage ~130GB, oc-mirror workspace ~7GB,
-# ISO files ~3GB, binaries ~3GB, OS and other ~7GB, plus large buffer
-info "Resizing disk to 700GB..."
-sudo qemu-img resize "${POOL_PATH}/${LZ_VM_NAME}.qcow2" 700G
+# Resize disk: 1000GB for disconnected deployment, 600GB otherwise
+if is_enclave_disconnected; then
+    LZ_DISK_SIZE="1000G"
+else
+    LZ_DISK_SIZE="600G"
+fi
+# 600GB: Quay ~130GB, oc-mirror ~7GB, ISO ~3GB, binaries ~3GB, OS and buffer
+# 1000GB: extra headroom for full release mirror and OLM catalogs in disconnected env
+info "Resizing disk to ${LZ_DISK_SIZE}..."
+sudo qemu-img resize "${POOL_PATH}/${LZ_VM_NAME}.qcow2" "$LZ_DISK_SIZE"
 
 # Refresh pool so libvirt sees the new volume
 info "Refreshing libvirt pool..."

--- a/scripts/lib/config.sh
+++ b/scripts/lib/config.sh
@@ -12,6 +12,7 @@
 # Functions:
 #   load_devscripts_config [CLUSTER_NAME]  - Load dev-scripts config file (required)
 #   try_load_devscripts_config [CLUSTER_NAME] - Load dev-scripts config (optional, no error)
+#   is_enclave_disconnected               - True if ENCLAVE_DEPLOYMENT_MODE=disconnected
 #   get_env_json_value PATH [ENV_FILE]     - Extract value from environment.json using jq
 
 # Load dev-scripts configuration file for a cluster
@@ -58,6 +59,13 @@ try_load_devscripts_config() {
     # shellcheck source=/dev/null
     source "$config_file"
     return 0
+}
+
+# Return 0 if Enclave is running in disconnected mode.
+# Uses ENCLAVE_DEPLOYMENT_MODE: "disconnected" (case-insensitive) = true, anything else = false.
+is_enclave_disconnected() {
+    local deployment_mode="${ENCLAVE_DEPLOYMENT_MODE:-}"
+    [[ "${deployment_mode,,}" == "disconnected" ]]
 }
 
 # Extract a value from environment.json using jq


### PR DESCRIPTION
- Add is_enclave_disconnected() in config.sh: returns true when ENCLAVE_DEPLOYMENT_MODE=disconnected (case-insensitive).
- provision_landing_zone.sh: resize LZ disk to 1000G when disconnected, 600G otherwise, using is_enclave_disconnected().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Provisioning now dynamically allocates disk space based on deployment mode: ~600GB for connected deployments and ~1000GB for disconnected deployments (replacing a fixed size).
  * Improved informational messaging during the provisioning flow for clearer setup progress visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->