### PR TITLE
Add plugin deployment framework

### DIFF
--- a/config/global.example.yaml
+++ b/config/global.example.yaml
@@ -55,14 +55,22 @@ quayBackendRGWConfiguration:
 # ============================================================================
 # Storage Backend
 # ============================================================================
-# Storage backend for block devices for quay database and assisted installer
+# Storage plugin for block devices for quay database and assisted installer
+# Selects which storage plugin (plugins/lvms/ or plugins/odf/) to deploy
 # Options: lvms or odf
-# blockStorageBackend: odf
-blockStorageBackend: lvms
+# storage_plugin: odf
+storage_plugin: lvms
+
+# Plugins to deploy during the pipeline (default: only the storage plugin above)
+# Uncomment and extend to enable additional plugins
+# enabled_plugins:
+#   - lvms
+#   - example
 
 # ============================================================================
 # Storage Configuration (LVMS) (optional)
 # ============================================================================
+# Device selector — restrict which disks LVMS manages (omit to use all disks)
 #lvmsConfig:
 #  deviceSelector:
 #    optionalPaths:
@@ -73,7 +81,7 @@ blockStorageBackend: lvms
 # ============================================================================
 # Storage Configuration (ODF)
 # ============================================================================
-# When odf is set, it is needed to configure the odfExternalConfig variable
+# When odf is set, configure the odfExternalConfig variable
 # with the data obtained from ceph-external-cluster-details-exporter.py script
 # odfExternalConfig:
 #  '[{"name": "external-cluster-user-command",

--- a/defaults/deployment.yaml
+++ b/defaults/deployment.yaml
@@ -8,5 +8,17 @@ diskEncryption: false
 # Default oc-mirror log level. Override in config/global.yaml for more verbosity.
 ocMirrorLogLevel: info
 
+# Default storage plugin. Override in config/global.yaml to use odf.
+storage_plugin: lvms
+
+# Backward-compatible alias for storage_plugin, used by templates and quay tasks.
+# Will be removed when those are migrated to use storage_plugin directly.
+blockStorageBackend: "{{ storage_plugin }}"
+
+# Plugins to deploy during the pipeline. Override in config/global.yaml to add or remove plugins.
+# By default only the selected storage plugin is enabled.
+enabled_plugins:
+  - "{{ storage_plugin }}"
+
 # Default pull secret path. Override in config/global.yaml if stored elsewhere.
 pullSecretPath: "{{ workingDir }}/config/pull-secret.json"

--- a/operators/openshift-pipelines-operator-rh/operator_update_pipeline.yaml
+++ b/operators/openshift-pipelines-operator-rh/operator_update_pipeline.yaml
@@ -100,7 +100,7 @@
             script: |
                 #!/bin/bash
 
-                python ./approve_installplans.py "{{ storage_operators[blockStorageBackend] + operators }}" "$(params.dry-run)" > "$(results.status-report.path)"
+                python ./approve_installplans.py "{{ storage_operators[storage_plugin] + operators }}" "$(params.dry-run)" > "$(results.status-report.path)"
                 rc=$?
                 echo -n "${rc}" > "$(results.exit-code.path)"
                 exit "${rc}"

--- a/playbooks/05-operators.yaml
+++ b/playbooks/05-operators.yaml
@@ -4,7 +4,9 @@
 #
 # Performs:
 # - Disable default catalog sources (disconnected mode)
-# - Install storage operators (LVMS/ODF)
+# - Auto-discover and deploy foundation plugins (type: foundation)
+#   Storage plugins (LVMS/ODF) run here, BEFORE core operators,
+#   so that Quay can rely on the storage backend being present.
 # - Install general operators from defaults/operators.yaml
 #
 # Usage:
@@ -27,6 +29,29 @@
       ansible.builtin.debug:
         msg: "Installing operators in {{ 'disconnected' if (disconnected | default(true)) else 'connected' }} mode"
       tags: always
