### PR TITLE
cluster upgrade tekton pipeline

### DIFF
--- a/hack/cluster_upgrade.py
+++ b/hack/cluster_upgrade.py
@@ -1,0 +1,180 @@
+import sys
+import subprocess
+import json
+import time
+import logging
+
+
+def parse_jsonpath_value(raw: str) -> str:
+    return raw.strip().strip("'\"")
+
+
+def wait_for_resource_status(
+    kind: str, name: str, status_field: str, desired_state: str
+) -> None:
+    timeout = time.time() + (3 * 60 * 60)  # 3 hours
+    while True:
+        result = subprocess.run(
+            [
+                "oc",
+                "get",
+                kind,
+                name,
+                "-o",
+                f"jsonpath='{{.status.{status_field}}}'",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if parse_jsonpath_value(result.stdout or "") == desired_state:
+            logging.info(
+                f"{kind}/{name} has reached status.{status_field}={desired_state}."
+            )
+            return
+        if time.time() > timeout:
+            raise TimeoutError(
+                f"{kind}/{name} did not reach status.{status_field}={desired_state} within 3 hours"
+            )
+        time.sleep(10)
+
+
+def get_current_version():
+    result = subprocess.run(
+        [
+            "oc",
+            "get",
+            "clusterversion.config.openshift.io",
+            "version",
+            "-o",
+            "jsonpath='{.status.desired.version}'",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    return parse_jsonpath_value(result.stdout)
+
+
+def semver_key(v_string):
+    # Separate the numeric part from the tag (e.g., '1.2.0-rc1' -> ['1.2.0', 'rc1'])
+    parts = v_string.split("-", 1)
+    main_version = tuple(map(int, parts[0].split(".")))
+
+    if len(parts) == 1:
+        # No suffix: Use a high-value marker so 1.2.0 > 1.2.0-rc1
+        return (main_version, (float("inf"),))
+    else:
+        # Has suffix: Return the numeric part and the string tag
+        return (main_version, (0, parts[1]))
+
+
+def get_available_versions():
+    result = subprocess.run(
+        ["oc", "get", "clusterversion.config.openshift.io", "version", "-o", "json"],
+        capture_output=True,
+        text=True,
+    )
+    return [
+        update["version"]
+        for update in json.loads(result.stdout)["status"]["availableUpdates"]
+    ]
+
+
+def get_cluster_operators():
+    result = subprocess.run(
+        ["oc", "get", "clusteroperator.config.openshift.io", "-o", "json"],
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)["items"]
+
+
+def check_cluster_operators_ready() -> bool:
+    cluster_operators = get_cluster_operators()
+    cluster_operators_success = True
+    for co in cluster_operators:
+        co_name = co["metadata"]["name"]
+        co_status_conditions = co["status"]["conditions"]
+        for condition in co_status_conditions:
+            condition_status = condition["status"]
+            condition_type = condition["type"]
+            if condition_type == "Degraded" and condition_status == "True":
+                logging.error(f"Cluster Operator {co_name} is Degraded.")
+                cluster_operators_success = False
+            if condition_type == "Available" and condition_status == "False":
+                logging.error(f"Cluster Operator {co_name} is not Available.")
+                cluster_operators_success = False
+            if condition_type == "Upgradeable" and condition_status == "False":
+                logging.error(f"Cluster Operator {co_name} is not Upgradeable.")
+                cluster_operators_success = False
+    return cluster_operators_success
+
+
+def upgrade_cluster(desired_version: str):
+    subprocess.run(
+        [
+            "oc",
+            "patch",
+            "clusterversion.config.openshift.io",
+            "version",
+            "--type",
+            "merge",
+            "-p",
+            f'{{"spec": {{"desiredUpdate": {{"version": "{desired_version}"}}}}}}',
+        ],
+        capture_output=True,
+        text=True,
+    )
+    wait_for_resource_status(
+        "clusterversion.config.openshift.io", "version", "desired.version", desired_version
+    )
+    wait_for_resource_status(
+        "clusterversion.config.openshift.io", "version", "history[0].state", "Completed"
+    )
+
+
+def main():
+    desired_version = sys.argv[1]
+
+    raw_dry_run = sys.argv[2] if len(sys.argv) > 2 else "False"
+    dry_run = raw_dry_run.lower() in ("true", "yes")
+
+    current_version = get_current_version()
+
+    if semver_key(desired_version) < semver_key(current_version):
+        raise Exception(
+            f"Current version {current_version} is newer than desired version {desired_version}."
+        )
+
+    if current_version == desired_version:
+        logging.info(
+            f"Cluster is already at or moving towards version {desired_version}."
+        )
+        wait_for_resource_status(
+            "clusterversion.config.openshift.io",
+            "version",
+            "history[0].state",
+            "Completed",
+        )
+        print(f"Upgrade to {desired_version} is Completed.")
+        return
+
+    available_versions = get_available_versions()
+    if desired_version not in available_versions:
+        raise Exception(
+            f"Desired version {desired_version} is not available. Available versions: {available_versions}."
+        )
+
+    if not check_cluster_operators_ready():
+        raise Exception(f"At least one Cluster Operator is not ready.")
+
+    if dry_run:
+        logging.info(f"Execution is set to DRY-RUN. Exiting.")
+        print(f"Cluster upgrade to version {desired_version} is ready to be performed.")
+        return
+
+    upgrade_cluster(desired_version)
+    print(f"Upgrade to {desired_version} is Completed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/hack/cluster_upgrade.py
+++ b/hack/cluster_upgrade.py
@@ -1,17 +1,25 @@
-import sys
-import subprocess
-import json
-import time
-import logging
+#!/usr/bin/env python3
 
+import json
+import logging
+import os
+import re
+import subprocess
+import sys
+import time
+from typing import Any, Optional
+
+# This script is meant to be run under python3.9
 
 def parse_jsonpath_value(raw: str) -> str:
+    """Strip surrounding whitespace and quotes from a JSONPath output value."""
     return raw.strip().strip("'\"")
 
 
 def wait_for_resource_status(
     kind: str, name: str, status_field: str, desired_state: str
 ) -> None:
+    """Poll a resource's status field until it reaches the desired state or 3 hours elapse."""
     timeout = time.time() + (3 * 60 * 60)  # 3 hours
     while True:
         result = subprocess.run(
@@ -26,7 +34,16 @@ def wait_for_resource_status(
             capture_output=True,
             text=True,
         )
-        if parse_jsonpath_value(result.stdout or "") == desired_state:
+        if result.returncode != 0:
+            logging.warning(
+                "oc get %s/%s failed (exit %d): %s",
+                kind,
+                name,
+                result.returncode,
+                result.stderr.strip() or "<no stderr>",
+            )
+        current_state = parse_jsonpath_value(result.stdout or "")
+        if current_state == desired_state:
             logging.info(
                 f"{kind}/{name} has reached status.{status_field}={desired_state}."
             )
@@ -34,11 +51,13 @@ def wait_for_resource_status(
         if time.time() > timeout:
             raise TimeoutError(
                 f"{kind}/{name} did not reach status.{status_field}={desired_state} within 3 hours"
+                f" (last observed: {current_state!r})"
             )
         time.sleep(10)
 
 
-def get_current_version():
+def get_current_version() -> str:
+    """Return the cluster's current desired version from ClusterVersion."""
     result = subprocess.run(
         [
             "oc",
@@ -51,44 +70,86 @@ def get_current_version():
         capture_output=True,
         text=True,
     )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"oc get clusterversion failed (exit {result.returncode}):"
+            f" stderr={result.stderr.strip()!r} stdout={result.stdout.strip()!r}"
+        )
     return parse_jsonpath_value(result.stdout)
 
 
-def semver_key(v_string):
+def semver_key(v_string: str) -> tuple[tuple[int, ...], tuple[int, str, int]]:
+    """Return a sort key for semantic version strings so release versions rank above pre-releases.
+
+    A version without a suffix (e.g. '4.20.0') sorts higher than one with a suffix
+    (e.g. '4.20.0-rc1'), matching the convention that release > pre-release.
+    Suffixes are split into a label and a number (e.g. 'rc10' -> ('rc', 10)) so that
+    numeric ordering is used instead of lexicographic ('rc9' < 'rc10').
+    """
     # Separate the numeric part from the tag (e.g., '1.2.0-rc1' -> ['1.2.0', 'rc1'])
     parts = v_string.split("-", 1)
     main_version = tuple(map(int, parts[0].split(".")))
 
     if len(parts) == 1:
-        # No suffix: Use a high-value marker so 1.2.0 > 1.2.0-rc1
-        return (main_version, (float("inf"),))
+        # No suffix: (sys.maxsize, "", 0) beats any (0, "rcN", n) in element-wise tuple comparison
+        return (main_version, (sys.maxsize, "", 0))
     else:
-        # Has suffix: Return the numeric part and the string tag
-        return (main_version, (0, parts[1]))
+        # Split suffix into label + number so 'rc9' < 'rc10' (not 'rc9' > 'rc10' lexicographically)
+        m = re.match(r'^([a-zA-Z]*)(\d*)$', parts[1])
+        label = m.group(1) if m else parts[1]
+        num = int(m.group(2)) if m and m.group(2) else 0
+        return (main_version, (0, label, num))
 
 
-def get_available_versions():
+def get_available_versions() -> Optional[list[str]]:
+    """Return the list of versions the cluster can upgrade to, or None if the update graph is unavailable."""
     result = subprocess.run(
         ["oc", "get", "clusterversion.config.openshift.io", "version", "-o", "json"],
         capture_output=True,
         text=True,
     )
-    return [
-        update["version"]
-        for update in json.loads(result.stdout)["status"]["availableUpdates"]
-    ]
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"oc get clusterversion failed (exit {result.returncode}):"
+            f" stderr={result.stderr.strip()!r} stdout={result.stdout.strip()!r}"
+        )
+    try:
+        raw_json = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"oc get clusterversion returned invalid JSON: {exc};"
+            f" stdout={result.stdout.strip()!r}"
+        ) from exc
+    raw = raw_json.get("status", {}).get("availableUpdates")
+    if raw is None:
+        return None
+    return [update["version"] for update in raw]
 
 
-def get_cluster_operators():
+def get_cluster_operators() -> list[dict[str, Any]]:
+    """Return all ClusterOperator objects from the cluster."""
     result = subprocess.run(
         ["oc", "get", "clusteroperator.config.openshift.io", "-o", "json"],
         capture_output=True,
         text=True,
     )
-    return json.loads(result.stdout)["items"]
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"oc get clusteroperator failed (exit {result.returncode}):"
+            f" stderr={result.stderr.strip()!r} stdout={result.stdout.strip()!r}"
+        )
+    try:
+        raw_json = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"oc get clusteroperator returned invalid JSON: {exc};"
+            f" stdout={result.stdout.strip()!r}"
+        ) from exc
+    return raw_json["items"]
 
 
 def check_cluster_operators_ready() -> bool:
+    """Return True if all ClusterOperators are Available, not Degraded, and Upgradeable."""
     cluster_operators = get_cluster_operators()
     cluster_operators_success = True
     for co in cluster_operators:
@@ -109,8 +170,10 @@ def check_cluster_operators_ready() -> bool:
     return cluster_operators_success
 
 
-def upgrade_cluster(desired_version: str):
-    subprocess.run(
+def upgrade_cluster(desired_version: str) -> None:
+    """Patch ClusterVersion to trigger an upgrade and wait for it to complete."""
+    logging.info(f"Patching clusterversion to desired_version={desired_version}")
+    result = subprocess.run(
         [
             "oc",
             "patch",
@@ -124,18 +187,46 @@ def upgrade_cluster(desired_version: str):
         capture_output=True,
         text=True,
     )
+    if result.returncode != 0:
+        logging.error(
+            "oc patch clusterversion to %s failed (exit %d): stderr=%r stdout=%r",
+            desired_version,
+            result.returncode,
+            result.stderr.strip(),
+            result.stdout.strip(),
+        )
+        raise RuntimeError(
+            f"oc patch clusterversion to {desired_version} failed (exit {result.returncode})"
+        )
     wait_for_resource_status(
-        "clusterversion.config.openshift.io", "version", "desired.version", desired_version
+        "clusterversion.config.openshift.io",
+        "version",
+        "desired.version",
+        desired_version,
     )
     wait_for_resource_status(
         "clusterversion.config.openshift.io", "version", "history[0].state", "Completed"
     )
 
 
-def main():
-    desired_version = sys.argv[1]
+def write_status_report(message: str) -> None:
+    """Write message to the Tekton result file path set in STATUS_REPORT_PATH, if present."""
+    path = os.environ.get("STATUS_REPORT_PATH")
+    if path:
+        with open(path, "w") as f:
+            f.write(message)
 
-    raw_dry_run = sys.argv[2] if len(sys.argv) > 2 else "False"
+
+def main() -> None:
+    """Validate preconditions and upgrade the cluster to the version set in OCP_VERSION.
+
+    Reads OCP_VERSION and DRY_RUN from environment variables. Raises if the desired
+    version is older than the current one, not listed in available updates, or if any
+    ClusterOperator is not ready. In dry-run mode, stops before applying the upgrade.
+    """
+    desired_version = os.environ["OCP_VERSION"]
+
+    raw_dry_run = os.environ.get("DRY_RUN", "false")
     dry_run = raw_dry_run.lower() in ("true", "yes")
 
     current_version = get_current_version()
@@ -155,26 +246,33 @@ def main():
             "history[0].state",
             "Completed",
         )
-        print(f"Upgrade to {desired_version} is Completed.")
+        write_status_report(f"Upgrade to {desired_version} is Completed.")
         return
 
     available_versions = get_available_versions()
-    if desired_version not in available_versions:
+    if available_versions is None:
+        raise Exception("clusterversion availableUpdates is null (update graph not fetched).")
+    elif desired_version not in available_versions:
         raise Exception(
             f"Desired version {desired_version} is not available. Available versions: {available_versions}."
         )
 
     if not check_cluster_operators_ready():
-        raise Exception(f"At least one Cluster Operator is not ready.")
+        raise Exception("At least one Cluster Operator is not ready.")
 
     if dry_run:
-        logging.info(f"Execution is set to DRY-RUN. Exiting.")
-        print(f"Cluster upgrade to version {desired_version} is ready to be performed.")
+        logging.info("Execution is set to DRY-RUN. Exiting.")
+        write_status_report(f"Cluster upgrade to version {desired_version} is ready to be performed.")
         return
 
     upgrade_cluster(desired_version)
-    print(f"Upgrade to {desired_version} is Completed.")
+    write_status_report(f"Upgrade to {desired_version} is Completed.")
 
 
 if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)-8s %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S",
+    )
     main()

--- a/operators/openshift-pipelines-operator-rh/README.md
+++ b/operators/openshift-pipelines-operator-rh/README.md
@@ -1,0 +1,30 @@
+# Tekton resources
+
+Tekton Tasks and Pipelines are provided to perform various operations in the management cluster.
+
+## Cluster Upgrade
+
+Performs a cluster version upgrade.
+
+PipelineRun example:
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+name: cluster-upgrade-dry-run
+namespace: openshift-pipelines
+spec:
+params:
+- name: dry-run
+  value: "true"
+pipelineRef:
+  name: cluster-upgrade
+taskRunTemplate:
+  serviceAccountName: cluster-upgrade
+timeouts:
+  pipeline: "3h"
+workspaces:
+- name: shared-data
+  emptyDir: {}
+```

--- a/operators/openshift-pipelines-operator-rh/README.md
+++ b/operators/openshift-pipelines-operator-rh/README.md
@@ -12,19 +12,16 @@ PipelineRun example:
 apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
-name: cluster-upgrade-dry-run
-namespace: openshift-pipelines
+  name: cluster-upgrade-dry-run
+  namespace: openshift-pipelines
 spec:
-params:
-- name: dry-run
-  value: "true"
-pipelineRef:
-  name: cluster-upgrade
-taskRunTemplate:
-  serviceAccountName: cluster-upgrade
-timeouts:
-  pipeline: "3h"
-workspaces:
-- name: shared-data
-  emptyDir: {}
+  params:
+    - name: dry-run
+      value: "true"
+  pipelineRef:
+    name: cluster-upgrade
+  taskRunTemplate:
+    serviceAccountName: cluster-upgrade
+  timeouts:
+    pipeline: "3h"
 ```

--- a/operators/openshift-pipelines-operator-rh/cluster_upgrade_pipeline.yaml
+++ b/operators/openshift-pipelines-operator-rh/cluster_upgrade_pipeline.yaml
@@ -1,0 +1,138 @@
+---
+- name: Get mirrored OpenShift versions
+  ansible.builtin.set_fact:
+    mirrored_versions: "{{ openshift_versions | map(attribute='version') | list }}"
+
+- name: Fail fast if version is not mirrored
+  ansible.builtin.fail:
+    msg: "Desired Cluster Version {{ mgmt_openshift_version }} is not mirrored (mirrored versions: {{ mirrored_versions }})"
+  when: mgmt_openshift_version not in mirrored_versions
+
+- name: Get OpenShift CLI image from OpenShift release
+  ansible.builtin.command: >
+    {{ rootDir }}/bin/oc adm release info --registry-config={{ rootDir }}/config/pull-secret.json --image-for cli
+    quay.io/openshift-release-dev/ocp-release:{{ mgmt_openshift_version }}-x86_64
+  register: r_oc_cli_image
+  changed_when: false
+
+- name: Set image facts
+  ansible.builtin.set_fact:
+    oc_cli_image: "{{ r_oc_cli_image.stdout }}"
+
+- name: Create Cluster Upgrade ServiceAccount
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: cluster-upgrade
+        namespace: openshift-pipelines
+
+- name: Create Cluster Upgrade ClusterRole
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: cluster-upgrade
+      rules:
+        - apiGroups: ["config.openshift.io"]
+          resources: ["clusterversions", "clusteroperators"]
+          verbs: ["get", "list", "patch", "update", "watch"]
+
+- name: Create Cluster Upgrade ClusterRoleBinding
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: cluster-upgrade
+      subjects:
+        - kind: ServiceAccount
+          name: cluster-upgrade
+          namespace: openshift-pipelines
+      roleRef:
+        kind: ClusterRole
+        name: cluster-upgrade
+        apiGroup: rbac.authorization.k8s.io
+
+- name: Create Cluster Upgrade Task
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: tekton.dev/v1
+      kind: Task
+      metadata:
+        name: cluster-upgrade
+        namespace: openshift-pipelines
+      spec:
+        params:
+          - name: dry-run
+            description: "If true, only identifies pending upgrade"
+            type: string
+            default: "false"
+        results:
+          - name: exit-code
+            description: "Success of cluster upgrade (exit code)"
+          - name: status-report
+            description: "Report of cluster upgrade"
+        workspaces:
+          - name: shared-data
+        steps:
+          - name: generate-script
+            image: "{{ oc_cli_image }}"
+            workingDir: $(workspaces.shared-data.path)
+            script: |
+                #!/bin/bash
+
+                cat <<EOF > cluster_upgrade.py
+                {{ lookup('ansible.builtin.file', '../hack/cluster_upgrade.py') }}
+                EOF
+          - name: cluster-upgrade
+            image: "{{ oc_cli_image }}"
+            workingDir: $(workspaces.shared-data.path)
+            script: |
+                #!/bin/bash
+
+                python ./cluster_upgrade.py "{{ mgmt_openshift_version }}" "$(params.dry-run)" > $(results.status-report.path)
+                echo -n $? > $(results.exit-code.path)
+
+- name: Create Cluster Upgrade Pipeline
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: tekton.dev/v1
+      kind: Pipeline
+      metadata:
+        name: cluster-upgrade
+        namespace: openshift-pipelines
+      spec:
+        params:
+          - name: dry-run
+            type: string
+            description: "If true, only identifies pending upgrade"
+            default: "false"
+        results:
+          - name: exit-code
+            description: "Success of cluster upgrade (exit code)"
+            value: $(tasks.cluster-upgrade.results.exit-code)
+          - name: status-report
+            description: "Report of cluster upgrade"
+            value: $(tasks.cluster-upgrade.results.status-report)
+        workspaces:
+          - name: shared-data
+        tasks:
+          - name: cluster-upgrade
+            workspaces:
+              - name: shared-data
+                workspace: shared-data
+            retries: 5
+            taskRef:
+              name: cluster-upgrade
+            params:
+              - name: dry-run
+                value: $(params.dry-run)
+            timeout: "3h"

--- a/operators/openshift-pipelines-operator-rh/cluster_upgrade_pipeline.yaml
+++ b/operators/openshift-pipelines-operator-rh/cluster_upgrade_pipeline.yaml
@@ -10,7 +10,7 @@
 
 - name: Get OpenShift CLI image from OpenShift release
   ansible.builtin.command: >
-    {{ rootDir }}/bin/oc adm release info --registry-config={{ rootDir }}/config/pull-secret.json --image-for cli
+    {{ workingDir }}/bin/oc adm release info --registry-config={{ workingDir }}/config/pull-secret.json --image-for cli
     quay.io/openshift-release-dev/ocp-release:{{ mgmt_openshift_version }}-x86_64
   register: r_oc_cli_image
   changed_when: false
@@ -39,8 +39,11 @@
         name: cluster-upgrade
       rules:
         - apiGroups: ["config.openshift.io"]
-          resources: ["clusterversions", "clusteroperators"]
-          verbs: ["get", "list", "patch", "update", "watch"]
+          resources: ["clusterversions"]
+          verbs: ["get", "list", "patch"]
+        - apiGroups: ["config.openshift.io"]
+          resources: ["clusteroperators"]
+          verbs: ["get", "list"]
 
 - name: Create Cluster Upgrade ClusterRoleBinding
   kubernetes.core.k8s:
@@ -70,35 +73,28 @@
         namespace: openshift-pipelines
       spec:
         params:
+          - name: ocp-version
+            type: string
+            description: Target OCP version (e.g. 4.20.12)
           - name: dry-run
             description: "If true, only identifies pending upgrade"
             type: string
             default: "false"
         results:
-          - name: exit-code
-            description: "Success of cluster upgrade (exit code)"
           - name: status-report
-            description: "Report of cluster upgrade"
-        workspaces:
-          - name: shared-data
+            description: "Final status message from the upgrade script"
         steps:
-          - name: generate-script
+          - name: upgrade-and-wait
             image: "{{ oc_cli_image }}"
-            workingDir: $(workspaces.shared-data.path)
+            env:
+              - name: OCP_VERSION
+                value: $(params.ocp-version)
+              - name: DRY_RUN
+                value: $(params.dry-run)
+              - name: STATUS_REPORT_PATH
+                value: $(results.status-report.path)
             script: |
-                #!/bin/bash
-
-                cat <<EOF > cluster_upgrade.py
                 {{ lookup('ansible.builtin.file', '../hack/cluster_upgrade.py') }}
-                EOF
-          - name: cluster-upgrade
-            image: "{{ oc_cli_image }}"
-            workingDir: $(workspaces.shared-data.path)
-            script: |
-                #!/bin/bash
-
-                python ./cluster_upgrade.py "{{ mgmt_openshift_version }}" "$(params.dry-run)" > $(results.status-report.path)
-                echo -n $? > $(results.exit-code.path)
 
 - name: Create Cluster Upgrade Pipeline
   kubernetes.core.k8s:
@@ -111,28 +107,26 @@
         namespace: openshift-pipelines
       spec:
         params:
+          - name: ocp-version
+            type: string
+            description: Target OCP version (e.g. 4.20.12)
+            default: "{{ mgmt_openshift_version }}"
           - name: dry-run
             type: string
             description: "If true, only identifies pending upgrade"
             default: "false"
         results:
-          - name: exit-code
-            description: "Success of cluster upgrade (exit code)"
-            value: $(tasks.cluster-upgrade.results.exit-code)
           - name: status-report
             description: "Report of cluster upgrade"
             value: $(tasks.cluster-upgrade.results.status-report)
-        workspaces:
-          - name: shared-data
         tasks:
           - name: cluster-upgrade
-            workspaces:
-              - name: shared-data
-                workspace: shared-data
             retries: 5
             taskRef:
               name: cluster-upgrade
             params:
               - name: dry-run
                 value: $(params.dry-run)
+              - name: ocp-version
+                value: $(params.ocp-version)
             timeout: "3h"

--- a/operators/openshift-pipelines-operator-rh/tasks.yaml
+++ b/operators/openshift-pipelines-operator-rh/tasks.yaml
@@ -22,3 +22,7 @@
 - name: Create Clair Import Pipeline
   ansible.builtin.include_tasks:
     file: clair_import_pipeline.yaml
+
+- name: Create Cluster Upgrade Pipeline
+  ansible.builtin.include_tasks:
+    file: cluster_upgrade_pipeline.yaml


### PR DESCRIPTION
Started from https://github.com/rh-ecosystem-edge/gori-lab/pull/290, that's commit c355c7a

The pipeline has been reduced to one task. The two task approach (write script and then execute it) did not work fine. The problem came at the time the working pod needed to be retried since it was evicted from the working node. The workspace being in an empty dir meant that the new pod in the new node wasn't working fine. The solution has been to directly inline the python code in the Task and write results from the python code instead from the bash script. exit-code result has been removed since it didn't tell us anything we didn't have from the task.

There have been a few more changes, improvements in the code, etc... Follow the commits to see the differences in each file with the different fixes to make it run fine.

part of https://redhat.atlassian.net/browse/MGMT-23449

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated OpenShift cluster upgrade workflow with dry-run support, target validation, operator readiness checks, semver-aware version selection, polling with timeout, and status reporting.
  * Tekton Task and Pipeline to run upgrades with retries and a 3h timeout; exposes ocp-version and dry-run parameters and returns a status result.
  * ServiceAccount, ClusterRole, and ClusterRoleBinding to permit controlled cluster-version operations.

* **Documentation**
  * Added Tekton resources docs and a Cluster Upgrade example PipelineRun for dry-run and production use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->