### PR TITLE
Global variables schema validation

### DIFF
--- a/playbooks/tasks/defaults_schema_validation.yaml
+++ b/playbooks/tasks/defaults_schema_validation.yaml
@@ -1,55 +1,59 @@
-- name: validate variables schema
-  ansible.utils.validate:
-    data: "{{ vars }}"
-    criteria: "{{ lookup('ansible.builtin.file', '../../schemas/variables.yaml') | from_yaml | to_json }}"
-    engine: ansible.utils.jsonschema
+- name: Load shared schema definitions
+  ansible.builtin.set_fact:
+    schema_definitions: "{{ lookup('ansible.builtin.file', '../../schemas/definitions.yaml') | from_yaml }}"
 
 - name: validate defaults/deployment.yaml schema
   ansible.utils.validate:
     data: "{{ lookup('ansible.builtin.file', '../../defaults/deployment.yaml') | from_yaml | to_json }}"
-    criteria: "{{ lookup('ansible.builtin.file', '../../schemas/deployment.yaml') | from_yaml | to_json }}"
+    criteria: "{{ lookup('ansible.builtin.file', '../../schemas/deployment.yaml') | from_yaml | combine(schema_definitions, recursive=True) | to_json }}"
     engine: ansible.utils.jsonschema
 
 - name: validate defaults/catalogs.yaml schema
   ansible.utils.validate:
     data: "{{ lookup('ansible.builtin.file', '../../defaults/catalogs.yaml') | from_yaml | to_json }}"
-    criteria: "{{ lookup('ansible.builtin.file', '../../schemas/catalogs.yaml') | from_yaml | to_json }}"
+    criteria: "{{ lookup('ansible.builtin.file', '../../schemas/catalogs.yaml') | from_yaml | combine(schema_definitions, recursive=True) | to_json }}"
     engine: ansible.utils.jsonschema
 
 - name: validate defaults/content_images.yaml schema
   ansible.utils.validate:
     data: "{{ lookup('ansible.builtin.file', '../../defaults/content_images.yaml') | from_yaml | to_json }}"
-    criteria: "{{ lookup('ansible.builtin.file', '../../schemas/content_images.yaml') | from_yaml | to_json }}"
+    criteria: "{{ lookup('ansible.builtin.file', '../../schemas/content_images.yaml') | from_yaml | combine(schema_definitions, recursive=True) | to_json }}"
     engine: ansible.utils.jsonschema
 
 - name: validate defaults/control_binaries.yaml schema
   ansible.utils.validate:
     data: "{{ lookup('ansible.builtin.file', '../../defaults/control_binaries.yaml') | from_yaml | to_json }}"
-    criteria: "{{ lookup('ansible.builtin.file', '../../schemas/control_binaries.yaml') | from_yaml | to_json }}"
+    criteria: "{{ lookup('ansible.builtin.file', '../../schemas/control_binaries.yaml') | from_yaml | combine(schema_definitions, recursive=True) | to_json }}"
     engine: ansible.utils.jsonschema
 
 - name: validate defaults/operators.yaml schema
   ansible.utils.validate:
     data: "{{ lookup('ansible.builtin.file', '../../defaults/operators.yaml') | from_yaml | to_json }}"
-    criteria: "{{ lookup('ansible.builtin.file', '../../schemas/operators.yaml') | from_yaml | to_json }}"
+    criteria: "{{ lookup('ansible.builtin.file', '../../schemas/operators.yaml') | from_yaml | combine(schema_definitions, recursive=True) | to_json }}"
     engine: ansible.utils.jsonschema
 
 - name: validate defaults/platforms.yaml schema
   ansible.utils.validate:
     data: "{{ lookup('ansible.builtin.file', '../../defaults/platforms.yaml') | from_yaml | to_json }}"
-    criteria: "{{ lookup('ansible.builtin.file', '../../schemas/platforms.yaml') | from_yaml | to_json }}"
+    criteria: "{{ lookup('ansible.builtin.file', '../../schemas/platforms.yaml') | from_yaml | combine(schema_definitions, recursive=True) | to_json }}"
     engine: ansible.utils.jsonschema
 
 - name: validate defaults/mirror_registry.yaml schema
   ansible.utils.validate:
     data: "{{ lookup('ansible.builtin.file', '../../defaults/mirror_registry.yaml') | from_yaml | to_json }}"
-    criteria: "{{ lookup('ansible.builtin.file', '../../schemas/mirror_registry.yaml') | from_yaml | to_json }}"
+    criteria: "{{ lookup('ansible.builtin.file', '../../schemas/mirror_registry.yaml') | from_yaml | combine(schema_definitions, recursive=True) | to_json }}"
     engine: ansible.utils.jsonschema
 
 - name: validate defaults/quay_operator.yaml schema
   ansible.utils.validate:
     data: "{{ lookup('ansible.builtin.file', '../../defaults/quay_operator.yaml') | from_yaml | to_json }}"
-    criteria: "{{ lookup('ansible.builtin.file', '../../schemas/quay_operator.yaml') | from_yaml | to_json }}"
+    criteria: "{{ lookup('ansible.builtin.file', '../../schemas/quay_operator.yaml') | from_yaml | combine(schema_definitions, recursive=True) | to_json }}"
+    engine: ansible.utils.jsonschema
+
+- name: validate defaults/k8s.yaml schema
+  ansible.utils.validate:
+    data: "{{ lookup('ansible.builtin.file', '../../defaults/k8s.yaml') | from_yaml | to_json }}"
+    criteria: "{{ lookup('ansible.builtin.file', '../../schemas/k8s.yaml') | from_yaml | combine(schema_definitions, recursive=True) | to_json }}"
     engine: ansible.utils.jsonschema
 
 - name: Find all plugin.yaml files
