### PR TITLE
Add `no_log` to secret-handling tasks and fix pullSecret combine

### DIFF
--- a/operators/odf-operator/tasks.yaml
+++ b/operators/odf-operator/tasks.yaml
@@ -1,4 +1,5 @@
 - name: Ensure Secret is present
+  no_log: true
   kubernetes.core.k8s:
     state: present
     definition:

--- a/operators/quay-operator/tasks.yaml
+++ b/operators/quay-operator/tasks.yaml
@@ -1,4 +1,5 @@
 - name: Create or update quay-config Secret
+  no_log: true
   kubernetes.core.k8s:
     state: present
     definition:
@@ -155,6 +156,7 @@
 
 
 - name: Create user
+  no_log: true
   ansible.builtin.uri:
     url: "https://registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/api/v1/user/initialize"
     method: POST
@@ -179,6 +181,7 @@
     - r_quay_user.status | default(0) == 200 or r_quay_user.json.message | default("") == "Cannot initialize user in a non-empty database"
 
 - name: Generate pull secret for internal mirror
+  no_log: true
   ansible.builtin.set_fact:
     pullSecretQuay: >-
       {"auths":{
@@ -189,12 +192,14 @@
 
 # We need to check if the pullSecret is a string (surrounded by single quotes) or a dict/json (not surrounded)
 - name: combine pull secrets for connected mode if pullSecret is already a dictionary
+  no_log: true
   when:
     - not (disconnected | default(true))
     - pullSecret is mapping
   ansible.builtin.set_fact:
-    pullSecretNew: "{{ pullSecret | ansible.builtin.combine(pullSecretQuay, recursive=True) }}"
+    pullSecretNew: "{{ pullSecret | ansible.builtin.combine(pullSecretQuay, recursive=True) | to_json }}"
 - name: combine pull secrets for connected mode if pullSecret is a JSON string
+  no_log: true
   when:
     - not (disconnected | default(true))
     - pullSecret is not mapping
@@ -202,11 +207,13 @@
     pullSecretNew: "{{ pullSecret | from_json | ansible.builtin.combine(pullSecretQuay, recursive=True) | to_json }}"
 
 - name: Set pull secret for disconnected (no combine)
+  no_log: true
   when: disconnected | default(true)
   ansible.builtin.set_fact:
     pullSecretNew: "{{ pullSecretQuay }}"
 
 - name: Patch cluster pull-secret
+  no_log: true
   kubernetes.core.k8s:
     state: patched
     definition:
@@ -224,6 +231,7 @@
   until: r_patch_cluster_pullsecret is success
 
 - name: Create pull-secret file with the combination
+  no_log: true
   ansible.builtin.copy:
     content: "{{ pullSecretQuay }}"
     dest: "{{ workingDir }}/config/pull-secret.quay.json"

--- a/playbooks/07-configure-discovery.yaml
+++ b/playbooks/07-configure-discovery.yaml
@@ -31,10 +31,12 @@
       until: r_namespace_infraenv is success
 
     - name: Read pull secret from file
+      no_log: true
       ansible.builtin.set_fact:
         pull_secret_content: "{{ lookup('file', '{{ workingDir }}/config/pull-secret.quay.json') | from_json }}"
 
     - name: Create pullsecret for infraenv
+      no_log: true
       environment:
         KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
       kubernetes.core.k8s:

--- a/playbooks/tasks/configure_certificates.yaml
+++ b/playbooks/tasks/configure_certificates.yaml
@@ -3,6 +3,7 @@
 # Only included when custom certificates are provided
 
 - name: Create TLS secret for ingress controller
+  no_log: true
   environment:
     KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
   kubernetes.core.k8s:
@@ -41,6 +42,7 @@
   until: r_patch_ingress_controller is success
 
 - name: Create TLS secret for API server
+  no_log: true
   environment:
     KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
   kubernetes.core.k8s:

--- a/playbooks/tasks/mirror_registry.yaml
+++ b/playbooks/tasks/mirror_registry.yaml
@@ -9,30 +9,36 @@
     - r_container_quay_app.containers | default([]) | length == 0
   block:
     - name: Deploy mirror-registry
+      no_log: true
       ansible.builtin.command: |
         {{ workingDir }}/bin/mirror-registry  install --quayHostname "{{ quayHostname }}" --quayRoot {{ workingDir }}/data --initPassword "{{ quayPassword }}" --initUser "{{ quayUser }}"
       register: r_mirror_registry
 
 - name: Generate pull secret for internal mirror
+  no_log: true
   ansible.builtin.set_fact:
     pullSecretInternal: '{"auths":{"{{ quayHostname }}:8443":{"auth":"{{ (quayUser + ":" + quayPassword) | ansible.builtin.b64encode }}"}}}'
 
 # We need to check if the pullSecret is a string (surrounded by single quotes) or a dict/json (not surrounded)
 - name: combine pull secrets if pullSecret is already a dictionary
+  no_log: true
   when: pullSecret is mapping
   ansible.builtin.set_fact:
-    pullSecretNew: "{{ pullSecret | ansible.builtin.combine(pullSecretInternal, recursive=True) }}"
+    pullSecretNew: "{{ pullSecret | ansible.builtin.combine(pullSecretInternal, recursive=True) | to_json }}"
 - name: combine pull secrets if pullSecret is a JSON string
+  no_log: true
   when: pullSecret is not mapping
   ansible.builtin.set_fact:
     pullSecretNew: "{{ pullSecret | from_json | ansible.builtin.combine(pullSecretInternal, recursive=True) | to_json }}"
 
 - name: Create pull-secret file with the combination
+  no_log: true
   ansible.builtin.copy:
     content: "{{ pullSecretNew }}"
     dest: "{{ pullSecretPath }}"
 
 - name: Create pull-secret internal file with the combination
+  no_log: true
   ansible.builtin.copy:
     content: "{{ pullSecretInternal }}"
     dest: "{{ workingDir }}/config/pull-secret.internal.json"

--- a/playbooks/tasks/post_install_config.yaml
+++ b/playbooks/tasks/post_install_config.yaml
@@ -12,6 +12,7 @@
   until: r_namespace_creds_exists is success
 
 - name: Create quay-credentials Secret
+  no_log: true
   environment:
     KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
   kubernetes.core.k8s:


### PR DESCRIPTION
Add `no_log: true` to all Ansible tasks that handle sensitive data (pull secrets, credentials, TLS keys, kubeconfigs) to prevent credential leakage in CI logs when tasks fail.

Fix missing `to_json` filter in `pullSecret` combine tasks for the mapping branch, which caused Kubernetes to reject the patch with `cannot unmarshal object into Go struct field Secret.stringData of type string`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Suppressed logging of sensitive information including registry credentials, pull-secrets, and TLS certificates across multiple deployment and configuration tasks to prevent accidental exposure in audit logs and system monitoring.
  * Enhanced pull-secret content serialization and handling across mirror registry and Quay deployment scenarios to ensure consistent JSON formatting and improved reliability in multi-cluster environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->