### PR TITLE
sync openshift pipelines on day2

### DIFF
--- a/playbooks/06-day2.yaml
+++ b/playbooks/06-day2.yaml
@@ -44,6 +44,8 @@
         file: ../operators/openshift-pipelines-operator-rh/tasks.yaml
         apply:
           tags: openshift-pipelines
+          environment:
+            KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
       tags: openshift-pipelines
 
     - name: Configure Quay in disconnected environments

--- a/playbooks/06-day2.yaml
+++ b/playbooks/06-day2.yaml
@@ -39,6 +39,13 @@
             KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
       tags: acm-cis
 
+    - name: Configure OpenShift Pipelines
+      ansible.builtin.include_tasks:
+        file: ../operators/openshift-pipelines-operator-rh/tasks.yaml
+        apply:
+          tags: openshift-pipelines
+      tags: openshift-pipelines
+
     - name: Configure Quay in disconnected environments
       when: disconnected | default(true)
       ansible.builtin.include_tasks:

--- a/sync.sh
+++ b/sync.sh
@@ -83,3 +83,7 @@ echo -e "\e[38;5;10m Done...\033[0m"; date
 echo -p "ACM ClusterImageSets .." -n1 -s
     ansible-playbook playbooks/06-day2.yaml -e@$global_vars -e@$certs_vars --tags acm-cis 2>&1 | tee -a ${log}
 echo -e "\e[38;5;10m Done...\033[0m"; date
+
+echo -p "OpenShift Pipelines .." -n1 -s
+    ansible-playbook playbooks/06-day2.yaml -e@$global_vars -e@$certs_vars --tags openshift-pipelines 2>&1 | tee -a ${log}
+echo -e "\e[38;5;10m Done...\033[0m"; date


### PR DESCRIPTION
openshift-pipelines operator includes tasks to apply tekton resources to the management cluster to facilitate various day 2 operations such as updates.

the tasks are templated based on the versions of the operators, management cluster version, and more.

this PR adds to the sync.sh entrypoint a step to generate and apply these tekton resources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * OpenShift Pipelines configuration has been added to the automated Day-2 operations workflow, extending platform deployment capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->