@@ -63,7 +67,7 @@
 - name: "Validate plugin schema: {{ item.path | regex_replace('.*/plugins/', 'plugins/') }}"
   ansible.utils.validate:
     data: "{{ lookup('ansible.builtin.file', item.path) | from_yaml | to_json }}"
-    criteria: "{{ lookup('ansible.builtin.file', '../../schemas/plugin.yaml') | from_yaml | to_json }}"
+    criteria: "{{ lookup('ansible.builtin.file', '../../schemas/plugin.yaml') | from_yaml | combine(schema_definitions, recursive=True) | to_json }}"
     engine: ansible.utils.jsonschema
   loop: "{{ r_plugin_files.files }}"
   loop_control:

--- a/playbooks/tasks/variables_schema_validation.yaml
+++ b/playbooks/tasks/variables_schema_validation.yaml
@@ -1,0 +1,47 @@
+- name: Load shared schema definitions
+  ansible.builtin.set_fact:
+    schema_definitions: "{{ lookup('ansible.builtin.file', '../../schemas/definitions.yaml') | from_yaml }}"
+
+- name: Load variables schema
+  ansible.builtin.set_fact:
+    variables_schema: "{{ lookup('ansible.builtin.file', '../../schemas/variables.yaml') | from_yaml | combine(schema_definitions, recursive=True) | to_json }}"
+
+- name: Find valid fixtures
+  ansible.builtin.find:
+    paths: "{{ playbook_dir }}/../schemas/fixtures/valid"
+    patterns: "*.yaml"
+  register: valid_fixtures
+
+- name: Validate valid fixtures
+  ansible.utils.validate:
+    data: "{{ lookup('ansible.builtin.file', item.path) | from_yaml | to_json }}"
+    criteria: "{{ variables_schema }}"
+    engine: ansible.utils.jsonschema
+  loop: "{{ valid_fixtures.files }}"
+  loop_control:
+    label: "{{ item.path | basename }}"
+
+- name: Find invalid fixtures
+  ansible.builtin.find:
+    paths: "{{ playbook_dir }}/../schemas/fixtures/invalid"
+    patterns: "*.yaml"
+  register: invalid_fixtures
+
+- name: Validate invalid fixtures (expect failure)
+  ansible.utils.validate:
+    data: "{{ lookup('ansible.builtin.file', item.path) | from_yaml | to_json }}"
+    criteria: "{{ variables_schema }}"
+    engine: ansible.utils.jsonschema
+  loop: "{{ invalid_fixtures.files }}"
+  loop_control:
+    label: "{{ item.path | basename }}"
+  register: invalid_results
+  ignore_errors: true
+
+- name: Assert invalid fixtures failed validation
+  ansible.builtin.assert:
+    that: item.failed
+    fail_msg: "Invalid fixture {{ item.item.path | basename }} unexpectedly passed schema validation"
+  loop: "{{ invalid_results.results }}"
+  loop_control:
+    label: "{{ item.item.path | basename }}"

--- a/playbooks/validate-schema.yaml
+++ b/playbooks/validate-schema.yaml
@@ -9,9 +9,16 @@
   hosts: localhost
   gather_facts: false
   tasks:
-    - name: Include schema validation tasks
+    - name: Include defaults schema validation tasks
       ansible.builtin.include_tasks:
-        file: tasks/schema_validation.yaml
+        file: tasks/defaults_schema_validation.yaml
+        apply:
+          tags: schema-validation
+      tags: schema-validation
+
+    - name: Include variables schema validation tasks
+      ansible.builtin.include_tasks:
+        file: tasks/variables_schema_validation.yaml
         apply:
           tags: schema-validation
       tags: schema-validation

--- a/schemas/definitions.yaml
+++ b/schemas/definitions.yaml
@@ -1,0 +1,56 @@
+---
+definitions:
+  ipv4Address:
+    type: string
+    pattern: "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
+    description: IPv4 address
+  cidr:
+    type: string
+    pattern: "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/(3[0-2]|[12]?[0-9])$"
+    description: CIDR notation network address
+  macAddress:
+    type: string
+    pattern: "^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$"
+    description: MAC address in colon-separated hex notation
+  nonEmptyString:
+    type: string
+    minLength: 1
+    description: A non-empty string value
+  disconnected:
+    type: boolean
+    description: >-
+      Whether the deployment is disconnected (air-gapped). Default: true.
+      Set to false for connected deployments.
+  diskEncryption:
+    type: boolean
+    description: >-
+      Whether to enable disk encryption using TPM v2. Default: false.
+      Set to true to encrypt the installation partition on all nodes.
+  ocMirrorLogLevel:
+    type: string
+    enum: [trace, debug, info, error]
+    description: "Log level for oc-mirror. Default: info."
+  quayBackendRGWIsSecure:
+    type: boolean
+    description: Whether to use HTTPS for backend storage
+  quayBackendRGWMaximumChunkSizeMb:
+    type: integer
+    minimum: 1
+    description: Maximum multipart upload chunk size in MB
+  quayBackendRGWMinimumChunkSizeMb:
+    type: integer
+    minimum: 1
+    description: Minimum multipart upload chunk size in MB
+  quayBackendRGWPort:
+    type: integer
+    minimum: 1
+    maximum: 65535
+    description: Port for backend storage endpoint
+  quayBackendRGWServerSideAssembly:
+    type: boolean
+    description: Enable server-side assembly for multipart uploads
+  quayBackendStoragePath:
+    type: string
+    pattern: "^/"
+    description: Path for backend storage
+

