### PR TITLE
Quay disconnected: always use 10 parallel-layers for oc-mirror

### DIFF
--- a/operators/quay-operator/quay_disconnected.yaml
+++ b/operators/quay-operator/quay_disconnected.yaml
@@ -34,7 +34,7 @@
       --dest-tls-verify=false \
       --src-tls-verify=false \
       --parallel-images 10 \
-      --parallel-layers {{ 1 if quayBackend == 'LocalStorage' else 10 }} \
+      --parallel-layers 10 \
       --retry-times 10 \
       --retry-delay 0 \
       --image-timeout 40m0s \


### PR DESCRIPTION
Trying again to use --parallel-layers 10 for oc-mirror regardless of quayBackend (LocalStorage or other).
Previously LocalStorage used 1 to avoid issues; re-enable 10 for faster mirroring.