### PR TITLE
pin rhoai to 3.3.0

### DIFF
--- a/defaults/model_operators.yaml
+++ b/defaults/model_operators.yaml
@@ -27,7 +27,7 @@ model_operators:
   - name: rhods-operator
     version: 3.3.0
     channel: fast-3.x
-    init_version: 3.0.0
+    init_version: 3.3.0
   - name: servicemeshoperator3
     version: 3.2.2
     channel: stable


### PR DESCRIPTION
missed one in #133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated RHODS Operator initialization configuration from version 3.0.0 to 3.3.0, ensuring proper alignment with the current release channel while maintaining operational stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->