--- a/schemas/deployment.yaml
+++ b/schemas/deployment.yaml
@@ -6,20 +6,11 @@ type: object
 additionalProperties: false
 properties:
   disconnected:
-    type: boolean
-    description: >-
-      Whether the deployment is disconnected (air-gapped). Default: true.
-      Set to false for connected deployments.
+    "$ref": "#/definitions/disconnected"
   diskEncryption:
-    type: boolean
-    description: >-
-      Whether to enable disk encryption using TPM v2. Default: false.
-      Set to true to encrypt the installation partition on all nodes.
+    "$ref": "#/definitions/diskEncryption"
   ocMirrorLogLevel:
-    type: string
-    enum: [trace, debug, info, error]
-    description: >-
-      Log level for oc-mirror. Default: info.
+    "$ref": "#/definitions/ocMirrorLogLevel"
   pullSecretPath:
     type: string
     description: >-

--- a/schemas/fixtures/invalid/invalid-additional-property.yaml
+++ b/schemas/fixtures/invalid/invalid-additional-property.yaml
@@ -1,0 +1,43 @@
+---
+# Fixture: unrecognized field at top level
+# Expected failure: additionalProperties is false; unknown fields are rejected
+unknownFieldwithAnUnknownName: this-should-not-be-here
+workingDir: /home/enclave
+baseDomain: enclave-test.nodns.in
+clusterName: mgmt
+machineNetwork: 192.168.2.0/24
+apiVIP: 192.168.2.201
+ingressVIP: 192.168.2.202
+defaultDNS: 9.30.31.32
+defaultGateway: 192.168.2.10
+defaultPrefix: 24
+rendezvousIP: 192.168.2.24
+lzBmcIP: 100.64.1.10
+quayUser: admin
+quayPassword: password
+quayBackend: LocalStorage
+blockStorageBackend: lvms
+pullSecret: {"auths":{}}
+sshPubPath: /home/enclave/.ssh/id_rsa.pub
+agent_hosts:
+  - name: mgmt-ctl01
+    macAddress: 0c:c4:7a:62:fe:ec
+    ipAddress: 192.168.2.24
+    redfish: 192.168.1.101
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl02
+    macAddress: 0c:c4:7a:62:fe:ed
+    ipAddress: 192.168.2.25
+    redfish: 192.168.1.102
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl03
+    macAddress: 0c:c4:7a:62:fe:ee
+    ipAddress: 192.168.2.26
+    redfish: 192.168.1.103
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password

--- a/schemas/fixtures/invalid/invalid-empty-string.yaml
+++ b/schemas/fixtures/invalid/invalid-empty-string.yaml
@@ -1,0 +1,42 @@
+---
+# Fixture: empty string on a required nonEmptyString field
+# Expected failure: clusterName must have minLength: 1
+workingDir: /home/enclave
+baseDomain: enclave-test.nodns.in
+clusterName: ""
+machineNetwork: 192.168.2.0/24
+apiVIP: 192.168.2.201
+ingressVIP: 192.168.2.202
+defaultDNS: 9.30.31.32
+defaultGateway: 192.168.2.10
+defaultPrefix: 24
+rendezvousIP: 192.168.2.24
+lzBmcIP: 100.64.1.10
+quayUser: admin
+quayPassword: password
+quayBackend: LocalStorage
+blockStorageBackend: lvms
+pullSecret: {"auths":{}}
+sshPubPath: /home/enclave/.ssh/id_rsa.pub
+agent_hosts:
+  - name: mgmt-ctl01
+    macAddress: 0c:c4:7a:62:fe:ec
+    ipAddress: 192.168.2.24
+    redfish: 192.168.1.101
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl02
+    macAddress: 0c:c4:7a:62:fe:ed
+    ipAddress: 192.168.2.25
+    redfish: 192.168.1.102
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl03
+    macAddress: 0c:c4:7a:62:fe:ee
+    ipAddress: 192.168.2.26
+    redfish: 192.168.1.103
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password

--- a/schemas/fixtures/invalid/invalid-enum.yaml
+++ b/schemas/fixtures/invalid/invalid-enum.yaml
@@ -1,0 +1,43 @@
+---
+# Invalid fixture: unknown blockStorageBackend value
+# Expected failure: blockStorageBackend must be one of [lvms, odf].
+workingDir: /home/enclave
+baseDomain: enclave-test.nodns.in
+clusterName: mgmt
+machineNetwork: 192.168.2.0/24
+apiVIP: 192.168.2.201
+ingressVIP: 192.168.2.202
+defaultDNS: 9.30.31.32
+defaultGateway: 192.168.2.10
+defaultPrefix: 24
+rendezvousIP: 192.168.2.24
+lzBmcIP: 100.64.1.10
+quayUser: admin
+quayPassword: password
+quayBackend: LocalStorage
+blockStorageBackend: nfs
+pullSecret: {"auths":{}}
+sshPubPath: /home/enclave/.ssh/id_rsa.pub
+agent_hosts:
+  - name: mgmt-ctl01
+    macAddress: 0c:c4:7a:62:fe:ec
+    ipAddress: 192.168.2.24
+    redfish: 192.168.1.101
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl02
+    macAddress: 0c:c4:7a:62:fe:ed
+    ipAddress: 192.168.2.25
+    redfish: 192.168.1.102
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl03
+    macAddress: 0c:c4:7a:62:fe:ee
+    ipAddress: 192.168.2.26
+    redfish: 192.168.1.103
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+

