### PR TITLE
Add plugin mirroring integration

### DIFF
--- a/operators/quay-operator/quay_disconnected.yaml
+++ b/operators/quay-operator/quay_disconnected.yaml
@@ -2,6 +2,10 @@
 # Quay disconnected tasks: imageset for oc-mirror and mirror run.
 # This file is included only when disconnected | default(true).
 
+- name: Collect plugin registries for registries.conf
+  ansible.builtin.include_tasks:
+    file: "../../playbooks/tasks/collect_plugin_registries.yaml"
+
 - name: Copy imagesetconfiguration to imagesetconfiguration.internal.yaml
   ansible.builtin.copy:
     src: "{{ workingDir }}/config/imagesetconfiguration.yaml"

--- a/playbooks/02-mirror.yaml
+++ b/playbooks/02-mirror.yaml
@@ -47,6 +47,17 @@
         success_msg: "Running in disconnected mode - proceeding with mirroring"
       tags: mirror-registry
 
+    - name: Collect plugin operators for imageset
+      ansible.builtin.include_tasks:
+        file: tasks/collect_core_plugin_operators.yaml
+        apply:
+          tags:
+            - mirror-registry
+            - mirror-plugins
+      tags:
+        - mirror-registry
+        - mirror-plugins
+
     - name: Include tasks for mirror-registry
       ansible.builtin.include_tasks:
         file: tasks/mirror_registry.yaml

--- a/playbooks/tasks/collect_core_plugin_operators.yaml
+++ b/playbooks/tasks/collect_core_plugin_operators.yaml
@@ -1,0 +1,46 @@
+---
+# Collect operator definitions from all enabled plugins
+# so they can be included in the main imageset for a single oc-mirror run.
+#
+# This avoids running separate oc-mirror invocations per plugin, which
+# would overwrite the catalog index and lose operators from earlier runs.
+#
+# Sets fact: _core_plugin_operators (list of operator dicts)
+
+- name: Find plugin descriptors
+  ansible.builtin.find:
+    paths: "{{ playbook_dir }}/../plugins"
+    patterns: "plugin.yaml"
+    recurse: true
+    depth: 2
+  register: r_cp_find
+
+- name: Read plugin descriptors
+  ansible.builtin.slurp:
+    src: "{{ item }}"
+  loop: "{{ r_cp_find.files | map(attribute='path') | list }}"
+  register: r_cp_slurp
+
+- name: Build combined plugin operators list
+  vars:
+    _enabled: >-
+      {{ r_cp_slurp.results
+         | map(attribute='content')
+         | map('b64decode')
+         | map('from_yaml')
+         | selectattr('name', 'in', enabled_plugins)
+         | list }}
+    _core: >-
+      {{ (_enabled | rejectattr('mirror', 'defined') | list)
+         + (_enabled | selectattr('mirror', 'equalto', 'core') | list) }}
+  ansible.builtin.set_fact:
+    _core_plugin_operators: >-
+      {{ _core
+         | selectattr('operators', 'defined')
+         | map(attribute='operators')
+         | flatten
+         | list }}
+
+- name: Display plugin operators to mirror
+  ansible.builtin.debug:
+    msg: "Plugin operators to include in imageset: {{ _core_plugin_operators | map(attribute='name') | list }}"

