### PR TITLE
Add plugin schema, example plugin, and validation

### DIFF
--- a/.github/workflows/e2e-deployment.yml
+++ b/.github/workflows/e2e-deployment.yml
@@ -72,6 +72,7 @@ jobs:
               - 'schemas/**'
               - 'templates/**'
               - 'operators/**'
+              - 'plugins/**'
               - 'files/**'
               - 'hack/**'
               - '.github/workflows/e2e-deployment.yml'

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -6,6 +6,9 @@ on:
   merge_group:
     types: [checks_requested]
 
+permissions:
+  contents: read
+
 # Prevent concurrent runs for the same PR (use run_id as fallback for merge_group)
 concurrency:
   group: pr-validation-${{ github.event.pull_request.number || github.run_id }}
@@ -294,4 +297,51 @@ jobs:
         with:
           name: makefile-log
           path: makefile.log
+          retention-days: 7
+
+  # Job 7: Plugin validation
+  plugins:
+    name: Plugin Validation
+    runs-on: [self-hosted, pr-validation]
+    container:
+      image: quay.io/eerez/enclave-lab-ci:latest
+      options: --user root
+    timeout-minutes: 5
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run plugin validation
+        run: |
+          set -o pipefail
+          echo "## Plugin Validation" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if make validate-plugins 2>&1 | tee plugins.log; then
+            echo "### ✅ Plugin validation passed!" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+            tail -20 plugins.log >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "### ❌ Plugin validation failed" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Please fix the plugin structure issues below:" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+            tail -50 plugins.log >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
+
+      - name: Upload plugin validation log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: plugins-log
+          path: plugins.log
           retention-days: 7

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@
 #   make validate-ansible      - Validate Ansible playbooks with ansible-lint
 #   make validate-tags         - Validate Ansible playbook tags
 #   make validate-makefile     - Validate Makefile syntax
+#   make validate-plugins      - Validate plugin directory structure
 #
 # CI Infrastructure targets:
 #   make environment                      - Create test infrastructure (VMs, networks, BMC)
@@ -19,7 +20,7 @@
 #   make verify                           - Verify infrastructure is working
 #   make clean                            - Clean up infrastructure
 
-.PHONY: help validate validate-shell validate-yaml validate-json-schema validate-ansible validate-tags validate-makefile build-ci-image push-ci-image test-ci-image build-push-ci-image environment provision-landing-zone verify-landing-zone install-enclave verify-enclave-installation deploy-cluster deploy-cluster-prepare deploy-cluster-mirror deploy-cluster-install deploy-cluster-post-install deploy-cluster-operators deploy-cluster-day2 deploy-cluster-discovery verify clean verify-cluster verify-cleanup generate-cluster-name setup-working-dir collect-step-logs preflight-checks collect-artifacts-basic collect-artifacts-deployment collect-artifacts-full ci-flow-connected ci-flow-disconnected
+.PHONY: help validate validate-shell validate-yaml validate-json-schema validate-ansible validate-tags validate-makefile validate-plugins build-ci-image push-ci-image test-ci-image build-push-ci-image environment provision-landing-zone verify-landing-zone install-enclave verify-enclave-installation deploy-cluster deploy-cluster-prepare deploy-cluster-mirror deploy-cluster-install deploy-cluster-post-install deploy-cluster-operators deploy-cluster-day2 deploy-cluster-discovery verify clean verify-cluster verify-cleanup generate-cluster-name setup-working-dir collect-step-logs preflight-checks collect-artifacts-basic collect-artifacts-deployment collect-artifacts-full ci-flow-connected ci-flow-disconnected
 
 # Configuration
 DEV_SCRIPTS_PATH ?=
@@ -42,6 +43,7 @@ help:
 	@echo "  make validate-ansible      - Validate Ansible playbooks with ansible-lint"
 	@echo "  make validate-tags         - Validate Ansible playbook tags"
 	@echo "  make validate-makefile     - Validate Makefile syntax"
+	@echo "  make validate-plugins      - Validate plugin directory structure"
 	@echo ""
 	@echo "CI Image targets:"
 	@echo "  make build-ci-image        - Build CI container image locally"
