### PR TITLE
Add declarative plugin load-time validation

### DIFF
--- a/docs/PLUGIN_ARCHITECTURE.md
+++ b/docs/PLUGIN_ARCHITECTURE.md
@@ -1,0 +1,299 @@
+# Enclave Plugin Architecture
+
+## Overview
+
+The plugin system allows components (storage backends, AI/ML stacks, GPU operators) to be packaged as self-contained units under `plugins/`. Each plugin carries its own operator definitions, mirroring configuration, deployment logic, and defaults. The core pipeline discovers and runs plugins through a standard interface without component-specific branching.
+
+## Directory Structure
+
+A plugin is a directory under `plugins/` with a single descriptor and optional task files:
+
+```
+plugins/lvms/
+  plugin.yaml              <- the descriptor (required) -- all data in one file
+  tasks/
+    deploy.yaml            <- post-operator deployment logic
+    quay.yaml              <- Quay storage integration
+    pre-validate.yaml      <- pre-deployment checks (optional)
+    post-validate.yaml     <- post-deployment checks (optional)
+    pre-install-validate.yaml <- hardware checks before cluster install (optional)
+```
+
+### The Descriptor: `plugin.yaml`
+
+This is the only required file. It contains all plugin data: metadata, operator definitions, defaults, and registry entries.
+
+```yaml
+name: lvms
+type: foundation
+order: 10
+mirror: core
+
+operators:
+  - name: lvms-operator
+    version: 4.20.0
+    channel: stable-4.20
+    init_version: 4.20.0
+    namespace: openshift-storage
+    source: cs-redhat-operator-index-v4-20
+
+requires:
+  files:
+    - path: "tasks/deploy.yaml"
+      description: "LVMS deployment tasks"
+    - path: "tasks/quay.yaml"
+      description: "LVMS Quay storage configuration"
+
+defaults:
+  lvmsDefaults:
+    deviceClassName: vg1
+    defaultStorageClass: true
+    thinPoolConfig:
+      name: vg1-pool-1
+      sizePercent: 90
+      overprovisionRatio: 10
+
+registries:
+  - location: "registry.redhat.io/lvms4"
+    mirror: "lvms4"
+```
+
+| Field | What it does |
+|-------|-------------|
+| `name` | Plugin identifier. Must match the directory name. |
+| `type` | `foundation` -- deploys before core operators (storage, networking). `addon` -- deployed separately. |
+| `order` | Deploy order among same-type plugins. Lower = first. LVMS is 10, ODF is 10. |
+| `mirror` | How images are mirrored. `core` = mirrored in the core run. `plugin` = plugin runs its own oc-mirror. `none` = skip. |
+| `catalog` | Operator catalog name (`redhat` or `certified`). Defaults to `redhat`. |
+| `operators` | List of OLM operators to install. Each entry is passed to `configure_operator.yaml`. |
+| `installOperators` | Set to `false` to skip operator installation (mirror-only plugins). Defaults to `true`. |
+| `defaults` | Variables loaded into Ansible scope before tasks run. Keeps config namespaced per plugin. |
+| `registries` | Registry mirror entries for MCE patching and `registries.conf`. |
+| `additionalImages` | Extra images to include in the plugin's oc-mirror image set. |
+| `blockedImages` | Images to exclude from mirroring (by tag, digest, or pattern). |
+| `requires` | Declarative requirements validated at load time, before any deployment work begins. See [Load-Time Validation](#load-time-validation). |
+
+The plugin descriptor is validated by JSON Schema (`schemas/plugin.yaml`) during `make validate`. The validator (`make validate-plugins`) also checks directory structure.
+
+### Lifecycle Files
+
+Each file is optional and lives under `tasks/`. The plugin runner (`deploy_plugin.yaml`) checks if it exists before including it. If it's missing, that step is skipped.
+
+Here's what runs and in what order:
+
+```
+1. Load plugin.yaml              <- always
+2. Load defaults                  <- from plugin.yaml defaults section
+3. Validate requirements          <- assert requires.vars and requires.files
+4. tasks/pre-validate.yaml       <- "is the cluster ready for me?"
+5. Mirror (plugin-mode only)      <- template imageset, run oc-mirror, apply manifests
+6. Install operators              <- from plugin.yaml operators list (if installOperators != false)
+7. tasks/deploy.yaml             <- "create my CRs"
+8. tasks/post-validate.yaml      <- "did it work?"
+```
+
+Step 3 is the load-time validation gate. If any declared requirement is missing, the plugin fails immediately -- before mirroring, operator installation, or deployment.
+
+Separately, during Quay operator setup:
+
+```
+tasks/quay.yaml                  <- "here's how Quay should use my storage"
+```
+
+## Example: LVMS Plugin
+
+LVMS is a foundation plugin that provides LVM-based block storage on local disks.
+
+### `plugin.yaml`
+
+```yaml
+name: lvms
+type: foundation
+order: 10
+mirror: core
+
+operators:
+  - name: lvms-operator
+    version: 4.20.0
+    channel: stable-4.20
+    init_version: 4.20.0
+    namespace: openshift-storage
+    source: cs-redhat-operator-index-v4-20
+
+requires:
+  files:
+    - path: "tasks/deploy.yaml"
+      description: "LVMS deployment tasks"
+    - path: "tasks/quay.yaml"
+      description: "LVMS Quay storage configuration"
+
+defaults:
+  lvmsConfigDefaults:
+    deviceSelector:
+      forceWipeDevicesAndDestroyAllData: true
+  lvmsDefaults:
+    deviceClassName: vg1
+    defaultStorageClass: true
+    thinPoolConfig:
+      name: vg1-pool-1
+      sizePercent: 90
+      overprovisionRatio: 10
+
+registries:
+  - location: "registry.redhat.io/lvms4"
+    mirror: "lvms4"
+```
+
+The `defaults` section gets loaded into Ansible scope. The naming convention `lvmsDefaults.*` keeps things namespaced so plugins don't step on each other's variables. Users can override them in `config/global.yaml`.
+
+### `tasks/deploy.yaml`
+
+```yaml
+- name: "Ensure LVMCluster exists"
+  vars:
+    _spec: |
+      storage:
+        deviceClasses:
+          - name: {{ lvmsDefaults.deviceClassName }}
+            default: {{ lvmsDefaults.defaultStorageClass }}
+            thinPoolConfig:
+              name: {{ lvmsDefaults.thinPoolConfig.name }}
+              sizePercent: {{ lvmsDefaults.thinPoolConfig.sizePercent }}
+              overprovisionRatio: {{ lvmsDefaults.thinPoolConfig.overprovisionRatio }}
+            ...
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: lvm.topolvm.io/v1alpha1
+      kind: LVMCluster
+      metadata:
+        name: lvm-storage
+        namespace: openshift-storage
+      spec: "{{ _spec | from_yaml }}"
+```
+
+After the operator is installed, this creates the LVMCluster CR using variables from `defaults`.
+
+### `tasks/quay.yaml`
+
+When `storage_plugin: lvms` is set, the Quay operator includes `plugins/lvms/tasks/quay.yaml` to configure Quay's storage backend. The Quay operator uses dynamic inclusion:
+
+```yaml
+- name: Run storage plugin Quay tasks
+  ansible.builtin.include_tasks:
+    file: "{{ playbook_dir }}/../plugins/{{ storage_plugin }}/tasks/quay.yaml"
+```
+
+Adding a new storage option requires creating `plugins/<name>/tasks/quay.yaml` with no changes to the Quay operator code.
+
+## Pipeline Integration
+
+### Early Validation
+
+Before any phase that consumes plugin data, `validate_enabled_plugins.yaml` runs. It discovers all enabled plugins that declare a `requires` block, loads their defaults, and asserts that required variables and files are present. This happens at the start of both Phase 2 (Mirror) and Phase 5 (Operators), so a missing requirement fails the run immediately instead of after 30+ minutes of mirroring.
+
+The per-plugin validation in `deploy_plugin.yaml` remains as defense-in-depth during individual plugin deployment.
+
+### Mirroring (disconnected)
+
+Plugins with `mirror: core` have their operators collected by `collect_core_plugin_operators.yaml` and included in the core oc-mirror run. Plugins with `mirror: plugin` run their own oc-mirror invocation during step 5 of their lifecycle.
+
+Operators with `csvMirror: true` have their `csvNames` entries added as separate packages in the image set.
+
+### Pre-install Validation
+
+Before cluster installation, plugins with `tasks/pre-install-validate.yaml` run hardware checks against discovered hosts.
+
+### Operator Installation
+
+Foundation plugins deploy before core operators (Quay, GitOps). This ordering ensures storage is available when Quay creates its PVCs.
+
+```
+1. Validate enabled plugin requirements (early gate)
+2. Disable default CatalogSources (disconnected)
+3. Deploy foundation plugins (sorted by order):
+   -> load defaults -> validate requirements -> pre-validate -> mirror -> operators -> deploy -> post-validate
+4. Install core operators
+   -> Quay includes plugins/{storage_plugin}/tasks/quay.yaml
+5. Deploy addon plugins (sorted by order)
+```
+
+### Standalone Deploy
+
+Plugins can be deployed independently:
+
+```bash
+make deploy-plugin PLUGIN=lvms
+# or directly:
+ansible-playbook playbooks/deploy-plugin.yaml -e plugin_name=lvms -e workingDir=/home/cloud-user
+```
+
+## Validation
+
+Every plugin is validated at two levels:
+
+1. **JSON Schema** (`schemas/plugin.yaml`) -- validates field types, required fields, enum values, operator structure, and registry entries. Runs via `ansible.utils.validate` during `make validate`.
+
+2. **Shell script** (`scripts/verification/validate_plugins.sh`) -- validates directory structure:
+   - `plugin.yaml` exists with required fields
+   - Task files are valid Ansible task lists
+   - No unexpected files outside `plugin.yaml`, `tasks/`, and `files/`
+
+## Load-Time Validation
+
+Plugins can declare requirements in the `requires` block. These are validated at two points:
+
+1. **Early validation** (`validate_enabled_plugins.yaml`) -- runs at the start of Phase 2 (Mirror) and Phase 5 (Operators), before any mirroring or operator work begins. This is the primary gate that prevents wasting time on long-running operations when a requirement is missing.
+2. **Per-plugin validation** (`deploy_plugin.yaml`) -- runs when each plugin is individually deployed. Acts as defense-in-depth.
+
+If a requirement isn't met, the run fails with a clear error message.
+
+Two requirement types are supported:
+
+| Type | Purpose | Example |
+|------|---------|---------|
+| `vars` | Assert an Ansible variable is defined | `odfExternalConfig` |
+| `files` | Assert a file exists in the plugin directory | `tasks/deploy.yaml` |
+
+Each entry supports an optional `when` condition (Jinja2 expression). If the condition evaluates to false, the check is skipped.
+
+Example from the ODF plugin:
+
+```yaml
+requires:
+  vars:
+    - name: odfExternalConfig
+      when: "{{ storage_plugin == 'odf' }}"
+      description: "External Ceph cluster connection details from ceph-external-cluster-details-exporter.py"
+  files:
+    - path: "tasks/deploy.yaml"
+      description: "ODF deployment tasks"
+    - path: "tasks/quay.yaml"
+      description: "ODF Quay storage configuration"
+```
+
+Don't add `requires.vars` entries for variables that come from `plugin.defaults` -- those are always defined after defaults loading. Don't validate cluster state here (KUBECONFIG, CRDs) -- that's what `pre-validate` is for.
+
+## Adding a New Plugin
+
+1. Create `plugins/your-plugin/plugin.yaml` with `name` and `type`
+2. Add `operators` list if you need OLM operators
+3. Add `defaults` with your configurable parameters
+4. Add `registries` if disconnected mirroring is needed
+5. Add `requires` to declare variables or files that must exist at load time
+6. Add `tasks/deploy.yaml` with your post-operator setup logic
+7. Add `tasks/quay.yaml` if your plugin provides storage for Quay
+8. Run `make validate-plugins` to verify
+9. Add your plugin name to `enabled_plugins` in `config/global.yaml`
+
+No core files need to be modified.
+
+## Current Plugins
+
+| Plugin | Type | Order | Mirror | What it does |
+|--------|------|-------|--------|-------------|
+| `lvms` | foundation | 10 | core | LVM-based block storage for edge/single-node |
+| `odf` | foundation | 10 | core | OpenShift Data Foundation (external Ceph) |
+| `openshift-ai` | addon | 100 | plugin | OpenShift AI (RHOAI) with service mesh and dependencies |
+| `nvidia-gpu` | addon | 110 | plugin | NVIDIA GPU operator for GPU-accelerated workloads |
+| `example` | addon | 999 | none | Reference implementation (does nothing useful) |

--- a/docs/PLUGIN_ARCHITECTURE.md
+++ b/docs/PLUGIN_ARCHITECTURE.md
@@ -12,6 +12,7 @@ A plugin is a directory under `plugins/` with a single descriptor and optional t
 plugins/lvms/
   plugin.yaml              <- the descriptor (required) -- all data in one file
   tasks/
+    early-validate.yaml    <- custom validation before mirroring, no cluster access (optional)
     deploy.yaml            <- post-operator deployment logic
     quay.yaml              <- Quay storage integration
     pre-validate.yaml      <- pre-deployment checks (optional)
@@ -85,14 +86,15 @@ Here's what runs and in what order:
 1. Load plugin.yaml              <- always
 2. Load defaults                  <- from plugin.yaml defaults section
 3. Validate requirements          <- assert requires.vars and requires.files
-4. tasks/pre-validate.yaml       <- "is the cluster ready for me?"
-5. Mirror (plugin-mode only)      <- template imageset, run oc-mirror, apply manifests
-6. Install operators              <- from plugin.yaml operators list (if installOperators != false)
-7. tasks/deploy.yaml             <- "create my CRs"
-8. tasks/post-validate.yaml      <- "did it work?"
+4. tasks/early-validate.yaml     <- custom validation (no cluster access)
+5. tasks/pre-validate.yaml       <- "is the cluster ready for me?"
+6. Mirror (plugin-mode only)      <- template imageset, run oc-mirror, apply manifests
+7. Install operators              <- from plugin.yaml operators list (if installOperators != false)
+8. tasks/deploy.yaml             <- "create my CRs"
+9. tasks/post-validate.yaml      <- "did it work?"
 ```
 
-Step 3 is the load-time validation gate. If any declared requirement is missing, the plugin fails immediately -- before mirroring, operator installation, or deployment.
+Steps 3-4 are the load-time validation gate. If any declared requirement is missing or the early-validate script fails, the plugin fails immediately -- before mirroring, operator installation, or deployment. Note that `early-validate.yaml` runs before the cluster exists, so it cannot use KUBECONFIG. Use it for config format checks, external connectivity validation, or other pre-flight logic.
 
 Separately, during Quay operator setup:
 
@@ -274,6 +276,42 @@ requires:
 
 Don't add `requires.vars` entries for variables that come from `plugin.defaults` -- those are always defined after defaults loading. Don't validate cluster state here (KUBECONFIG, CRDs) -- that's what `pre-validate` is for.
 
+## Validation-Only Plugins
+
+A plugin doesn't have to deploy anything. If a plugin has no `operators`, no `mirror` config, and no `tasks/deploy.yaml`, all deployment steps are skipped -- only validation runs. This is useful for pre-flight checks, config verification, or environment validation that should gate the pipeline.
+
+A validation-only plugin can hook into any of these checkpoints:
+
+| File | Pipeline phase | Cluster access | Auto-discovered |
+|------|---------------|----------------|-----------------|
+| `early-validate.yaml` | Phase 2 (Mirror) and Phase 5 (Operators) start | No | Yes -- any enabled plugin with `requires` |
+| `pre-install-validate.yaml` | Phase 3 (Deploy), before cluster install | No | Yes |
+| `pre-validate.yaml` | Phase 5 (Operators), inside `deploy_plugin.yaml` | Yes | Only `type: foundation` plugins |
+| `post-validate.yaml` | Phase 5 (Operators), inside `deploy_plugin.yaml` | Yes | Only `type: foundation` plugins |
+
+`pre-validate.yaml` and `post-validate.yaml` run inside `deploy_plugin.yaml`, which is only triggered automatically for `type: foundation` plugins (via `deploy_foundation_plugins.yaml`). Use `type: foundation` with an `order` field for validation-only plugins that need cluster access.
+
+Example -- a plugin that validates network config before mirroring:
+
+```yaml
+# plugins/check-network/plugin.yaml
+name: check-network
+type: foundation
+order: 1
+
+requires:
+  vars:
+    - name: externalGateway
+      description: "Gateway IP for external network"
+```
+
+```yaml
+# plugins/check-network/tasks/early-validate.yaml
+- name: Verify gateway is reachable
+  ansible.builtin.command: ping -c 1 -W 3 {{ externalGateway }}
+  changed_when: false
+```
+
 ## Adding a New Plugin
 
 1. Create `plugins/your-plugin/plugin.yaml` with `name` and `type`
@@ -281,10 +319,11 @@ Don't add `requires.vars` entries for variables that come from `plugin.defaults`
 3. Add `defaults` with your configurable parameters
 4. Add `registries` if disconnected mirroring is needed
 5. Add `requires` to declare variables or files that must exist at load time
-6. Add `tasks/deploy.yaml` with your post-operator setup logic
-7. Add `tasks/quay.yaml` if your plugin provides storage for Quay
-8. Run `make validate-plugins` to verify
-9. Add your plugin name to `enabled_plugins` in `config/global.yaml`
+6. Add `tasks/early-validate.yaml` for custom pre-flight checks that don't need cluster access (optional)
+7. Add `tasks/deploy.yaml` with your post-operator setup logic
+8. Add `tasks/quay.yaml` if your plugin provides storage for Quay
+9. Run `make validate-plugins` to verify
+10. Add your plugin name to `enabled_plugins` in `config/global.yaml`
 
 No core files need to be modified.
 

--- a/playbooks/02-mirror.yaml
+++ b/playbooks/02-mirror.yaml
@@ -47,6 +47,17 @@
         success_msg: "Running in disconnected mode - proceeding with mirroring"
       tags: mirror-registry
 
+    - name: Validate enabled plugin requirements
+      ansible.builtin.include_tasks:
+        file: tasks/validate_enabled_plugins.yaml
+        apply:
+          tags:
+            - mirror-registry
+            - mirror-plugins
+      tags:
+        - mirror-registry
+        - mirror-plugins
+
     - name: Collect plugin operators for imageset
       ansible.builtin.include_tasks:
         file: tasks/collect_core_plugin_operators.yaml

--- a/playbooks/05-operators.yaml
+++ b/playbooks/05-operators.yaml
@@ -30,6 +30,17 @@
         msg: "Installing operators in {{ 'disconnected' if (disconnected | default(true)) else 'connected' }} mode"
       tags: always
 
+    - name: Validate enabled plugin requirements
+      ansible.builtin.include_tasks:
+        file: tasks/validate_enabled_plugins.yaml
+        apply:
+          tags:
+            - foundation-plugins
+            - operators
+      tags:
+        - foundation-plugins
+        - operators
+
     - name: Disable default operator catalog sources
       when: disconnected | default(true) | bool
       ansible.builtin.command: |

--- a/playbooks/tasks/collect_core_plugin_operators.yaml
+++ b/playbooks/tasks/collect_core_plugin_operators.yaml
@@ -32,7 +32,7 @@
          | list }}
     _core: >-
       {{ (_enabled | rejectattr('mirror', 'defined') | list)
-         + (_enabled | selectattr('mirror', 'equalto', 'core') | list) }}
+         + (_enabled | selectattr('mirror', 'defined') | selectattr('mirror', 'equalto', 'core') | list) }}
   ansible.builtin.set_fact:
     _core_plugin_operators: >-
       {{ _core

--- a/playbooks/tasks/collect_plugin_registries.yaml
+++ b/playbooks/tasks/collect_plugin_registries.yaml
@@ -29,7 +29,7 @@
          | list }}
     _core: >-
       {{ (_enabled | rejectattr('mirror', 'defined') | list)
-         + (_enabled | selectattr('mirror', 'equalto', 'core') | list) }}
+         + (_enabled | selectattr('mirror', 'defined') | selectattr('mirror', 'equalto', 'core') | list) }}
   ansible.builtin.set_fact:
     _core_plugin_registries: >-
       {{ _core

--- a/playbooks/tasks/deploy_plugin.yaml
+++ b/playbooks/tasks/deploy_plugin.yaml
@@ -62,7 +62,7 @@
 
 - name: Validate plugin requirements (vars)
   ansible.builtin.assert:
-    that: "{{ item.name }} is defined"
+    that: "item.name in vars"
     fail_msg: >-
       Plugin '{{ plugin.name }}' requires variable '{{ item.name }}' but it is not defined.
       {{ item.description | default('') }}

--- a/playbooks/tasks/deploy_plugin.yaml
+++ b/playbooks/tasks/deploy_plugin.yaml
@@ -60,6 +60,50 @@
   when: plugin.defaults is defined
   tags: always
 
+- name: Validate plugin requirements (vars)
+  ansible.builtin.assert:
+    that: "{{ item.name }} is defined"
+    fail_msg: >-
+      Plugin '{{ plugin.name }}' requires variable '{{ item.name }}' but it is not defined.
+      {{ item.description | default('') }}
+  loop: "{{ plugin.requires.vars | default([]) }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when:
+    - plugin.requires is defined
+    - plugin.requires.vars is defined
+    - item.when | default(true) | bool
+  tags: always
+
+- name: Stat plugin required files
+  ansible.builtin.stat:
+    path: "{{ plugin_dir }}/{{ item.path }}"
+  loop: "{{ plugin.requires.files | default([]) }}"
+  loop_control:
+    label: "{{ item.path }}"
+  register: r_required_files
+  when:
+    - plugin.requires is defined
+    - plugin.requires.files is defined
+  tags: always
+
+- name: Validate plugin requirements (files)
+  ansible.builtin.assert:
+    that: r_required_files.results[ansible_loop.index0].stat.exists
+    fail_msg: >-
+      Plugin '{{ plugin.name }}' requires file '{{ item.path }}' but it was not found at
+      {{ plugin_dir }}/{{ item.path }}.
+      {{ item.description | default('') }}
+  loop: "{{ plugin.requires.files | default([]) }}"
+  loop_control:
+    label: "{{ item.path }}"
+    extended: true
+  when:
+    - plugin.requires is defined
+    - plugin.requires.files is defined
+    - item.when | default(true) | bool
+  tags: always
+
 - name: Run pre-validate
   ansible.builtin.include_tasks:
     file: "{{ plugin_dir }}/tasks/pre-validate.yaml"

--- a/playbooks/tasks/validate_enabled_plugins.yaml
+++ b/playbooks/tasks/validate_enabled_plugins.yaml
@@ -1,0 +1,46 @@
+---
+# Early validation of all enabled plugins' requirements.
+#
+# Iterates over every enabled plugin that declares a `requires` block,
+# loads its defaults, and asserts that all required vars/files are present.
+# This runs BEFORE any mirroring or operator work, so failures surface
+# immediately instead of after 30+ minutes of oc-mirror.
+#
+# Include this task file at the start of any phase that consumes plugin data.
+
+- name: Find plugin descriptors
+  ansible.builtin.find:
+    paths: "{{ playbook_dir }}/../plugins"
+    patterns: "plugin.yaml"
+    recurse: true
+    depth: 2
+  register: _vp_find
+
+- name: Read plugin descriptors
+  ansible.builtin.slurp:
+    src: "{{ item }}"
+  loop: "{{ _vp_find.files | map(attribute='path') | list }}"
+  register: _vp_slurp
+
+- name: Filter to enabled plugins with requirements
+  ansible.builtin.set_fact:
+    _vp_plugins_to_validate: >-
+      {{ _vp_slurp.results
+         | map(attribute='content')
+         | map('b64decode')
+         | map('from_yaml')
+         | selectattr('name', 'in', enabled_plugins)
+         | selectattr('requires', 'defined')
+         | list }}
+
+- name: Display plugins to validate
+  ansible.builtin.debug:
+    msg: "Validating requirements for plugins: {{ _vp_plugins_to_validate | map(attribute='name') | list }}"
+
+- name: Validate plugin requirements
+  ansible.builtin.include_tasks: tasks/validate_single_plugin.yaml
+  loop: "{{ _vp_plugins_to_validate }}"
+  loop_control:
+    loop_var: _vp_plugin
+    label: "{{ _vp_plugin.name }}"
+  when: _vp_plugins_to_validate | length > 0

--- a/playbooks/tasks/validate_single_plugin.yaml
+++ b/playbooks/tasks/validate_single_plugin.yaml
@@ -60,3 +60,11 @@
     - _vp_plugin.requires is defined
     - _vp_plugin.requires.files is defined
     - item.when | default(true) | bool
+
+# Optional custom validation script. Runs before mirroring and deployment,
+# so no cluster access (KUBECONFIG) is available. Use this for config format
+# checks, external connectivity validation, or other pre-flight logic.
+- name: "Validate {{ _vp_plugin.name }} | Run early-validate"
+  ansible.builtin.include_tasks:
+    file: "{{ _vp_plugin_dir }}/tasks/early-validate.yaml"
+  when: lookup('ansible.builtin.fileglob', _vp_plugin_dir ~ '/tasks/early-validate.yaml') | length > 0

--- a/playbooks/tasks/validate_single_plugin.yaml
+++ b/playbooks/tasks/validate_single_plugin.yaml
@@ -22,7 +22,7 @@
 
 - name: "Validate {{ _vp_plugin.name }} | Validate required variables"
   ansible.builtin.assert:
-    that: "{{ item.name }} is defined"
+    that: "item.name in vars"
     fail_msg: >-
       Plugin '{{ _vp_plugin.name }}' requires variable '{{ item.name }}' but it is not defined.
       {{ item.description | default('') }}

--- a/playbooks/tasks/validate_single_plugin.yaml
+++ b/playbooks/tasks/validate_single_plugin.yaml
@@ -1,0 +1,62 @@
+---
+# Validate a single plugin's requirements (vars and files).
+#
+# Called from validate_enabled_plugins.yaml via include_tasks.
+#
+# Required loop variable:
+#   _vp_plugin: parsed plugin descriptor dict (from plugin.yaml)
+
+- name: "Validate {{ _vp_plugin.name }} | Set plugin directory"
+  ansible.builtin.set_fact:
+    _vp_plugin_dir: "{{ playbook_dir }}/../plugins/{{ _vp_plugin.name }}"
+
+# Load defaults so that variables provided by the plugin itself are in scope
+# before we check requires.vars.
+- name: "Validate {{ _vp_plugin.name }} | Load plugin defaults"  # noqa: var-naming[no-jinja]
+  ansible.builtin.set_fact:
+    "{{ item.key }}": "{{ item.value }}"
+  loop: "{{ _vp_plugin.defaults | default({}) | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+  when: _vp_plugin.defaults is defined
+
+- name: "Validate {{ _vp_plugin.name }} | Validate required variables"
+  ansible.builtin.assert:
+    that: "{{ item.name }} is defined"
+    fail_msg: >-
+      Plugin '{{ _vp_plugin.name }}' requires variable '{{ item.name }}' but it is not defined.
+      {{ item.description | default('') }}
+  loop: "{{ _vp_plugin.requires.vars | default([]) }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when:
+    - _vp_plugin.requires is defined
+    - _vp_plugin.requires.vars is defined
+    - item.when | default(true) | bool
+
+- name: "Validate {{ _vp_plugin.name }} | Stat required files"
+  ansible.builtin.stat:
+    path: "{{ _vp_plugin_dir }}/{{ item.path }}"
+  loop: "{{ _vp_plugin.requires.files | default([]) }}"
+  loop_control:
+    label: "{{ item.path }}"
+  register: _vp_required_files
+  when:
+    - _vp_plugin.requires is defined
+    - _vp_plugin.requires.files is defined
+
+- name: "Validate {{ _vp_plugin.name }} | Validate required files exist"
+  ansible.builtin.assert:
+    that: _vp_required_files.results[ansible_loop.index0].stat.exists
+    fail_msg: >-
+      Plugin '{{ _vp_plugin.name }}' requires file '{{ item.path }}' but it was not found at
+      {{ _vp_plugin_dir }}/{{ item.path }}.
+      {{ item.description | default('') }}
+  loop: "{{ _vp_plugin.requires.files | default([]) }}"
+  loop_control:
+    label: "{{ item.path }}"
+    extended: true
+  when:
+    - _vp_plugin.requires is defined
+    - _vp_plugin.requires.files is defined
+    - item.when | default(true) | bool

--- a/plugins/lvms/plugin.yaml
+++ b/plugins/lvms/plugin.yaml
@@ -12,6 +12,13 @@ operators:
     namespace: openshift-storage
     source: cs-redhat-operator-index-v4-20
 
+requires:
+  files:
+    - path: "tasks/deploy.yaml"
+      description: "LVMS deployment tasks"
+    - path: "tasks/quay.yaml"
+      description: "LVMS Quay storage configuration"
+
 defaults:
   lvmsConfigDefaults:
     deviceSelector:

--- a/plugins/odf/plugin.yaml
+++ b/plugins/odf/plugin.yaml
@@ -28,6 +28,17 @@ operators:
       - odr-cluster-operator
       - odr-hub-operator
 
+requires:
+  vars:
+    - name: odfExternalConfig
+      when: "{{ storage_plugin == 'odf' }}"
+      description: "External Ceph cluster connection details from ceph-external-cluster-details-exporter.py"
+  files:
+    - path: "tasks/deploy.yaml"
+      description: "ODF deployment tasks"
+    - path: "tasks/quay.yaml"
+      description: "ODF Quay storage configuration"
+
 defaults:
   odfDefaults:
     defaultStorageClass: true

--- a/schemas/plugin.yaml
+++ b/schemas/plugin.yaml
@@ -65,6 +65,38 @@ definitions:
       - location
       - mirror
 
+  requirement_var:
+    type: object
+    additionalProperties: false
+    properties:
+      name:
+        type: string
+        description: Ansible variable name that must be defined.
+      description:
+        type: string
+        description: Human-readable description shown on failure.
+      when:
+        type: string
+        description: Jinja2 condition — skip check if false.
+    required:
+      - name
+
+  requirement_file:
+    type: object
+    additionalProperties: false
+    properties:
+      path:
+        type: string
+        description: File path relative to plugin directory.
+      description:
+        type: string
+        description: Human-readable description shown on failure.
+      when:
+        type: string
+        description: Jinja2 condition — skip check if false.
+    required:
+      - path
+
 additionalProperties: false
 properties:
   name:
@@ -123,6 +155,21 @@ properties:
       items:
         type: string
         description: The full tag, digest, or pattern of images to block from mirroring.
+  requires:
+    type: object
+    description: Declarative requirements validated at plugin load time.
+    additionalProperties: false
+    properties:
+      vars:
+        type: array
+        description: Ansible variables that must be defined.
+        items:
+          $ref: "#/definitions/requirement_var"
+      files:
+        type: array
+        description: Files that must exist within the plugin directory.
+        items:
+          $ref: "#/definitions/requirement_file"
 required:
   - name
   - type

--- a/scripts/verification/validate_plugins.sh
+++ b/scripts/verification/validate_plugins.sh
@@ -82,7 +82,8 @@ import yaml, sys
 filepath = sys.argv[1]
 required_fields = ['name', 'type']
 valid_fields = ['name', 'type', 'order', 'mirror', 'catalog', 'operators', 'defaults',
-                'installOperators', 'registries', 'additionalImages', 'blockedImages']
+                'installOperators', 'registries', 'additionalImages', 'blockedImages',
+                'requires']
 
 try:
     with open(filepath) as f:


### PR DESCRIPTION
## Summary

- Add a `requires` block to `plugin.yaml` so plugins can declare required variables and files
- Validate requirements immediately after loading defaults, before mirroring or deployment
- Missing requirements fail with a clear error message instead of cryptic failures deep in the pipeline
- Add `requires` declarations to ODF (`odfExternalConfig` conditional on `storage_plugin`) and LVMS (task files)
- Run early validation at the start of Phase 2 (Mirror) and Phase 5 (Operators), so missing requirements are caught before the 30+ minute oc-mirror run, not after
- Update schema, validation script, and plugin architecture docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive plugin architecture docs describing packaging, lifecycle, validation, mirroring modes, operator installation, and current plugins.

* **New Features**
  * Plugins can declare required variables and files; schema added to validate those declarations.
  * Early and runtime validation enforces declared plugin prerequisites during mirroring and operator phases.
  * Support for optional plugin-provided pre-validation hooks.
  * Several plugins updated to declare new requirements and Quay-related tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->