+
+    - name: Disable default operator catalog sources
+      when: disconnected | default(true) | bool
+      ansible.builtin.command: |
+        {{ workingDir }}/bin/oc patch OperatorHub cluster --type=merge -p='{"spec":{"disableAllDefaultSources":true}}'
+      environment:
+        KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+      register: r_patch_operatorhub
+      changed_when: "'(no change)' not in r_patch_operatorhub.stdout"
+      tags:
+        - foundation-plugins
+        - operators
+
+    - name: Auto-discover and deploy foundation plugins
+      ansible.builtin.include_tasks:
+        file: tasks/deploy_foundation_plugins.yaml
+        apply:
+          tags:
+            - foundation-plugins
+            - operators
+      tags:
+        - foundation-plugins
+        - operators
 
     - name: Configure operators
       ansible.builtin.include_tasks:

--- a/playbooks/deploy-plugin.yaml
+++ b/playbooks/deploy-plugin.yaml
@@ -1,0 +1,36 @@
+---
+# Deploy a plugin to the OpenShift cluster
+#
+# This playbook loads the plugin configuration, applies defaults,
+# and runs the plugin lifecycle: pre-validate -> mirror -> operators -> deploy -> post-validate.
+#
+# Usage:
+#   ansible-playbook playbooks/deploy-plugin.yaml -e workingDir=/home/cloud-user -e plugin_name=example
+#
+# Required variables:
+#   workingDir: Working directory on the Landing Zone
+#   plugin_name: Name of the plugin directory under plugins/
+
+- name: Deploy plugin - {{ plugin_name | default('UNSET') }}
+  hosts: localhost
+  gather_facts: false
+  environment:
+    PATH: "{{ workingDir | default('') }}/bin:{{ lookup('env', 'PATH') }}"
+  tasks:
+    - name: Validate workingDir is provided
+      ansible.builtin.assert:
+        that:
+          - workingDir is defined
+          - workingDir | length > 0
+        fail_msg: "workingDir must be provided (e.g., -e workingDir=/home/cloud-user)"
+      tags: always
+
+    - name: Load common variables
+      ansible.builtin.include_tasks:
+        file: common/load-vars.yaml
+      tags: always
+
+    - name: Deploy plugin
+      ansible.builtin.include_tasks:
+        file: tasks/deploy_plugin.yaml
+      tags: always

--- a/playbooks/tasks/configure_operators.yaml
+++ b/playbooks/tasks/configure_operators.yaml
@@ -2,14 +2,9 @@
 - name: Configure operators
   block:
 
-    - name: Disable default operator catalog sources
-      when: disconnected | default(true) | bool
-      ansible.builtin.command: |
-        {{ workingDir }}/bin/oc patch OperatorHub cluster --type=json -p='[{"op":"replace","path":"/spec/disableAllDefaultSources","value":true}]'
-
     - name: Include configure_operator
       ansible.builtin.include_tasks: configure_operator.yaml
-      loop: "{{ storage_operators[blockStorageBackend] + operators }}"
+      loop: "{{ storage_operators[storage_plugin] + operators }}"
       loop_control:
         loop_var: operator
 

--- a/playbooks/tasks/deploy_foundation_plugins.yaml
+++ b/playbooks/tasks/deploy_foundation_plugins.yaml
@@ -1,0 +1,53 @@
+---
+# Auto-discover and deploy all foundation plugins (type: foundation)
+# sorted by order field.
+#
+# Only plugins listed in enabled_plugins are deployed.
+#
+# Called from 05-operators.yaml before configure_operators.
+
+- name: Find all plugin descriptors
+  ansible.builtin.find:
+    paths: "{{ playbook_dir }}/../plugins"
+    patterns: "plugin.yaml"
+    recurse: true
+    depth: 2
+  register: r_foundation_find
+
+- name: Read plugin descriptors
+  ansible.builtin.slurp:
+    src: "{{ item }}"
+  loop: "{{ r_foundation_find.files | map(attribute='path') | list }}"
+  register: r_foundation_slurp
+
+- name: Parse foundation plugin descriptors
+  ansible.builtin.set_fact:
+    _foundation_all_parsed: >-
+      {{ r_foundation_slurp.results
+         | map(attribute='content')
+         | map('b64decode')
+         | map('from_yaml')
+         | selectattr('type', 'equalto', 'foundation')
+         | selectattr('name', 'in', enabled_plugins)
+         | selectattr('order', 'defined')
+         | sort(attribute='order')
+         | list }}
+
+- name: Build foundation plugin deploy list
+  ansible.builtin.set_fact:
+    _foundation_deploy_list: >-
+      {{ _foundation_all_parsed | map(attribute='name') | list }}
+
+- name: Display foundation plugins to deploy
+  ansible.builtin.debug:
+    msg: "Foundation plugins to deploy (sorted by order): {{ _foundation_deploy_list }}"
+
+- name: Deploy foundation plugin
+  ansible.builtin.include_tasks:
+    file: tasks/deploy_plugin.yaml
+  vars:
+    plugin_name: "{{ _foundation_plugin_name }}"
+  loop: "{{ _foundation_deploy_list }}"
+  loop_control:
+    loop_var: _foundation_plugin_name
+  when: _foundation_deploy_list | length > 0

