### PR TITLE
block rhaiis, rhelai1 and quay(builder) images - reduce 120GiB from mirror

### DIFF
--- a/templates/imagesetconfiguration.yaml.j2
+++ b/templates/imagesetconfiguration.yaml.j2
@@ -72,6 +72,13 @@ mirror:
     - name: {{ aap_bootstrap_job.image }}:{{ aap_bootstrap_job.tag }}
 
   blockedimages:
+    - name: registry.redhat.io/quay/quay-builder-qemu-rhcos-rhel8
+    - name: registry.redhat.io/quay/quay-builder-rhel8
+    - name: registry.redhat.io/rhaiis/vllm-cuda-rhel9
+    - name: registry.redhat.io/rhaiis/vllm-rocm-rhel9
+    - name: registry.redhat.io/rhaiis/vllm-spyre-rhel9
+    - name: registry.redhat.io/rhaiis/vllm-cpu-rhel9
+    - name: registry.redhat.io/rhelai1/instructlab-nvidia-rhel9
     - name: registry.redhat.io/rhoai/odh-dashboard-rhel8
     - name: registry.redhat.io/rhoai/odh-dashboard-rhel9
     - name: registry.redhat.io/rhoai/odh-codeflare-operator-rhel9


### PR DESCRIPTION
<img width="1145" height="134" alt="image" src="https://github.com/user-attachments/assets/17831fc6-826d-4ff6-9fb1-7a04e53b35d2" />
<img width="1146" height="88" alt="image" src="https://github.com/user-attachments/assets/cc09db2b-15f0-4f06-8f28-a76b131e169e" />
<img width="1145" height="223" alt="image" src="https://github.com/user-attachments/assets/378ab13d-d815-49a2-af52-f4e619bfd1ea" />

all in all ~120GiB reduced


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Extended container image configuration to include additional Red Hat images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->