### PR TITLE
revert pull secret ambiguous type and add initial schema validation

### DIFF
--- a/config/global.example.yaml
+++ b/config/global.example.yaml
@@ -101,7 +101,7 @@ blockStorageBackend: lvms
 # Pull Secret and SSH Public Key Configuration
 # ============================================================================
 # Obtain from: https://console.redhat.com/openshift/install/pull-secret
-pullSecret: '{"auths":{"YOUR_PULL_SECRET"}}'
+pullSecret: {"auths":{}} # Replace with your Pull Secret
 
 # SSH public key path for cluster nodes
 sshPubPath: "YOUR_SSH_PUB_KEY_PATH"

--- a/config/global.example.yaml
+++ b/config/global.example.yaml
@@ -101,6 +101,7 @@ blockStorageBackend: lvms
 # Pull Secret and SSH Public Key Configuration
 # ============================================================================
 # Obtain from: https://console.redhat.com/openshift/install/pull-secret
+# Do not wrap the pull secret in quotes
 pullSecret: {"auths":{}} # Replace with your Pull Secret
 
 # SSH public key path for cluster nodes

--- a/config/global.example.yaml
+++ b/config/global.example.yaml
@@ -101,8 +101,8 @@ blockStorageBackend: lvms
 # Pull Secret and SSH Public Key Configuration
 # ============================================================================
 # Obtain from: https://console.redhat.com/openshift/install/pull-secret
-# Do not wrap the pull secret in quotes
-pullSecret: {"auths":{}} # Replace with your Pull Secret
+# Replace with your Pull Secret and do not wrap the pull secret in quotes
+pullSecret: {"auths":{}}
 
 # SSH public key path for cluster nodes
 sshPubPath: "YOUR_SSH_PUB_KEY_PATH"

--- a/operators/quay-operator/tasks.yaml
+++ b/operators/quay-operator/tasks.yaml
@@ -190,21 +190,11 @@
       {"auth":"{{ (quayUser + ":" + quayPassword) | ansible.builtin.b64encode }}"}
       }}
 
-# We need to check if the pullSecret is a string (surrounded by single quotes) or a dict/json (not surrounded)
-- name: combine pull secrets for connected mode if pullSecret is already a dictionary
+- name: Combine pull secrets for connected mode
   no_log: true
-  when:
-    - not (disconnected | default(true))
-    - pullSecret is mapping
+  when: not (disconnected | default(true))
   ansible.builtin.set_fact:
-    pullSecretNew: "{{ pullSecret | ansible.builtin.combine(pullSecretQuay, recursive=True) | to_json }}"
-- name: combine pull secrets for connected mode if pullSecret is a JSON string
-  no_log: true
-  when:
-    - not (disconnected | default(true))
-    - pullSecret is not mapping
-  ansible.builtin.set_fact:
-    pullSecretNew: "{{ pullSecret | from_json | ansible.builtin.combine(pullSecretQuay, recursive=True) | to_json }}"
+    pullSecretNew: "{{ pullSecret | ansible.builtin.combine(pullSecretQuay, recursive=true) }}"
 
 - name: Set pull secret for disconnected (no combine)
   no_log: true
@@ -223,7 +213,7 @@
         name: pull-secret
         namespace: openshift-config
       stringData:
-        .dockerconfigjson: "{{ pullSecretNew }}"
+        .dockerconfigjson: "{{ pullSecretNew | to_json }}"
       type: kubernetes.io/dockerconfigjson
   register: r_patch_cluster_pullsecret
   retries: "{{ k8s_retries }}"

--- a/playbooks/tasks/mirror_cache.yaml
+++ b/playbooks/tasks/mirror_cache.yaml
@@ -17,7 +17,7 @@
 
 - name: Combine pull secrets
   ansible.builtin.set_fact:
-    __pull_secret_cache: "{{ pullSecret | from_json | ansible.builtin.combine(__pull_secret_dc, recursive=true) }}"
+    __pull_secret_cache: "{{ pullSecret | ansible.builtin.combine(__pull_secret_dc, recursive=true) }}"
   no_log: true
 
 - name: Create pull-secret-cache file with the combination

--- a/playbooks/tasks/mirror_registry.yaml
+++ b/playbooks/tasks/mirror_registry.yaml
@@ -19,17 +19,10 @@
   ansible.builtin.set_fact:
     pullSecretInternal: '{"auths":{"{{ quayHostname }}:8443":{"auth":"{{ (quayUser + ":" + quayPassword) | ansible.builtin.b64encode }}"}}}'
 
-# We need to check if the pullSecret is a string (surrounded by single quotes) or a dict/json (not surrounded)
-- name: combine pull secrets if pullSecret is already a dictionary
+- name: Combine pull secrets
   no_log: true
-  when: pullSecret is mapping
   ansible.builtin.set_fact:
-    pullSecretNew: "{{ pullSecret | ansible.builtin.combine(pullSecretInternal, recursive=True) | to_json }}"
-- name: combine pull secrets if pullSecret is a JSON string
-  no_log: true
-  when: pullSecret is not mapping
-  ansible.builtin.set_fact:
-    pullSecretNew: "{{ pullSecret | from_json | ansible.builtin.combine(pullSecretInternal, recursive=True) | to_json }}"
+    pullSecretNew: "{{ pullSecret | ansible.builtin.combine(pullSecretInternal, recursive=true) }}"
 
 - name: Create pull-secret file with the combination
   no_log: true

--- a/playbooks/tasks/schema_validation.yaml
+++ b/playbooks/tasks/schema_validation.yaml
@@ -1,3 +1,9 @@
+- name: validate variables schema
+  ansible.utils.validate:
+    data: "{{ vars }}"
+    criteria: "{{ lookup('ansible.builtin.file', '../../schemas/variables.yaml') | from_yaml | to_json }}"
+    engine: ansible.utils.jsonschema
+
 - name: validate defaults/deployment.yaml schema
   ansible.utils.validate:
     data: "{{ lookup('ansible.builtin.file', '../../defaults/deployment.yaml') | from_yaml | to_json }}"

--- a/schemas/variables.yaml
+++ b/schemas/variables.yaml
@@ -1,0 +1,12 @@
+---
+"$schema": "http://json-schema.org/draft-07/schema"
+version: "1.0"
+type: object
+
+additionalProperties: true
+properties:
+  pullSecret:
+    type: object
+    description: Pull Secret
+required:
+- pullSecret

--- a/scripts/verification/validate.sh
+++ b/scripts/verification/validate.sh
@@ -64,7 +64,7 @@ validate_yaml() {
 validate_json_schema() {
     print_header "Validating JSON schema"
 
-    if ansible-playbook playbooks/validate-schema.yaml -e "workingDir=test"; then
+    if ansible-playbook playbooks/validate-schema.yaml -e@config/global.example.yaml; then
         print_success "JSON schema validation passed"
         return 0
     else


### PR DESCRIPTION
reverts:
- #109
- #138
- #34 (updates)

main is currently broken: https://github.com/rh-ecosystem-edge/enclave/actions/runs/23526868007/job/68482070309

generally speaking, a variable should have a single type and that should be validated with schema validation. adding an initial schema validation in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unified pull-secret handling and ensured registry credential merges are consistently serialized for reliable cluster patching.

* **New Features**
  * Added variables schema validation to catch configuration issues earlier.

* **Documentation / Examples**
  * Example configuration updated to use object-style pullSecret with clearer replacement guidance.

* **Chores**
  * Validation tooling now reads example configuration from a file during checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->