--- a/schemas/fixtures/invalid/invalid-ip.yaml
+++ b/schemas/fixtures/invalid/invalid-ip.yaml
@@ -1,0 +1,43 @@
+---
+# Invalid fixture: malformed IP address in apiVIP
+# Expected failure: apiVIP does not match the IPv4 pattern in definitions.yaml.
+workingDir: /home/enclave
+baseDomain: enclave-test.nodns.in
+clusterName: mgmt
+machineNetwork: 192.168.2.0/24
+apiVIP: not-an-ip
+ingressVIP: 192.168.2.202
+defaultDNS: 9.30.31.32
+defaultGateway: 192.168.2.10
+defaultPrefix: 24
+rendezvousIP: 192.168.2.24
+lzBmcIP: 100.64.1.10
+quayUser: admin
+quayPassword: password
+quayBackend: LocalStorage
+blockStorageBackend: lvms
+pullSecret: {"auths":{}}
+sshPubPath: /home/enclave/.ssh/id_rsa.pub
+agent_hosts:
+  - name: mgmt-ctl01
+    macAddress: 0c:c4:7a:62:fe:ec
+    ipAddress: 192.168.2.24
+    redfish: 192.168.1.101
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl02
+    macAddress: 0c:c4:7a:62:fe:ed
+    ipAddress: 192.168.2.25
+    redfish: 192.168.1.102
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl03
+    macAddress: 0c:c4:7a:62:fe:ee
+    ipAddress: 192.168.2.26
+    redfish: 192.168.1.103
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+

--- a/schemas/fixtures/invalid/invalid-port.yaml
+++ b/schemas/fixtures/invalid/invalid-port.yaml
@@ -1,0 +1,49 @@
+---
+# Invalid fixture: port value below minimum
+# Expected failure: quayBackendRGWConfiguration.port must be >= 1 (minimum: 1).
+workingDir: /home/enclave
+baseDomain: enclave-test.nodns.in
+clusterName: mgmt
+machineNetwork: 192.168.2.0/24
+apiVIP: 192.168.2.201
+ingressVIP: 192.168.2.202
+defaultDNS: 9.30.31.32
+defaultGateway: 192.168.2.10
+defaultPrefix: 24
+rendezvousIP: 192.168.2.24
+lzBmcIP: 100.64.1.10
+quayUser: admin
+quayPassword: password
+quayBackend: RadosGWStorage
+quayBackendRGWConfiguration:
+  access_key: EXAMPLE_ACCESS_KEY
+  secret_key: EXAMPLE_SECRET_KEY
+  bucket_name: quay-storage
+  hostname: radosgw.enclave-test.nodns.in
+  port: 0
+blockStorageBackend: lvms
+pullSecret: {"auths":{}}
+sshPubPath: /home/enclave/.ssh/id_rsa.pub
+agent_hosts:
+  - name: mgmt-ctl01
+    macAddress: 0c:c4:7a:62:fe:ec
+    ipAddress: 192.168.2.24
+    redfish: 192.168.1.101
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl02
+    macAddress: 0c:c4:7a:62:fe:ed
+    ipAddress: 192.168.2.25
+    redfish: 192.168.1.102
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl03
+    macAddress: 0c:c4:7a:62:fe:ee
+    ipAddress: 192.168.2.26
+    redfish: 192.168.1.103
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+

--- a/schemas/fixtures/invalid/invalid-rgw-unknown-key.yaml
+++ b/schemas/fixtures/invalid/invalid-rgw-unknown-key.yaml
@@ -1,0 +1,48 @@
+---
+# Fixture: unknown key in quayBackendRGWConfiguration
+# Expected failure: additionalProperties: false rejects unrecognized RGW keys
+workingDir: /home/enclave
+baseDomain: enclave-test.nodns.in
+clusterName: mgmt
+machineNetwork: 192.168.2.0/24
+apiVIP: 192.168.2.201
+ingressVIP: 192.168.2.202
+defaultDNS: 9.30.31.32
+defaultGateway: 192.168.2.10
+defaultPrefix: 24
+rendezvousIP: 192.168.2.24
+lzBmcIP: 100.64.1.10
+quayUser: admin
+quayPassword: password
+quayBackend: RadosGWStorage
+blockStorageBackend: lvms
+pullSecret: {"auths":{}}
+sshPubPath: /home/enclave/.ssh/id_rsa.pub
+quayBackendRGWConfiguration:
+  access_key: EXAMPLE_ACCESS_KEY
+  secret_key: EXAMPLE_SECRET_KEY
+  bucket_name: quay-storage
+  hostname: radosgw.enclave-test.nodns.in
+  unknownRGWKey: should-not-be-here
+agent_hosts:
+  - name: mgmt-ctl01
+    macAddress: 0c:c4:7a:62:fe:ec
+    ipAddress: 192.168.2.24
+    redfish: 192.168.1.101
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl02
+    macAddress: 0c:c4:7a:62:fe:ed
+    ipAddress: 192.168.2.25
+    redfish: 192.168.1.102
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl03
+    macAddress: 0c:c4:7a:62:fe:ee
+    ipAddress: 192.168.2.26
+    redfish: 192.168.1.103
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password

