### PR TITLE
Add CI image build workflow

### DIFF
--- a/.github/workflows/Dockerfile.ci
+++ b/.github/workflows/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi
+FROM registry.access.redhat.com/ubi10/ubi@sha256:1b616c4a90d6444b394d5c8f4bd9e15a394d95dd628925d0ec80c257fdc5099c
 
 # Configure DNS
 RUN echo "nameserver 8.8.8.8" > /etc/resolv.conf && \
@@ -6,11 +6,10 @@ RUN echo "nameserver 8.8.8.8" > /etc/resolv.conf && \
 
 # Install EPEL for additional packages like shellcheck
 RUN dnf install -y \
-    https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
+    https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm && \
     dnf clean all
 
 # Install system dependencies
-# UBI9 comes with curl-minimal, replace it with full curl
 RUN dnf install -y --allowerasing \
     ca-certificates \
     curl \
@@ -32,14 +31,17 @@ RUN dnf config-manager --add-repo https://download.docker.com/linux/rhel/docker-
 RUN pip3 install --no-cache-dir \
     yamllint \
     ansible-core \
-    ansible-lint \
-    jsonschema
+    ansible-lint
+
+# Install Python dependencies (kubernetes client, etc.)
+COPY ansible_pip_requirements.txt /tmp/ansible_pip_requirements.txt
+RUN pip3 install --no-cache-dir -r /tmp/ansible_pip_requirements.txt && \
+    rm /tmp/ansible_pip_requirements.txt
 
 # Pre-install Ansible Galaxy collections
-# Copy requirements.yml from repository root
-COPY requirements.yml /tmp/requirements.yml
-RUN ansible-galaxy collection install -r /tmp/requirements.yml && \
-    rm /tmp/requirements.yml
+COPY ansible_collections.txt /tmp/ansible_collections.txt
+RUN ansible-galaxy collection install -r /tmp/ansible_collections.txt && \
+    rm /tmp/ansible_collections.txt
 
 # Symlink collections to /usr/local for system-wide access
 RUN mkdir -p /usr/local/share/ansible/collections && \
@@ -50,9 +52,5 @@ ENV ANSIBLE_COLLECTIONS_PATH=/usr/local/share/ansible/collections:/root/.ansible
 
 # Set working directory
 WORKDIR /workspace
-
-# Configure DNS (in case it's needed at runtime)
-RUN echo "nameserver 8.8.8.8" > /etc/resolv.conf && \
-    echo "nameserver 8.8.4.4" >> /etc/resolv.conf
 
 CMD ["/bin/bash"]

--- a/.github/workflows/build-push-tarball.yml
+++ b/.github/workflows/build-push-tarball.yml
@@ -12,16 +12,23 @@ on:
   merge_group:
     types: [checks_requested]
 
+permissions:
+  contents: read
+
 jobs:
+  # Job 0: Resolve CI image — build SHA-tagged image if Dockerfile.ci changed
+  resolve-image:
+    uses: ./.github/workflows/resolve-ci-image.yml
+    secrets: inherit
+
   build-push-tarball:
+    needs: resolve-image
     runs-on: [self-hosted, pr-validation]
     container:
-      image: quay.io/eerez/enclave-lab-ci:latest
+      image: ${{ needs.resolve-image.outputs.image }}
       volumes:
         - /var/run/docker.sock:/var/run/docker.sock
       options: --user root
-    permissions:
-      contents: read
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -1,0 +1,39 @@
+name: CI Image Build
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-image-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci-image:
+    name: CI Image Build
+    runs-on: [self-hosted, pr-validation]
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build CI image
+        run: make -f Makefile.ci build-ci-image
+
+      - name: Test CI image
+        run: make -f Makefile.ci test-ci-image
+
+      - name: Push CI image
+        env:
+          QUAY_USER: ${{ secrets.QUAY_USER }}
+          QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+        run: make -f Makefile.ci push-ci-image

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -16,12 +16,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Job 0: Resolve CI image — build SHA-tagged image if Dockerfile.ci changed
+  resolve-image:
+    uses: ./.github/workflows/resolve-ci-image.yml
+    secrets: inherit
+
   # Job 1: Shell script validation
   shellcheck:
     name: Shell Script Validation
+    needs: resolve-image
     runs-on: [self-hosted, pr-validation]
     container:
-      image: quay.io/eerez/enclave-lab-ci:latest
+      image: ${{ needs.resolve-image.outputs.image }}
       options: --user root
     timeout-minutes: 5
     defaults:
@@ -66,9 +72,10 @@ jobs:
   # Job 2: YAML validation
   yamllint:
     name: YAML Validation
+    needs: resolve-image
     runs-on: [self-hosted, pr-validation]
     container:
-      image: quay.io/eerez/enclave-lab-ci:latest
+      image: ${{ needs.resolve-image.outputs.image }}
       options: --user root
     timeout-minutes: 5
     defaults:
@@ -113,9 +120,10 @@ jobs:
   # Job 3: JSON schema validation
   json-schema:
     name: JSON Schema Validation
+    needs: resolve-image
     runs-on: [self-hosted, pr-validation]
     container:
-      image: quay.io/eerez/enclave-lab-ci:latest
+      image: ${{ needs.resolve-image.outputs.image }}
       options: --user root
     timeout-minutes: 5
     defaults:
@@ -160,9 +168,10 @@ jobs:
   # Job 4: Ansible playbook validation
   ansible-lint:
     name: Ansible Playbook Validation
+    needs: resolve-image
     runs-on: [self-hosted, pr-validation]
     container:
-      image: quay.io/eerez/enclave-lab-ci:latest
+      image: ${{ needs.resolve-image.outputs.image }}
       options: --user root
     timeout-minutes: 5
     defaults:
@@ -207,9 +216,10 @@ jobs:
   # Job 5: Ansible playbook tags validation
   ansible-tags:
     name: Ansible Tags Validation
+    needs: resolve-image
     runs-on: [self-hosted, pr-validation]
     container:
-      image: quay.io/eerez/enclave-lab-ci:latest
+      image: ${{ needs.resolve-image.outputs.image }}
       options: --user root
     timeout-minutes: 5
     defaults:
@@ -303,9 +313,10 @@ jobs:
   # Job 7: Makefile validation
   makefile:
     name: Makefile Validation
+    needs: resolve-image
     runs-on: [self-hosted, pr-validation]
     container:
-      image: quay.io/eerez/enclave-lab-ci:latest
+      image: ${{ needs.resolve-image.outputs.image }}
       options: --user root
     timeout-minutes: 5
     defaults:
@@ -350,9 +361,10 @@ jobs:
   # Job 7: Plugin validation
   plugins:
     name: Plugin Validation
+    needs: resolve-image
     runs-on: [self-hosted, pr-validation]
     container:
-      image: quay.io/eerez/enclave-lab-ci:latest
+      image: ${{ needs.resolve-image.outputs.image }}
       options: --user root
     timeout-minutes: 5
     defaults:

