### PR TITLE
Allow specify LimitRange to operator namespaces

### DIFF
--- a/defaults/operators.yaml
+++ b/defaults/operators.yaml
@@ -47,13 +47,13 @@ operators:
     source: cs-redhat-operator-index-v4-20
     global: true
     limits:
-    - default:
-        cpu: 20m
-        memory: 64Mi
-      defaultRequest:
-        cpu: 10m
-        memory: 32Mi
-      type: Container
+      - default:
+          cpu: 20m
+          memory: 64Mi
+        defaultRequest:
+          cpu: 10m
+          memory: 32Mi
+        type: Container
 
   - name: netobserv-operator
     version: 1.11.0

--- a/defaults/operators.yaml
+++ b/defaults/operators.yaml
@@ -46,6 +46,14 @@ operators:
     namespace: openshift-pipelines
     source: cs-redhat-operator-index-v4-20
     global: true
+    limits:
+    - default:
+        cpu: 20m
+        memory: 64Mi
+      defaultRequest:
+        cpu: 10m
+        memory: 32Mi
+      type: Container
 
   - name: netobserv-operator
     version: 1.11.0

--- a/playbooks/tasks/configure_operator.yaml
+++ b/playbooks/tasks/configure_operator.yaml
@@ -10,6 +10,23 @@
   delay: "{{ k8s_delay }}"
   until: r_namespace_exists is success
 
+- name: "Apply LimitRange to namespace if needed"
+  when: operator.limits | default("") | length > 0
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: LimitRange
+      metadata:
+        name: "{{ operator.namespace }}-limits"
+        namespace: "{{ operator.namespace }}"
+      spec:
+        limits: "{{ operator.limits }}"
+  register: r_limit_range_exists
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_limit_range_exists is success
+
 - name: "Check if OperatorGroup already exists in namespace"
   when: operator.namespace != "openshift-operators"
   kubernetes.core.k8s_info:

--- a/schemas/operators.yaml
+++ b/schemas/operators.yaml
@@ -41,6 +41,9 @@ definitions:
       global:
         type: boolean
         description: Configure operator to watch the entire cluster.
+      limits:
+        type: array
+        description: Specify the LimitRange for the operator namespace
     dependencies:
       csvMirror:
       - csvNames


### PR DESCRIPTION
Helps for https://github.com/gori-project/GoRI/issues/714

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added resource limit configuration for operators with per-container CPU and memory thresholds (defaults: 20m CPU, 64Mi memory; requests: 10m CPU, 32Mi memory).
  * Operators now enforce configured resource constraints through automatic limit range creation when limits are specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->