### PR TITLE
only install core plugin operators

### DIFF
--- a/playbooks/tasks/deploy_plugin.yaml
+++ b/playbooks/tasks/deploy_plugin.yaml
@@ -165,7 +165,9 @@
   loop: "{{ plugin.operators }}"
   loop_control:
     loop_var: operator
-  when: plugin.operators is defined
+  when:
+    - plugin.operators is defined
+    - plugin.mirror | default('none') == 'core'
   tags: operators
 
 - name: Run deploy


### PR DESCRIPTION
OpenShift AI and Nvidia GPU plugins should not be installed on the management cluster, as opposed to... core plugins?

this PR sets operator installation only to core plugins.