### PR TITLE
Fix pullSecret combine when surrounded by single quotes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ config/*.yaml
 debug.yaml
 .claude
 CLAUDE.md
+tmp/
 
 # IDE folders
 .vscode/

--- a/operators/quay-operator/tasks.yaml
+++ b/operators/quay-operator/tasks.yaml
@@ -189,7 +189,13 @@
 - name: Combine pull secrets for connected mode
   when: not (disconnected | default(true))
   ansible.builtin.set_fact:
-    pullSecretNew: "{{ pullSecret | ansible.builtin.combine(pullSecretQuay, recursive=true) }}"
+    # We need to check if the pullSecret is a string (surrounded by single quotes) or a dict/json (not surrounded)
+    pullSecretNew: >-
+      {% if pullSecret | type_debug == 'dict' %}
+        {{ pullSecret | ansible.builtin.combine(pullSecretQuay, recursive=true) | to_json }}
+      {% else %}
+        {{ pullSecret | from_json | ansible.builtin.combine(pullSecretQuay, recursive=true) | to_json }}
+      {% endif %}
 
 - name: Set pull secret for disconnected (no combine)
   when: disconnected | default(true)
@@ -206,7 +212,7 @@
         name: pull-secret
         namespace: openshift-config
       stringData:
-        .dockerconfigjson: "{{ pullSecretNew | to_json }}"
+        .dockerconfigjson: "{{ pullSecretNew }}"
       type: kubernetes.io/dockerconfigjson
   register: r_patch_cluster_pullsecret
   retries: "{{ k8s_retries }}"

--- a/playbooks/tasks/mirror_registry.yaml
+++ b/playbooks/tasks/mirror_registry.yaml
@@ -19,7 +19,13 @@
 
 - name: Combine pull secrets
   ansible.builtin.set_fact:
-    pullSecretNew: "{{ pullSecret | ansible.builtin.combine(pullSecretInternal, recursive=true) }}"
+    # We need to check if the pullSecret is a string (surrounded by single quotes) or a dict/json (not surrounded)
+    pullSecretNew: >-
+      {% if pullSecret | type_debug == 'dict' %}
+        {{ pullSecret | ansible.builtin.combine(pullSecretInternal, recursive=true) | to_json }}
+      {% else %}
+        {{ pullSecret | from_json | ansible.builtin.combine(pullSecretInternal, recursive=true) | to_json }}
+      {% endif %}
 
 - name: Create pull-secret file with the combination
   ansible.builtin.copy:


### PR DESCRIPTION
If pullSecret is surrounded by single quotes, ansible treats it as a string and not as a dictionary, and fails to merge it with another PS

This commit will convert to dict when needed, so PS can be written with or without single quotes surrounding it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull-secret handling for registry and mirror operations: credentials can be provided as native objects or JSON strings, are detected and parsed when needed, merged recursively, and avoid unnecessary re-serialization when updating cluster pull-secrets for more reliable updates.

* **Chores**
  * Added a temporary directory ignore pattern to prevent committing transient files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->