--- a/playbooks/tasks/deploy_plugin.yaml
+++ b/playbooks/tasks/deploy_plugin.yaml
@@ -1,0 +1,189 @@
+---
+# Reusable tasks for deploying a plugin
+#
+# Required variables:
+#   plugin_name: Name of the plugin directory under plugins/
+#   workingDir: Working directory on the Landing Zone
+#
+# This file is included from both deploy-plugin.yaml (standalone) and
+# 05-operators.yaml (core pipeline integration).
+
+- name: Validate plugin_name is provided
+  ansible.builtin.assert:
+    that:
+      - plugin_name is defined
+      - plugin_name | length > 0
+      - plugin_name is regex('^[A-Za-z0-9][A-Za-z0-9._-]*$')
+    fail_msg: "plugin_name must be a valid name (alphanumeric, dots, hyphens, underscores; no path separators)"
+  tags: always
+
+- name: Set plugin directory
+  ansible.builtin.set_fact:
+    plugin_dir: "{{ playbook_dir }}/../plugins/{{ plugin_name }}"
+  tags: always
+
+- name: Verify plugin.yaml exists
+  ansible.builtin.stat:
+    path: "{{ plugin_dir }}/plugin.yaml"
+  register: r_plugin_yaml
+  tags: always
+
+- name: Fail if plugin.yaml is missing
+  ansible.builtin.assert:
+    that: r_plugin_yaml.stat.exists
+    fail_msg: "Plugin descriptor not found: {{ plugin_dir }}/plugin.yaml"
+  tags: always
+
+- name: Load plugin descriptor
+  ansible.builtin.include_vars:
+    file: "{{ plugin_dir }}/plugin.yaml"
+    name: plugin
+  tags: always
+
+- name: Display plugin info
+  ansible.builtin.debug:
+    msg: "Deploying plugin '{{ plugin.name }}' (type={{ plugin.type }}, order={{ plugin.order | default('unset') }}, mirror={{ plugin.mirror | default('none') }})"
+  tags: always
+
+# Dynamically set each key in plugin.defaults as an Ansible fact.
+# The dict2items loop is required because set_fact needs explicit key: value
+# pairs — the free-form `set_fact: "{{ dict }}"` renders to a string and
+# does not expand into individual facts.
+# noqa: var-naming[no-jinja] is needed because Jinja2 in the variable name
+# is the only way to set dynamic fact names from a dict.
+- name: Load plugin defaults  # noqa: var-naming[no-jinja]
+  ansible.builtin.set_fact:
+    "{{ item.key }}": "{{ item.value }}"
+  loop: "{{ plugin.defaults | default({}) | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+  when: plugin.defaults is defined
+  tags: always
+
+- name: Run pre-validate
+  ansible.builtin.include_tasks:
+    file: "{{ plugin_dir }}/tasks/pre-validate.yaml"
+    apply:
+      tags: pre-validate
+      environment:
+        KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  when: lookup('ansible.builtin.fileglob', plugin_dir ~ '/tasks/pre-validate.yaml') | length > 0
+  tags: pre-validate
+
+- name: Template plugin imageset configuration
+  ansible.builtin.template:
+    src: "{{ playbook_dir }}/../templates/plugin-imageset.yaml.j2"
+    dest: "{{ workingDir }}/plugin-{{ plugin_name }}-imageset.yaml"
+  when:
+    - plugin.mirror | default('none') == 'plugin'
+    - disconnected | default(true) | bool
+    - plugin.operators is defined
+  tags: mirror
+
+- name: Run oc-mirror for plugin
+  ansible.builtin.shell: |
+    {{ workingDir }}/bin/oc-mirror --v2 \
+      --log-level {{ ocMirrorLogLevel }} \
+      --authfile "{{ pullSecretPath }}" \
+      -c {{ workingDir }}/plugin-{{ plugin_name }}-imageset.yaml \
+      --workspace file://{{ workingDir }}/config/oc-mirror-workspace \
+      docker://{{ quayHostname }}:8443 \
+      --dest-tls-verify=false \
+      --parallel-images 10 \
+      --parallel-layers 10 \
+      --retry-times 10 \
+      --retry-delay 0 \
+      > {{ workingDir }}/logs/oc-mirror-plugin-{{ plugin_name }}.progress.$(date +%s).log 2>&1
+  retries: 10
+  delay: 10
+  register: r_plugin_mirror
+  until: r_plugin_mirror is success
+  when:
+    - plugin.mirror | default('none') == 'plugin'
+    - disconnected | default(true) | bool
+  tags: mirror
+
+- name: Apply updated mirror manifests to cluster
+  ansible.builtin.shell: |
+    {{ workingDir }}/bin/oc apply \
+      -f {{ workingDir }}/config/oc-mirror-workspace/working-dir/cluster-resources/ \
+      --server-side --force-conflicts
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  when:
+    - plugin.mirror | default('none') == 'plugin'
+    - disconnected | default(true) | bool
+    - r_plugin_mirror is defined
+    - r_plugin_mirror is success
+  tags: mirror
+
+- name: Wait for updated CatalogSource to be ready
+  kubernetes.core.k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: CatalogSource
+    namespace: openshift-marketplace
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  register: r_catalog_sources
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: >-
+    r_catalog_sources.resources | default([])
+    | selectattr('status', 'defined')
+    | selectattr('status.connectionState', 'defined')
+    | selectattr('status.connectionState.lastObservedState', 'equalto', 'READY')
+    | list | length >= (r_catalog_sources.resources | length)
+  when:
+    - plugin.mirror | default('none') == 'plugin'
+    - disconnected | default(true) | bool
+    - r_plugin_mirror is defined
+    - r_plugin_mirror is success
+  tags: mirror
+
+- name: Patch MCE custom-registries with plugin entries
+  ansible.builtin.include_tasks:
+    file: tasks/patch_mce_registries.yaml
+    apply:
+      tags: mirror
+      environment:
+        KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  vars:
+    plugin_registries_entries: "{{ plugin.registries }}"
+  when:
+    - plugin.registries is defined
+    - plugin.mirror | default('none') in ['core', 'plugin']
+    - disconnected | default(true) | bool
+  tags: mirror
+
+- name: Install plugin operators
+  ansible.builtin.include_tasks:
+    file: tasks/configure_operator.yaml
+    apply:
+      tags: operators
+      environment:
+        KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  loop: "{{ plugin.operators }}"
+  loop_control:
+    loop_var: operator
+  when: plugin.operators is defined
+  tags: operators
+
+- name: Run deploy
+  ansible.builtin.include_tasks:
+    file: "{{ plugin_dir }}/tasks/deploy.yaml"
+    apply:
+      tags: deploy
+      environment:
+        KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  when: lookup('ansible.builtin.fileglob', plugin_dir ~ '/tasks/deploy.yaml') | length > 0
+  tags: deploy
+
+- name: Run post-validate
+  ansible.builtin.include_tasks:
+    file: "{{ plugin_dir }}/tasks/post-validate.yaml"
+    apply:
+      tags: post-validate
+      environment:
+        KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  when: lookup('ansible.builtin.fileglob', plugin_dir ~ '/tasks/post-validate.yaml') | length > 0
+  tags: post-validate

