### PR TITLE
remove model configuration from bootstrap

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -175,12 +175,6 @@ echo -p "Catalog source ACM policy .." -n1 -s
     ansible-playbook playbooks/06-day2.yaml -e@$global_vars -e@$certs_vars --tags acm-policy-catalogsources 2>&1 | tee -a ${log}
 echo -e "\e[38;5;10m Done...\033[0m"; date
 
-echo -p "Model config.. " -n1 -s
-    ansible-playbook playbooks/deploy-plugin.yaml -e@$global_vars -e plugin_name=openshift-ai 2>&1 | tee -a ${log}
-    ansible-playbook playbooks/deploy-plugin.yaml -e@$global_vars -e plugin_name=nvidia-gpu 2>&1 | tee -a ${log}
-echo -e "\e[38;5;10m Done...\033[0m"; date
-
-
 # Showing login information
 printf '%b\n' "$(tail -3 ${workingDir}/ocp-cluster/.openshift_install.log \
   | cut -d= -f4- \


### PR DESCRIPTION
remove bootstrap backwards compatibility for model configuration, following introduction of `enabled_plugins`.

replacement:
```
enabled_plugins:
  ...
  - openshift-ai
  - nvidia-gpu
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the initialization script by removing automated plugin deployment steps, reducing setup complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->