### PR TITLE
Split model-configuration ACM policy to fix RHOAI 3.3.0 LWS race conditiom

### DIFF
--- a/plugins/openshift-ai/files/10-policy-operators.yaml.j2
+++ b/plugins/openshift-ai/files/10-policy-operators.yaml.j2
@@ -5,7 +5,7 @@ metadata:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
     policy.open-cluster-management.io/standards: NIST SP 800-53
-  name: openshift-ai-configuration
+  name: model-prerequisites
   namespace: openshift-acm-policies
 spec:
   disabled: false
@@ -15,7 +15,7 @@ spec:
       apiVersion: policy.open-cluster-management.io/v1
       kind: ConfigurationPolicy
       metadata:
-        name: openshift-ai-configuration
+        name: model-prerequisites
       spec:
         evaluationInterval:
           compliant: 2h
@@ -303,33 +303,3 @@ spec:
               source: {{ mirror_rh_operator_catalog }}
               sourceNamespace: openshift-marketplace
               installPlanApproval: Automatic
-        # Create DataScienceCluster with KServe Only
-        - complianceType: mustonlyhave
-          metadataComplianceType: musthave
-          objectDefinition:
-            apiVersion: datasciencecluster.opendatahub.io/v1
-            kind: DataScienceCluster
-            metadata:
-              name: default-dsc
-            spec:
-              components:
-                codeflare:
-                  managementState: Removed
-                dashboard:
-                  managementState: Removed
-                datasciencepipelines:
-                  managementState: Removed
-                kserve:
-                  managementState: Managed
-                kueue:
-                  managementState: Removed
-                modelmeshserving:
-                  managementState: Removed
-                ray:
-                  managementState: Removed
-                trainingoperator:
-                  managementState: Removed
-                trustyai:
-                  managementState: Removed
-                workbenches:
-                  managementState: Removed

--- a/plugins/openshift-ai/files/11-policy-crd-ready.yaml.j2
+++ b/plugins/openshift-ai/files/11-policy-crd-ready.yaml.j2
@@ -1,0 +1,40 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+  name: model-operators-crd-ready
+  namespace: openshift-acm-policies
+spec:
+  dependencies:
+  - apiVersion: policy.open-cluster-management.io/v1
+    compliance: Compliant
+    kind: Policy
+    name: model-prerequisites
+    namespace: openshift-acm-policies
+  disabled: false
+  remediationAction: inform
+  policy-templates:
+  - objectDefinition:
+      apiVersion: policy.open-cluster-management.io/v1
+      kind: ConfigurationPolicy
+      metadata:
+        name: model-operators-crd-ready
+      spec:
+        evaluationInterval:
+          compliant: 5m
+          noncompliant: 45s
+        object-templates:
+        # Gate on LeaderWorkerSet CRD being registered by the lws operator.
+        # This ConfigurationPolicy only becomes Compliant once the CRD exists,
+        # which ensures the DataScienceCluster policy (which depends on this one)
+        # is not applied until KServe can safely resolve LeaderWorkerSet resources.
+        - complianceType: musthave
+          metadataComplianceType: musthave
+          objectDefinition:
+            apiVersion: apiextensions.k8s.io/v1
+            kind: CustomResourceDefinition
+            metadata:
+              name: leaderworkersets.leaderworkerset.x-k8s.io

--- a/plugins/openshift-ai/files/12-policy-datasciencecluster.yaml.j2
+++ b/plugins/openshift-ai/files/12-policy-datasciencecluster.yaml.j2
@@ -1,0 +1,59 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+  name: model-configuration
+  namespace: openshift-acm-policies
+spec:
+  dependencies:
+  - apiVersion: policy.open-cluster-management.io/v1
+    compliance: Compliant
+    kind: Policy
+    name: model-operators-crd-ready
+    namespace: openshift-acm-policies
+  disabled: false
+  remediationAction: enforce
+  policy-templates:
+  - objectDefinition:
+      apiVersion: policy.open-cluster-management.io/v1
+      kind: ConfigurationPolicy
+      metadata:
+        name: model-configuration
+      spec:
+        evaluationInterval:
+          compliant: 2h
+          noncompliant: 45s
+        object-templates:
+        # Create DataScienceCluster with KServe Only
+        - complianceType: mustonlyhave
+          metadataComplianceType: musthave
+          objectDefinition:
+            apiVersion: datasciencecluster.opendatahub.io/v1
+            kind: DataScienceCluster
+            metadata:
+              name: default-dsc
+            spec:
+              components:
+                codeflare:
+                  managementState: Removed
+                dashboard:
+                  managementState: Removed
+                datasciencepipelines:
+                  managementState: Removed
+                kserve:
+                  managementState: Managed
+                kueue:
+                  managementState: Removed
+                modelmeshserving:
+                  managementState: Removed
+                ray:
+                  managementState: Removed
+                trainingoperator:
+                  managementState: Removed
+                trustyai:
+                  managementState: Removed
+                workbenches:
+                  managementState: Removed