--- a/playbooks/tasks/collect_plugin_registries.yaml
+++ b/playbooks/tasks/collect_plugin_registries.yaml
@@ -1,0 +1,44 @@
+---
+# Collect registry mirror entries from all enabled plugins
+# so they can be included in registries.conf for oc-mirror.
+#
+# Sets fact: _core_plugin_registries (list of dicts with 'location' and 'mirror')
+
+- name: Find plugin descriptors
+  ansible.builtin.find:
+    paths: "{{ playbook_dir }}/../plugins"
+    patterns: "plugin.yaml"
+    recurse: true
+    depth: 2
+  register: r_pr_find
+
+- name: Read plugin descriptors
+  ansible.builtin.slurp:
+    src: "{{ item }}"
+  loop: "{{ r_pr_find.files | map(attribute='path') | list }}"
+  register: r_pr_slurp
+
+- name: Build combined plugin registries list
+  vars:
+    _enabled: >-
+      {{ r_pr_slurp.results
+         | map(attribute='content')
+         | map('b64decode')
+         | map('from_yaml')
+         | selectattr('name', 'in', enabled_plugins)
+         | list }}
+    _core: >-
+      {{ (_enabled | rejectattr('mirror', 'defined') | list)
+         + (_enabled | selectattr('mirror', 'equalto', 'core') | list) }}
+  ansible.builtin.set_fact:
+    _core_plugin_registries: >-
+      {{ _core
+         | selectattr('registries', 'defined')
+         | map(attribute='registries')
+         | flatten
+         | list }}
+
+- name: Display plugin registries
+  ansible.builtin.debug:
+    msg: "Plugin registries to include in registries.conf: {{ _core_plugin_registries | map(attribute='location') | list }}"
+  when: _core_plugin_registries | length > 0

--- a/templates/imagesetconfiguration.yaml.j2
+++ b/templates/imagesetconfiguration.yaml.j2
@@ -37,7 +37,8 @@ mirror:
     - catalog: {{ rh_operator_catalog }}:{{ rh_operator_catalog_version }}
       packages:
         - name: kubevirt-hyperconverged
-{% for operator in operators + model_operators + storage_operators[blockStorageBackend] %}
+        - name: kubernetes-nmstate-operator
+{% for operator in operators + model_operators + storage_operators[blockStorageBackend] + (_core_plugin_operators | default([])) %}
 {% set additional_operator_names = operator.csvNames if (operator.csvMirror | default(false) | bool) else [] %}
 {% for operator_name in [operator.name] + additional_operator_names %}
         - name: {{ operator_name }}

--- a/templates/registries.conf.j2
+++ b/templates/registries.conf.j2
@@ -271,3 +271,23 @@
   location = "quay.io/argoproj"
 [[registry.mirror]]
   location = "{{ quayHostname }}:8443/argoproj"
+
+[[registry]]
+  prefix = ""
+  location = "registry.redhat.io/ansible-automation-platform-25"
+[[registry.mirror]]
+  location = "{{ quayHostname }}:8443/ansible-automation-platform-25"
+
+[[registry]]
+  prefix = ""
+  location = "registry.redhat.io/ansible-automation-platform"
+[[registry.mirror]]
+  location = "{{ quayHostname }}:8443/ansible-automation-platform"
+{% for reg in (_core_plugin_registries | default([])) %}
+
+[[registry]]
+  prefix = ""
+  location = "{{ reg.location }}"
+[[registry.mirror]]
+  location = "{{ quayHostname }}:8443/{{ reg.mirror }}"
+{% endfor %}


### PR DESCRIPTION
## Summary
- Add `collect_core_plugin_operators.yaml` and `collect_plugin_registries.yaml` tasks that auto-discover operator and registry entries from enabled plugin descriptors
- Integrate plugin operators into the oc-mirror imageset (`imagesetconfiguration.yaml.j2`) so they are mirrored alongside core operators in a single run
- Integrate plugin registry entries into `registries.conf.j2` for disconnected registry mapping
- Add plugin registry collection to Quay disconnected workflow (`quay_disconnected.yaml`)

## Details
Plugins with `mirror: core` (the default) declare their operators and registries in `plugin.yaml`. This PR collects those declarations at mirror time and includes them in the existing oc-mirror run — no separate per-plugin mirroring.

The plugin operator and registry lists are empty until storage is extracted into plugins (follow-up PR). Existing hardcoded storage entries are preserved for backward compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collects and includes plugin operators in mirror operations.
  * Extends image set configuration to include core plugin operators.
  * Adds plugin registries into registry configuration for mirroring.
  * Enables automatic discovery and integration of plugin operators and registries into mirror workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->