### PR TITLE
oc-mirror blocked images section fix

### DIFF
--- a/templates/imagesetconfiguration.yaml.j2
+++ b/templates/imagesetconfiguration.yaml.j2
@@ -60,97 +60,97 @@ mirror:
     - name: registry.connect.redhat.com/hashicorp/vault-k8s:1.7.0-ubi
     - name: registry.connect.redhat.com/hashicorp/vault:1.20.4-ubi
 
-  blockedimages:
-    - name: registry.redhat.io/quay/quay-builder-qemu-rhcos-rhel8
-    - name: registry.redhat.io/quay/quay-builder-rhel8
-    - name: registry.redhat.io/rhaiis/vllm-cuda-rhel9
-    - name: registry.redhat.io/rhaiis/vllm-rocm-rhel9
-    - name: registry.redhat.io/rhaiis/vllm-spyre-rhel9
-    - name: registry.redhat.io/rhaiis/vllm-cpu-rhel9
-    - name: registry.redhat.io/rhelai1/instructlab-nvidia-rhel9
-    - name: registry.redhat.io/rhoai/odh-dashboard-rhel8
-    - name: registry.redhat.io/rhoai/odh-dashboard-rhel9
-    - name: registry.redhat.io/rhoai/odh-codeflare-operator-rhel9
-    - name: registry.redhat.io/rhoai/odh-codeflare-operator-rhel8
-    - name: registry.redhat.io/rhoai/odh-data-science-pipelines-operator-controller-rhel8
-    - name: registry.redhat.io/rhoai/odh-data-science-pipelines-operator-controller-rhel9
-    - name: registry.redhat.io/rhoai/odh-data-science-pipelines-argo-argoexec-rhel9
-    - name: registry.redhat.io/rhoai/odh-data-science-pipelines-argo-workflowcontroller-rhel9
-    - name: registry.redhat.io/rhoai/odh-data-science-pipelines-argo-argoexec-rhel8
-    - name: registry.redhat.io/rhoai/odh-data-science-pipelines-argo-workflowcontroller-rhel8
-    - name: registry.redhat.io/rhoai/odh-kueue-controller-rhel8
-    - name: registry.redhat.io/rhoai/odh-kueue-controller-rhel9
-    - name: registry.redhat.io/rhoai/odh-modelmesh-serving-controller-rhel8
-    - name: registry.redhat.io/rhoai/odh-modelmesh-serving-controller-rhel9
-    - name: registry.redhat.io/rhoai/odh-kuberay-operator-controller-rhel8
-    - name: registry.redhat.io/rhoai/odh-kuberay-operator-controller-rhel9
-    - name: registry.redhat.io/rhoai/odh-training-cuda128-torch28-py312-rhel9
-    - name: registry.redhat.io/rhoai/odh-training-rocm62-torch24-py311-rhel9
-    - name: registry.redhat.io/rhoai/odh-training-cuda121-torch24-py311-rhel9
-    - name: registry.redhat.io/rhoai/odh-training-cuda124-torch25-py311-rhel9
-    - name: registry.redhat.io/rhoai/odh-training-rocm62-torch25-py311-rhel9
-    - name: registry.redhat.io/rhoai/odh-training-rocm64-torch28-py312-rhel9
-    - name: registry.redhat.io/rhoai/odh-training-operator-rhel8
-    - name: registry.redhat.io/rhoai/odh-training-operator-rhel9
-    - name: registry.redhat.io/rhoai/odh-trustyai-service-rhel8
-    - name: registry.redhat.io/rhoai/odh-trustyai-service-rhel9
-    - name: registry.redhat.io/rhoai/odh-trustyai-service-operator-rhel9
-    - name: registry.redhat.io/rhoai/odh-trustyai-service-operator-rhel8
-    - name: registry.redhat.io/rhoai/odh-trustyai-vllm-orchestrator-gateway-rhel9
-    - name: registry.redhat.io/rhoai/odh-trustyai-ragas-lls-provider-dsp-rhel9
-    - name: registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cpu-py311-rhel9
-    - name: registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cuda-py312-rhel9
-    - name: registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cuda-py311-rhel9
-    - name: registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-rocm-py311-rhel9
-    - name: registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-rocm-py312-rhel9
-    - name: registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-cuda-py311-rhel9
-    - name: registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-cuda-py312-rhel9
-    - name: registry.redhat.io/rhoai/odh-workbench-jupyter-trustyai-cpu-py312-rhel9
-    - name: registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cpu-py312-rhel9
-    - name: registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-rocm-py311-rhel9
-    - name: registry.redhat.io/rhoai/odh-workbench-jupyter-tensorflow-cuda-py311-rhel9
-    - name: registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-rocm-py312-rhel9
-    - name: registry.redhat.io/rhoai/odh-workbench-jupyter-tensorflow-cuda-py312-rhel9
-    - name: registry.redhat.io/rhoai/odh-workbench-jupyter-tensorflow-rocm-py311-rhel9
-    - name: registry.redhat.io/rhoai/odh-workbench-jupyter-trustyai-cpu-py311-rhel9
-    - name: registry.redhat.io/rhoai/odh-workbench-jupyter-tensorflow-rocm-py312-rhel9
-    - name: registry.redhat.io/rhoai/odh-workbench-codeserver-datascience-cpu-py311-rhel9
-    - name: registry.redhat.io/rhoai/odh-workbench-jupyter-datascience-cpu-py312-rhel9
-    - name: registry.redhat.io/rhoai/odh-workbench-codeserver-datascience-cpu-py312-rhel9
-    - name: registry.redhat.io/rhoai/odh-workbench-jupyter-datascience-cpu-py311-rhel9
-    - name: registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-rhel9
-    - name: registry.redhat.io/rhoai/odh-feature-server-rhel9
-    - name: registry.redhat.io/rhoai/odh-guardrails-detector-huggingface-runtime-rhel9
-    - name: registry.redhat.io/rhoai/odh-llama-stack-core-rhel9
-    - name: registry.redhat.io/rhoai/odh-llama-stack-k8s-operator-rhel9
-    - name: registry.redhat.io/rhoai/odh-ta-lmes-job-rhel9
-    - name: registry.redhat.io/rhoai/odh-pipeline-runtime-minimal-cpu-py311-rhel9
-    - name: registry.redhat.io/rhoai/odh-pipeline-runtime-pytorch-rocm-py311-rhel9
-    - name: registry.redhat.io/rhoai/odh-pipeline-runtime-pytorch-cuda-py311-rhel9
-    - name: registry.redhat.io/rhoai/odh-pipeline-runtime-tensorflow-rocm-py311-rhel9
-    - name: registry.redhat.io/rhoai/odh-pipeline-runtime-tensorflow-cuda-py312-rhel9
-    - name: registry.redhat.io/rhoai/odh-pipeline-runtime-tensorflow-rocm-py312-rhel9
-    - name: registry.redhat.io/rhoai/odh-pipeline-runtime-minimal-cpu-py312-rhel9
-    - name: registry.redhat.io/rhoai/odh-pipeline-runtime-pytorch-cuda-py312-rhel9
-    - name: registry.redhat.io/rhoai/odh-pipeline-runtime-tensorflow-cuda-py311-rhel9
-    - name: registry.redhat.io/rhoai/odh-pipeline-runtime-pytorch-rocm-py312-rhel9
-    - name: registry.redhat.io/rhoai/odh-pipeline-runtime-datascience-cpu-py311-rhel9
-    - name: registry.redhat.io/rhoai/odh-pipeline-runtime-datascience-cpu-py312-rhel9
-    - name: registry.redhat.io/rhoai/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-rhel9
-    - name: registry.redhat.io/rhoai/odh-ml-pipelines-cache-rhel8
-    - name: registry.redhat.io/rhoai/odh-ml-pipelines-api-server-rhel8
-    - name: registry.redhat.io/rhoai/odh-ml-pipelines-artifact-manager-rhel8
-    - name: registry.redhat.io/rhoai/odh-ml-pipelines-persistenceagent-rhel8
-    - name: registry.redhat.io/rhoai/odh-ml-pipelines-api-server-v2-rhel8
-    - name: registry.redhat.io/rhoai/odh-ml-pipelines-persistenceagent-v2-rhel8
-    - name: registry.redhat.io/rhoai/odh-ml-pipelines-api-server-v2-rhel9
-    - name: registry.redhat.io/rhoai/odh-ml-pipelines-scheduledworkflow-rhel8
-    - name: registry.redhat.io/rhoai/odh-ml-pipelines-persistenceagent-v2-rhel9
-    - name: registry.redhat.io/rhoai/odh-ml-pipelines-scheduledworkflow-v2-rhel8
-    - name: registry.redhat.io/rhoai/odh-ml-pipelines-scheduledworkflow-v2-rhel9
-    - name: registry.redhat.io/rhoai/odh-ml-pipelines-driver-rhel8
-    - name: registry.redhat.io/rhoai/odh-ml-pipelines-runtime-generic-rhel8
-    - name: registry.redhat.io/rhoai/odh-ml-pipelines-launcher-rhel8
-    - name: registry.redhat.io/rhoai/odh-ml-pipelines-driver-rhel9
-    - name: registry.redhat.io/rhoai/odh-ml-pipelines-launcher-rhel9
-    - name: registry.redhat.io/rhoai/odh-ml-pipelines-runtime-generic-rhel9
+  blockedImages:
+    - registry.redhat.io/quay/quay-builder-qemu-rhcos-rhel8
+    - registry.redhat.io/quay/quay-builder-rhel8
+    - registry.redhat.io/rhaiis/vllm-cuda-rhel9
+    - registry.redhat.io/rhaiis/vllm-rocm-rhel9
+    - registry.redhat.io/rhaiis/vllm-spyre-rhel9
+    - registry.redhat.io/rhaiis/vllm-cpu-rhel9
+    - registry.redhat.io/rhelai1/instructlab-nvidia-rhel9
+    - registry.redhat.io/rhoai/odh-dashboard-rhel8
+    - registry.redhat.io/rhoai/odh-dashboard-rhel9
+    - registry.redhat.io/rhoai/odh-codeflare-operator-rhel9
+    - registry.redhat.io/rhoai/odh-codeflare-operator-rhel8
+    - registry.redhat.io/rhoai/odh-data-science-pipelines-operator-controller-rhel8
+    - registry.redhat.io/rhoai/odh-data-science-pipelines-operator-controller-rhel9
+    - registry.redhat.io/rhoai/odh-data-science-pipelines-argo-argoexec-rhel9
+    - registry.redhat.io/rhoai/odh-data-science-pipelines-argo-workflowcontroller-rhel9
+    - registry.redhat.io/rhoai/odh-data-science-pipelines-argo-argoexec-rhel8
+    - registry.redhat.io/rhoai/odh-data-science-pipelines-argo-workflowcontroller-rhel8
+    - registry.redhat.io/rhoai/odh-kueue-controller-rhel8
+    - registry.redhat.io/rhoai/odh-kueue-controller-rhel9
+    - registry.redhat.io/rhoai/odh-modelmesh-serving-controller-rhel8
+    - registry.redhat.io/rhoai/odh-modelmesh-serving-controller-rhel9
+    - registry.redhat.io/rhoai/odh-kuberay-operator-controller-rhel8
+    - registry.redhat.io/rhoai/odh-kuberay-operator-controller-rhel9
+    - registry.redhat.io/rhoai/odh-training-cuda128-torch28-py312-rhel9
+    - registry.redhat.io/rhoai/odh-training-rocm62-torch24-py311-rhel9
+    - registry.redhat.io/rhoai/odh-training-cuda121-torch24-py311-rhel9
+    - registry.redhat.io/rhoai/odh-training-cuda124-torch25-py311-rhel9
+    - registry.redhat.io/rhoai/odh-training-rocm62-torch25-py311-rhel9
+    - registry.redhat.io/rhoai/odh-training-rocm64-torch28-py312-rhel9
+    - registry.redhat.io/rhoai/odh-training-operator-rhel8
+    - registry.redhat.io/rhoai/odh-training-operator-rhel9
+    - registry.redhat.io/rhoai/odh-trustyai-service-rhel8
+    - registry.redhat.io/rhoai/odh-trustyai-service-rhel9
+    - registry.redhat.io/rhoai/odh-trustyai-service-operator-rhel9
+    - registry.redhat.io/rhoai/odh-trustyai-service-operator-rhel8
+    - registry.redhat.io/rhoai/odh-trustyai-vllm-orchestrator-gateway-rhel9
+    - registry.redhat.io/rhoai/odh-trustyai-ragas-lls-provider-dsp-rhel9
+    - registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cpu-py311-rhel9
+    - registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cuda-py312-rhel9
+    - registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cuda-py311-rhel9
+    - registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-rocm-py311-rhel9
+    - registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-rocm-py312-rhel9
+    - registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-cuda-py311-rhel9
+    - registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-cuda-py312-rhel9
+    - registry.redhat.io/rhoai/odh-workbench-jupyter-trustyai-cpu-py312-rhel9
+    - registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cpu-py312-rhel9
+    - registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-rocm-py311-rhel9
+    - registry.redhat.io/rhoai/odh-workbench-jupyter-tensorflow-cuda-py311-rhel9
+    - registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-rocm-py312-rhel9
+    - registry.redhat.io/rhoai/odh-workbench-jupyter-tensorflow-cuda-py312-rhel9
+    - registry.redhat.io/rhoai/odh-workbench-jupyter-tensorflow-rocm-py311-rhel9
+    - registry.redhat.io/rhoai/odh-workbench-jupyter-trustyai-cpu-py311-rhel9
+    - registry.redhat.io/rhoai/odh-workbench-jupyter-tensorflow-rocm-py312-rhel9
+    - registry.redhat.io/rhoai/odh-workbench-codeserver-datascience-cpu-py311-rhel9
+    - registry.redhat.io/rhoai/odh-workbench-jupyter-datascience-cpu-py312-rhel9
+    - registry.redhat.io/rhoai/odh-workbench-codeserver-datascience-cpu-py312-rhel9
+    - registry.redhat.io/rhoai/odh-workbench-jupyter-datascience-cpu-py311-rhel9
+    - registry.redhat.io/rhoai/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-rhel9
+    - registry.redhat.io/rhoai/odh-feature-server-rhel9
+    - registry.redhat.io/rhoai/odh-guardrails-detector-huggingface-runtime-rhel9
+    - registry.redhat.io/rhoai/odh-llama-stack-core-rhel9
+    - registry.redhat.io/rhoai/odh-llama-stack-k8s-operator-rhel9
+    - registry.redhat.io/rhoai/odh-ta-lmes-job-rhel9
+    - registry.redhat.io/rhoai/odh-pipeline-runtime-minimal-cpu-py311-rhel9
+    - registry.redhat.io/rhoai/odh-pipeline-runtime-pytorch-rocm-py311-rhel9
+    - registry.redhat.io/rhoai/odh-pipeline-runtime-pytorch-cuda-py311-rhel9
+    - registry.redhat.io/rhoai/odh-pipeline-runtime-tensorflow-rocm-py311-rhel9
+    - registry.redhat.io/rhoai/odh-pipeline-runtime-tensorflow-cuda-py312-rhel9
+    - registry.redhat.io/rhoai/odh-pipeline-runtime-tensorflow-rocm-py312-rhel9
+    - registry.redhat.io/rhoai/odh-pipeline-runtime-minimal-cpu-py312-rhel9
+    - registry.redhat.io/rhoai/odh-pipeline-runtime-pytorch-cuda-py312-rhel9
+    - registry.redhat.io/rhoai/odh-pipeline-runtime-tensorflow-cuda-py311-rhel9
+    - registry.redhat.io/rhoai/odh-pipeline-runtime-pytorch-rocm-py312-rhel9
+    - registry.redhat.io/rhoai/odh-pipeline-runtime-datascience-cpu-py311-rhel9
+    - registry.redhat.io/rhoai/odh-pipeline-runtime-datascience-cpu-py312-rhel9
+    - registry.redhat.io/rhoai/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-rhel9
+    - registry.redhat.io/rhoai/odh-ml-pipelines-cache-rhel8
+    - registry.redhat.io/rhoai/odh-ml-pipelines-api-server-rhel8
+    - registry.redhat.io/rhoai/odh-ml-pipelines-artifact-manager-rhel8
+    - registry.redhat.io/rhoai/odh-ml-pipelines-persistenceagent-rhel8
+    - registry.redhat.io/rhoai/odh-ml-pipelines-api-server-v2-rhel8
+    - registry.redhat.io/rhoai/odh-ml-pipelines-persistenceagent-v2-rhel8
+    - registry.redhat.io/rhoai/odh-ml-pipelines-api-server-v2-rhel9
+    - registry.redhat.io/rhoai/odh-ml-pipelines-scheduledworkflow-rhel8
+    - registry.redhat.io/rhoai/odh-ml-pipelines-persistenceagent-v2-rhel9
+    - registry.redhat.io/rhoai/odh-ml-pipelines-scheduledworkflow-v2-rhel8
+    - registry.redhat.io/rhoai/odh-ml-pipelines-scheduledworkflow-v2-rhel9
+    - registry.redhat.io/rhoai/odh-ml-pipelines-driver-rhel8
+    - registry.redhat.io/rhoai/odh-ml-pipelines-runtime-generic-rhel8
+    - registry.redhat.io/rhoai/odh-ml-pipelines-launcher-rhel8
+    - registry.redhat.io/rhoai/odh-ml-pipelines-driver-rhel9
+    - registry.redhat.io/rhoai/odh-ml-pipelines-launcher-rhel9
+    - registry.redhat.io/rhoai/odh-ml-pipelines-runtime-generic-rhel9


### PR DESCRIPTION
https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/disconnected_environments/installing-mirroring-disconnected#oc-mirror-imageset-config-params_installing-mirroring-disconnected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated mirror configuration structure: renamed blocked images configuration key and changed the list format to a simplified structure for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->