### PR TITLE
Combine pullSecrets using when instead of jinja templating

### DIFF
--- a/operators/quay-operator/tasks.yaml
+++ b/operators/quay-operator/tasks.yaml
@@ -187,16 +187,19 @@
       {"auth":"{{ (quayUser + ":" + quayPassword) | ansible.builtin.b64encode }}"}
       }}
 
-- name: Combine pull secrets for connected mode
-  when: not (disconnected | default(true))
+# We need to check if the pullSecret is a string (surrounded by single quotes) or a dict/json (not surrounded)
+- name: combine pull secrets for connected mode if pullSecret is already a dictionary
+  when:
+    - not (disconnected | default(true))
+    - pullSecret is mapping
   ansible.builtin.set_fact:
-    # We need to check if the pullSecret is a string (surrounded by single quotes) or a dict/json (not surrounded)
-    pullSecretNew: >-
-      {% if pullSecret | type_debug == 'dict' %}
-        {{ pullSecret | ansible.builtin.combine(pullSecretQuay, recursive=true) | to_json }}
-      {% else %}
-        {{ pullSecret | from_json | ansible.builtin.combine(pullSecretQuay, recursive=true) | to_json }}
-      {% endif %}
+    pullSecretNew: "{{ pullSecret | ansible.builtin.combine(pullSecretQuay, recursive=True) }}"
+- name: combine pull secrets for connected mode if pullSecret is a JSON string
+  when:
+    - not (disconnected | default(true))
+    - pullSecret is not mapping
+  ansible.builtin.set_fact:
+    pullSecretNew: "{{ pullSecret | from_json | ansible.builtin.combine(pullSecretQuay, recursive=True) | to_json }}"
 
 - name: Set pull secret for disconnected (no combine)
   when: disconnected | default(true)

--- a/playbooks/tasks/mirror_registry.yaml
+++ b/playbooks/tasks/mirror_registry.yaml
@@ -17,15 +17,15 @@
   ansible.builtin.set_fact:
     pullSecretInternal: '{"auths":{"{{ quayHostname }}:8443":{"auth":"{{ (quayUser + ":" + quayPassword) | ansible.builtin.b64encode }}"}}}'
 
-- name: Combine pull secrets
+# We need to check if the pullSecret is a string (surrounded by single quotes) or a dict/json (not surrounded)
+- name: combine pull secrets if pullSecret is already a dictionary
+  when: pullSecret is mapping
   ansible.builtin.set_fact:
-    # We need to check if the pullSecret is a string (surrounded by single quotes) or a dict/json (not surrounded)
-    pullSecretNew: >-
-      {% if pullSecret | type_debug == 'dict' %}
-        {{ pullSecret | ansible.builtin.combine(pullSecretInternal, recursive=true) | to_json }}
-      {% else %}
-        {{ pullSecret | from_json | ansible.builtin.combine(pullSecretInternal, recursive=true) | to_json }}
-      {% endif %}
+    pullSecretNew: "{{ pullSecret | ansible.builtin.combine(pullSecretInternal, recursive=True) }}"
+- name: combine pull secrets if pullSecret is a JSON string
+  when: pullSecret is not mapping
+  ansible.builtin.set_fact:
+    pullSecretNew: "{{ pullSecret | from_json | ansible.builtin.combine(pullSecretInternal, recursive=True) | to_json }}"
 
 - name: Create pull-secret file with the combination
   ansible.builtin.copy:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored pull secret handling logic in operator and playbook deployment configurations by separating combined task definitions into distinct, explicitly-gated tasks for improved organization and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->