### PR TITLE
Add pre-install validation gate between Ironic boot and wait

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -149,7 +149,7 @@ echo -e "\e[38;5;10m Done...\033[0m"; date
 
 echo -p "Acquiring Hardware .. " -n1 -s
     # setup content for and boot machines
-    ansible-playbook playbooks/03-deploy.yaml -e@$global_vars -e@$certs_vars --tags hardware 2>&1 | tee -a ${log}
+    ansible-playbook playbooks/03-deploy.yaml -e@$global_vars -e@$certs_vars --tags hardware,pre-install-validate 2>&1 | tee -a ${log}
 echo -e "\e[38;5;10m Done...\033[0m"; date
 
 echo -p "Deploying management cluster .. " -n1 -s

--- a/playbooks/03-deploy.yaml
+++ b/playbooks/03-deploy.yaml
@@ -59,6 +59,13 @@
           tags: hardware
       tags: hardware
 
+    - name: Pre-install validate plugins
+      ansible.builtin.include_tasks:
+        file: tasks/pre_install_validate_plugins.yaml
+        apply:
+          tags: pre-install-validate
+      tags: pre-install-validate
+
     - name: Wait for all hosts to reach active state
       loop: "{{ agent_hosts }}"
       loop_control:

--- a/playbooks/tasks/configure_ocp_abi.yaml
+++ b/playbooks/tasks/configure_ocp_abi.yaml
@@ -88,6 +88,79 @@
     path: "{{ workingDir }}/ocp-cluster/abi-iso/"
     state: directory
 
+- name: Inject installation gate into agent ISO
+  when: installation_gate | default(true) | bool
+  block:
+    - name: Write gate script content
+      ansible.builtin.copy:
+        dest: "{{ workingDir }}/ocp-cluster/installation-gate.sh"
+        mode: "0755"
+        content: |
+          #!/bin/bash
+          echo "=========================================="
+          echo "  Installation gate is ACTIVE"
+          echo "  Waiting for release signal..."
+          echo "  To proceed, run:"
+          echo "    touch /var/tmp/proceed-with-installation"
+          echo "=========================================="
+          while [ ! -f /var/tmp/proceed-with-installation ]; do
+            sleep 5
+          done
+          echo "Gate released. Proceeding with installation..."
+
+    - name: Extract ignition and inject gate service
+      ansible.builtin.shell: |
+        set -euo pipefail
+
+        GATE_SCRIPT_B64=$(base64 -w0 {{ workingDir }}/ocp-cluster/installation-gate.sh)
+
+        podman run --privileged --rm \
+          -v {{ workingDir }}/ocp-cluster:/data:z -w /data \
+          quay.io/coreos/coreos-installer:release \
+          iso ignition show agent.x86_64.iso \
+        | jq --compact-output \
+            --arg script_b64 "$GATE_SCRIPT_B64" \
+            '
+            # Add gate script file
+            .storage.files += [{
+              "path": "/usr/local/bin/installation-gate.sh",
+              "mode": 493,
+              "contents": { "source": ("data:text/plain;charset=utf-8;base64," + $script_b64) },
+              "overwrite": true
+            }]
+            # Add gate service unit
+            | .systemd.units += [{
+              "name": "installation-gate.service",
+              "enabled": true,
+              "contents": "[Unit]\nDescription=Installation gate - blocks start-cluster-installation\nBefore=start-cluster-installation.service\n\n[Service]\nType=oneshot\nExecStart=/usr/local/bin/installation-gate.sh\nRemainAfterExit=yes\nStandardOutput=journal+console\n\n[Install]\nRequiredBy=start-cluster-installation.service\n"
+            }]
+            # Add drop-in to make start-cluster-installation depend on gate
+            | (.systemd.units[] |
+                select(.name == "start-cluster-installation.service")) |=
+                . + { "dropins": ((.dropins // []) + [{
+                  "name": "10-wait-for-gate.conf",
+                  "contents": "[Unit]\nRequires=installation-gate.service\nAfter=installation-gate.service\n"
+                }]) }
+            ' \
+        > {{ workingDir }}/ocp-cluster/gated.ign
+
+    - name: Embed gated ignition back into agent ISO
+      ansible.builtin.command:
+        cmd: >-
+          podman run --privileged --rm
+          -v {{ workingDir }}/ocp-cluster:/data:z
+          -w /data
+          quay.io/coreos/coreos-installer:release
+          iso ignition embed -f -i gated.ign agent.x86_64.iso
+
+    - name: Remove temporary gate files
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - "{{ workingDir }}/ocp-cluster/gated.ign"
+        - "{{ workingDir }}/ocp-cluster/installation-gate.sh"
+
 - name: Move to {{ workingDir }}/ocp-cluster/abi-iso/
   ansible.builtin.command:
     cmd: mv "{{ workingDir }}/ocp-cluster/agent.x86_64.iso" "{{ workingDir }}/ocp-cluster/abi-iso/agent.x86_64.iso"

