### PR TITLE
Add validation to check that agent_hosts has exactly 3 hosts

### DIFF
--- a/config/global.example.yaml
+++ b/config/global.example.yaml
@@ -117,7 +117,7 @@ agent_hosts:
     rootDisk: YOUR_ROOT_DISK_PATH     # Example: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: YOUR_REDFISH_USER
     redfishPassword: YOUR_REDFISH_PASSWORD
-  # Add more hosts as needed (minimum 3 for HA)
+  # Add a total of 3 agent hosts, no more, no less
 
 # For complex network setups you can use mapInterfaces and networkConfig
 # instead of the macAddress and ipAddress parameters

--- a/validations.sh
+++ b/validations.sh
@@ -250,6 +250,12 @@ validation pass pull_secret "Pull secret validated"
 ## Redfish
 validation_section redfish
 
+number_of_hosts=$(getValue .agent_hosts | jq length)
+if [[ $number_of_hosts -ne 3 ]]; then
+    validation fail number_of_agent_hosts "Number of agent_hosts is ${number_of_hosts}. It should be 3"
+fi
+validation pass number_of_agent_hosts "Number of agent_hosts is 3"
+
 # validate redfish access
 for host in 0 1 2; do
     host_name=$(getValue .agent_hosts[$host].name)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Validation now enforces exactly 3 agent hosts; misconfigurations trigger clear error messages.

* **Documentation**
  * Updated configuration guidance to clarify the strict 3-host requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->