### PR TITLE
Add new signatures after the internal quay mirroring

### DIFF
--- a/operators/quay-operator/quay_disconnected.yaml
+++ b/operators/quay-operator/quay_disconnected.yaml
@@ -49,3 +49,8 @@
   ansible.builtin.file:
     path: "{{ lookup('env','HOME') }}/.config/containers/registries.conf"
     state: absent
+
+- name: Apply release signature ConfigMap
+  ansible.builtin.command:
+    cmd: |
+      {{ workingDir }}/bin/oc apply -f {{ workingDir }}/config/oc-mirror-workspace-quay/working-dir/cluster-resources/signature-configmap.yaml

--- a/playbooks/06-day2.yaml
+++ b/playbooks/06-day2.yaml
@@ -54,6 +54,8 @@
         file: ../operators/quay-operator/quay_disconnected.yaml
         apply:
           tags: quay-disconnected
+          environment:
+            KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
       tags: quay-disconnected
 
     - name: Configure Clair in disconnected environments


### PR DESCRIPTION
Without this, trying to upgrade a cluster after a sync from LZ to quay registry fails as the update cannot be verified.

This was found in the context of https://redhat.atlassian.net/browse/MGMT-23449

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a deployment step to the Quay operator’s disconnected workflow to apply the release signature ConfigMap after registry configuration cleanup.
  * Added an environment override so Quay disconnected tasks run with the cluster kubeconfig context, aligning their execution environment with other Day‑2 disconnected/cluster configuration steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->