@@ -152,6 +154,9 @@ validate-tags:
 
 validate-makefile:
 	@./scripts/verification/validate.sh makefile
+
+validate-plugins:
+	@./scripts/verification/validate.sh plugins
 
 # CI Image targets
 CI_IMAGE_NAME ?= quay.io/eerez/enclave-lab-ci

--- a/plugins/example/plugin.yaml
+++ b/plugins/example/plugin.yaml
@@ -1,0 +1,7 @@
+---
+name: example
+type: addon
+order: 999
+
+defaults:
+  example_message: "Hello from example plugin"

--- a/plugins/example/tasks/deploy.yaml
+++ b/plugins/example/tasks/deploy.yaml
@@ -1,0 +1,4 @@
+---
+- name: Example plugin deployed
+  ansible.builtin.debug:
+    msg: "{{ example_message }}"

--- a/plugins/example/tasks/post-validate.yaml
+++ b/plugins/example/tasks/post-validate.yaml
@@ -1,0 +1,4 @@
+---
+- name: Example plugin validated
+  ansible.builtin.debug:
+    msg: "Example plugin post-validation passed"

--- a/plugins/example/tasks/pre-validate.yaml
+++ b/plugins/example/tasks/pre-validate.yaml
@@ -1,0 +1,14 @@
+---
+- name: Verify cluster is accessible
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Namespace
+    name: default
+  register: r_cluster_check
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_cluster_check is success
+
+- name: Cluster is accessible
+  ansible.builtin.debug:
+    msg: "Cluster is accessible - example plugin pre-validation passed"

--- a/schemas/plugin.yaml
+++ b/schemas/plugin.yaml
@@ -1,0 +1,107 @@
+---
+"$schema": "http://json-schema.org/draft-07/schema"
+version: "1.0"
+type: object
+
+definitions:
+  operator:
+    type: object
+    additionalProperties: false
+    properties:
+      name:
+        type: string
+        description: Operator package name as it appears in the catalog.
+      version:
+        type: string
+        description: Operator version.
+      channel:
+        type: string
+        description: Update channel for the operator.
+      init_version:
+        type: string
+        description: Initial operator version.
+      namespace:
+        type: string
+        description: Target namespace where the operator will be installed.
+      source:
+        type: string
+        description: Catalog source name (from oc-mirror configuration).
+      csvNames:
+        type: array
+        items:
+          type: string
+        description: ClusterServiceVersion names for the operator.
+      csvMirror:
+        type: boolean
+        description: Mirror operator packages listed under csvNames.
+      extraMirrorPackages:
+        type: array
+        items:
+          type: string
+        description: Additional packages to mirror as bare entries without version constraints.
+      global:
+        type: boolean
+        description: Configure operator to watch the entire cluster.
+    dependencies:
+      csvMirror:
+      - csvNames
+    required:
+      - name
+      - version
+      - channel
+      - init_version
+
+  registry:
+    type: object
+    additionalProperties: false
+    properties:
+      location:
+        type: string
+        description: Source registry location (e.g. registry.redhat.io/lvms4).
+      mirror:
+        type: string
+        description: Mirror path under the internal Quay registry.
+    required:
+      - location
+      - mirror
+
+additionalProperties: false
+properties:
+  name:
+    type: string
+    description: Plugin identifier. Must match the directory name.
+    pattern: "^[A-Za-z0-9][A-Za-z0-9._-]*$"
+  type:
+    type: string
+    enum:
+      - foundation
+      - addon
+    description: Plugin type. foundation plugins deploy before core operators.
+  order:
+    type: integer
+    description: Deploy order among same-type plugins. Lower values deploy first.
+  mirror:
+    type: string
+    enum:
+      - core
+      - plugin
+      - none
+    description: >-
+      How images are mirrored. core = included in the main oc-mirror run.
+      plugin = plugin runs its own oc-mirror during deploy. none = no mirroring.
+  operators:
+    type: array
+    description: List of OLM operators to install.
+    items:
+      $ref: "#/definitions/operator"
+  defaults:
+    type: object
+    description: Default variables loaded into Ansible scope before plugin tasks run.
+  registries:
+    type: array
+    description: Registry mirror entries for MCE custom-registries patching.
+    items:
+      $ref: "#/definitions/registry"
+required:
+  - name
+  - type