--- a/schemas/fixtures/invalid/invalid-storage-path.yaml
+++ b/schemas/fixtures/invalid/invalid-storage-path.yaml
@@ -1,0 +1,50 @@
+---
+# Invalid fixture: storage_path without a leading slash
+# Expected failure: quayBackendRGWConfiguration.storage_path must match ^/
+# (pattern constraint from quayBackendStoragePath definition).
+workingDir: /home/enclave
+baseDomain: enclave-test.nodns.in
+clusterName: mgmt
+machineNetwork: 192.168.2.0/24
+apiVIP: 192.168.2.201
+ingressVIP: 192.168.2.202
+defaultDNS: 9.30.31.32
+defaultGateway: 192.168.2.10
+defaultPrefix: 24
+rendezvousIP: 192.168.2.24
+lzBmcIP: 100.64.1.10
+quayUser: admin
+quayPassword: password
+quayBackend: RadosGWStorage
+quayBackendRGWConfiguration:
+  access_key: EXAMPLE_ACCESS_KEY
+  secret_key: EXAMPLE_SECRET_KEY
+  bucket_name: quay-storage
+  hostname: radosgw.enclave-test.nodns.in
+  storage_path: no-leading-slash
+blockStorageBackend: lvms
+pullSecret: {"auths":{}}
+sshPubPath: /home/enclave/.ssh/id_rsa.pub
+agent_hosts:
+  - name: mgmt-ctl01
+    macAddress: 0c:c4:7a:62:fe:ec
+    ipAddress: 192.168.2.24
+    redfish: 192.168.1.101
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl02
+    macAddress: 0c:c4:7a:62:fe:ed
+    ipAddress: 192.168.2.25
+    redfish: 192.168.1.102
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl03
+    macAddress: 0c:c4:7a:62:fe:ee
+    ipAddress: 192.168.2.26
+    redfish: 192.168.1.103
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+

--- a/schemas/fixtures/invalid/odf-without-external-config.yaml
+++ b/schemas/fixtures/invalid/odf-without-external-config.yaml
@@ -1,0 +1,44 @@
+---
+# Invalid fixture: odf block storage without odfExternalConfig
+# Expected failure: variables schema requires odfExternalConfig
+# when blockStorageBackend is odf.
+workingDir: /home/enclave
+baseDomain: enclave-test.nodns.in
+clusterName: mgmt
+machineNetwork: 192.168.2.0/24
+apiVIP: 192.168.2.201
+ingressVIP: 192.168.2.202
+defaultDNS: 9.30.31.32
+defaultGateway: 192.168.2.10
+defaultPrefix: 24
+rendezvousIP: 192.168.2.24
+lzBmcIP: 100.64.1.10
+quayUser: admin
+quayPassword: password
+quayBackend: LocalStorage
+blockStorageBackend: odf
+pullSecret: {"auths":{}}
+sshPubPath: /home/enclave/.ssh/id_rsa.pub
+agent_hosts:
+  - name: mgmt-ctl01
+    macAddress: 0c:c4:7a:62:fe:ec
+    ipAddress: 192.168.2.24
+    redfish: 192.168.1.101
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl02
+    macAddress: 0c:c4:7a:62:fe:ed
+    ipAddress: 192.168.2.25
+    redfish: 192.168.1.102
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl03
+    macAddress: 0c:c4:7a:62:fe:ee
+    ipAddress: 192.168.2.26
+    redfish: 192.168.1.103
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+

--- a/schemas/fixtures/invalid/radosgw-without-rgw-config.yaml
+++ b/schemas/fixtures/invalid/radosgw-without-rgw-config.yaml
@@ -1,0 +1,44 @@
+---
+# Invalid fixture: RadosGWStorage without quayBackendRGWConfiguration
+# Expected failure: variables schema requires quayBackendRGWConfiguration
+# when quayBackend is RadosGWStorage.
+workingDir: /home/enclave
+baseDomain: enclave-test.nodns.in
+clusterName: mgmt
+machineNetwork: 192.168.2.0/24
+apiVIP: 192.168.2.201
+ingressVIP: 192.168.2.202
+defaultDNS: 9.30.31.32
+defaultGateway: 192.168.2.10
+defaultPrefix: 24
+rendezvousIP: 192.168.2.24
+lzBmcIP: 100.64.1.10
+quayUser: admin
+quayPassword: password
+quayBackend: RadosGWStorage
+blockStorageBackend: lvms
+pullSecret: {"auths":{}}
+sshPubPath: /home/enclave/.ssh/id_rsa.pub
+agent_hosts:
+  - name: mgmt-ctl01
+    macAddress: 0c:c4:7a:62:fe:ec
+    ipAddress: 192.168.2.24
+    redfish: 192.168.1.101
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl02
+    macAddress: 0c:c4:7a:62:fe:ed
+    ipAddress: 192.168.2.25
+    redfish: 192.168.1.102
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl03
+    macAddress: 0c:c4:7a:62:fe:ee
+    ipAddress: 192.168.2.26
+    redfish: 192.168.1.103
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+

--- a/schemas/fixtures/valid/local-lvms.yaml
+++ b/schemas/fixtures/valid/local-lvms.yaml
@@ -1,0 +1,44 @@
+---
+# Fixture: LocalStorage backend + lvms block storage
+# Validates that quayBackendRGWConfiguration is NOT required for LocalStorage
+# and that odfExternalConfig is NOT required for lvms.
+workingDir: /home/enclave
+baseDomain: enclave-test.nodns.in
+clusterName: mgmt
+machineNetwork: 192.168.2.0/24
+apiVIP: 192.168.2.201
+ingressVIP: 192.168.2.202
+defaultDNS: 9.30.31.32
+defaultGateway: 192.168.2.10
+defaultPrefix: 24
+rendezvousIP: 192.168.2.24
+lzBmcIP: 100.64.1.10
+quayUser: admin
+quayPassword: password
+quayBackend: LocalStorage
+blockStorageBackend: lvms
+pullSecret: {"auths":{}}
+sshPubPath: /home/enclave/.ssh/id_rsa.pub
+agent_hosts:
+  - name: mgmt-ctl01
+    macAddress: 0c:c4:7a:62:fe:ec
+    ipAddress: 192.168.2.24
+    redfish: 192.168.1.101
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl02
+    macAddress: 0c:c4:7a:62:fe:ed
+    ipAddress: 192.168.2.25
+    redfish: 192.168.1.102
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl03
+    macAddress: 0c:c4:7a:62:fe:ee
+    ipAddress: 192.168.2.26
+    redfish: 192.168.1.103
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+

