### PR TITLE
Add MAXIMUM_LAYER_SIZE configuration for Quay registry

### DIFF
--- a/defaults/quay_operator.yaml
+++ b/defaults/quay_operator.yaml
@@ -2,6 +2,7 @@
 # Quay features
 quayFeatureProxyStorage: true
 quayFeatureQuotaManagement: false
+quayMaximumLayerSize: "100G"
 
 # Default storage configuration for all Quay backends
 quayBackendDefaults:

--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -663,6 +663,17 @@ quayFeatureProxyStorage: true
 quayFeatureQuotaManagement: true
 ```
 
+#### `quayMaximumLayerSize`
+
+**Description**: Maximum layer size for the Quay registry. Auto-set in `defaults/quay_operator.yaml` — only override in `config/global.yaml` when a non-default value is needed.
+
+**Type**: String
+
+**Default** (`defaults/quay_operator.yaml`):
+```yaml
+quayMaximumLayerSize: "100G"
+```
+
 ### Quay Backend Storage
 
 #### `quayBackend`

--- a/operators/quay-operator/tasks.yaml
+++ b/operators/quay-operator/tasks.yaml
@@ -47,6 +47,7 @@
           TESTING: false
           FEATURE_PROXY_STORAGE: {{ quayFeatureProxyStorage | bool | lower }}
           FEATURE_QUOTA_MANAGEMENT: {{ quayFeatureQuotaManagement | bool | lower }}
+          MAXIMUM_LAYER_SIZE: {{ quayMaximumLayerSize }}
         clair-config.yaml: |
           indexer:
             airgap: true

--- a/schemas/quay_operator.yaml
+++ b/schemas/quay_operator.yaml
@@ -11,6 +11,10 @@ properties:
   quayFeatureQuotaManagement:
     type: boolean
     description: Enable quota management feature for Quay
+  quayMaximumLayerSize:
+    type: string
+    description: Maximum layer size for Quay registry in M or G units (e.g. 100G, 20M)
+    pattern: "^[0-9]+(G|M)$"
   quayBackendDefaults:
     type: object
     description: Default configuration applied to all Quay backends
@@ -56,5 +60,6 @@ properties:
 required:
   - quayFeatureProxyStorage
   - quayFeatureQuotaManagement
+  - quayMaximumLayerSize
   - quayBackendDefaults
   - quayBackendRGWDefaults


### PR DESCRIPTION
Add `quayMaximumLayerSize` parameter (default: `100G`) to control the maximum layer size accepted by the Quay registry. This prevents upload failures when mirroring large container images.

MGMT-23630

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable Quay registry maximum layer size with default "100G" (overridable via global config).
* **Validation**
  * Configuration now enforces format (integer + "M" or "G") and requires the setting.
* **Configuration**
  * The new value is included when generating the Quay registry configuration so it is applied at deploy time.
* **Documentation**
  * Docs updated with purpose, default, format, and override instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->