--- a/scripts/verification/validate.sh
+++ b/scripts/verification/validate.sh
@@ -191,6 +191,18 @@ validate_makefile() {
     fi
 }
 
+validate_plugins() {
+    print_header "Validating plugin directory structure"
+
+    if "${ENCLAVE_DIR}/scripts/verification/validate_plugins.sh"; then
+        print_success "Plugin validation passed"
+        return 0
+    else
+        print_error "Plugin validation failed"
+        return 1
+    fi
+}
+
 # Main function
 validate_all() {
     local failed=0
@@ -207,6 +219,7 @@ validate_all() {
     validate_ansible || failed=1
     validate_tags || failed=1
     validate_makefile || failed=1
+    validate_plugins || failed=1
 
     if [ $failed -eq 0 ]; then
         echo -e "${GREEN}╔════════════════════════════════════════╗${NC}"
@@ -243,11 +256,14 @@ case "${1:-all}" in
     makefile)
         validate_makefile
         ;;
+    plugins)
+        validate_plugins
+        ;;
     all)
         validate_all
         ;;
     *)
-        echo "Usage: $0 {all|shell|yaml|json-schema|ansible|tags|makefile}"
+        echo "Usage: $0 {all|shell|yaml|json-schema|ansible|tags|makefile|plugins}"
         exit 1
         ;;
 esac

