### PR TITLE
Fix duplicate platform.channels entries in imagesetconfiguration template

### DIFF
--- a/templates/imagesetconfiguration.yaml.j2
+++ b/templates/imagesetconfiguration.yaml.j2
@@ -4,10 +4,25 @@ apiVersion: mirror.openshift.io/v2alpha1
 mirror:
   platform:
     channels:
+{% set channels = {} %}
 {% for v in openshift_versions %}
-      - name: stable-{{ v.version.split('.')[:2] | join('.') }}
-        minVersion: {{ v.version }}
-        maxVersion: {{ v.version }}
+{%   set channel_name = 'stable-' + v.version.split('.')[:2] | join('.') %}
+{%   set patch = v.version.split('.')[2] | int %}
+{%   if channel_name not in channels %}
+{%     set _ = channels.update({channel_name: {'min_patch': patch, 'min_ver': v.version, 'max_patch': patch, 'max_ver': v.version}}) %}
+{%   else %}
+{%     if patch < channels[channel_name]['min_patch'] %}
+{%       set _ = channels[channel_name].update({'min_patch': patch, 'min_ver': v.version}) %}
+{%     endif %}
+{%     if patch > channels[channel_name]['max_patch'] %}
+{%       set _ = channels[channel_name].update({'max_patch': patch, 'max_ver': v.version}) %}
+{%     endif %}
+{%   endif %}
+{% endfor %}
+{% for channel_name, data in channels.items() %}
+      - name: {{ channel_name }}
+        minVersion: {{ data.min_ver }}
+        maxVersion: {{ data.max_ver }}
 {% endfor %}
     graph: true
   operators:


### PR DESCRIPTION
The previous template emitted one channel entry per item in openshift_versions. When multiple versions share the same minor (e.g. 4.20.8 and 4.20.10), this produced duplicate stable-4.20 entries that oc-mirror rejects.

Replace the simple per-version loop with a two-pass approach:
- First pass: group versions by channel name using a dict, tracking the minimum and maximum patch level per channel. Patch levels are compared as integers, so 10 > 8 rather than "10" < "8" lexicographically.
- Second pass: emit one channel entry per unique channel with the correct minVersion and maxVersion.

Insertion order of channels in the output matches the order in which each minor version is first encountered in openshift_versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Channel configuration system now dynamically aggregates based on version availability instead of using hard-coded entries, improving flexibility and accuracy in channel management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->