### PR TITLE
[HOLD] Handle pre-existing Subscriptions in disconnected mode

### DIFF
--- a/playbooks/tasks/configure_operator.yaml
+++ b/playbooks/tasks/configure_operator.yaml
@@ -56,6 +56,139 @@
     namespace: "{{ operator.namespace }}"
   register: r_sub_check
 
+# Handle pre-existing subscriptions that reference a non-existent CatalogSource.
+# For example, the ingress-operator creates a servicemeshoperator3 Subscription
+# with source: redhat-operators, which doesn't exist in disconnected mode.
+# The ingress-operator actively manages the subscription spec and overwrites any
+# changes, so instead of fighting it we create a CatalogSource alias that makes
+# the existing subscription resolve to the mirrored catalog.
+- name: "Handle pre-existing Subscription with wrong source (disconnected mode)"
+  when:
+    - r_sub_check.resources | length > 0
+    - disconnected | default(true) | bool
+    - r_sub_check.resources[0].spec.source != operator.source
+  block:
+    - name: "Check if CatalogSource '{{ r_sub_check.resources[0].spec.source }}' exists"
+      kubernetes.core.k8s_info:
+        api_version: operators.coreos.com/v1alpha1
+        kind: CatalogSource
+        name: "{{ r_sub_check.resources[0].spec.source }}"
+        namespace: openshift-marketplace
+      register: r_sub_source_cs
+
+    - name: "Get image from CatalogSource '{{ operator.source }}'"
+      kubernetes.core.k8s_info:
+        api_version: operators.coreos.com/v1alpha1
+        kind: CatalogSource
+        name: "{{ operator.source }}"
+        namespace: openshift-marketplace
+      register: r_correct_cs
+      when: r_sub_source_cs.resources | length == 0
+
+    - name: "Fail if mirrored CatalogSource '{{ operator.source }}' is missing"
+      ansible.builtin.fail:
+        msg: >-
+          CatalogSource '{{ operator.source }}' not found in openshift-marketplace.
+          Cannot create alias for pre-existing Subscription '{{ operator.name }}'
+          (source: {{ r_sub_check.resources[0].spec.source }}).
+          Ensure the mirrored catalog is available before installing this operator.
+      when:
+        - r_sub_source_cs.resources | length == 0
+        - r_correct_cs.resources | length == 0
+
+    - name: "Create CatalogSource alias '{{ r_sub_check.resources[0].spec.source }}' pointing to mirror"
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: operators.coreos.com/v1alpha1
+          kind: CatalogSource
+          metadata:
+            name: "{{ r_sub_check.resources[0].spec.source }}"
+            namespace: openshift-marketplace
+          spec:
+            sourceType: grpc
+            image: "{{ r_correct_cs.resources[0].spec.image }}"
+            updateStrategy:
+              registryPoll:
+                interval: 10m
+      when:
+        - r_sub_source_cs.resources | length == 0
+        - r_correct_cs.resources | length > 0
+
+    - name: "Set alias catalog availability flag"
+      ansible.builtin.set_fact:
+        alias_catalog_available: "{{ (r_sub_source_cs.resources | length > 0) or (r_correct_cs.resources | default([]) | length > 0) }}"
+
+    - name: "Wait for CatalogSource '{{ r_sub_check.resources[0].spec.source }}' to be READY"
+      kubernetes.core.k8s_info:
+        api_version: operators.coreos.com/v1alpha1
+        kind: CatalogSource
+        name: "{{ r_sub_check.resources[0].spec.source }}"
+        namespace: openshift-marketplace
+      register: r_alias_cs_ready
+      retries: "{{ k8s_retries }}"
+      delay: "{{ k8s_delay }}"
+      until:
+        - r_alias_cs_ready.resources | length > 0
+        - r_alias_cs_ready.resources[0].status.connectionState.lastObservedState | default('') == 'READY'
+      when: alias_catalog_available | bool
+
+    - name: "Wait for InstallPlan ({{ operator.name }})"
+      kubernetes.core.k8s_info:
+        api_version: operators.coreos.com/v1alpha1
+        kind: Subscription
+        name: "{{ operator.name }}"
+        namespace: "{{ operator.namespace }}"
+      register: r_sub_installplan
+      retries: "{{ k8s_retries }}"
+      delay: "{{ k8s_delay }}"
+      until:
+        - r_sub_installplan.resources[0].status.installplan is defined
+        - r_sub_installplan.resources[0].status.installplan.name | default('') | length > 0
+      when: alias_catalog_available | bool
+
+    - name: "Approve InstallPlan for {{ operator.name }}"
+      kubernetes.core.k8s:
+        state: present
+        merge_type: merge
+        definition:
+          apiVersion: operators.coreos.com/v1alpha1
+          kind: InstallPlan
+          metadata:
+            name: "{{ r_sub_installplan.resources[0].status.installplan.name }}"
+            namespace: "{{ operator.namespace }}"
+          spec:
+            approved: true
+      when: alias_catalog_available | bool
+
+    - name: "Wait for CSV ({{ operator.name }})"
+      kubernetes.core.k8s_info:
+        api_version: operators.coreos.com/v1alpha1
+        kind: Subscription
+        name: "{{ operator.name }}"
+        namespace: "{{ operator.namespace }}"
+      register: r_subscription
+      retries: "{{ k8s_retries }}"
+      delay: "{{ k8s_delay }}"
+      until:
+        - r_subscription.resources[0].status.currentCSV is defined
+        - r_subscription.resources[0].status.currentCSV | length > 0
+      when: alias_catalog_available | bool
+
+    - name: "Wait until CSV is Succeeded ({{ operator.name }})"
+      kubernetes.core.k8s_info:
+        api_version: operators.coreos.com/v1alpha1
+        kind: ClusterServiceVersion
+        name: "{{ r_subscription.resources[0].status.currentCSV }}"
+        namespace: "{{ operator.namespace }}"
+      register: r_csv
+      retries: "{{ k8s_retries }}"
+      delay: "{{ k8s_delay }}"
+      until:
+        - r_csv.resources[0].status.phase is defined
+        - r_csv.resources[0].status.phase == "Succeeded"
+      when: alias_catalog_available | bool
+
 - name: "Ensure Subscription exists (Automatic)"
   when:
     - r_sub_check.resources | length == 0


