### PR TITLE
extract cincinnati plugin

### DIFF
--- a/defaults/deployment.yaml
+++ b/defaults/deployment.yaml
@@ -19,6 +19,7 @@ blockStorageBackend: "{{ storage_plugin }}"
 # By default only the selected storage plugin is enabled.
 enabled_plugins:
   - "{{ storage_plugin }}"
+  - cincinnati
 
 # Default pull secret path. Override in config/global.yaml if stored elsewhere.
 pullSecretPath: "{{ workingDir }}/config/pull-secret.json"

--- a/defaults/operators.yaml
+++ b/defaults/operators.yaml
@@ -22,15 +22,6 @@ operators:
     namespace: open-cluster-management
     source: cs-redhat-operator-index-v4-20
 
-  - name: cincinnati-operator
-    version: 5.0.3
-    channel: v1
-    init_version: 5.0.3
-    namespace: openshift-update-service
-    source: cs-redhat-operator-index-v4-20
-    csvNames:
-      - update-service-operator
-
   - name: openshift-gitops-operator
     version: 1.19.2
     channel: gitops-1.19

--- a/operators/multicluster-engine/tasks.yaml
+++ b/operators/multicluster-engine/tasks.yaml
@@ -268,12 +268,6 @@
 
           [[registry]]
             prefix = ""
-            location = "registry.redhat.io/openshift-update-service"
-          [[registry.mirror]]
-            location = "registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/openshift-update-service"
-
-          [[registry]]
-            prefix = ""
             location = "quay.io/argoproj"
           [[registry.mirror]]
             location = "registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/argoproj"

--- a/plugins/cincinnati/plugin.yaml
+++ b/plugins/cincinnati/plugin.yaml
@@ -1,0 +1,19 @@
+---
+name: cincinnati
+type: foundation
+order: 10
+mirror: core
+
+operators:
+  - name: cincinnati-operator
+    version: 5.0.3
+    channel: v1
+    init_version: 5.0.3
+    namespace: openshift-update-service
+    source: cs-redhat-operator-index-v4-20
+    csvNames:
+      - update-service-operator
+
+registries:
+  - location: "registry.redhat.io/openshift-update-service"
+    mirror: "openshift-update-service"

--- a/plugins/cincinnati/tasks/deploy.yaml
+++ b/plugins/cincinnati/tasks/deploy.yaml
@@ -1,4 +1,3 @@
----
 - name: Create OpenShift Update Service application object
   environment:
     KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"

--- a/templates/registries.conf.j2
+++ b/templates/registries.conf.j2
@@ -244,12 +244,6 @@
 
 [[registry]]
   prefix = ""
-  location = "registry.redhat.io/openshift-update-service"
-[[registry.mirror]]
-  location = "{{ quayHostname }}:8443/openshift-update-service"
-
-[[registry]]
-  prefix = ""
   location = "quay.io/argoproj"
 [[registry.mirror]]
   location = "{{ quayHostname }}:8443/argoproj"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated cincinnati operator configuration into a dedicated foundation plugin with centralized registry mappings.
  * Removed cincinnati operator from the default operators list, with configuration now managed through the plugin.
  * Registry entries for openshift-update-service have been relocated to plugin-specific configuration files.
  * Added cincinnati to the default enabled plugins list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->