### PR TITLE
Fix Slack notification invalid_attachments error

### DIFF
--- a/.github/actions/notify-slack/action.yml
+++ b/.github/actions/notify-slack/action.yml
@@ -104,6 +104,8 @@ runs:
         fi
 
         # Build compact Slack payload
+        # Blocks must be at the top level (not inside attachments).
+        # The attachment provides the color bar on the left.
         PAYLOAD=$(jq -n \
           --arg text "$MESSAGE_TEXT" \
           --arg color "$COLOR" \
@@ -111,17 +113,25 @@ runs:
           --argjson actions "$ACTIONS" \
           '{
             "text": $text,
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": $text,
+                  "emoji": true
+                }
+              },
+              {
+                "type": "section",
+                "fields": $fields
+              },
+              $actions
+            ],
             "attachments": [
               {
                 "color": $color,
-                "text": $text,
-                "blocks": [
-                  {
-                    "type": "section",
-                    "fields": $fields
-                  },
-                  $actions
-                ]
+                "fallback": $text
               }
             ]
           }')


### PR DESCRIPTION
Move blocks from inside attachments to the top level of the payload. Slack incoming webhooks only support blocks at the top level, not nested inside attachments. Keep the attachment for the color bar using the legacy fallback field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Slack notification message formatting to restructure how messages are composed and displayed. Enhanced message organization with improved payload structure for clearer notification presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->