--- a/.github/workflows/resolve-ci-image.yml
+++ b/.github/workflows/resolve-ci-image.yml
@@ -1,0 +1,65 @@
+name: Resolve CI Image
+
+on:
+  workflow_call:
+    secrets:
+      QUAY_USER:
+        required: false
+      QUAY_TOKEN:
+        required: false
+    outputs:
+      image:
+        description: CI image ref to use for validation jobs
+        value: ${{ jobs.resolve-image.outputs.image }}
+
+permissions:
+  contents: read
+
+jobs:
+  resolve-image:
+    name: Resolve CI Image
+    runs-on: [self-hosted, pr-validation]
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
+    outputs:
+      image: ${{ steps.resolve.outputs.image }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check for CI image file changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            changed:
+              - '.github/workflows/Dockerfile.ci'
+              - 'ansible_collections.txt'
+              - 'ansible_pip_requirements.txt'
+
+      - name: Build CI image
+        if: steps.filter.outputs.changed == 'true'
+        run: make -f Makefile.ci build-ci-image CI_IMAGE_TAG=sha-${{ github.sha }} CI_IMAGE_LABELS=quay.expires-after=7d
+
+      - name: Test CI image
+        if: steps.filter.outputs.changed == 'true'
+        run: make -f Makefile.ci test-ci-image CI_IMAGE_TAG=sha-${{ github.sha }}
+
+      - name: Push CI image
+        if: steps.filter.outputs.changed == 'true'
+        env:
+          QUAY_USER: ${{ secrets.QUAY_USER }}
+          QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+        run: make -f Makefile.ci push-ci-image CI_IMAGE_TAG=sha-${{ github.sha }}
+
+      - name: Set image output
+        id: resolve
+        run: |
+          if [[ "${{ steps.filter.outputs.changed }}" == "true" ]]; then
+            echo "image=quay.io/edge-infrastructure/enclave-lab-ci:sha-${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "image=quay.io/edge-infrastructure/enclave-lab-ci:latest" >> "$GITHUB_OUTPUT"
+          fi

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -13,9 +13,10 @@ ENVIRONMENT_JSON := $(WORKING_DIR)/environment-$(ENCLAVE_CLUSTER_NAME).json
 CONFIG_NAME := config_$(ENCLAVE_CLUSTER_NAME).sh
 
 # CI Image
-CI_IMAGE_NAME ?= quay.io/eerez/enclave-lab-ci
+CI_IMAGE_NAME ?= quay.io/edge-infrastructure/enclave-lab-ci
 CI_IMAGE_TAG ?= latest
 CI_IMAGE_FULL := $(CI_IMAGE_NAME):$(CI_IMAGE_TAG)
+CI_IMAGE_LABELS ?=
 
 include Makefile
 
@@ -245,18 +246,25 @@ validate-plugins:
 
 build-ci-image:
 	@echo "Building CI image: $(CI_IMAGE_FULL)"
-	podman build -f .github/workflows/Dockerfile.ci -t $(CI_IMAGE_FULL) .
+	podman build $(if $(CI_IMAGE_LABELS),--label $(CI_IMAGE_LABELS),) -f .github/workflows/Dockerfile.ci -t $(CI_IMAGE_FULL) .
 	@echo "CI image built successfully: $(CI_IMAGE_FULL)"
 
 push-ci-image:
-	@echo "Pushing CI image: $(CI_IMAGE_FULL)"
 	@if [ -z "$$QUAY_USER" ] || [ -z "$$QUAY_TOKEN" ]; then \
 		echo "Error: QUAY_USER and QUAY_TOKEN environment variables must be set"; \
 		exit 1; \
 	fi
 	@echo "$$QUAY_TOKEN" | podman login quay.io -u "$$QUAY_USER" --password-stdin
-	podman push $(CI_IMAGE_FULL)
-	@echo "CI image pushed successfully: $(CI_IMAGE_FULL)"
+	@set -e; \
+	sha=$$(git rev-parse --short HEAD); \
+	sha_image=$(CI_IMAGE_NAME):$$sha; \
+	echo "Tagging $(CI_IMAGE_FULL) as $$sha_image"; \
+	podman tag $(CI_IMAGE_FULL) $$sha_image; \
+	echo "Pushing $(CI_IMAGE_FULL)"; \
+	podman push $(CI_IMAGE_FULL); \
+	echo "Pushing $$sha_image"; \
+	podman push $$sha_image; \
+	echo "CI image pushed successfully: $(CI_IMAGE_FULL), $$sha_image"
 
 test-ci-image:
 	@echo "Testing CI image: $(CI_IMAGE_FULL)"


### PR DESCRIPTION
Build and push the CI image to quay.io/edge-infrastructure/enclave-lab-ci
on every merge to main via a dedicated ci-image.yml workflow.

In PR and merge queue runs, both pr-validation.yml and build-push-tarball.yml
resolve the CI image dynamically via a shared reusable workflow
(resolve-ci-image.yml): if Dockerfile.ci, ansible_collections.txt, or
ansible_pip_requirements.txt changed, build and push a transient image tagged
sha-<github.sha> with a 7-day Quay expiry label and use it for all validation
jobs; otherwise fall back to :latest. This eliminates the need for a second PR
after merging CI image changes, while keeping the common path free of build
overhead.

Update Dockerfile.ci to install Ansible Galaxy collections from
ansible_collections.txt and Python dependencies from ansible_pip_requirements.txt,
replacing the removed requirements.yml.

Fix the image namespace from quay.io/eerez/ to quay.io/edge-infrastructure/
across all workflows. Add CI_IMAGE_LABELS support to the Makefile
build-ci-image target to allow passing quay.expires-after at build time.

Switch base image from UBI9 to UBI10 (Python 3.12) to match the RHEL10
landing zone environment. Update EPEL to epel-release-latest-10.

Also remove the duplicate resolv.conf write at the end of the Dockerfile:
Docker/Podman always mount their own /etc/resolv.conf at container start,
overwriting anything set in the image. The first block at the top of the
Dockerfile is sufficient to ensure DNS works during the build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated CI image build-and-publish workflow (manual and main-triggered) and a PR-aware image resolution step so CI jobs use the appropriate image.
  * CI image build now publishes both latest and SHA-tagged images for clearer versioning.

* **Chores**
  * Updated default CI image repository.
  * Pinned the base image to a digest for improved image reproducibility and security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->