### PR TITLE
Add plugin schema validation to Ansible playbook validation

### DIFF
--- a/playbooks/tasks/schema_validation.yaml
+++ b/playbooks/tasks/schema_validation.yaml
@@ -70,6 +70,23 @@
     criteria: "{{ lookup('ansible.builtin.file', '../../schemas/lvms_operator.yaml') | from_yaml | to_json }}"
     engine: ansible.utils.jsonschema
 
+- name: Find all plugin.yaml files
+  ansible.builtin.find:
+    paths: "{{ playbook_dir }}/../plugins"
+    patterns: "plugin.yaml"
+    recurse: true
+    depth: 2
+  register: r_plugin_files
+
+- name: "Validate plugin schema: {{ item.path | regex_replace('.*/plugins/', 'plugins/') }}"
+  ansible.utils.validate:
+    data: "{{ lookup('ansible.builtin.file', item.path) | from_yaml | to_json }}"
+    criteria: "{{ lookup('ansible.builtin.file', '../../schemas/plugin.yaml') | from_yaml | to_json }}"
+    engine: ansible.utils.jsonschema
+  loop: "{{ r_plugin_files.files }}"
+  loop_control:
+    label: "{{ item.path | basename }}"
+
 - name: Include deployment vars
   ansible.builtin.include_vars: ../../defaults/platforms.yaml
 


### PR DESCRIPTION
## Summary
- Add plugin.yaml schema validation to `playbooks/tasks/schema_validation.yaml`
- Discovers all `plugins/*/plugin.yaml` files and validates each against `schemas/plugin.yaml`
- Complements the CI shell script validation from #155

Follow-up to reviewer comment on #155.