### PR TITLE
Persist podman socket directory permissions with tmpfiles.d

### DIFF
--- a/scripts/runners/setup_github_runners_podman.sh
+++ b/scripts/runners/setup_github_runners_podman.sh
@@ -100,6 +100,11 @@ EOF
 info "Setting directory permissions..."
 chmod 755 /run/podman
 
+# Persist directory permissions across reboots and socket restarts.
+# Without this, systemd recreates /run/podman with 0700 (root-only),
+# blocking non-root users from accessing the socket even if SocketMode=0666.
+echo 'd /run/podman 0755 root root -' > /etc/tmpfiles.d/podman-socket.conf
+
 info "Restarting podman.socket with new permissions..."
 systemctl daemon-reload
 systemctl restart podman.socket


### PR DESCRIPTION
## Summary
- Add `/etc/tmpfiles.d/podman-socket.conf` to ensure `/run/podman` is created with `0755`
- Fixes `statfs /var/run/docker.sock: permission denied` errors in container jobs
- Systemd recreates `/run/podman` with `0700` on socket restart, blocking non-root access even though `SocketMode=0666` is set — the directory permissions prevent reaching the socket