### PR TITLE
add plugin image set support for additional and blocked images

### DIFF
--- a/schemas/plugin.yaml
+++ b/schemas/plugin.yaml
@@ -102,6 +102,18 @@ properties:
     description: Registry mirror entries for MCE custom-registries patching.
     items:
       $ref: "#/definitions/registry"
+  additionalImages:
+      type: array
+      description: The additional images configuration of the image set.
+      items:
+        type: string
+        description: The tag or digest of the image to mirror.
+  blockedImages:
+      type: array
+      description: The blocked images configuration of the image set.
+      items:
+        type: string
+        description: The full tag, digest, or pattern of images to block from mirroring.
 required:
   - name
   - type

--- a/scripts/verification/validate_plugins.sh
+++ b/scripts/verification/validate_plugins.sh
@@ -82,7 +82,7 @@ import yaml, sys
 filepath = sys.argv[1]
 required_fields = ['name', 'type']
 valid_fields = ['name', 'type', 'order', 'mirror', 'operators', 'defaults',
-                'registries']
+                'registries', 'additionalImages', 'blockedImages']
 
 try:
     with open(filepath) as f:

--- a/templates/plugin-imageset.yaml.j2
+++ b/templates/plugin-imageset.yaml.j2
@@ -18,4 +18,16 @@ mirror:
 {% for pkg in operator.extraMirrorPackages | default([]) %}
         - name: {{ pkg }}
 {% endfor %}
+{% if operator.additionalImages | default([]) | length > 0 %}
+  additionalImages:
+{% for img in operator.additionalImages %}
+    - name: {{ img }}
+{% endfor %}
+{% endif %}
+{% if operator.blockedImages | default([]) | length > 0 %}
+  blockedImages:
+{% for img in operator.blockedImages %}
+    - name: {{ img }}
+{% endfor %}
+{% endif %}
 {% endfor %}

--- a/templates/plugin-imageset.yaml.j2
+++ b/templates/plugin-imageset.yaml.j2
@@ -18,15 +18,15 @@ mirror:
 {% for pkg in operator.extraMirrorPackages | default([]) %}
         - name: {{ pkg }}
 {% endfor %}
-{% if operator.additionalImages | default([]) | length > 0 %}
+{% if plugin.additionalImages | default([]) | length > 0 %}
   additionalImages:
-{% for img in operator.additionalImages %}
+{% for img in plugin.additionalImages %}
     - name: {{ img }}
 {% endfor %}
 {% endif %}
-{% if operator.blockedImages | default([]) | length > 0 %}
+{% if plugin.blockedImages | default([]) | length > 0 %}
   blockedImages:
-{% for img in operator.blockedImages %}
+{% for img in plugin.blockedImages %}
     - name: {{ img }}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
add support for `additionalImages` and `blockedImages` as described in https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/disconnected_environments/installing-mirroring-disconnected#oc-mirror-imageset-config-params_installing-mirroring-disconnected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `additionalImages` configuration to specify extra images for mirroring
  * Added `blockedImages` configuration to exclude specific images from mirroring operations
  * Both settings available at plugin and operator levels for flexible control over image mirror behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->