### PR DESCRIPTION
In disconnected mode, the default `CatalogSource` `redhat-operators` doesn't exist. Instead, you have a mirrored catalog, e.g. `cs-redhat-operator-index`. All our operator definitions set `operator.source: cs-redhat-operator-index`.
The problem is that some of the components create Subscriptions on their own. For example, the ingress operator automatically creates a `servicemeshoperator3` Subscription with `source: redhat-operators`. 

## Summary
- Add handling for pre-existing Subscriptions that point to non-existent CatalogSources in disconnected mode (e.g., `servicemeshoperator3` referencing `redhat-operators`)
- Creates a CatalogSource alias pointing to the mirrored catalog image
- Waits for InstallPlan, approves it, and waits for CSV to reach Succeeded state

## Context
This is part of a series of PRs splitting the `extract-storage-plugins` branch into independent, reviewable changes. This PR is a standalone improvement with no dependencies.

When operators are pre-installed (e.g., via OLM defaults), their Subscriptions may reference CatalogSources that don't exist in a disconnected environment. This block detects that situation and creates a mirrored CatalogSource alias so the operator can update properly.

## Test plan
- [ ] Verify `make validate` passes
- [ ] Deploy disconnected cluster with pre-existing operator Subscriptions
- [ ] Verify CatalogSource alias is created and operator updates successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved handling for pre-existing operator subscriptions that reference a different catalog source, enabling safe reconciliation and continuation of installs.
  * Automatic creation of catalog aliases when missing so installations can proceed despite source mismatches.
  * Added readiness checks, polling, and automatic approval of install plans and operator CSVs to ensure deployments reach a succeeded state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->