### PR TITLE
Avoid redundant mirrorring to internal quay on bootstrap

### DIFF
--- a/playbooks/06-day2.yaml
+++ b/playbooks/06-day2.yaml
@@ -49,7 +49,7 @@
       tags: openshift-pipelines
 
     - name: Configure Quay in disconnected environments
-      when: disconnected | default(true)
+      when: disconnected | default(true) and configureQuayDisconnected | default(false) | bool
       ansible.builtin.include_tasks:
         file: ../operators/quay-operator/quay_disconnected.yaml
         apply:

--- a/sync.sh
+++ b/sync.sh
@@ -73,7 +73,8 @@ echo -p "Building local cache .. " -n1 -s
 echo -e "\e[38;5;10m Done...\033[0m"; date
 
 echo -p "Quay disconnected .." -n1 -s
-    ansible-playbook playbooks/06-day2.yaml -e@$global_vars -e@$certs_vars --tags quay-disconnected 2>&1 | tee -a ${log}
+    # Enables quay-disconnected tasks in 06-day2
+    ansible-playbook playbooks/06-day2.yaml -e@$global_vars -e@$certs_vars -e configureQuayDisconnected=true --tags quay-disconnected 2>&1 | tee -a ${log}
 echo -e "\e[38;5;10m Done...\033[0m"; date
 
 echo -p "Clair disconnected .." -n1 -s


### PR DESCRIPTION
Added a configureQuayDisconnected flag in order to invoke mirroring to internal quay only on sync.
I.e. no need to mirror twice to the same registry during the bootstrap flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration flag to enable more granular control over Quay configuration in disconnected environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->