### PR TITLE
Move odr operators from csvNames to extraMirrorPackages

### DIFF
--- a/defaults/storage_operators.yaml
+++ b/defaults/storage_operators.yaml
@@ -18,9 +18,10 @@ storage_operators:  # Install operator depending blockStorageBackend variable
         - ocs-client-operator
         - cephcsi-operator
         - odf-external-snapshotter-operator
+      csvMirror: true
+      extraMirrorPackages:
         - odr-cluster-operator
         - odr-hub-operator
-      csvMirror: true
   lvms:
     - name: lvms-operator
       version: 4.20.0

--- a/schemas/operators.yaml
+++ b/schemas/operators.yaml
@@ -33,6 +33,11 @@ definitions:
       csvMirror:
         type: boolean
         description: Mirror operator packages listed under csvNames.
+      extraMirrorPackages:
+        type: array
+        items:
+          type: string
+        description: Additional packages to mirror as bare entries without version constraints.
       global:
         type: boolean
         description: Configure operator to watch the entire cluster.

--- a/templates/imagesetconfiguration.yaml.j2
+++ b/templates/imagesetconfiguration.yaml.j2
@@ -47,6 +47,9 @@ mirror:
               minVersion: {{ operator.init_version }}
               maxVersion: {{ operator.version }}
 {% endfor %}
+{% for pkg in operator.extraMirrorPackages | default([]) %}
+        - name: {{ pkg }}
+{% endfor %}
 {% endfor %}
 
   additionalImages:


### PR DESCRIPTION
`odr-cluster-operator` and `odr-hub-operator` do not share the same version as the parent `odf-operator` (currently `4.20.7-rhodf`). 

Having them in csvNames caused two issues:
1. `oc-mirror` tried to mirror them with version `4.20.7-rhodf` which they do not have as a package version
2. `approve_installplans.py` waited for CSVs that never appear, timing out after 30 minutes

Move them to a new `extraMirrorPackages` field that mirrors packages as bare entries without version constraints, and does not feed into the CSV approval wait loop.

Related PRs: https://github.com/rh-ecosystem-edge/enclave/pull/137

```
Failed to read [clusterserviceversion.operators.coreos.com/odr-cluster-operator.v4.20.7-rhodf](http://clusterserviceversion.operators.coreos.com/odr-cluster-operator.v4.20.7-rhodf) in namespace openshift-storage: Error from server (NotFound): [clusterserviceversions.operators.coreos.com](http://clusterserviceversions.operators.coreos.com/) "odr-cluster-operator.v4.20.7-rhodf" not found
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying additional packages to mirror without version constraints through a new configuration option, providing more granular control over package mirroring alongside existing CSV mirroring settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->