--- a/playbooks/tasks/patch_mce_registries.yaml
+++ b/playbooks/tasks/patch_mce_registries.yaml
@@ -1,0 +1,100 @@
+---
+# Patch the MCE custom-registries ConfigMap with plugin registry mirror entries.
+#
+# Required variables:
+#   plugin_registries_entries: list of dicts with 'location' and 'mirror' (per plugin schema)
+#   clusterName: cluster name for Quay route
+#   baseDomain: base domain for Quay route
+
+- name: Read current custom-registries ConfigMap
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: ConfigMap
+    name: custom-registries
+    namespace: multicluster-engine
+  register: r_custom_registries
+
+- name: Skip if custom-registries ConfigMap does not exist
+  ansible.builtin.debug:
+    msg: "custom-registries ConfigMap not found — skipping registry patching (connected mode or MCE not deployed)"
+  when: r_custom_registries.resources | length == 0
+
+- name: Patch MCE registries with plugin entries
+  when: r_custom_registries.resources | length > 0
+  block:
+    - name: Get current registries.conf content
+      ansible.builtin.set_fact:
+        current_registries_conf: "{{ r_custom_registries.resources[0].data['registries.conf'] }}"
+
+    - name: Parse existing TOML location values
+      ansible.builtin.set_fact:
+        _toml_locations: >-
+          {{ current_registries_conf | regex_findall('location\s*=\s*"([^"]*)"') }}
+
+    - name: Determine new registry entries to add
+      ansible.builtin.set_fact:
+        new_registry_entries: >-
+          {{
+            plugin_registries_entries
+            | selectattr('location', 'defined')
+            | rejectattr('location', 'in', _toml_locations)
+            | list
+          }}
+
+    - name: Report entries already present
+      ansible.builtin.debug:
+        msg: >-
+          Skipping already-present entries:
+          {{ plugin_registries_entries
+             | selectattr('location', 'defined')
+             | selectattr('location', 'in', _toml_locations)
+             | map(attribute='location')
+             | list }}
+      when: >-
+        (plugin_registries_entries
+         | selectattr('location', 'defined')
+         | selectattr('location', 'in', _toml_locations)
+         | list | length) > 0
+
+    - name: Build TOML fragment for new entries
+      ansible.builtin.set_fact:
+        registry_toml_fragment: |
+          {% for entry in new_registry_entries %}
+
+          [[registry]]
+            prefix = ""
+            location = "{{ entry.location }}"
+          [[registry.mirror]]
+            location = "registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/{{ entry.mirror | default(entry.location | split('/') | last) }}"
+          {% endfor %}
+      when: new_registry_entries | length > 0
+
+    - name: Update custom-registries ConfigMap with new entries
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: custom-registries
+            namespace: multicluster-engine
+            labels:
+              app: assisted-service
+          data:
+            ca-bundle.crt: "{{ r_custom_registries.resources[0].data['ca-bundle.crt'] }}"
+            registries.conf: "{{ current_registries_conf }}{{ registry_toml_fragment }}"
+      when: new_registry_entries | length > 0
+      register: r_update_registries
+      retries: 3
+      delay: 5
+      until: r_update_registries is success
+
+    - name: Report patching result
+      ansible.builtin.debug:
+        msg: >-
+          {% if new_registry_entries | length > 0 %}
+          Added {{ new_registry_entries | length }} registry entries:
+          {{ new_registry_entries | map(attribute='location') | list }}
+          {% else %}
+          All plugin registry entries already present — nothing to add.
+          {% endif %}