--- a/playbooks/tasks/pre_install_validate_plugins.yaml
+++ b/playbooks/tasks/pre_install_validate_plugins.yaml
@@ -1,0 +1,156 @@
+---
+- name: Add rendezvous node to inventory
+  ansible.builtin.add_host:
+    name: rendezvous
+    ansible_host: "{{ rendezvousIP }}"
+    ansible_user: core
+    ansible_ssh_private_key_file: "{{ sshPubPath | replace('.pub', '') }}"
+    ansible_ssh_common_args: "-o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10"
+
+# Nodes were just booted via Ironic and may not have SSH ready yet.
+# delegate_to connection failures (UNREACHABLE) are fatal and bypass
+# Ansible's retries/until mechanism, so we must wait for connectivity
+# explicitly before any delegated tasks.
+- name: Wait for rendezvous node to become reachable
+  ansible.builtin.wait_for_connection:
+    timeout: 300
+    sleep: 10
+  delegate_to: rendezvous
+
+- name: Read Assisted Service env file from rendezvous node
+  ansible.builtin.slurp:
+    src: /etc/assisted/rendezvous-host.env
+  delegate_to: rendezvous
+  register: r_rendezvous_env
+  retries: 30
+  delay: 5
+  until: r_rendezvous_env is success
+  no_log: true
+
+- name: Extract auth token from env file
+  ansible.builtin.set_fact:
+    _assisted_token_match: "{{ (r_rendezvous_env.content | b64decode) | regex_search('USER_AUTH_TOKEN=(.+)', '\\1') | default([]) }}"
+  no_log: true
+
+- name: Fail if auth token not found
+  ansible.builtin.fail:
+    msg: "USER_AUTH_TOKEN not found in /etc/assisted/rendezvous-host.env on rendezvous node"
+  when: _assisted_token_match | length == 0
+
+- name: Set auth token fact
+  ansible.builtin.set_fact:
+    _assisted_auth_token: "{{ _assisted_token_match | first }}"
+  no_log: true
+
+- name: Wait for Assisted Service cluster to be registered
+  ansible.builtin.uri:
+    url: "http://{{ rendezvousIP }}:8090/api/assisted-install/v2/clusters"
+    method: GET
+    headers:
+      Authorization: "{{ _assisted_auth_token }}"
+    status_code: [200]
+  register: r_assisted_clusters
+  retries: 60
+  delay: 5
+  until:
+    - r_assisted_clusters is success
+    - r_assisted_clusters.json | length > 0
+  no_log: true
+
+- name: Extract cluster info
+  ansible.builtin.set_fact:
+    assisted_cluster_id: "{{ r_assisted_clusters.json[0].id }}"
+    assisted_service_url: "http://{{ rendezvousIP }}:8090/api/assisted-install/v2"
+    assisted_auth_token: "{{ _assisted_auth_token }}"
+  no_log: true
+
+- name: Display initial cluster status
+  ansible.builtin.debug:
+    msg: "Assisted Service cluster status: {{ r_assisted_clusters.json[0].status }}"
+
+- name: Wait for all hosts to be ready
+  ansible.builtin.uri:
+    url: "{{ assisted_service_url }}/clusters/{{ assisted_cluster_id }}/hosts"
+    method: GET
+    headers:
+      Authorization: "{{ assisted_auth_token }}"
+  register: r_assisted_hosts
+  retries: 60
+  delay: 5
+  until: >-
+    r_assisted_hosts.json | length >= (agent_hosts | length)
+    and (r_assisted_hosts.json
+        | selectattr('status', 'equalto', 'known')
+        | list | length) >= (agent_hosts | length)
+  no_log: true
+
+- name: Display discovered hosts
+  ansible.builtin.debug:
+    msg: "All {{ r_assisted_hosts.json | length }} hosts are ready (status: known)"
+
+- name: Set discovered hosts fact
+  ansible.builtin.set_fact:
+    discovered_hosts: "{{ r_assisted_hosts.json }}"
+
+- name: Find plugins with tasks/pre-install-validate.yaml
+  ansible.builtin.find:
+    paths: "{{ playbook_dir }}/../plugins"
+    patterns: "pre-install-validate.yaml"
+    recurse: true
+    depth: 3
+  register: r_pre_install_plugins
+
+- name: Read plugin descriptors for filtering
+  ansible.builtin.slurp:
+    src: "{{ item }}/plugin.yaml"
+  loop: "{{ r_pre_install_plugins.files | map(attribute='path') | map('dirname') | map('dirname') | unique | list | sort }}"
+  register: r_pre_install_slurp
+  when: r_pre_install_plugins.files | length > 0
+
+- name: Build enabled plugin name list
+  ansible.builtin.set_fact:
+    _pre_install_included_names: >-
+      {{ r_pre_install_slurp.results | default([])
+         | map(attribute='content')
+         | map('b64decode')
+         | map('from_yaml')
+         | selectattr('name', 'in', enabled_plugins)
+         | map(attribute='name')
+         | list }}
+  when: r_pre_install_plugins.files | length > 0
+
+- name: Build filtered plugin paths
+  ansible.builtin.set_fact:
+    _pre_install_plugin_paths: >-
+      {{ r_pre_install_slurp.results | default([])
+         | map(attribute='item')
+         | select('search', '/(' + (_pre_install_included_names | join('|')) + ')$')
+         | list | sort }}
+  when:
+    - r_pre_install_plugins.files | length > 0
+    - _pre_install_included_names | default([]) | length > 0
+
+- name: Run pre-install validation for each plugin
+  ansible.builtin.include_tasks:
+    file: tasks/run_pre_install_validate.yaml
+    apply:
+      tags: pre-install-validate
+  loop: "{{ _pre_install_plugin_paths | default([]) }}"
+  loop_control:
+    loop_var: plugin_path
+  when: _pre_install_plugin_paths | default([]) | length > 0
+
+- name: Release installation gate on rendezvous node
+  ansible.builtin.file:
+    path: /var/tmp/proceed-with-installation
+    state: touch
+    mode: "0644"
+  delegate_to: rendezvous
+  retries: 3
+  delay: 5
+  register: r_gate_release
+  until: r_gate_release is success
+
+- name: Display gate release status
+  ansible.builtin.debug:
+    msg: "Installation gate released - cluster installation will proceed"