--- a/scripts/verification/validate_plugins.sh
+++ b/scripts/verification/validate_plugins.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# Plugin Validation Script
+# Validates that all plugins under plugins/ have correct structure and valid YAML
+#
+# Checks per plugin:
+#   1. plugin.yaml exists and is a valid YAML mapping with required fields (name, type)
+#   2. Task files under tasks/ are valid YAML task lists (if present)
+#   3. No unexpected files outside plugin.yaml and tasks/ directory
+#
+# Full field validation (types, enums, operator structure) is handled by JSON Schema
+# in playbooks/tasks/schema_validation.yaml using schemas/plugin.yaml.
+
+set -euo pipefail
+
+# Detect Enclave repository root
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+ENCLAVE_DIR="$(cd -- "${SCRIPT_DIR}/../.." &>/dev/null && pwd)"
+
+# Source shared utilities
+source "${ENCLAVE_DIR}/scripts/lib/output.sh"
+
+PLUGINS_DIR="${ENCLAVE_DIR}/plugins"
+FAILED=0
+
+if [ ! -d "$PLUGINS_DIR" ]; then
+    echo "No plugins directory found, skipping plugin validation"
+    exit 0
+fi
+
+# Count plugins
+PLUGIN_COUNT=0
+for plugin_dir in "$PLUGINS_DIR"/*/; do
+    [ -d "$plugin_dir" ] || continue
+    PLUGIN_COUNT=$((PLUGIN_COUNT + 1))
+done
+
+if [ "$PLUGIN_COUNT" -eq 0 ]; then
+    echo "No plugins found, skipping plugin validation"
+    exit 0
+fi
+
+echo "Validating $PLUGIN_COUNT plugin(s)..."
+echo ""
+
+# Helper: validate a YAML file is a list of task mappings
+validate_yaml_tasklist() {
+    python3 -c "
+import yaml, sys
+try:
+    with open(sys.argv[1]) as f:
+        data = yaml.safe_load(f)
+except Exception as e:
+    print(str(e), file=sys.stderr)
+    sys.exit(1)
+if not isinstance(data, list):
+    print(f'Expected YAML list of tasks, got {type(data).__name__}', file=sys.stderr)
+    sys.exit(1)
+for i, item in enumerate(data):
+    if not isinstance(item, dict):
+        print(f'Task {i} is not a mapping', file=sys.stderr)
+        sys.exit(1)
+" "$1"
+}
+
+for plugin_dir in "$PLUGINS_DIR"/*/; do
+    [ -d "$plugin_dir" ] || continue
+    plugin_name=$(basename "$plugin_dir")
+    plugin_failed=0
+    echo "--- Plugin: $plugin_name ---"
+
+    # 1. Check plugin.yaml exists and has required fields
+    plugin_yaml="${plugin_dir}plugin.yaml"
+    if [ ! -f "$plugin_yaml" ]; then
+        error "  Missing plugin.yaml"
+        FAILED=1
+        continue
+    fi
+
+    if ! python3 -c "
+import yaml, sys
+
+filepath = sys.argv[1]
+required_fields = ['name', 'type']
+valid_fields = ['name', 'type', 'order', 'mirror', 'operators', 'defaults',
+                'registries']
+
+try:
+    with open(filepath) as f:
+        data = yaml.safe_load(f)
+except Exception as e:
+    print(f'  plugin.yaml is not valid YAML: {e}', file=sys.stderr)
+    sys.exit(1)
+
+if not isinstance(data, dict):
+    print('  plugin.yaml must be a YAML mapping', file=sys.stderr)
+    sys.exit(1)
+
+missing = [f for f in required_fields if f not in data]
+if missing:
+    print(f'  plugin.yaml missing required fields: {missing}', file=sys.stderr)
+    sys.exit(1)
+
+unexpected = [f for f in data if f not in valid_fields]
+if unexpected:
+    print(f'  plugin.yaml has unexpected fields: {unexpected}', file=sys.stderr)
+    sys.exit(1)
+" "$plugin_yaml" 2>&1; then
+        FAILED=1
+        plugin_failed=1
+    fi
+
+    # 2. Validate task files under tasks/ are valid task lists
+    if [ -d "${plugin_dir}tasks" ]; then
+        for task_file in "${plugin_dir}"tasks/*.yaml; do
+            [ -f "$task_file" ] || continue
+            if ! validate_yaml_tasklist "$task_file" 2>/dev/null; then
+                error "  tasks/$(basename "$task_file") must be a YAML list of tasks"
+                FAILED=1
+                plugin_failed=1
+            fi
+        done
+    fi
+
+    # 3. Check for unexpected files/directories (only plugin.yaml and tasks/ allowed)
+    for entry in "${plugin_dir}"*; do
+        entry_name=$(basename "$entry")
+        if [ "$entry_name" != "plugin.yaml" ] && [ "$entry_name" != "tasks" ]; then
+            error "  Unexpected file or directory: $entry_name (only plugin.yaml and tasks/ are allowed)"
+            FAILED=1
+            plugin_failed=1
+        fi
+    done
+
+    if [ $plugin_failed -eq 0 ]; then
+        echo "  OK"
+    fi
+done
+
+echo ""
+if [ $FAILED -eq 0 ]; then
+    success "All plugins validated successfully"
+    exit 0
+else
+    error "Plugin validation failed"
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Define plugin contract via JSON Schema (`schemas/plugin.yaml`) specifying required fields, operator/registry definitions, plugin types (foundation/addon), and mirror modes
- Add example plugin (`plugins/example/`) as a template for new plugin development
- Add `validate_plugins.sh` script checking plugin structure, YAML validity, and required fields
- Add `validate-plugins` Makefile target and CI job in PR validation workflow
- Add `merge_group` trigger and `plugins/**` path filter to E2E deployment workflow

## Context
This is part of a series of PRs splitting the `extract-storage-plugins` branch into independent, reviewable changes. This PR establishes the plugin specification and validation — no runtime behavior changes. Subsequent PRs build on this foundation.

## Files
- `schemas/plugin.yaml` — JSON Schema for plugin descriptors
- `plugins/example/plugin.yaml` — Example addon plugin
- `plugins/example/tasks/{deploy,post-validate,pre-validate}.yaml` — Example lifecycle tasks
- `scripts/verification/validate_plugins.sh` — Plugin validation script
- `scripts/verification/validate.sh` — Added `plugins` validation function
- `Makefile` — Added `validate-plugins` target
- `.github/workflows/pr-validation.yml` — Added Plugin Validation job, `merge_group` trigger
- `.github/workflows/e2e-deployment.yml` — Added `merge_group` trigger, `plugins/**` path filter

## Test plan
- [ ] Run `make validate-plugins` — passes with example plugin
- [ ] Run `make validate` — includes plugin validation
- [ ] CI Plugin Validation job runs on PR