### PR TITLE
Add missing lsof installation

### DIFF
--- a/setup_env.sh
+++ b/setup_env.sh
@@ -9,6 +9,7 @@ dnf install -y \
     httpd \
     httpd-tools \
     ipcalc \
+    lsof \
     nmstate \
     openssl \
     podman \


### PR DESCRIPTION
Fixes https://github.com/gori-project/GoRI/issues/832

Added `lsof` into the list of clis to be installed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a system prerequisite package to the environment setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->