--- a/playbooks/tasks/run_pre_install_validate.yaml
+++ b/playbooks/tasks/run_pre_install_validate.yaml
@@ -1,0 +1,20 @@
+---
+- name: Load plugin descriptor for {{ plugin_path | basename }}
+  ansible.builtin.include_vars:
+    file: "{{ plugin_path }}/plugin.yaml"
+    name: _piv_plugin
+
+# See deploy_plugin.yaml for why dict2items loop + noqa is needed here.
+- name: Load plugin defaults for {{ plugin_path | basename }}  # noqa: var-naming[no-jinja]
+  ansible.builtin.set_fact:
+    "{{ item.key }}": "{{ item.value }}"
+  loop: "{{ _piv_plugin.defaults | default({}) | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+  when: _piv_plugin.defaults is defined
+
+- name: Run pre-install validation for {{ plugin_path | basename }}
+  ansible.builtin.include_tasks:
+    file: "{{ plugin_path }}/tasks/pre-install-validate.yaml"
+    apply:
+      tags: pre-install-validate

--- a/plugins/example/tasks/pre-install-validate.yaml
+++ b/plugins/example/tasks/pre-install-validate.yaml
@@ -1,0 +1,4 @@
+---
+- name: Log discovered host count
+  ansible.builtin.debug:
+    msg: "Example plugin pre-install validation: {{ discovered_hosts | length }} host(s) discovered"


### PR DESCRIPTION
## Summary
- Add `pre_install_validate_plugins.yaml` that runs plugin pre-install validation hooks between Ironic boot and wait phases
- Add `run_pre_install_validate.yaml` for executing validation on the rendezvous node
- Insert pre-install validation step in `03-deploy.yaml` between boot and wait
- Add example pre-install-validate hook to the example plugin
- Add `pre-install-validate` tag to `bootstrap.sh`

## Dependencies
- Merge after #155 (plugin schema) - **already merged**
- Merge after #156 (Ironic boot/wait split) - provides the gap between boot and wait phases
-  Merge after #163 (Add plugin framework) - provides the plugin pre-validation step

## Test plan
- [x] `make validate` passes
- [x] Pre-install validation runs between boot and wait phases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a pre-install validation phase that runs before hosts reach active state.
  * Hardware acquisition now triggers the pre-install validation step during deployment.
  * Automatic discovery and per-plugin pre-install checks are executed as part of deployment.
  * Example plugin logs discovered host count during pre-install validation.
  * Optional gating of automatic cluster start via an installation gate is supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->