--- a/plugins/openshift-ai/files/30-placementbinding.yaml
+++ b/plugins/openshift-ai/files/30-placementbinding.yaml
@@ -10,4 +10,10 @@ placementRef:
 subjects:
 - apiGroup: policy.open-cluster-management.io
   kind: Policy
-  name: openshift-ai-configuration
+  name: model-prerequisites
+- apiGroup: policy.open-cluster-management.io
+  kind: Policy
+  name: model-operators-crd-ready
+- apiGroup: policy.open-cluster-management.io
+  kind: Policy
+  name: model-configuration

--- a/plugins/openshift-ai/tasks/deploy.yaml
+++ b/plugins/openshift-ai/tasks/deploy.yaml
@@ -9,13 +9,37 @@
   delay: "{{ k8s_delay }}"
   until: r_namespace_model_config is success
 
+- name: Create ACM Policy for Model prerequisites
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  kubernetes.core.k8s:
+    state: present
+    namespace: openshift-acm-policies
+    definition: "{{ lookup('ansible.builtin.template', plugin_dir ~ '/files/10-policy-operators.yaml.j2') | from_yaml }}"
+  register: r_acm_policy_model_prerequisites
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_acm_policy_model_prerequisites is success
+
+- name: Create ACM Policy for Model operators CRD readiness
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  kubernetes.core.k8s:
+    state: present
+    namespace: openshift-acm-policies
+    definition: "{{ lookup('ansible.builtin.template', plugin_dir ~ '/files/11-policy-crd-ready.yaml.j2') | from_yaml }}"
+  register: r_acm_policy_model_crd_ready
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_acm_policy_model_crd_ready is success
+
 - name: Create ACM Policy for Model configuration
   environment:
     KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
   kubernetes.core.k8s:
     state: present
     namespace: openshift-acm-policies
-    definition: "{{ lookup('ansible.builtin.template', plugin_dir ~ '/files/10-policy.yaml.j2') | from_yaml }}"
+    definition: "{{ lookup('ansible.builtin.template', plugin_dir ~ '/files/12-policy-datasciencecluster.yaml.j2') | from_yaml }}"
   register: r_acm_policy_model_config
   retries: "{{ k8s_retries }}"
   delay: "{{ k8s_delay }}"


### PR DESCRIPTION
RHOAI 3.3.0 KServe fails when the LeaderWorkerSet CRD is not present
at reconciliation time. The root cause is that a single ConfigurationPolicy
applies all object-templates at once: the DataScienceCluster can be created
before the LWS operator finishes installing and registering its CRDs.

Split the original model-configuration policy into three policies with an
explicit dependency chain:

  model-prerequisites → model-operators-crd-ready → model-configuration

1. model-prerequisites (10-policy-operators.yaml.j2)
   Installs all operators: NFD, NVIDIA GPU, cert-manager, Service Mesh,
   RHCL, LeaderWorkerSet, and RHOAI. Replaces the original monolithic
   10-policy.yaml.j2.

2. model-operators-crd-ready (11-policy-crd-ready.yaml.j2)
   Inform-only policy that gates on the leaderworkersets.leaderworkerset.x-k8s.io
   CRD existing on the managed cluster. Depends on model-prerequisites.
   Becomes Compliant only after the LWS operator has actually registered
   its CRD - stronger than depending on the Subscription object alone, which
   only tells OLM to install the operator but does not wait for it to finish.

3. model-configuration (12-policy-datasciencecluster.yaml.j2)
   Creates the DataScienceCluster with KServe. Depends on
   model-operators-crd-ready, so it is only enforced after the LWS CRD is
   confirmed present, preventing the KServe reconciler from hitting
   "no matches for kind LeaderWorkerSet in version leaderworkerset.x-k8s.io/v1".

Update PlacementBinding to include all three policies and model_config.yaml
to apply the three policy objects in order.

https://redhat.atlassian.net/browse/MGMT-23719

https://github.com/gori-project/GoRI/issues/842

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added prerequisite and CRD-ready checks to validate resources before model-related policies are applied.
  * Introduced a model configuration policy that enforces cluster settings so only the model serving component (kserve) is managed.

* **Chores**
  * Split policies into separate, linked policies and updated policy bindings to reference the new structure.
  * Deployment tasks updated to apply the new policy set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->