### PR TITLE
Set EPEL metadata_expire to avoid 404s during mirror rotations

### DIFF
--- a/scripts/runners/install_runner_ci_requirements.sh
+++ b/scripts/runners/install_runner_ci_requirements.sh
@@ -88,6 +88,14 @@ info "Step 3: Installing EPEL repository (for additional packages)"
 sudo dnf install -y epel-release || {
     warning "EPEL repository not available, will install validation tools via pip"
 }
+# Set metadata_expire to avoid 404s during EPEL mirror metadata rotations.
+# Without this, dnf refreshes metadata on every run and can hit stale
+# repodata files that were just purged from all mirrors.
+if [ -f /etc/yum.repos.d/epel.repo ]; then
+    if ! grep -q '^metadata_expire=' /etc/yum.repos.d/epel.repo; then
+        sudo sed -i '/^\[epel\]/a metadata_expire=4h' /etc/yum.repos.d/epel.repo
+    fi
+fi
 success "EPEL repository configured"
 echo ""
 


### PR DESCRIPTION
## Summary
- Add `metadata_expire=4h` to EPEL repo config in runner setup script
- Prevents dnf from refreshing metadata on every run, avoiding 404s when EPEL mirrors rotate repodata files
- Idempotent: skips if already configured