--- a/schemas/deployment.yaml
+++ b/schemas/deployment.yaml
@@ -24,6 +24,21 @@ properties:
     type: string
     description: >-
       Path to the pull secret JSON file. Default: {{ workingDir }}/config/pull-secret.json.
+  storage_plugin:
+    type: string
+    enum: [lvms, odf]
+    description: >-
+      Which storage plugin to deploy. Default: lvms.
+  enabled_plugins:
+    type: array
+    items:
+      type: string
+    description: >-
+      List of plugins to deploy during the pipeline. Default: [storage_plugin].
+  blockStorageBackend:
+    type: string
+    description: >-
+      Backward-compatible alias for storage_plugin. Will be removed after migration.
 
 required:
   - disconnected

--- a/scripts/deployment/deploy_plugin.sh
+++ b/scripts/deployment/deploy_plugin.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
-# Deploy a specific phase of the OpenShift cluster deployment
+# Deploy a plugin to the OpenShift cluster
 #
-# This script connects to the Landing Zone VM and runs a specific
-# Enclave Lab ansible playbook phase.
+# This script connects to the Landing Zone VM and runs the
+# deploy-plugin.yaml playbook for the specified plugin.
 #
-# Usage: ./deploy_phase.sh <playbook-file> [ansible-playbook extra args]
-# Example: ./deploy_phase.sh 04-post-install.yaml
-# Example: ./deploy_phase.sh 02-mirror.yaml --tags mirror-plugins
+# Usage: ./deploy_plugin.sh <plugin-name> [ansible-playbook extra args]
+# Example: ./deploy_plugin.sh openshift-ai
+# Example: ./deploy_plugin.sh openshift-ai --tags mirror
 
 set -euo pipefail
 
