### PR TITLE
Fix: Add `merge_group` trigger to PR workflows

### DIFF
--- a/.github/workflows/build-push-tarball.yml
+++ b/.github/workflows/build-push-tarball.yml
@@ -8,6 +8,8 @@ on:
       - '*'
   pull_request:
     types: [opened, synchronize, reopened]
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   build-push-tarball:

--- a/.github/workflows/e2e-deployment.yml
+++ b/.github/workflows/e2e-deployment.yml
@@ -37,6 +37,8 @@ on:
         type: boolean
   pull_request:
     types: [opened, synchronize, reopened]
+  merge_group:
+    types: [checks_requested]
 
 # Allow parallel execution with unique cluster names per run
 # Each job gets isolated VMs, networks, and resources
@@ -87,6 +89,9 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "should_run=true" >> $GITHUB_OUTPUT
             echo "▶️  Manual trigger - E2E will run" | tee -a $GITHUB_STEP_SUMMARY
+          elif [[ "${{ github.event_name }}" == "merge_group" ]]; then
+            echo "should_run=true" >> $GITHUB_OUTPUT
+            echo "▶️  Merge queue - E2E will run" | tee -a $GITHUB_STEP_SUMMARY
           elif [[ "${{ steps.filter.outputs.e2e }}" == "true" ]]; then
             echo "should_run=true" >> $GITHUB_OUTPUT
             echo "✓ E2E-relevant files changed - E2E will run" | tee -a $GITHUB_STEP_SUMMARY
@@ -308,7 +313,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Cleanup infrastructure
-        if: always() && (github.event.inputs.cleanup_after == 'true' || github.event.inputs.cleanup_after == true || github.event_name == 'pull_request')
+        if: always() && (github.event.inputs.cleanup_after == 'true' || github.event.inputs.cleanup_after == true || github.event_name == 'pull_request' || github.event_name == 'merge_group')
         run: |
           echo "## Cleanup Infrastructure" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/infra-verify.yml
+++ b/.github/workflows/infra-verify.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened]
+  merge_group:
+    types: [checks_requested]
 
 # Allow parallel execution with unique cluster names per run
 # Each job gets isolated VMs, networks, and resources

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -3,10 +3,12 @@ name: PR Validation
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  merge_group:
+    types: [checks_requested]
 
-# Prevent concurrent runs for the same PR
+# Prevent concurrent runs for the same PR (use run_id as fallback for merge_group)
 concurrency:
-  group: pr-validation-${{ github.event.pull_request.number }}
+  group: pr-validation-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Without the `merge_group` event, GitHub Merge Queue creates a merge group but no workflow responds, causing PRs to stall indefinitely. 
Add `merge_group` trigger to all four PR-triggered workflows and fix the pr-validation concurrency group to use run_id as fallback since merge_group events lack a pull_request number.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration pipeline to validate code changes during merge queue processing
  * Improved workflow concurrency handling to support additional merge scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->