### PR TITLE
e2e-disconnected: longer timeout and increase Quay PVC

### DIFF
--- a/.github/workflows/nightly-e2e-disconnected.yml
+++ b/.github/workflows/nightly-e2e-disconnected.yml
@@ -30,7 +30,7 @@ jobs:
   nightly-disconnected-deployment:
     name: Nightly Disconnected Deployment
     runs-on: [self-hosted, enclave-disconnected]
-    timeout-minutes: 480  # 8 hours
+    timeout-minutes: 600  # 10 hours
 
     env:
       DEV_SCRIPTS_PATH: ${{ vars.DEV_SCRIPTS_PATH }}

--- a/operators/quay-operator/quay_lvms.yaml
+++ b/operators/quay-operator/quay_lvms.yaml
@@ -94,7 +94,7 @@
             - ReadWriteOnce
           resources:
             requests:
-              storage: 600Gi
+              storage: 1000Gi
           storageClassName: lvms-vg1
 
   - name: Patch Quay app deployment to mount registry storage PVC (LVMS)

--- a/scripts/setup/configure_devscripts.sh
+++ b/scripts/setup/configure_devscripts.sh
@@ -74,13 +74,13 @@ echo "Creating dev-scripts configuration at: $CONFIG_FILE"
 ENCLAVE_NUM_MASTERS="${ENCLAVE_NUM_MASTERS:-3}"
 ENCLAVE_NUM_LANDINGZONE="${ENCLAVE_NUM_LANDINGZONE:-1}"
 
-# VM extra disk size: 800G for disconnected (mirroring), 60G for connected
+# VM extra disk size: 1200G for disconnected (mirroring), 60G for connected
 DEPLOYMENT_MODE="${ENCLAVE_DEPLOYMENT_MODE:-disconnected}"
 if [ "$DEPLOYMENT_MODE" = "connected" ]; then
     VM_EXTRADISKS_SIZE_VAL="60G"
     MASTER_MEMORY_VAL=24576    # 24 GB for connected
 else
-    VM_EXTRADISKS_SIZE_VAL="800G"
+    VM_EXTRADISKS_SIZE_VAL="1200G"
     MASTER_MEMORY_VAL=32768    # 32 GB for disconnected
 fi
 

--- a/scripts/setup/validate_prerequisites.sh
+++ b/scripts/setup/validate_prerequisites.sh
@@ -16,7 +16,14 @@ source "${ENCLAVE_DIR}/scripts/lib/output.sh"
 # Configuration
 DEV_SCRIPTS_PATH="${DEV_SCRIPTS_PATH:-}"
 MIN_RAM_GB=48
-MIN_DISK_GB=200
+
+# Required disk depends on deployment mode
+DEPLOYMENT_MODE="${ENCLAVE_DEPLOYMENT_MODE:-${DEPLOYMENT_MODE:-disconnected}}"
+if [[ "${DEPLOYMENT_MODE,,}" == "disconnected" ]]; then
+    MIN_DISK_GB=1200
+else
+    MIN_DISK_GB=200
+fi
 
 # Track validation status
 VALIDATION_FAILED=0
@@ -165,8 +172,9 @@ if [ -d "/opt" ]; then
     if [ "$AVAILABLE_GB" -ge "$MIN_DISK_GB" ]; then
         success "Sufficient disk space on /opt: ${AVAILABLE_GB}GB (minimum: ${MIN_DISK_GB}GB)"
     else
-        warning "Low disk space on /opt: ${AVAILABLE_GB}GB (recommended: ${MIN_DISK_GB}GB+)"
-        info_indent "Environment requires ~200GB (3 masters x 120GB + Landing Zone 60GB)"
+        warning "Low disk space on /opt: ${AVAILABLE_GB}GB (recommended: ${MIN_DISK_GB}GB+ for ${DEPLOYMENT_MODE} mode)"
+        info_indent "Disconnected: ~1200GB+ (VM extra disks 1200G for mirroring + masters + Landing Zone)"
+        info_indent "Connected: ~200GB (3 masters x 120GB + Landing Zone 60GB)"
     fi
 else
     warning "/opt directory does not exist (will be created)"


### PR DESCRIPTION
- nightly-e2e-disconnected: increase job timeout 8h -> 10h to avoid premature cancellation during mirror and full E2E
- quay_lvms: request 1000Gi for Quay registry storage (was 600Gi)
- configure_devscripts: VM extra disk 1200G for disconnected (was 800G) to support the larger mirror

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased timeout for nightly automated test runs (8h → 10h).
  * Expanded persistent storage allocation for LVMS setup (600Gi → 1000Gi).
  * Increased VM disk allocation for disconnected/mirroring deployment (800G → 1200G).
  * Added deployment-mode-aware disk validation: disconnected deployments now require a higher minimum disk (1000GB).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->