### PR TITLE
[pre_install_validate_plugins] Increase waiting time from 5 minutes to 15minutes

### DIFF
--- a/playbooks/tasks/pre_install_validate_plugins.yaml
+++ b/playbooks/tasks/pre_install_validate_plugins.yaml
@@ -13,7 +13,7 @@
 # explicitly before any delegated tasks.
 - name: Wait for rendezvous node to become reachable
   ansible.builtin.wait_for_connection:
-    timeout: 300
+    timeout: 900
     sleep: 10
   delegate_to: rendezvous
 


### PR DESCRIPTION
Some baremetal nodes can take longer restarting, due to memory, raids, etc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended timeout duration for connectivity validation during pre-installation checks to prevent premature failures on slower connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->