@@ -23,15 +23,28 @@ source "${ENCLAVE_DIR}/scripts/lib/ssh.sh"
 
 # Check arguments
 if [ $# -lt 1 ]; then
-    error "Usage: $0 <playbook-file> [--tags <tags>]"
-    error "Example: $0 04-post-install.yaml"
-    error "Example: $0 02-mirror.yaml --tags mirror-plugins"
+    error "Usage: $0 <plugin-name> [--tags <tags>]"
+    error "Example: $0 openshift-ai"
+    error "Example: $0 openshift-ai --tags mirror"
     exit 1
 fi
 
-PLAYBOOK_FILE="$1"
+PLUGIN_NAME="$1"
 shift
 ANSIBLE_EXTRA_ARGS="$*"
+
+# Validate plugin name format (prevent path traversal)
+if [[ ! "$PLUGIN_NAME" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+    error "Invalid plugin name: '$PLUGIN_NAME'"
+    error "Plugin name must match: ^[A-Za-z0-9][A-Za-z0-9._-]*$"
+    exit 1
+fi
+
+# Validate plugin exists locally
+if [ ! -f "${ENCLAVE_DIR}/plugins/${PLUGIN_NAME}/plugin.yaml" ]; then
+    error "Plugin not found: plugins/${PLUGIN_NAME}/plugin.yaml"
+    exit 1
+fi
 
 # Validate required environment variables
 require_env_var "DEV_SCRIPTS_PATH"
@@ -61,7 +74,7 @@ setup_ssh_config "$CLUSTER_IP"
 # Deployment mode: connected or disconnected (default: disconnected)
 DEPLOYMENT_MODE="${ENCLAVE_DEPLOYMENT_MODE:-disconnected}"
 
-info "Running phase: $PLAYBOOK_FILE"
+info "Deploying plugin: $PLUGIN_NAME"
 info "Landing Zone: $CLUSTER_IP"
 info "Deployment mode: $DEPLOYMENT_MODE"
 info ""
@@ -73,8 +86,8 @@ if ! ssh_test_connection; then
 fi
 
 # Verify Enclave Lab is installed
-if ! ssh_file_exists "$LZ_ENCLAVE_DIR/playbooks/$PLAYBOOK_FILE"; then
-    error "Playbook not found: $LZ_ENCLAVE_DIR/playbooks/$PLAYBOOK_FILE"
+if ! ssh_file_exists "$LZ_ENCLAVE_DIR/plugins/${PLUGIN_NAME}/plugin.yaml"; then
+    error "Plugin not found on Landing Zone: $LZ_ENCLAVE_DIR/plugins/${PLUGIN_NAME}/plugin.yaml"
     exit 1
 fi
 
@@ -86,6 +99,7 @@ fi
 
 # Build ansible-playbook command with extra vars
 EXTRA_VARS_CONTENT="workingDir: /home/${LZ_USER}
+plugin_name: ${PLUGIN_NAME}
 "
 
 # Set disconnected mode based on DEPLOYMENT_MODE
@@ -104,18 +118,19 @@ $EXTRA_VARS_CONTENT
 EOF
 
 # Run ansible-playbook with the extra vars file
-LOG_FILE="deployment_$(basename "$PLAYBOOK_FILE" .yaml).log"
+LOG_FILE="deployment_plugin_${PLUGIN_NAME}.log"
 info "Running playbook (logging to $LOG_FILE)..."
-# shellcheck disable=SC2086  # SSH_OPTS and ANSIBLE_EXTRA_ARGS need word splitting
-ssh -t $SSH_OPTS "$LZ_SSH" "cd $LZ_ENCLAVE_DIR && bash -c 'set -o pipefail; ansible-playbook playbooks/$PLAYBOOK_FILE -e @phase_vars.yaml $ANSIBLE_EXTRA_ARGS 2>&1 | tee $LOG_FILE'"
-
-PHASE_EXIT_CODE=$?
+# shellcheck disable=SC2086  # SSH_OPTS needs word splitting
+set +e
+ssh -t $SSH_OPTS "$LZ_SSH" "cd $LZ_ENCLAVE_DIR && bash -c 'set -o pipefail; ansible-playbook playbooks/deploy-plugin.yaml -e @phase_vars.yaml $ANSIBLE_EXTRA_ARGS 2>&1 | tee $LOG_FILE'"
+PLUGIN_EXIT_CODE=$?
+set -e
 
 echo ""
-if [ $PHASE_EXIT_CODE -eq 0 ]; then
-    success "Phase completed successfully: $PLAYBOOK_FILE"
+if [ $PLUGIN_EXIT_CODE -eq 0 ]; then
+    success "Plugin deployed successfully: $PLUGIN_NAME"
 else
-    error "Phase failed: $PLAYBOOK_FILE (exit code: $PHASE_EXIT_CODE)"
+    error "Plugin deployment failed: $PLUGIN_NAME (exit code: $PLUGIN_EXIT_CODE)"
     info "Check logs: ssh ${LZ_SSH} 'cat $LZ_ENCLAVE_DIR/$LOG_FILE'"
     exit 1
 fi

--- a/scripts/infrastructure/generate_enclave_vars.sh
+++ b/scripts/infrastructure/generate_enclave_vars.sh
@@ -145,7 +145,7 @@ quayBackendLocalStorageConfiguration:
 # ============================================================================
 # Storage backend for block devices for quay database and assisted installer
 # Options: lvms or odf
-blockStorageBackend: lvms
+storage_plugin: lvms
 
 # ============================================================================
 # Storage Configuration (LVMS) (optional)

--- a/templates/plugin-imageset.yaml.j2
+++ b/templates/plugin-imageset.yaml.j2
@@ -1,0 +1,21 @@
+---
+kind: ImageSetConfiguration
+apiVersion: mirror.openshift.io/v2alpha1
+mirror:
+  operators:
+    - catalog: {{ rh_operator_catalog }}:{{ rh_operator_catalog_version }}
+      packages:
+{% for operator in plugin.operators | default([]) %}
+{% set additional_operator_names = operator.csvNames if (operator.csvMirror | default(false) | bool) else [] %}
+{% for operator_name in [operator.name] + additional_operator_names %}
+        - name: {{ operator_name }}
+          defaultChannel: {{ operator.channel }}
+          channels:
+            - name: {{ operator.channel }}
+              minVersion: {{ operator.init_version }}
+              maxVersion: {{ operator.version }}
+{% endfor %}
+{% for pkg in operator.extraMirrorPackages | default([]) %}
+        - name: {{ pkg }}
+{% endfor %}
+{% endfor %}


### PR DESCRIPTION
## Summary
- Add plugin lifecycle runner (`deploy_plugin.yaml`) that executes deploy, pre-validate, and post-validate hooks
- Add foundation plugin auto-discovery (`deploy_foundation_plugins.yaml`)
- Add standalone playbook entry point (`deploy-plugin.yaml`)
- Add shell script `deploy_plugin.sh` for deploying individual plugins via SSH
- Add extra-args support to `deploy_phase.sh` for passing additional Ansible parameters
- Add per-plugin ImageSetConfiguration template (`plugin-imageset.yaml.j2`)
- Add `storage_plugin` and `enabled_plugins` to deployment defaults and schema
- Integrate foundation plugin deployment into `05-operators.yaml`

## Dependencies
- Merge after #155 (plugin schema + validation) - **already merged**

## Test plan
- [ ] `make validate` passes
- [ ] Plugin deployment framework loads without errors in Ansible check mode
- [ ] Foundation plugin auto-discovery finds plugins with `type: foundation`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added explicit plugin discovery/deployment and a CLI to deploy named plugins.
  - Plugin mirroring support for air-gapped deployments.

* **Configuration Changes**
  - Introduced `storage_plugin` (lvms/odf) and `enabled_plugins` list.
  - Kept backward-compatible alias for `blockStorageBackend` to avoid breaking existing setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->