### PR TITLE
imagesetconfig add option to mirror additional operators defined as CSVs

### DIFF
--- a/defaults/storage_operators.yaml
+++ b/defaults/storage_operators.yaml
@@ -18,6 +18,9 @@ storage_operators:  # Install operator depending blockStorageBackend variable
         - ocs-client-operator
         - cephcsi-operator
         - odf-external-snapshotter-operator
+        - odr-cluster-operator
+        - odr-hub-operator
+      csvMirror: true
   lvms:
     - name: lvms-operator
       version: 4.20.0

--- a/schemas/operators.yaml
+++ b/schemas/operators.yaml
@@ -30,9 +30,15 @@ definitions:
         items:
           type: string
           description: ClusterServiceVersion name for the operator.
+      csvMirror:
+        type: boolean
+        description: Mirror operator packages listed under csvNames.
       global:
         type: boolean
         description: Configure operator to watch the entire cluster.
+    dependencies:
+      csvMirror:
+      - csvNames
     required:
     - name
     - version

--- a/templates/imagesetconfiguration.yaml.j2
+++ b/templates/imagesetconfiguration.yaml.j2
@@ -38,27 +38,16 @@ mirror:
       packages:
         - name: kubevirt-hyperconverged
 {% for operator in operators + model_operators + storage_operators[blockStorageBackend] %}
-        - name: {{ operator.name }}
+{% set additional_operator_names = operator.csvNames if (operator.csvMirror | default(false) | bool) else [] %}
+{% for operator_name in [operator.name] + additional_operator_names %}
+        - name: {{ operator_name }}
           defaultChannel: {{ operator.channel }}
           channels:
             - name: {{ operator.channel }}
               minVersion: {{ operator.init_version }}
               maxVersion: {{ operator.version }}
 {% endfor %}
-{% if blockStorageBackend == "odf" %}
-        - name: mcg-operator
-        - name: odf-csi-addons-operator
-        - name: ocs-client-operator
-        - name: odf-prometheus-operator
-        - name: recipe
-        - name: rook-ceph-operator
-        - name: cephcsi-operator
-        - name: odf-dependencies
-        - name: odr-cluster-operator
-        - name: odr-hub-operator
-        - name: ocs-operator
-        - name: odf-external-snapshotter-operator
-{% endif %}
+{% endfor %}
 
   additionalImages:
     - name: registry.redhat.io/ubi8/ubi:latest


### PR DESCRIPTION
this PR adds an option to define mirroring for additional operators per operator as described under csvNames.

a side effect of this PR is less content to mirror for ODF.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for two new storage operators to the system configuration
  * Introduced operator mirroring capability to improve package resolution during installation

* **Configuration Updates**
  * Updated operator configuration schema to support the new mirroring feature

<!-- end of auto-generated comment: release notes by coderabbit.ai -->