### PR TITLE
add plugin image set support for certified operator catalog

### DIFF
--- a/schemas/plugin.yaml
+++ b/schemas/plugin.yaml
@@ -89,6 +89,12 @@ properties:
     description: >-
       How images are mirrored. core = included in the main oc-mirror run.
       plugin = plugin runs its own oc-mirror during deploy. none = no mirroring.
+  catalog:
+    type: string
+    description: The Operator catalog name to include in the image set.
+    enum:
+      - redhat
+      - certified
   operators:
     type: array
     description: List of OLM operators to install.

--- a/scripts/verification/validate_plugins.sh
+++ b/scripts/verification/validate_plugins.sh
@@ -81,7 +81,7 @@ import yaml, sys
 
 filepath = sys.argv[1]
 required_fields = ['name', 'type']
-valid_fields = ['name', 'type', 'order', 'mirror', 'operators', 'defaults',
+valid_fields = ['name', 'type', 'order', 'mirror', 'catalog', 'operators', 'defaults',
                 'registries']
 
 try:

--- a/templates/plugin-imageset.yaml.j2
+++ b/templates/plugin-imageset.yaml.j2
@@ -1,9 +1,13 @@
+{% set catalog_image = rh_operator_catalog ~ ':' ~ rh_operator_catalog_version %}
+{% if (plugin.catalog | default("")) == "certified" %}
+{% set catalog_image = certified_operator_catalog ~ ':' ~ certified_operator_catalog_version %}
+{% endif %}
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1
 mirror:
   operators:
-    - catalog: {{ rh_operator_catalog }}:{{ rh_operator_catalog_version }}
+    - catalog: {{ catalog_image }}
       packages:
 {% for operator in plugin.operators | default([]) %}
 {% set additional_operator_names = operator.csvNames if (operator.csvMirror | default(false) | bool) else [] %}


### PR DESCRIPTION
Nvidia GPU plugin mirrors content from the certified operators index.

this PR adds support to defined `redhat` or `certified` catalog.