--- a/schemas/fixtures/valid/local-odf.yaml
+++ b/schemas/fixtures/valid/local-odf.yaml
@@ -1,0 +1,47 @@
+---
+# Fixture: LocalStorage backend + odf block storage
+# Validates that LocalStorage + odf is accepted: no quayBackendRGWConfiguration
+# required, but odfExternalConfig is required.
+workingDir: /home/enclave
+baseDomain: enclave-test.nodns.in
+clusterName: mgmt
+machineNetwork: 192.168.2.0/24
+apiVIP: 192.168.2.201
+ingressVIP: 192.168.2.202
+defaultDNS: 9.30.31.32
+defaultGateway: 192.168.2.10
+defaultPrefix: 24
+rendezvousIP: 192.168.2.24
+lzBmcIP: 100.64.1.10
+quayUser: admin
+quayPassword: password
+quayBackend: LocalStorage
+blockStorageBackend: odf
+odfExternalConfig: >-
+  [{"name": "external-cluster-user-command", "kind": "ConfigMap",
+  "data": {"userKey": "AQBf0000000000000000000000==", "userID": "ocs-client"}}]
+pullSecret: {"auths":{}}
+sshPubPath: /home/enclave/.ssh/id_rsa.pub
+agent_hosts:
+  - name: mgmt-ctl01
+    macAddress: 0c:c4:7a:62:fe:ec
+    ipAddress: 192.168.2.24
+    redfish: 192.168.1.101
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl02
+    macAddress: 0c:c4:7a:62:fe:ed
+    ipAddress: 192.168.2.25
+    redfish: 192.168.1.102
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl03
+    macAddress: 0c:c4:7a:62:fe:ee
+    ipAddress: 192.168.2.26
+    redfish: 192.168.1.103
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+

--- a/schemas/fixtures/valid/radosgw-lvms-all-optionals.yaml
+++ b/schemas/fixtures/valid/radosgw-lvms-all-optionals.yaml
@@ -1,0 +1,69 @@
+---
+# Fixture: RadosGWStorage + lvms with all optional fields set
+# Exercises: disconnected, diskEncryption, ocMirrorLogLevel, defaultNtpServers,
+# lvmsConfig, bmcSystemId, and all optional quayBackendRGWConfiguration overrides.
+workingDir: /home/enclave
+baseDomain: enclave-test.nodns.in
+clusterName: mgmt
+machineNetwork: 192.168.2.0/24
+apiVIP: 192.168.2.201
+ingressVIP: 192.168.2.202
+defaultDNS: 9.30.31.32
+defaultGateway: 192.168.2.10
+defaultPrefix: 24
+rendezvousIP: 192.168.2.24
+lzBmcIP: 100.64.1.10
+disconnected: false
+diskEncryption: true
+ocMirrorLogLevel: trace
+defaultNtpServers:
+  - 192.168.2.5
+  - 192.168.2.6
+quayUser: admin
+quayPassword: password
+quayBackend: RadosGWStorage
+quayBackendRGWConfiguration:
+  access_key: EXAMPLE_ACCESS_KEY
+  secret_key: EXAMPLE_SECRET_KEY
+  bucket_name: quay-storage
+  hostname: radosgw.enclave-test.nodns.in
+  is_secure: false
+  port: 8080
+  minimum_chunk_size_mb: 50
+  maximum_chunk_size_mb: 250
+  server_side_assembly: false
+  storage_path: /custom/registry
+blockStorageBackend: lvms
+lvmsConfig:
+  deviceSelector:
+    optionalPaths:
+      - /dev/disk/by-path/pci-0000:00:11.4-ata-2.0
+      - /dev/disk/by-path/pci-0000:00:11.4-ata-3.0
+pullSecret: {"auths":{}}
+sshPubPath: /home/enclave/.ssh/id_rsa.pub
+agent_hosts:
+  - name: mgmt-ctl01
+    macAddress: 0c:c4:7a:62:fe:ec
+    ipAddress: 192.168.2.24
+    redfish: 192.168.1.101
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+    bmcSystemId: "2"
+  - name: mgmt-ctl02
+    macAddress: 0c:c4:7a:62:fe:ed
+    ipAddress: 192.168.2.25
+    redfish: 192.168.1.102
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+    bmcSystemId: "2"
+  - name: mgmt-ctl03
+    macAddress: 0c:c4:7a:62:fe:ee
+    ipAddress: 192.168.2.26
+    redfish: 192.168.1.103
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+    bmcSystemId: "2"
+

