### PR TITLE
Increase e2e-deployment timeout for disconnected mode

### DIFF
--- a/.github/workflows/e2e-deployment.yml
+++ b/.github/workflows/e2e-deployment.yml
@@ -113,7 +113,7 @@ jobs:
   e2e-deployment:
     name: E2E Deployment Test
     runs-on: [self-hosted, enclave-large]
-    timeout-minutes: 210  # 3.5 hours
+    timeout-minutes: ${{ (github.event.inputs.deployment_mode == 'disconnected' && 360) || 210 }}
     needs: check-e2e-needed
     if: needs.check-e2e-needed.outputs.should_run == 'true'
 


### PR DESCRIPTION
Set timeout dynamically based on deployment mode: 6 hours for disconnected (which includes mirroring) vs 3.5 hours for connected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow timeout configuration to accommodate extended deployment scenarios when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->