### PR TITLE
Add missing ansible.posix collection to requirements.yml

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -16,3 +16,5 @@ collections:
     version: ">=2.0.0"
   - name: community.general
     version: ">=2.0.0"
+  - name: ansible.posix
+    version: ">=2.0.0"


### PR DESCRIPTION
## Summary
- PR #165 added `ansible.posix` to `ansible_collections.txt` (offline installs) but missed `requirements.yml`
- `install_enclave.sh` installs collections from `requirements.yml`, so `ansible.posix` was never installed on the landing zone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added required system dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->