### PR TITLE
remove storage plugins entries from MCE registries.conf

### DIFF
--- a/operators/multicluster-engine/tasks.yaml
+++ b/operators/multicluster-engine/tasks.yaml
@@ -148,24 +148,6 @@
 
           [[registry]]
             prefix = ""
-            location = "registry.redhat.io/lvms4"
-          [[registry.mirror]]
-            location = "registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/lvms4"
-
-          [[registry]]
-            prefix = ""
-            location = "registry.redhat.io/odf4"
-          [[registry.mirror]]
-            location = "registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/odf4"
-
-          [[registry]]
-            prefix = ""
-            location = "registry.redhat.io/rhceph"
-          [[registry.mirror]]
-            location = "registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/rhceph"
-
-          [[registry]]
-            prefix = ""
             location = "registry.redhat.io/cert-manager"
           [[registry.mirror]]
             location = "registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/cert-manager"


### PR DESCRIPTION
based on https://github.com/rh-ecosystem-edge/enclave/pull/169#issuecomment-4145211764

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified registry configuration for disconnected environments by removing three mirror entries for local storage, storage services, and Ceph components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->