--- a/schemas/fixtures/valid/radosgw-odf.yaml
+++ b/schemas/fixtures/valid/radosgw-odf.yaml
@@ -1,0 +1,52 @@
+---
+# Fixture: RadosGWStorage backend + odf block storage
+# Validates that both quayBackendRGWConfiguration and odfExternalConfig are
+# accepted together, and that both conditional requirements are satisfied.
+workingDir: /home/enclave
+baseDomain: enclave-test.nodns.in
+clusterName: mgmt
+machineNetwork: 192.168.2.0/24
+apiVIP: 192.168.2.201
+ingressVIP: 192.168.2.202
+defaultDNS: 9.30.31.32
+defaultGateway: 192.168.2.10
+defaultPrefix: 24
+rendezvousIP: 192.168.2.24
+lzBmcIP: 100.64.1.10
+quayUser: admin
+quayPassword: password
+quayBackend: RadosGWStorage
+quayBackendRGWConfiguration:
+  access_key: EXAMPLE_ACCESS_KEY
+  secret_key: EXAMPLE_SECRET_KEY
+  bucket_name: quay-storage
+  hostname: radosgw.enclave-test.nodns.in
+blockStorageBackend: odf
+odfExternalConfig: >-
+  [{"name": "external-cluster-user-command", "kind": "ConfigMap",
+  "data": {"userKey": "AQBf0000000000000000000000==", "userID": "ocs-client"}}]
+pullSecret: {"auths":{}}
+sshPubPath: /home/enclave/.ssh/id_rsa.pub
+agent_hosts:
+  - name: mgmt-ctl01
+    macAddress: 0c:c4:7a:62:fe:ec
+    ipAddress: 192.168.2.24
+    redfish: 192.168.1.101
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl02
+    macAddress: 0c:c4:7a:62:fe:ed
+    ipAddress: 192.168.2.25
+    redfish: 192.168.1.102
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl03
+    macAddress: 0c:c4:7a:62:fe:ee
+    ipAddress: 192.168.2.26
+    redfish: 192.168.1.103
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+

--- a/schemas/k8s.yaml
+++ b/schemas/k8s.yaml
@@ -1,0 +1,20 @@
+---
+"$schema": "http://json-schema.org/draft-07/schema"
+version: "1.0"
+type: object
+
+additionalProperties: false
+properties:
+  k8s_retries:
+    type: integer
+    minimum: 1
+    description: Number of retries for k8s module calls
+  k8s_delay:
+    type: integer
+    minimum: 1
+    description: Delay in seconds between k8s module call retries
+
+required:
+  - k8s_retries
+  - k8s_delay
+

--- a/schemas/quay_operator.yaml
+++ b/schemas/quay_operator.yaml
@@ -21,9 +21,7 @@ properties:
     additionalProperties: false
     properties:
       storage_path:
-        type: string
-        description: Path for backend storage
-        pattern: "^/"
+        "$ref": "#/definitions/quayBackendStoragePath"
     required:
       - storage_path
   quayBackendRGWDefaults:
@@ -32,24 +30,15 @@ properties:
     additionalProperties: false
     properties:
       is_secure:
-        type: boolean
-        description: Whether to use HTTPS for backend storage
+        "$ref": "#/definitions/quayBackendRGWIsSecure"
       port:
-        type: integer
-        description: Port for backend storage endpoint
-        minimum: 1
-        maximum: 65535
+        "$ref": "#/definitions/quayBackendRGWPort"
       minimum_chunk_size_mb:
-        type: integer
-        description: Minimum multipart upload chunk size in MB
-        minimum: 1
+        "$ref": "#/definitions/quayBackendRGWMinimumChunkSizeMb"
       maximum_chunk_size_mb:
-        type: integer
-        description: Maximum multipart upload chunk size in MB
-        minimum: 1
+        "$ref": "#/definitions/quayBackendRGWMaximumChunkSizeMb"
       server_side_assembly:
-        type: boolean
-        description: Enable server-side assembly for multipart uploads
+        "$ref": "#/definitions/quayBackendRGWServerSideAssembly"
     required:
       - is_secure
       - port

--- a/schemas/variables.yaml
+++ b/schemas/variables.yaml
@@ -3,10 +3,177 @@
 version: "1.0"
 type: object
 
-additionalProperties: true
+additionalProperties: false
 properties:
+  agent_hosts:
+    type: array
+    minItems: 3
+    maxItems: 3
+    description: List of exactly 3 control plane nodes
+    items:
+      type: object
+      properties:
+        bmcSystemId:
+          type: string
+          description: Redfish system ID path component, defaults to '1'
+        ipAddress:
+          "$ref": "#/definitions/ipv4Address"
+        macAddress:
+          "$ref": "#/definitions/macAddress"
+        mapInterfaces:
+          type: object
+          description: Interface mapping configuration
+        name:
+          "$ref": "#/definitions/nonEmptyString"
+        networkConfig:
+          type: object
+          description: Network configuration
+        redfish:
+          "$ref": "#/definitions/ipv4Address"
+        redfishPassword:
+          "$ref": "#/definitions/nonEmptyString"
+        redfishUser:
+          "$ref": "#/definitions/nonEmptyString"
+        rootDisk:
+          "$ref": "#/definitions/nonEmptyString"
+      required:
+        - ipAddress
+        - macAddress
+        - name
+        - redfish
+        - redfishPassword
+        - redfishUser
+        - rootDisk
+  apiVIP:
+    "$ref": "#/definitions/ipv4Address"
+  baseDomain:
+    "$ref": "#/definitions/nonEmptyString"
+  blockStorageBackend:
+    type: string
+    enum: [lvms, odf]
+    description: Block storage backend for Quay database and assisted installer
+  clusterName:
+    "$ref": "#/definitions/nonEmptyString"
+  defaultDNS:
+    "$ref": "#/definitions/ipv4Address"
+  defaultGateway:
+    "$ref": "#/definitions/ipv4Address"
+  defaultNtpServers:
+    type: array
+    description: Additional NTP servers for cluster nodes
+    items:
+      type: string
+  defaultPrefix:
+    type: integer
+    minimum: 1
+    maximum: 32
+    description: Network prefix length (subnet mask bits)
+  disconnected:
+    "$ref": "#/definitions/disconnected"
+  diskEncryption:
+    "$ref": "#/definitions/diskEncryption"
+  ingressVIP:
+    "$ref": "#/definitions/ipv4Address"
+  lvmsConfig:
+    type: object
+    description: LVMS storage configuration
+    properties:
+      deviceSelector:
+        type: object
+        properties:
+          optionalPaths:
+            type: array
+            items:
+              type: string
+  lzBmcIP:
+    "$ref": "#/definitions/ipv4Address"
+  machineNetwork:
+    "$ref": "#/definitions/cidr"
+  ocMirrorLogLevel:
+    "$ref": "#/definitions/ocMirrorLogLevel"
+  odfExternalConfig:
+    type: string
+    description: ODF external cluster configuration JSON string
   pullSecret:
     type: object
     description: Pull Secret
