### PR TITLE
MGMT-23405: add in-cluster Quay fallback mirrors and CA trust

### DIFF
--- a/operators/quay-operator/quay_disconnected.yaml
+++ b/operators/quay-operator/quay_disconnected.yaml
@@ -49,3 +49,8 @@
   ansible.builtin.file:
     path: "{{ lookup('env','HOME') }}/.config/containers/registries.conf"
     state: absent
+
+# Apply oc-mirror-generated IDMS/ITMS to the cluster (fallback to internal Quay when LZ fails)
+# and add the Quay registry CA to image.config so nodes trust the registry for image pulls.
+- name: Apply Quay mirrors and trust registry CA for image pulls
+  ansible.builtin.include_tasks: quay_disconnected_mirrors.yaml

--- a/operators/quay-operator/quay_disconnected_mirrors.yaml
+++ b/operators/quay-operator/quay_disconnected_mirrors.yaml
@@ -1,0 +1,121 @@
+---
+# Quay disconnected: apply IDMS/ITMS from oc-mirror and trust Quay registry CA for image pulls.
+# Included from quay_disconnected.yaml.
+# Copy to idms-oc-mirror-internal.yaml / itms-oc-mirror-internal.yaml, rename the resource inside,
+# then apply so they coexist with the landing-zone IDMS/ITMS (idms-oc-mirror, itms-oc-mirror).
+# The cluster then has both: landing-zone mirrors (primary) and internal Quay mirrors (fallback).
+
+- name: Copy IDMS to idms-oc-mirror-internal.yaml
+  ansible.builtin.copy:
+    src: "{{ workingDir }}/config/oc-mirror-workspace-quay/working-dir/cluster-resources/idms-oc-mirror.yaml"
+    dest: "{{ workingDir }}/config/oc-mirror-workspace-quay/working-dir/cluster-resources/idms-oc-mirror-internal.yaml"
+    remote_src: true
+  register: quay_idms_copy
+  failed_when: false
+
+# oc-mirror v2 uses names like idms-release-0, idms-operator-0 (not idms-oc-mirror); rename all with '-internal' suffix.
+- name: Rename ImageDigestMirrorSet resources in IDMS manifest to avoid conflict with landing-zone
+  ansible.builtin.shell: |
+    sed -i 's/^\([[:space:]]*name:[[:space:]]*\)idms-\([^[:space:]]*\)[[:space:]]*$/\1idms-\2-internal/' "{{ workingDir }}/config/oc-mirror-workspace-quay/working-dir/cluster-resources/idms-oc-mirror-internal.yaml"
+  when: quay_idms_copy is not failed
+
+- name: Copy ITMS to itms-oc-mirror-internal.yaml
+  ansible.builtin.copy:
+    src: "{{ workingDir }}/config/oc-mirror-workspace-quay/working-dir/cluster-resources/itms-oc-mirror.yaml"
+    dest: "{{ workingDir }}/config/oc-mirror-workspace-quay/working-dir/cluster-resources/itms-oc-mirror-internal.yaml"
+    remote_src: true
+  register: quay_itms_copy
+  failed_when: false
+
+# oc-mirror v2 uses names like itms-release-0, itms-operator-0; rename all with -internal suffix.
+- name: Rename ImageTagMirrorSet resources in ITMS manifest to avoid conflict with landing-zone
+  ansible.builtin.shell: |
+    sed -i 's/^\([[:space:]]*name:[[:space:]]*\)itms-\([^[:space:]]*\)[[:space:]]*$/\1itms-\2-internal/' "{{ workingDir }}/config/oc-mirror-workspace-quay/working-dir/cluster-resources/itms-oc-mirror-internal.yaml"
+  when: quay_itms_copy is not failed
+
+- name: Apply Quay IDMS to cluster (fallback mirrors to internal Quay)
+  ansible.builtin.shell: "{{ workingDir }}/bin/oc apply -f {{ workingDir }}/config/oc-mirror-workspace-quay/working-dir/cluster-resources/idms-oc-mirror-internal.yaml"
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  when: quay_idms_copy is not failed
+
+- name: Apply Quay ITMS to cluster (fallback mirrors to internal Quay)
+  ansible.builtin.shell: "{{ workingDir }}/bin/oc apply -f {{ workingDir }}/config/oc-mirror-workspace-quay/working-dir/cluster-resources/itms-oc-mirror-internal.yaml"
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  when: quay_itms_copy is not failed
+
+# Trust the internal Quay registry's TLS cert for image pulls. Nodes pull from the Quay route
+# (default ingress cert); add the ingress CA to image.config so "x509: certificate signed by
+# unknown authority" is resolved.
+- name: Get ingress CA (signs default router/Quay route cert)
+  ansible.builtin.shell: |
+    {{ workingDir }}/bin/oc get secret router-ca -n openshift-ingress-operator -o jsonpath='{.data.tls\.crt}' | base64 -d
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  register: quay_registry_ingress_ca
+  changed_when: false
+  failed_when: false
+
+- name: Set Quay registry hostname for image trust
+  ansible.builtin.set_fact:
+    quay_registry_hostname: "registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}"
+
+- name: Get current image config additionalTrustedCA ConfigMap name
+  ansible.builtin.shell: |
+    {{ workingDir }}/bin/oc get image.config.openshift.io/cluster -o jsonpath='{.spec.additionalTrustedCA.name}'
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  register: image_config_trusted_ca_name
+  changed_when: false
+  failed_when: false
+
+- name: Create ConfigMap with Quay registry CA for image pulls
+  when: >-
+    quay_registry_ingress_ca.rc == 0 and quay_registry_ingress_ca.stdout | trim | length > 0
+    and (image_config_trusted_ca_name.stdout | trim | length == 0)
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: quay-registry-ca
+        namespace: openshift-config
+      data: "{{ { quay_registry_hostname: quay_registry_ingress_ca.stdout } }}"
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+
+- name: Add Quay registry CA to existing additionalTrustedCA ConfigMap
+  when: >-
+    quay_registry_ingress_ca.rc == 0 and quay_registry_ingress_ca.stdout | trim | length > 0
+    and (image_config_trusted_ca_name.stdout | trim | length > 0)
+    and (image_config_trusted_ca_name.stdout | trim != 'quay-registry-ca')
+  kubernetes.core.k8s:
+    state: patched
+    kind: ConfigMap
+    name: "{{ image_config_trusted_ca_name.stdout | trim }}"
+    namespace: openshift-config
+    merge_type: strategic-merge
+    definition:
+      data: "{{ { quay_registry_hostname: quay_registry_ingress_ca.stdout } }}"
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+
+- name: Patch image config to reference Quay registry CA ConfigMap
+  when: >-
+    quay_registry_ingress_ca.rc == 0 and quay_registry_ingress_ca.stdout | trim | length > 0
+    and (image_config_trusted_ca_name.stdout | trim | length == 0)
+  kubernetes.core.k8s:
+    state: patched
+    kind: Image
+    name: cluster
+    api_version: config.openshift.io/v1
+    namespace: ""
+    merge_type: merge
+    definition:
+      spec:
+        additionalTrustedCA:
+          name: quay-registry-ca
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"


### PR DESCRIPTION
Handle failover when the landing-zone (LZ) mirror registry is down or unreachable. In disconnected setups, nodes normally pull from the LZ Quay (mirror.<domain>:8443).
If that registry is stopped or unavailable, image pulls fail. This change adds the in-cluster Quay as a fallback so that IDMS/ITMS direct registry.redhat.io (and other sources) to the internal Quay when the LZ mirror cannot be reached, keeping pulls working.

quay_disconnected.yaml:
- After oc-mirror and registries.conf cleanup, include quay_disconnected_mirrors.yaml to apply in-cluster Quay mirrors and configure node trust for the Quay registry.

quay_disconnected_mirrors.yaml (new file):
- Copy oc-mirror-generated IDMS/ITMS to '-internal' variants and apply to the cluster so registry.redhat.io (and others) can fall back to the in-cluster Quay when the landing-zone mirror is unavailable. Coexists with landing-zone IDMS/ITMS.
- Add the ingress CA (router/Quay route cert) to image.config additionalTrustedCA so nodes trust the in-cluster Quay registry for image pulls and avoid x509 certificate errors. Creates or patches the ConfigMap and references it from image.config.openshift.io/cluster.