### PR TITLE
operator update change from single csvName to multiple csvNames and add csvNames for odf-operator

### DIFF
--- a/defaults/operators.yaml
+++ b/defaults/operators.yaml
@@ -28,7 +28,8 @@ operators:
     init_version: 5.0.3
     namespace: openshift-update-service
     source: cs-redhat-operator-index-v4-20
-    csvName: update-service-operator
+    csvNames:
+      - update-service-operator
 
   - name: openshift-gitops-operator
     version: 1.19.2
@@ -53,7 +54,8 @@ operators:
     namespace: openshift-netobserv-operator
     source: cs-redhat-operator-index-v4-20
     global: true
-    csvName: network-observability-operator
+    csvNames:
+      - network-observability-operator
 
   - name: cluster-logging
     version: 6.4.2
@@ -76,7 +78,8 @@ operators:
     init_version: 1.5.0
     namespace: openshift-oadp
     source: cs-redhat-operator-index-v4-20
-    csvName: oadp-operator
+    csvNames:
+      - oadp-operator
 
   - name: openshift-cert-manager-operator
     version: 1.18.1
@@ -84,7 +87,8 @@ operators:
     init_version: 1.18.0
     namespace: cert-manager-operator
     source: cs-redhat-operator-index-v4-20
-    csvName: cert-manager-operator
+    csvNames:
+      - cert-manager-operator
 
   - name: cluster-observability-operator
     version: 1.3.1
@@ -101,7 +105,8 @@ operators:
     namespace: external-secrets-operator
     source: cs-redhat-operator-index-v4-20
     global: true
-    csvName: external-secrets-operator
+    csvNames:
+      - external-secrets-operator
 
   - name: compliance-operator
     version: 1.8.2
@@ -117,7 +122,8 @@ operators:
     namespace: metallb-system
     source: cs-redhat-operator-index-v4-20
     global: true
-    csvName: metallb-operator
+    csvNames:
+      - metallb-operator
 
   # AAP is a dependency for osac-operator
   - name: ansible-automation-platform-operator
@@ -127,4 +133,5 @@ operators:
     namespace: ansible-aap
     source: cs-redhat-operator-index-v4-20
     global: true
-    csvName: aap-operator
+    csvNames:
+      - aap-operator

--- a/defaults/storage_operators.yaml
+++ b/defaults/storage_operators.yaml
@@ -6,6 +6,18 @@ storage_operators:  # Install operator depending blockStorageBackend variable
       init_version: 4.20.7-rhodf
       namespace: openshift-storage
       source: cs-redhat-operator-index-v4-20
+      csvNames:
+        - odf-operator
+        - odf-dependencies
+        - odf-csi-addons-operator
+        - rook-ceph-operator
+        - ocs-operator
+        - recipe
+        - mcg-operator
+        - odf-prometheus-operator
+        - ocs-client-operator
+        - cephcsi-operator
+        - odf-external-snapshotter-operator
   lvms:
     - name: lvms-operator
       version: 4.20.0

--- a/hack/operator_update.py
+++ b/hack/operator_update.py
@@ -140,10 +140,11 @@ def init_ns_op_version_map(
         op_name = op["name"]
         op_version = op["version"]
         op_namespace = op["namespace"]
-        op_csv_name = op.get("csvName")
-        ns_op_version_map.setdefault(op_namespace, {})[
-            op_csv_name or op_name
-        ] = op_version.replace("+", "-")
+        op_csv_names = op.get("csvNames") or [op_name]
+        for op_csv_name in op_csv_names:
+            ns_op_version_map.setdefault(op_namespace, {})[op_csv_name] = (
+                op_version.replace("+", "-")
+            )
 
     return ns_op_version_map
 

--- a/playbooks/tasks/configure_operator.yaml
+++ b/playbooks/tasks/configure_operator.yaml
@@ -97,7 +97,7 @@
         name: "{{ operator.name }}"
         source: "{{ operator.source if (disconnected | default(true)) else 'redhat-operators' }}"
         sourceNamespace: openshift-marketplace
-        startingCSV: "{{ operator.csvName | default(operator.name) }}.v{{ operator.version | replace('+', '-') }}"
+        startingCSV: "{{ operator.csvNames | default([]) | first | default(operator.name) }}.v{{ operator.version | replace('+', '-') }}"
   register: r_sub_exists
   retries: "{{ k8s_retries }}"
   delay: "{{ k8s_delay }}"

--- a/schemas/operators.yaml
+++ b/schemas/operators.yaml
@@ -25,9 +25,11 @@ definitions:
       source:
         type: string
         description: Catalog source name (from oc-mirror configuration).
-      csvName:
-        type: string
-        description: ClusterServiceVersion name for the operator.
+      csvNames:
+        type: array
+        items:
+          type: string
+          description: ClusterServiceVersion name for the operator.
       global:
         type: boolean
         description: Configure operator to watch the entire cluster.


### PR DESCRIPTION
odf-operator installs dependencies using an operator called odf-dependencies.

when using a Subscription with installPlanApproval set to Manual, the dependent Subscriptions are also set to Manual. to approve them we explicit install them in advance (similar to the installation of multicluster-engine prior to advanced-cluster-management).

since this Subscription contains multiple CSVs we are modifying the operator update logic to support multiple csvNames. differently from multicluster-engine, in this case the installPlan is created in the same namespace, so it will suffice to add the list of csvNames to odf-operator itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ODF storage operator now bundles related storage components (Rook Ceph, OCS, MCG and companions) as part of its operator package.

* **Updates**
  * Operator configurations now accept multiple CSV identifiers, improving operator selection and subscription resolution during installs and updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->