+  quayBackend:
+    type: string
+    enum: [RadosGWStorage, LocalStorage]
+    description: Quay storage backend type
+  quayBackendRGWConfiguration:
+    type: object
+    description: RadosGW/S3 backend configuration for Quay
+    additionalProperties: false
+    properties:
+      access_key:
+        "$ref": "#/definitions/nonEmptyString"
+      bucket_name:
+        "$ref": "#/definitions/nonEmptyString"
+      hostname:
+        "$ref": "#/definitions/nonEmptyString"
+      is_secure:
+        "$ref": "#/definitions/quayBackendRGWIsSecure"
+      maximum_chunk_size_mb:
+        "$ref": "#/definitions/quayBackendRGWMaximumChunkSizeMb"
+      minimum_chunk_size_mb:
+        "$ref": "#/definitions/quayBackendRGWMinimumChunkSizeMb"
+      port:
+        "$ref": "#/definitions/quayBackendRGWPort"
+      secret_key:
+        "$ref": "#/definitions/nonEmptyString"
+      server_side_assembly:
+        "$ref": "#/definitions/quayBackendRGWServerSideAssembly"
+      storage_path:
+        "$ref": "#/definitions/quayBackendStoragePath"
+    required:
+      - access_key
+      - bucket_name
+      - hostname
+      - secret_key
+  quayPassword:
+    "$ref": "#/definitions/nonEmptyString"
+  quayUser:
+    "$ref": "#/definitions/nonEmptyString"
+  rendezvousIP:
+    "$ref": "#/definitions/ipv4Address"
+  sshPubPath:
+    "$ref": "#/definitions/nonEmptyString"
+  workingDir:
+    "$ref": "#/definitions/nonEmptyString"
+
 required:
-- pullSecret
+  - agent_hosts
+  - apiVIP
+  - baseDomain
+  - blockStorageBackend
+  - clusterName
+  - defaultDNS
+  - defaultGateway
+  - defaultPrefix
+  - ingressVIP
+  - lzBmcIP
+  - machineNetwork
+  - pullSecret
+  - quayBackend
+  - quayPassword
+  - quayUser
+  - rendezvousIP
+  - sshPubPath
+  - workingDir
+
+allOf:
+  - if:
+      properties:
+        quayBackend:
+          const: RadosGWStorage
+    then:
+      required:
+        - quayBackendRGWConfiguration
+  - if:
+      properties:
+        blockStorageBackend:
+          const: odf
+    then:
+      required:
+        - odfExternalConfig

--- a/scripts/verification/validate.sh
+++ b/scripts/verification/validate.sh
@@ -64,7 +64,7 @@ validate_yaml() {
 validate_json_schema() {
     print_header "Validating JSON schema"
 
-    if ansible-playbook playbooks/validate-schema.yaml -e@config/global.example.yaml; then
+    if ansible-playbook playbooks/validate-schema.yaml; then
         print_success "JSON schema validation passed"
         return 0
     else
@@ -134,7 +134,8 @@ validate_tags() {
         "playbooks/05-operators.yaml:operators:Configure operators"
         "playbooks/06-day2.yaml:clair-disconnected:Configure Clair in disconnected environments"
         "playbooks/06-day2.yaml:acm-policy-catalogsources:Mirrored catalogsource configuration ACM policy"
-        "playbooks/validate-schema.yaml:schema-validation:Include schema validation tasks"
+        "playbooks/validate-schema.yaml:schema-validation:Include defaults schema validation tasks"
+        "playbooks/validate-schema.yaml:schema-validation:Include variables schema validation tasks"
     )
 
     for test in "${tag_tests[@]}"; do


### PR DESCRIPTION
Split schema_validation.yaml into two focused task files:

- defaults_schema_validation.yaml: validates defaults/* files against their schemas (no user config required)
- variables_schema_validation.yaml: validates schemas/variables.yaml against fixtures in schemas/fixtures/valid/ (expect success) and schemas/fixtures/invalid/ (expect failure)

Add valid and invalid fixtures covering backend combinations and schema constraint violations.

Remove the dependency on config/global.example.yaml from the validate-json-schema CI step so the example file can have a documentation and template function rather than being used to validate values. With that we make sure that we don't have to put valid values in the example file that may be carried over inadvertidly when the file is used as a template for the real global.yaml

https://redhat.atlassian.net/browse/MGMT-23653

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>

Assisted-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized shared schema definitions; stronger, merged schema validation and a new k8s validation schema.

* **Tests**
  * Added many valid and invalid configuration fixtures covering IPs, ports, enums, empty-string, storage-path, conditional requirements, and unknown-field rejection.

* **Chores**
  * Split schema validation into separate defaults and variables phases and updated the validation flow and invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->