### PR TITLE
[HOLD] Add connected mode support for operator subscription approval

### DIFF
--- a/playbooks/tasks/configure_operator.yaml
+++ b/playbooks/tasks/configure_operator.yaml
@@ -59,7 +59,7 @@
 - name: "Ensure Subscription exists (Automatic)"
   when:
     - r_sub_check.resources | length == 0
-    - operator.namespace == "openshift-operators"
+    - operator.namespace == "openshift-operators" or not (disconnected | default(true) | bool)
   kubernetes.core.k8s:
     state: present
     definition:
@@ -72,7 +72,7 @@
         installPlanApproval: Automatic
         channel: "{{ operator.channel }}"
         name: "{{ operator.name }}"
-        source: "{{ operator.source if (disconnected | default(true)) else 'redhat-operators' }}"
+        source: "{{ operator.source }}"
         sourceNamespace: openshift-marketplace
   register: r_sub_exists
   retries: "{{ k8s_retries }}"
@@ -83,6 +83,7 @@
   when:
     - r_sub_check.resources | length == 0
     - operator.namespace != "openshift-operators"
+    - disconnected | default(true) | bool
   kubernetes.core.k8s:
     state: present
     definition:
@@ -95,9 +96,9 @@
         installPlanApproval: Manual
         channel: "{{ operator.channel }}"
         name: "{{ operator.name }}"
-        source: "{{ operator.source if (disconnected | default(true)) else 'redhat-operators' }}"
+        source: "{{ operator.source }}"
         sourceNamespace: openshift-marketplace
-        startingCSV: "{{ operator.csvNames | default([]) | first | default(operator.name) }}.v{{ operator.version | replace('+', '-') }}"
+        startingCSV: "{{ (operator.csvNames | default([]) | first | default(operator.name)) ~ '.v' ~ (operator.version | replace('+', '-')) }}"
   register: r_sub_exists
   retries: "{{ k8s_retries }}"
   delay: "{{ k8s_delay }}"
@@ -107,14 +108,15 @@
   when:
     - r_sub_check.resources | length == 0
     - operator.namespace != "openshift-operators"
+    - disconnected | default(true) | bool
   kubernetes.core.k8s_info:
     api_version: operators.coreos.com/v1alpha1
     kind: Subscription
     name: "{{ operator.name }}"
     namespace: "{{ operator.namespace }}"
   register: r_subscription
-  retries: 30
-  delay: 10
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
   until:
   - r_subscription.resources[0].status.installplan is defined
   - r_subscription.resources[0].status.installplan | length > 0
@@ -123,6 +125,7 @@
   when:
     - r_sub_check.resources | length == 0
     - operator.namespace != "openshift-operators"
+    - disconnected | default(true) | bool
   ansible.builtin.shell: |
     python ../helpers/operator-update/approve_installplans.py "{{ [operator] }}" "False"
   register: operator_update_result
@@ -131,21 +134,22 @@
   when:
     - r_sub_check.resources | length == 0
     - operator.namespace != "openshift-operators"
+    - disconnected | default(true) | bool
   ansible.builtin.debug:
     var: operator_update_result.stdout_lines
 
 - name: "Get Installed CSV ({{ operator.name }})"
   when:
     - r_sub_check.resources | length == 0
-    - operator.namespace == "openshift-operators"
+    - operator.namespace == "openshift-operators" or not (disconnected | default(true) | bool)
   kubernetes.core.k8s_info:
     api_version: operators.coreos.com/v1alpha1
     kind: Subscription
     name: "{{ operator.name }}"
     namespace: "{{ operator.namespace }}"
   register: r_subscription
-  retries: 30
-  delay: 10
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
   until:
   - r_subscription.resources[0].status.currentCSV is defined
   - r_subscription.resources[0].status.currentCSV | length > 0
@@ -153,15 +157,15 @@
 - name: "Wait until CSV is installed"
   when:
     - r_sub_check.resources | length == 0
-    - operator.namespace == "openshift-operators"
+    - operator.namespace == "openshift-operators" or not (disconnected | default(true) | bool)
   kubernetes.core.k8s_info:
     api_version: operators.coreos.com/v1alpha1
     kind: ClusterServiceVersion
     name: "{{ r_subscription.resources[0].status.currentCSV }}"
     namespace: "{{ operator.namespace }}"
   register: r_csv
-  retries: 30
-  delay: 30
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
   until:
   - r_csv.resources[0].status.phase is defined
   - r_csv.resources[0].status.phase | length > 0


### PR DESCRIPTION
## Summary
- Add `disconnected | default(true) | bool` condition to Manual subscription path so connected mode uses Automatic approval
- Simplify operator source to always use `{{ operator.source }}` instead of conditional logic
- Fix `startingCSV` string concatenation using Jinja2 `~` operator
- Use `k8s_retries`/`k8s_delay` variables consistently instead of hardcoded values

## Context
This is part of a series of PRs splitting the `extract-storage-plugins` branch into independent, reviewable changes. This PR is a standalone improvement with no dependencies.

Previously, Manual approval was used for all non-openshift-operators namespaces regardless of deployment mode. In connected mode, Automatic approval is simpler and avoids the need for InstallPlan approval automation.

## Test plan
- [ ] Verify `make validate` passes
- [ ] Deploy connected cluster — operators in custom namespaces use Automatic approval
- [ ] Deploy disconnected cluster — operators still use Manual approval with InstallPlan automation