### PR TITLE
Add make deploy-plugin target and auto-include storage_plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@
 #   make verify                           - Verify infrastructure is working
 #   make clean                            - Clean up infrastructure
 
-.PHONY: help validate validate-shell validate-yaml validate-json-schema validate-ansible validate-tags validate-makefile validate-plugins build-ci-image push-ci-image test-ci-image build-push-ci-image environment provision-landing-zone verify-landing-zone install-enclave verify-enclave-installation deploy-cluster deploy-cluster-prepare deploy-cluster-mirror deploy-cluster-install deploy-cluster-post-install deploy-cluster-operators deploy-cluster-day2 deploy-cluster-discovery verify clean verify-cluster verify-cleanup generate-cluster-name setup-working-dir collect-step-logs preflight-checks collect-artifacts-basic collect-artifacts-deployment collect-artifacts-full ci-flow-connected ci-flow-disconnected
+.PHONY: help validate validate-shell validate-yaml validate-json-schema validate-ansible validate-tags validate-makefile validate-plugins build-ci-image push-ci-image test-ci-image build-push-ci-image environment provision-landing-zone verify-landing-zone install-enclave verify-enclave-installation deploy-cluster deploy-cluster-prepare deploy-cluster-mirror deploy-cluster-install deploy-cluster-post-install deploy-cluster-operators deploy-cluster-day2 deploy-cluster-discovery deploy-plugin verify clean verify-cluster verify-cleanup generate-cluster-name setup-working-dir collect-step-logs preflight-checks collect-artifacts-basic collect-artifacts-deployment collect-artifacts-full ci-flow-connected ci-flow-disconnected
 
 # Configuration
 DEV_SCRIPTS_PATH ?=
@@ -86,6 +86,9 @@ help:
 	@echo "  make deploy-cluster-operators         - Phase 5: Install operators"
 	@echo "  make deploy-cluster-day2              - Phase 6: Day-2 operations"
 	@echo "  make deploy-cluster-discovery         - Phase 7: Configure hardware discovery"
+	@echo ""
+	@echo "Plugin deployment:"
+	@echo "  make deploy-plugin PLUGIN=<name>    - Deploy a single plugin (e.g., openshift-ai)"
 	@echo ""
 	@echo "Required configuration for CI targets:"
 	@echo "  DEV_SCRIPTS_PATH  - Path to dev-scripts installation (must be set)"
@@ -339,6 +342,14 @@ deploy-cluster-discovery:
 	@echo "=========================================="
 	@echo ""
 	@./scripts/deployment/deploy_phase.sh 07-configure-discovery.yaml
+
+# Deploy a single plugin
+deploy-plugin:
+	@echo "=========================================="
+	@echo "Deploying plugin: $(PLUGIN)"
+	@echo "=========================================="
+	@echo ""
+	@./scripts/deployment/deploy_plugin.sh $(PLUGIN)
 
 # Verify infrastructure
 verify:

--- a/docs/PLUGIN_ARCHITECTURE.md
+++ b/docs/PLUGIN_ARCHITECTURE.md
@@ -225,10 +225,20 @@ Foundation plugins deploy before core operators (Quay, GitOps). This ordering en
 Plugins can be deployed independently:
 
 ```bash
-make deploy-plugin PLUGIN=lvms
+make deploy-plugin PLUGIN=openshift-ai
 # or directly:
-ansible-playbook playbooks/deploy-plugin.yaml -e plugin_name=lvms -e workingDir=/home/cloud-user
+./scripts/deployment/deploy_plugin.sh openshift-ai
+# or with Ansible:
+ansible-playbook playbooks/deploy-plugin.yaml -e plugin_name=openshift-ai -e workingDir=/home/cloud-user
 ```
+
+The `deploy_plugin.sh` script accepts the same environment variables as `deploy_phase.sh`:
+- `STORAGE_PLUGIN` -- overrides the storage plugin (e.g., `odf`)
+- `ENABLED_PLUGINS` -- comma-separated list of enabled plugins (e.g., `lvms,openshift-ai`)
+
+### Automatic `storage_plugin` Inclusion
+
+The `storage_plugin` value (set in `config/global.yaml`) is automatically unioned into `enabled_plugins` during variable loading. This ensures that even if a user overrides `enabled_plugins` without listing the storage plugin, it will still be mirrored and deployed. If the storage plugin is already in the list, no duplication occurs.
 
 ## Validation
 

--- a/playbooks/common/load-vars.yaml
+++ b/playbooks/common/load-vars.yaml
@@ -25,3 +25,7 @@
     - k8s.yaml
   loop_control:
     loop_var: config_file
+
+- name: Ensure storage plugin is in enabled_plugins
+  ansible.builtin.set_fact:
+    enabled_plugins: "{{ enabled_plugins | union([storage_plugin]) }}"

--- a/scripts/deployment/deploy_plugin.sh
+++ b/scripts/deployment/deploy_plugin.sh
@@ -111,6 +111,26 @@ else
 "
 fi
 
+# Set storage plugin from STORAGE_PLUGIN env var (overrides default in config)
+if [ -n "${STORAGE_PLUGIN:-}" ]; then
+    EXTRA_VARS_CONTENT="${EXTRA_VARS_CONTENT}storage_plugin: ${STORAGE_PLUGIN}
+"
+    info "Storage plugin: $STORAGE_PLUGIN"
+fi
+
+# Set enabled plugins from ENABLED_PLUGINS env var (comma-separated)
+if [ -n "${ENABLED_PLUGINS:-}" ]; then
+    EXTRA_VARS_CONTENT="${EXTRA_VARS_CONTENT}enabled_plugins:
+"
+    IFS=',' read -ra _plugins <<< "$ENABLED_PLUGINS"
+    for _plugin in "${_plugins[@]}"; do
+        _plugin="${_plugin// /}"  # trim whitespace
+        EXTRA_VARS_CONTENT="${EXTRA_VARS_CONTENT}  - ${_plugin}
+"
+    done
+    info "Enabled plugins: $ENABLED_PLUGINS"
+fi
+
 # Create the extra vars file on Landing Zone
 # shellcheck disable=SC2087,SC2086  # We want client-side expansion of $EXTRA_VARS_CONTENT
 ssh $SSH_OPTS "$LZ_SSH" "cat > $LZ_ENCLAVE_DIR/phase_vars.yaml" <<EOF


### PR DESCRIPTION
## Summary

- Add `make deploy-plugin PLUGIN=<name>` target for deploying addon plugins, consistent with the existing Makefile interface (`make deploy-cluster`, `make deploy-cluster-operators`, etc.)
- Auto-union `storage_plugin` into `enabled_plugins` in `load-vars.yaml` so the storage plugin is always mirrored and deployed even if the user overrides `enabled_plugins` without including it
- Mirror `STORAGE_PLUGIN` and `ENABLED_PLUGINS` env var passthrough from `deploy_phase.sh` into `deploy_plugin.sh` for consistency between the two scripts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added plugin deployment capability allowing customization via environment variables for storage and enabled plugins.
  * Storage plugins are automatically included in deployments.

* **Documentation**
  * Updated plugin architecture documentation with standalone deployment examples and environment variable usage guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->