### PR TITLE
Fix OperatorGroup handling in configure_operator

### DIFF
--- a/playbooks/tasks/configure_operator.yaml
+++ b/playbooks/tasks/configure_operator.yaml
@@ -10,9 +10,27 @@
   delay: "{{ k8s_delay }}"
   until: r_namespace_exists is success
 
+- name: "Check if OperatorGroup already exists in namespace"
+  when: operator.namespace != "openshift-operators"
+  kubernetes.core.k8s_info:
+    api_version: operators.coreos.com/v1
+    kind: OperatorGroup
+    namespace: "{{ operator.namespace }}"
+  register: r_og_check
+
+- name: "Fail if multiple OperatorGroups exist in namespace"
+  when:
+    - operator.namespace != "openshift-operators"
+    - r_og_check.resources | default([]) | length > 1
+  ansible.builtin.fail:
+    msg: >-
+      Found {{ r_og_check.resources | length }} OperatorGroups in namespace {{ operator.namespace }},
+      but only one is allowed. Remove the extra OperatorGroups before proceeding.
+
 - name: "Ensure OperatorGroup exists (with target namespace)"
   when:
     - operator.namespace != "openshift-operators"
+    - r_og_check.resources | default([]) | length == 0
     - not (operator.global | default(false))
   kubernetes.core.k8s:
     state: present
@@ -20,7 +38,7 @@
       apiVersion: operators.coreos.com/v1
       kind: OperatorGroup
       metadata:
-        name: "{{ operator.name }}-og"
+        name: "{{ operator.namespace }}-og"
         namespace: "{{ operator.namespace }}"
       spec:
         targetNamespaces:
@@ -33,6 +51,7 @@
 - name: "Ensure OperatorGroup exists (global - without target namespace)"
   when:
     - operator.namespace != "openshift-operators"
+    - r_og_check.resources | default([]) | length == 0
     - operator.global | default(false)
   kubernetes.core.k8s:
     state: present
@@ -40,7 +59,7 @@
       apiVersion: operators.coreos.com/v1
       kind: OperatorGroup
       metadata:
-        name: "{{ operator.name }}-og"
+        name: "{{ operator.namespace }}-og"
         namespace: "{{ operator.namespace }}"
       spec: {}
   register: r_operatorgroup_exists


### PR DESCRIPTION
## Summary
- Check if an OperatorGroup already exists in a namespace before creating one, preventing conflicts when multiple operators share the same namespace
- Use `{{ operator.namespace }}-og` naming convention instead of `{{ operator.name }}-og` for consistent OperatorGroup naming

## Context
This is part of a series of PRs splitting the `extract-storage-plugins` branch into independent, reviewable changes. This PR is a standalone bug fix with no dependencies.

## Test plan
- [x] Verify `make validate` passes
- [ ] Deploy cluster with multiple operators sharing `openshift-storage` namespace (e.g., LVMS + ODF) — no OperatorGroup conflict

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a pre-check that detects existing OperatorGroup resources in the target namespace and stops the process if multiple are present, preventing conflicting deployments.
  * Prevented duplicate OperatorGroup creation by only creating one when none exist, and standardized OperatorGroup names to use the namespace identifier for consistent naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->