### PR TITLE
Download content as root into /var/www/html

### DIFF
--- a/playbooks/tasks/download_content.yaml
+++ b/playbooks/tasks/download_content.yaml
@@ -1,5 +1,6 @@
 ---
 - name: Download live rootfs images
+  become: true
   ansible.builtin.get_url:
     url: "{{ rootfs_img.url }}"
     dest: "/var/www/html/{{ (rootfs_img.url | ansible.builtin.split('/'))[-1] }}"
@@ -9,6 +10,7 @@
     loop_var: rootfs_img
 
 - name: Download live rootfs isos
+  become: true
   ansible.builtin.get_url:
     url: "{{ rootfs_iso.url }}"
     dest: "/var/www/html/{{ (rootfs_iso.url | ansible.builtin.split('/'))[-1] }}"

--- a/scripts/deployment/install_enclave.sh
+++ b/scripts/deployment/install_enclave.sh
@@ -129,13 +129,11 @@ if ! command -v httpd &>/dev/null; then
     sudo systemctl start httpd
     echo "  Creating /var/www/html directory..."
     sudo mkdir -p /var/www/html
-    sudo chown -R cloud-user:cloud-user /var/www/html
     sudo chmod 755 /var/www/html
 else
     echo "  httpd is already installed"
     # Ensure directory exists and has correct permissions
     sudo mkdir -p /var/www/html
-    sudo chown -R cloud-user:cloud-user /var/www/html
     sudo chmod 755 /var/www/html
 fi
 


### PR DESCRIPTION
At some point we introduced this bug, but it was never triggered in CI because we're running chown in CI

In this PR we're restoring the original behaviour (running ansible with --become) as well as removing the chown in CI to catch this kind of things

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Stopped applying recursive ownership changes to the web content directory while retaining directory creation and permissions.
  * Deployment download tasks updated to run with elevated privileges when fetching live root filesystem images and ISOs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->