### PR TITLE
Split Makefile into LZ-native and CI variants

### DIFF
--- a/.github/workflows/build-push-tarball.yml
+++ b/.github/workflows/build-push-tarball.yml
@@ -68,6 +68,7 @@ jobs:
       - name: Build tarball
         run: |
           tar --exclude='.git' --exclude='.gitignore' --exclude='.github' --exclude='scripts' \
+            --exclude='Makefile.ci' \
             -czvf /tmp/enclave.tar.gz .
           mv /tmp/enclave.tar.gz .
           ls -lh enclave.tar.gz
@@ -126,6 +127,7 @@ jobs:
           EXCLUDED_PATHS=(
             ".git/"
             ".github/"
+            "Makefile.ci"
           )
 
           for path in "${EXCLUDED_PATHS[@]}"; do

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -68,7 +68,7 @@ jobs:
           # Clean up Enclave test infrastructure using make clean
           if [ -d "$DEV_SCRIPTS_PATH" ]; then
             echo "Running: make clean" >> $GITHUB_STEP_SUMMARY
-            make clean || true
+            make -f Makefile.ci clean || true
             echo "✅ Standard cleanup complete" >> $GITHUB_STEP_SUMMARY
           else
             echo "⚠️ DEV_SCRIPTS_PATH not found: $DEV_SCRIPTS_PATH" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/e2e-deployment.yml
+++ b/.github/workflows/e2e-deployment.yml
@@ -1,7 +1,7 @@
 name: E2E Deployment
 
 # This workflow performs end-to-end deployment testing from scratch:
-# make clean && make environment && make provision-landing-zone && make install-enclave && make deploy-cluster
+# make -f Makefile.ci clean && make -f Makefile.ci environment && make -f Makefile.ci provision-landing-zone && make -f Makefile.ci install-enclave && make -f Makefile.ci deploy-cluster
 #
 # Trigger methods:
 # 1. Automatic: Runs on every pull request (opened, updated, reopened)
@@ -83,6 +83,7 @@ jobs:
               - 'playbooks/**'
               - 'scripts/**'
               - 'Makefile'
+              - 'Makefile.ci'
               - 'config/**'
               - 'defaults/**'
               - 'schemas/**'
@@ -151,7 +152,7 @@ jobs:
 
       - name: Setup cluster-specific working directory
         run: |
-          make setup-working-dir
+          make -f Makefile.ci setup-working-dir
           echo "WORKING_DIR=$(cat /tmp/working_dir)" >> $GITHUB_ENV
 
       - name: Pre-flight checks
@@ -177,7 +178,7 @@ jobs:
           echo "Cluster Network: ${ENCLAVE_CLUSTER_NETWORK:-not-set}" >> $GITHUB_STEP_SUMMARY
           echo "Working Directory: ${WORKING_DIR:-not-set}" >> $GITHUB_STEP_SUMMARY
 
-          make environment
+          make -f Makefile.ci environment
           echo "✅ Infrastructure created" >> $GITHUB_STEP_SUMMARY
 
       - name: Provision Landing Zone
@@ -185,7 +186,7 @@ jobs:
           echo "## Provisioning Landing Zone" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Installing CentOS Stream and configuring Landing Zone VM..." >> $GITHUB_STEP_SUMMARY
-          make provision-landing-zone
+          make -f Makefile.ci provision-landing-zone
           echo "✅ Landing Zone provisioned" >> $GITHUB_STEP_SUMMARY
 
       - name: Install Enclave Lab
@@ -193,7 +194,7 @@ jobs:
           echo "## Installing Enclave Lab" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Installing dev-scripts and required packages on Landing Zone..." >> $GITHUB_STEP_SUMMARY
-          make install-enclave
+          make -f Makefile.ci install-enclave
           echo "✅ Enclave Lab installed" >> $GITHUB_STEP_SUMMARY
 
       - name: Phase 1 - Prepare binaries and content
@@ -203,7 +204,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Downloading OpenShift binaries and content..." >> $GITHUB_STEP_SUMMARY
 
-          make deploy-cluster-prepare
+          make -f Makefile.ci deploy-cluster-prepare
 
           echo "✅ Phase 1 complete" >> $GITHUB_STEP_SUMMARY
 
@@ -215,7 +216,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Setting up local mirror registry (disconnected mode)..." >> $GITHUB_STEP_SUMMARY
 
-          make deploy-cluster-mirror
+          make -f Makefile.ci deploy-cluster-mirror
 
           echo "✅ Phase 2 complete" >> $GITHUB_STEP_SUMMARY
 
@@ -226,7 +227,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Deploying OpenShift cluster (mode: $ENCLAVE_DEPLOYMENT_MODE)..." >> $GITHUB_STEP_SUMMARY
 
-          make deploy-cluster-install
+          make -f Makefile.ci deploy-cluster-install
 
           echo "✅ Phase 3 complete - Cluster deployed" >> $GITHUB_STEP_SUMMARY
 
@@ -237,7 +238,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Configuring cluster (secrets, certificates, API health)..." >> $GITHUB_STEP_SUMMARY
 
-          make deploy-cluster-post-install
+          make -f Makefile.ci deploy-cluster-post-install
 
           echo "✅ Phase 4 complete" >> $GITHUB_STEP_SUMMARY
 
@@ -248,7 +249,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Installing and configuring operators..." >> $GITHUB_STEP_SUMMARY
 
-          make deploy-cluster-operators
+          make -f Makefile.ci deploy-cluster-operators
 
           echo "✅ Phase 5 complete" >> $GITHUB_STEP_SUMMARY
 
@@ -259,7 +260,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Configuring advanced features and policies..." >> $GITHUB_STEP_SUMMARY
 
-          make deploy-cluster-day2
+          make -f Makefile.ci deploy-cluster-day2
 
           echo "✅ Phase 6 complete" >> $GITHUB_STEP_SUMMARY
 
@@ -270,13 +271,13 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Configuring hardware discovery infrastructure..." >> $GITHUB_STEP_SUMMARY
 
-          make deploy-cluster-discovery
+          make -f Makefile.ci deploy-cluster-discovery
 
           echo "✅ Phase 7 complete - Full deployment complete" >> $GITHUB_STEP_SUMMARY
 
       - name: Verify cluster deployment
         id: verify_cluster
-        run: make verify-cluster
+        run: make -f Makefile.ci verify-cluster
 
       - name: Collect artifacts
         if: always()
@@ -343,7 +344,7 @@ jobs:
 
           # Run cleanup and capture output
           set +e
-          make clean 2>&1 | tee cleanup-logs/cleanup.log
+          make -f Makefile.ci clean 2>&1 | tee cleanup-logs/cleanup.log
           CLEANUP_EXIT_CODE=$?
           set -e
 

--- a/.github/workflows/infra-verify.yml
+++ b/.github/workflows/infra-verify.yml
@@ -102,7 +102,7 @@ jobs:
 
           # Run command and capture all output
           set +e
-          make environment 2>&1 | tee -a step-logs/02-setup-infrastructure.log
+          make -f Makefile.ci environment 2>&1 | tee -a step-logs/02-setup-infrastructure.log
           EXIT_CODE=${PIPESTATUS[0]}
           set -e
 
@@ -127,7 +127,7 @@ jobs:
           echo "## Provisioning Landing Zone" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Installing CentOS Stream and configuring Landing Zone VM..." >> $GITHUB_STEP_SUMMARY
-          make provision-landing-zone
+          make -f Makefile.ci provision-landing-zone
           echo "✅ Landing Zone provisioned" >> $GITHUB_STEP_SUMMARY
 
       - name: Install Enclave Lab (Connected Mode)
@@ -137,13 +137,13 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Running in connected mode for faster testing..." >> $GITHUB_STEP_SUMMARY
 
-          ENCLAVE_DEPLOYMENT_MODE=connected make install-enclave 2>&1 | tee step-logs/03-install-enclave.log
+          ENCLAVE_DEPLOYMENT_MODE=connected make -f Makefile.ci install-enclave 2>&1 | tee step-logs/03-install-enclave.log
 
       - name: Collect step logs
         if: always()
         env:
           WORKING_DIR: ${{ env.WORKING_DIR }}
-        run: make collect-step-logs
+        run: make -f Makefile.ci collect-step-logs
 
       - name: Collect artifacts
         if: always()
@@ -170,7 +170,7 @@ jobs:
 
           # Run cleanup and capture exit code
           set +e
-          make clean 2>&1 | tee step-logs/03-cleanup.log
+          make -f Makefile.ci clean 2>&1 | tee step-logs/03-cleanup.log
           CLEANUP_EXIT_CODE=$?
           set -e
 

--- a/.github/workflows/nightly-e2e-connected.yml
+++ b/.github/workflows/nightly-e2e-connected.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Setup cluster-specific working directory
         run: |
-          make setup-working-dir
+          make -f Makefile.ci setup-working-dir
           echo "WORKING_DIR=$(cat /tmp/working_dir)" >> $GITHUB_ENV
 
       - name: Workflow information
@@ -96,7 +96,7 @@ jobs:
           echo "Cluster Network: ${ENCLAVE_CLUSTER_NETWORK:-not-set}" >> $GITHUB_STEP_SUMMARY
           echo "Working Directory: ${WORKING_DIR:-not-set}" >> $GITHUB_STEP_SUMMARY
 
-          make environment
+          make -f Makefile.ci environment
           echo "✅ Infrastructure created" >> $GITHUB_STEP_SUMMARY
 
       - name: Provision Landing Zone
@@ -104,7 +104,7 @@ jobs:
           echo "## Provisioning Landing Zone" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Installing CentOS Stream and configuring Landing Zone VM..." >> $GITHUB_STEP_SUMMARY
-          make provision-landing-zone
+          make -f Makefile.ci provision-landing-zone
           echo "✅ Landing Zone provisioned" >> $GITHUB_STEP_SUMMARY
 
       - name: Install Enclave Lab
@@ -112,7 +112,7 @@ jobs:
           echo "## Installing Enclave Lab" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Installing dev-scripts and required packages on Landing Zone..." >> $GITHUB_STEP_SUMMARY
-          make install-enclave
+          make -f Makefile.ci install-enclave
           echo "✅ Enclave Lab installed" >> $GITHUB_STEP_SUMMARY
 
       - name: Phase 1 - Prepare binaries and content
@@ -122,7 +122,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Downloading OpenShift binaries and content..." >> $GITHUB_STEP_SUMMARY
 
-          make deploy-cluster-prepare
+          make -f Makefile.ci deploy-cluster-prepare
 
           echo "✅ Phase 1 complete" >> $GITHUB_STEP_SUMMARY
 
@@ -133,7 +133,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Deploying OpenShift cluster (mode: connected)..." >> $GITHUB_STEP_SUMMARY
 
-          make deploy-cluster-install
+          make -f Makefile.ci deploy-cluster-install
 
           echo "✅ Phase 2 complete - Cluster deployed" >> $GITHUB_STEP_SUMMARY
 
@@ -144,7 +144,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Configuring cluster (secrets, certificates, API health)..." >> $GITHUB_STEP_SUMMARY
 
-          make deploy-cluster-post-install
+          make -f Makefile.ci deploy-cluster-post-install
 
           echo "✅ Phase 3 complete" >> $GITHUB_STEP_SUMMARY
 
@@ -155,7 +155,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Installing and configuring operators..." >> $GITHUB_STEP_SUMMARY
 
-          make deploy-cluster-operators
+          make -f Makefile.ci deploy-cluster-operators
 
           echo "✅ Phase 4 complete" >> $GITHUB_STEP_SUMMARY
 
@@ -166,7 +166,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Configuring advanced features and policies..." >> $GITHUB_STEP_SUMMARY
 
-          make deploy-cluster-day2
+          make -f Makefile.ci deploy-cluster-day2
 
           echo "✅ Phase 5 complete" >> $GITHUB_STEP_SUMMARY
 
@@ -177,14 +177,14 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Configuring hardware discovery infrastructure..." >> $GITHUB_STEP_SUMMARY
 
-          make deploy-cluster-discovery
+          make -f Makefile.ci deploy-cluster-discovery
 
           echo "✅ Phase 6 complete - Full deployment complete" >> $GITHUB_STEP_SUMMARY
 
       - name: Verify cluster deployment
         if: success()
         id: verify_cluster
-        run: make verify-cluster
+        run: make -f Makefile.ci verify-cluster
 
       - name: Collect artifacts
         if: always()
@@ -269,7 +269,7 @@ jobs:
           echo "## Cleanup Infrastructure" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          make clean
+          make -f Makefile.ci clean
 
           echo "✅ Infrastructure cleaned up" >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/nightly-e2e-disconnected.yml
+++ b/.github/workflows/nightly-e2e-disconnected.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Setup cluster-specific working directory
         run: |
-          make setup-working-dir
+          make -f Makefile.ci setup-working-dir
           echo "WORKING_DIR=$(cat /tmp/working_dir)" >> $GITHUB_ENV
 
       - name: Workflow information
@@ -96,7 +96,7 @@ jobs:
           echo "Cluster Network: ${ENCLAVE_CLUSTER_NETWORK:-not-set}" >> $GITHUB_STEP_SUMMARY
           echo "Working Directory: ${WORKING_DIR:-not-set}" >> $GITHUB_STEP_SUMMARY
 
-          make environment
+          make -f Makefile.ci environment
           echo "✅ Infrastructure created" >> $GITHUB_STEP_SUMMARY
 
       - name: Provision Landing Zone
@@ -104,7 +104,7 @@ jobs:
           echo "## Provisioning Landing Zone" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Installing CentOS Stream and configuring Landing Zone VM..." >> $GITHUB_STEP_SUMMARY
-          make provision-landing-zone
+          make -f Makefile.ci provision-landing-zone
           echo "✅ Landing Zone provisioned" >> $GITHUB_STEP_SUMMARY
 
       - name: Install Enclave Lab
@@ -112,7 +112,7 @@ jobs:
           echo "## Installing Enclave Lab" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Installing dev-scripts and required packages on Landing Zone..." >> $GITHUB_STEP_SUMMARY
-          make install-enclave
+          make -f Makefile.ci install-enclave
           echo "✅ Enclave Lab installed" >> $GITHUB_STEP_SUMMARY
 
       - name: Phase 1 - Prepare binaries and content
@@ -122,7 +122,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Downloading OpenShift binaries and content..." >> $GITHUB_STEP_SUMMARY
 
-          make deploy-cluster-prepare
+          make -f Makefile.ci deploy-cluster-prepare
 
           echo "✅ Phase 1 complete" >> $GITHUB_STEP_SUMMARY
 
@@ -133,7 +133,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Setting up local mirror registry (disconnected mode)..." >> $GITHUB_STEP_SUMMARY
 
-          make deploy-cluster-mirror
+          make -f Makefile.ci deploy-cluster-mirror
 
           echo "✅ Phase 2 complete" >> $GITHUB_STEP_SUMMARY
 
@@ -144,7 +144,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Deploying OpenShift cluster (mode: disconnected)..." >> $GITHUB_STEP_SUMMARY
 
-          make deploy-cluster-install
+          make -f Makefile.ci deploy-cluster-install
 
           echo "✅ Phase 3 complete - Cluster deployed" >> $GITHUB_STEP_SUMMARY
 
@@ -155,7 +155,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Configuring cluster (secrets, certificates, API health)..." >> $GITHUB_STEP_SUMMARY
 
-          make deploy-cluster-post-install
+          make -f Makefile.ci deploy-cluster-post-install
 
           echo "✅ Phase 4 complete" >> $GITHUB_STEP_SUMMARY
 
@@ -166,7 +166,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Installing and configuring operators..." >> $GITHUB_STEP_SUMMARY
 
-          make deploy-cluster-operators
+          make -f Makefile.ci deploy-cluster-operators
 
           echo "✅ Phase 5 complete" >> $GITHUB_STEP_SUMMARY
 
@@ -177,7 +177,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Configuring advanced features and policies..." >> $GITHUB_STEP_SUMMARY
 
-          make deploy-cluster-day2
+          make -f Makefile.ci deploy-cluster-day2
 
           echo "✅ Phase 6 complete" >> $GITHUB_STEP_SUMMARY
 
@@ -188,7 +188,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Configuring hardware discovery infrastructure..." >> $GITHUB_STEP_SUMMARY
 
-          make deploy-cluster-discovery
+          make -f Makefile.ci deploy-cluster-discovery
 
           echo "✅ Phase 7 complete - Full deployment complete" >> $GITHUB_STEP_SUMMARY
 
@@ -197,7 +197,7 @@ jobs:
         id: verify_cluster
         run: |
           # Run standard cluster verification
-          make verify-cluster
+          make -f Makefile.ci verify-cluster
 
           # Additional verification for disconnected mode - check mirror registry
           LZ_IP=$(./scripts/utils/get_landing_zone_ip.sh)
@@ -290,7 +290,7 @@ jobs:
           echo "## Cleanup Infrastructure" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          make clean
+          make -f Makefile.ci clean
 
           echo "✅ Infrastructure cleaned up" >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -38,7 +38,7 @@ jobs:
           echo "## Shell Script Validation" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          if make validate-shell 2>&1 | tee shellcheck.log; then
+          if make -f Makefile.ci validate-shell 2>&1 | tee shellcheck.log; then
             echo "### ✅ Shell script validation passed!" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
@@ -85,7 +85,7 @@ jobs:
           echo "## YAML Validation" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          if make validate-yaml 2>&1 | tee yamllint.log; then
+          if make -f Makefile.ci validate-yaml 2>&1 | tee yamllint.log; then
             echo "### ✅ YAML validation passed!" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
@@ -132,7 +132,7 @@ jobs:
           echo "## JSON Schema Validation" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          if make validate-json-schema 2>&1 | tee json-schema.log; then
+          if make -f Makefile.ci validate-json-schema 2>&1 | tee json-schema.log; then
             echo "### ✅ JSON schema validation passed!" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
@@ -179,7 +179,7 @@ jobs:
           echo "## Ansible Playbook Validation" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          if make validate-ansible 2>&1 | tee ansible-lint.log; then
+          if make -f Makefile.ci validate-ansible 2>&1 | tee ansible-lint.log; then
             echo "### ✅ Ansible playbook validation passed!" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
@@ -226,7 +226,7 @@ jobs:
           echo "## Ansible Tags Validation" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          if make validate-tags 2>&1 | tee tags.log; then
+          if make -f Makefile.ci validate-tags 2>&1 | tee tags.log; then
             echo "### ✅ Ansible tags validation passed!" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "All critical playbook tags work correctly:" >> $GITHUB_STEP_SUMMARY
@@ -275,7 +275,7 @@ jobs:
           echo "## Makefile Validation" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          if make validate-makefile 2>&1 | tee makefile.log; then
+          if make -f Makefile.ci validate-makefile 2>&1 | tee makefile.log; then
             echo "### ✅ Makefile validation passed!" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
@@ -322,7 +322,7 @@ jobs:
           echo "## Plugin Validation" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          if make validate-plugins 2>&1 | tee plugins.log; then
+          if make -f Makefile.ci validate-plugins 2>&1 | tee plugins.log; then
             echo "### ✅ Plugin validation passed!" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "\`\`\`" >> $GITHUB_STEP_SUMMARY

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ deploy-plugin:
 		echo "Error: PLUGIN variable must be set. Usage: make deploy-plugin PLUGIN=<name>"; \
 		exit 1; \
 	fi
-	@$(AP) playbooks/deploy-plugin.yaml $(AP_FLAGS) -e plugin_name=$(PLUGIN)
+	@$(AP) playbooks/deploy-plugin.yaml $(AP_FLAGS) -e 'plugin_name=$(PLUGIN)'
 
 # Convenience targets
 bootstrap:

--- a/Makefile
+++ b/Makefile
@@ -1,413 +1,133 @@
 # Enclave Lab - Makefile
-#
-# Validation targets:
-#   make validate              - Run all validation checks
-#   make validate-shell        - Validate shell scripts with shellcheck
-#   make validate-yaml         - Validate YAML files with yamllint
-#   make validate-json-schema  - Validate JSON schema
-#   make validate-ansible      - Validate Ansible playbooks with ansible-lint
-#   make validate-tags         - Validate Ansible playbook tags
-#   make validate-makefile     - Validate Makefile syntax
-#   make validate-plugins      - Validate plugin directory structure
-#
-# CI Infrastructure targets:
-#   make environment                      - Create test infrastructure (VMs, networks, BMC)
-#   make provision-landing-zone           - Provision Landing Zone VM with CentOS Stream 10
-#   make verify-landing-zone              - Verify Landing Zone VM is properly configured
-#   make install-enclave                  - Install Enclave Lab on Landing Zone VM
-#   make verify-enclave-installation      - Verify Enclave Lab installation
-#   make deploy-cluster                   - Deploy OpenShift cluster using Enclave Lab
-#   make verify                           - Verify infrastructure is working
-#   make clean                            - Clean up infrastructure
+# Runs directly on the Landing Zone (no scripts/ dependency)
 
-.PHONY: help validate validate-shell validate-yaml validate-json-schema validate-ansible validate-tags validate-makefile validate-plugins build-ci-image push-ci-image test-ci-image build-push-ci-image environment provision-landing-zone verify-landing-zone install-enclave verify-enclave-installation deploy-cluster deploy-cluster-prepare deploy-cluster-mirror deploy-cluster-install deploy-cluster-post-install deploy-cluster-operators deploy-cluster-day2 deploy-cluster-discovery deploy-plugin verify clean verify-cluster verify-cleanup generate-cluster-name setup-working-dir collect-step-logs preflight-checks collect-artifacts-basic collect-artifacts-deployment collect-artifacts-full ci-flow-connected ci-flow-disconnected
+.PHONY: help setup setup-env setup-ansible validate-config validate-schema \
+        deploy-cluster deploy-cluster-prepare deploy-cluster-mirror \
+        deploy-cluster-pre-install-validate \
+        deploy-cluster-install deploy-cluster-post-install deploy-cluster-operators \
+        deploy-cluster-day2 deploy-cluster-discovery deploy-cluster-connected \
+        deploy-plugin bootstrap sync
 
 # Configuration
-DEV_SCRIPTS_PATH ?=
-WORKING_DIR ?= /opt/dev-scripts
+WORKING_DIR ?= $(HOME)
+DISCONNECTED ?= true
+PLUGIN ?=
+GLOBAL_VARS ?= config/global.yaml
+CERTS_VARS ?= config/certificates.yaml
+CLOUD_INFRA_VARS ?= config/cloud_infra.yaml
 
-# Cluster name for parallel execution isolation (can be overridden)
-ENCLAVE_CLUSTER_NAME ?= enclave-test
-ENVIRONMENT_JSON := $(WORKING_DIR)/environment-$(ENCLAVE_CLUSTER_NAME).json
-CONFIG_NAME := config_$(ENCLAVE_CLUSTER_NAME).sh
+# Ansible
+AP = ansible-playbook
+AP_FLAGS = -e workingDir=$(WORKING_DIR) -e disconnected=$(DISCONNECTED)
 
 # Default target
 help:
-	@echo "Enclave Lab - Makefile"
+	@echo "Enclave Lab - Landing Zone Makefile"
+	@echo ""
+	@echo "Setup targets:"
+	@echo "  make setup                            - Run full setup (setup-env + setup-ansible)"
+	@echo "  make setup-env                        - Install system packages and dependencies"
+	@echo "  make setup-ansible                    - Install Ansible collections and roles"
 	@echo ""
 	@echo "Validation targets:"
-	@echo "  make validate              - Run all validation checks"
-	@echo "  make validate-shell        - Validate shell scripts with shellcheck"
-	@echo "  make validate-yaml         - Validate YAML files with yamllint"
-	@echo "  make validate-json-schema  - Validate JSON schema"
-	@echo "  make validate-ansible      - Validate Ansible playbooks with ansible-lint"
-	@echo "  make validate-tags         - Validate Ansible playbook tags"
-	@echo "  make validate-makefile     - Validate Makefile syntax"
-	@echo "  make validate-plugins      - Validate plugin directory structure"
+	@echo "  make validate-config                  - Validate configuration files"
+	@echo "  make validate-schema                  - Validate configuration against JSON schemas"
 	@echo ""
-	@echo "CI Image targets:"
-	@echo "  make build-ci-image        - Build CI container image locally"
-	@echo "  make push-ci-image         - Push CI image to Quay.io"
-	@echo "  make test-ci-image         - Test CI image locally"
-	@echo "  make build-push-ci-image   - Build and push CI image"
-	@echo ""
-	@echo "CI Infrastructure targets:"
-	@echo "  make environment                      - Create test infrastructure (VMs, networks, BMC emulation)"
-	@echo "  make provision-landing-zone           - Provision Landing Zone VM with CentOS Stream 10"
-	@echo "  make verify-landing-zone              - Verify Landing Zone VM is properly configured"
-	@echo "  make install-enclave                  - Install Enclave Lab on Landing Zone VM"
-	@echo "  make verify-enclave-installation      - Verify Enclave Lab installation"
+	@echo "Deployment targets:"
 	@echo "  make deploy-cluster                   - Deploy OpenShift cluster (all phases)"
-	@echo "  make verify                           - Verify infrastructure setup"
-	@echo "  make clean                            - Clean up infrastructure"
-	@echo ""
-	@echo "CI Verification targets:"
-	@echo "  make verify-cluster                   - Verify OpenShift cluster deployment"
-	@echo "  make verify-cleanup                   - Verify infrastructure cleanup"
-	@echo ""
-	@echo "CI Helper targets:"
-	@echo "  make generate-cluster-name            - Generate unique cluster name (auto-called by setup-working-dir)"
-	@echo "  make setup-working-dir                - Setup cluster-specific working directory"
-	@echo "  make collect-step-logs                - Collect logs from dev-scripts and cluster"
-	@echo "  make preflight-checks                 - Run pre-flight environment checks"
-	@echo "  make collect-artifacts-basic          - Collect basic artifacts"
-	@echo "  make collect-artifacts-deployment     - Collect deployment artifacts"
-	@echo "  make collect-artifacts-full           - Collect all artifacts"
-	@echo ""
-	@echo "Local CI Testing targets:"
-	@echo "  make ci-flow-connected                - Run full CI flow locally (connected mode)"
-	@echo "  make ci-flow-disconnected             - Run full CI flow locally (disconnected mode)"
-	@echo ""
-	@echo "Deploy individual phases (for granular control):"
 	@echo "  make deploy-cluster-prepare           - Phase 1: Download binaries and content"
 	@echo "  make deploy-cluster-mirror            - Phase 2: Mirror registry setup (disconnected)"
+	@echo "  make deploy-cluster-pre-install-validate - Validate servers are ready before install"
 	@echo "  make deploy-cluster-install           - Phase 3: Deploy OpenShift cluster"
 	@echo "  make deploy-cluster-post-install      - Phase 4: Cluster configuration"
 	@echo "  make deploy-cluster-operators         - Phase 5: Install operators"
 	@echo "  make deploy-cluster-day2              - Phase 6: Day-2 operations"
 	@echo "  make deploy-cluster-discovery         - Phase 7: Configure hardware discovery"
+	@echo "  make deploy-cluster-connected         - Deploy in connected mode (DISCONNECTED=false)"
 	@echo ""
 	@echo "Plugin deployment:"
-	@echo "  make deploy-plugin PLUGIN=<name>    - Deploy a single plugin (e.g., openshift-ai)"
+	@echo "  make deploy-plugin PLUGIN=<name>      - Deploy a single plugin (e.g., openshift-ai)"
 	@echo ""
-	@echo "Required configuration for CI targets:"
-	@echo "  DEV_SCRIPTS_PATH  - Path to dev-scripts installation (must be set)"
+	@echo "Convenience targets:"
+	@echo "  make bootstrap                        - Bootstrap the Landing Zone"
+	@echo "  make sync                             - Sync configuration to the Landing Zone"
 	@echo ""
-	@echo "Optional configuration:"
-	@echo "  WORKING_DIR       - Working directory (default: /opt/dev-scripts)"
+	@echo "Configuration variables:"
+	@echo "  WORKING_DIR      - Working directory (default: $$HOME)"
+	@echo "  DISCONNECTED     - Disconnected mode (default: true)"
+	@echo "  PLUGIN           - Plugin name for deploy-plugin target"
+	@echo "  GLOBAL_VARS      - Path to global vars file (default: config/global.yaml)"
+	@echo "  CERTS_VARS       - Path to certificates vars file (default: config/certificates.yaml)"
+	@echo "  CLOUD_INFRA_VARS - Path to cloud infra vars file (default: config/cloud_infra.yaml)"
 	@echo ""
 	@echo "Current values:"
-	@echo "  DEV_SCRIPTS_PATH=$(DEV_SCRIPTS_PATH)"
 	@echo "  WORKING_DIR=$(WORKING_DIR)"
-	@echo "  BASE_WORKING_DIR=$(BASE_WORKING_DIR)"
-	@if [ -n "$(ENCLAVE_CLUSTER_NAME)" ]; then \
-		echo "  ENCLAVE_CLUSTER_NAME=$(ENCLAVE_CLUSTER_NAME)"; \
-	else \
-		echo "  ENCLAVE_CLUSTER_NAME=(will be auto-generated)"; \
-	fi
+	@echo "  DISCONNECTED=$(DISCONNECTED)"
 	@echo ""
-	@echo "Example workflow (full deployment):"
-	@echo "  make validate                # Validate code quality"
-	@echo "  export DEV_SCRIPTS_PATH=/path/to/dev-scripts"
-	@echo "  export BASE_WORKING_DIR=/opt/clusters"
-	@echo "  export CI_TOKEN=your-token"
-	@echo ""
-	@echo "  make environment                # Step 1: Create infrastructure (auto-generates cluster name)"
-	@echo "  make provision-landing-zone     # Step 2: Install OS on Landing Zone"
-	@echo "  make install-enclave            # Step 3: Install Enclave Lab"
-	@echo "  make deploy-cluster             # Step 4: Deploy OpenShift (all phases)"
-	@echo ""
-	@echo "  Or run the complete flow in one command:"
-	@echo "  make ci-flow-connected          # Runs all steps above automatically"
-	@echo ""
-	@echo "Example workflow (granular deployment):"
-	@echo "  # After install-enclave, deploy individual phases:"
-	@echo "  make deploy-cluster-prepare         # Phase 1: Prepare"
-	@echo "  make deploy-cluster-mirror          # Phase 2: Mirror (if disconnected)"
-	@echo "  make deploy-cluster-install         # Phase 3: Install cluster"
-	@echo "  make deploy-cluster-post-install    # Phase 4: Post-install config"
-	@echo "  make deploy-cluster-operators       # Phase 5: Operators"
-	@echo "  make deploy-cluster-day2            # Phase 6: Day-2 ops"
-	@echo "  make deploy-cluster-discovery       # Phase 7: Discovery"
-	@echo ""
-	@echo "Requirements for CI targets:"
-	@echo "  - dev-scripts with infra_only target support"
-	@echo "  - libvirt installed and running"
-	@echo "  - Sufficient resources (64GB+ RAM recommended)"
-	@echo "  - CI_TOKEN environment variable set"
+	@echo "Examples:"
+	@echo "  make deploy-cluster                                     # Full disconnected deployment"
+	@echo "  make deploy-cluster-connected                           # Full connected deployment"
+	@echo "  WORKING_DIR=/home/cloud-user make deploy-cluster        # Custom working directory"
+	@echo "  make deploy-plugin PLUGIN=openshift-ai                  # Deploy a plugin"
+
+# Setup targets
+setup: setup-env setup-ansible
+
+setup-env:
+	@sudo bash ./setup_env.sh
+
+setup-ansible:
+	@bash ./setup_ansible.sh
 
 # Validation targets
-validate:
-	@./scripts/verification/validate.sh all
+validate-config:
+	@bash ./validations.sh --global-vars $(GLOBAL_VARS) --certs-vars $(CERTS_VARS)
 
-validate-shell:
-	@./scripts/verification/validate.sh shell
+validate-schema:
+	@$(AP) playbooks/validate-schema.yaml -e@$(GLOBAL_VARS) -e@$(CERTS_VARS) --tags schema-validation
 
-validate-yaml:
-	@./scripts/verification/validate.sh yaml
-
-validate-json-schema:
-	@./scripts/verification/validate.sh json-schema
-
-validate-ansible:
-	@./scripts/verification/validate.sh ansible
-
-validate-tags:
-	@./scripts/verification/validate.sh tags
-
-validate-makefile:
-	@./scripts/verification/validate.sh makefile
-
-validate-plugins:
-	@./scripts/verification/validate.sh plugins
-
-# CI Image targets
-CI_IMAGE_NAME ?= quay.io/eerez/enclave-lab-ci
-CI_IMAGE_TAG ?= latest
-CI_IMAGE_FULL := $(CI_IMAGE_NAME):$(CI_IMAGE_TAG)
-
-build-ci-image:
-	@echo "Building CI image: $(CI_IMAGE_FULL)"
-	podman build -f .github/workflows/Dockerfile.ci -t $(CI_IMAGE_FULL) .
-	@echo "✅ CI image built successfully: $(CI_IMAGE_FULL)"
-
-push-ci-image:
-	@echo "Pushing CI image: $(CI_IMAGE_FULL)"
-	@if [ -z "$(QUAY_USER)" ] || [ -z "$(QUAY_TOKEN)" ]; then \
-		echo "Error: QUAY_USER and QUAY_TOKEN environment variables must be set"; \
-		exit 1; \
-	fi
-	@echo "$(QUAY_TOKEN)" | podman login quay.io -u "$(QUAY_USER)" --password-stdin
-	podman push $(CI_IMAGE_FULL)
-	@echo "✅ CI image pushed successfully: $(CI_IMAGE_FULL)"
-
-test-ci-image:
-	@echo "Testing CI image: $(CI_IMAGE_FULL)"
-	@echo ""
-	@echo "Test 1: Verify shellcheck is installed..."
-	@podman run --rm $(CI_IMAGE_FULL) shellcheck --version
-	@echo ""
-	@echo "Test 2: Verify yamllint is installed..."
-	@podman run --rm $(CI_IMAGE_FULL) yamllint --version
-	@echo ""
-	@echo "Test 3: Verify ansible-lint is installed..."
-	@podman run --rm $(CI_IMAGE_FULL) ansible-lint --version
-	@echo ""
-	@echo "Test 4: Verify ansible-core is installed..."
-	@podman run --rm $(CI_IMAGE_FULL) ansible --version
-	@echo ""
-	@echo "Test 5: Verify make is installed..."
-	@podman run --rm $(CI_IMAGE_FULL) make --version
-	@echo ""
-	@echo "Test 6: Verify docker CLI is installed..."
-	@podman run --rm $(CI_IMAGE_FULL) docker --version
-	@echo ""
-	@echo "✅ All CI image tests passed!"
-
-build-push-ci-image: build-ci-image push-ci-image
-	@echo "✅ CI image built and pushed successfully!"
-
-# Create test infrastructure
-environment:
-	@echo "=========================================="
-	@echo "Creating Enclave test environment"
-	@echo "=========================================="
-	@echo ""
-	@echo "Step 1: Validating prerequisites..."
-	@./scripts/setup/validate_prerequisites.sh
-	@echo ""
-	@echo "Step 2: Configuring dev-scripts environment..."
-	@./scripts/setup/configure_devscripts.sh
-	@echo ""
-	@echo "Step 3: Creating infrastructure (VMs, networks, BMC)..."
-	@echo "  (Using lock to prevent conflicts with parallel runners)"
-	@./scripts/utils/with_libvirt_lock.sh sh -c "cd $(DEV_SCRIPTS_PATH) && CONFIG=$(CONFIG_NAME) make infra_only && $(CURDIR)/scripts/infrastructure/configure_gpu_passthrough.sh"
-	@echo ""
-	@echo "Step 4: Verifying networks were created..."
-	@./scripts/infrastructure/verify_networks.sh
-	@echo ""
-	@echo "Step 5: Starting BMC emulation (sushy-tools)..."
-	@./scripts/infrastructure/start_sushy_tools.sh
-	@echo ""
-	@echo "Step 6: Generating environment metadata..."
-	@./scripts/infrastructure/generate_environment_json.sh
-	@echo ""
-	@echo "Step 7: Verifying infrastructure..."
-	@$(MAKE) verify
-	@echo ""
-	@echo "=========================================="
-	@echo "✅ Environment creation complete!"
-	@echo "=========================================="
-
-# Provision Landing Zone VM with CentOS Stream 10
-provision-landing-zone:
-	@echo "=========================================="
-	@echo "Provisioning Landing Zone VM"
-	@echo "=========================================="
-	@echo ""
-	@./scripts/infrastructure/provision_landing_zone.sh
-	@echo ""
-	@echo "Verifying Landing Zone VM..."
-	@$(MAKE) verify-landing-zone
-	@echo ""
-	@echo "=========================================="
-	@echo "✅ Landing Zone VM provisioned!"
-	@echo "=========================================="
-
-# Verify Landing Zone VM
-verify-landing-zone:
-	@echo "=========================================="
-	@echo "Verifying Landing Zone VM"
-	@echo "=========================================="
-	@echo ""
-	@./scripts/verification/verify_landing_zone.sh
-
-# Install Enclave Lab on Landing Zone VM
-install-enclave:
-	@echo "=========================================="
-	@echo "Installing Enclave Lab on Landing Zone"
-	@echo "=========================================="
-	@echo ""
-	@./scripts/deployment/install_enclave.sh
-	@echo ""
-	@echo "Verifying Enclave Lab installation..."
-	@$(MAKE) verify-enclave-installation
-	@echo ""
-	@echo "=========================================="
-	@echo "✅ Enclave Lab installation complete!"
-	@echo "=========================================="
-
-# Verify Enclave Lab installation
-verify-enclave-installation:
-	@echo "=========================================="
-	@echo "Verifying Enclave Lab Installation"
-	@echo "=========================================="
-	@echo ""
-	@./scripts/verification/verify_enclave_installation.sh
-
-# Deploy OpenShift cluster using Enclave Lab (all phases)
+# Deploy targets
 deploy-cluster:
-	@echo "=========================================="
-	@echo "Deploying OpenShift Cluster with Enclave Lab"
-	@echo "=========================================="
-	@echo ""
-	@./scripts/deployment/deploy_cluster.sh
+	@$(AP) playbooks/main.yaml $(AP_FLAGS)
 
-# Deploy individual phases (for granular control in CI)
 deploy-cluster-prepare:
-	@echo "=========================================="
-	@echo "Phase 1: Prepare - Download binaries and content"
-	@echo "=========================================="
-	@echo ""
-	@./scripts/deployment/deploy_phase.sh 01-prepare.yaml
+	@$(AP) playbooks/01-prepare.yaml $(AP_FLAGS)
 
 deploy-cluster-mirror:
-	@echo "=========================================="
-	@echo "Phase 2: Mirror - Set up local registry (disconnected only)"
-	@echo "=========================================="
-	@echo ""
-	@./scripts/deployment/deploy_phase.sh 02-mirror.yaml
+	@$(AP) playbooks/02-mirror.yaml $(AP_FLAGS)
+
+deploy-cluster-pre-install-validate:
+	@$(AP) playbooks/03-deploy.yaml $(AP_FLAGS) --tags pre-install-validate
 
 deploy-cluster-install:
-	@echo "=========================================="
-	@echo "Phase 3: Deploy - Deploy OpenShift cluster"
-	@echo "=========================================="
-	@echo ""
-	@./scripts/deployment/deploy_phase.sh 03-deploy.yaml
+	@$(AP) playbooks/03-deploy.yaml $(AP_FLAGS)
 
 deploy-cluster-post-install:
-	@echo "=========================================="
-	@echo "Phase 4: Post-Install - Cluster configuration"
-	@echo "=========================================="
-	@echo ""
-	@./scripts/deployment/deploy_phase.sh 04-post-install.yaml
+	@$(AP) playbooks/04-post-install.yaml $(AP_FLAGS)
 
 deploy-cluster-operators:
-	@echo "=========================================="
-	@echo "Phase 5: Operators - Install and configure operators"
-	@echo "=========================================="
-	@echo ""
-	@./scripts/deployment/deploy_phase.sh 05-operators.yaml
+	@$(AP) playbooks/05-operators.yaml $(AP_FLAGS)
 
 deploy-cluster-day2:
-	@echo "=========================================="
-	@echo "Phase 6: Day-2 - Advanced features and policies"
-	@echo "=========================================="
-	@echo ""
-	@./scripts/deployment/deploy_phase.sh 06-day2.yaml
+	@$(AP) playbooks/06-day2.yaml $(AP_FLAGS)
 
 deploy-cluster-discovery:
-	@echo "=========================================="
-	@echo "Phase 7: Configure Discovery - Hardware discovery (optional)"
-	@echo "=========================================="
-	@echo ""
-	@./scripts/deployment/deploy_phase.sh 07-configure-discovery.yaml
+	@$(AP) playbooks/07-configure-discovery.yaml $(AP_FLAGS) -e@$(CLOUD_INFRA_VARS)
 
-# Deploy a single plugin
+deploy-cluster-connected:
+	@$(MAKE) deploy-cluster DISCONNECTED=false
+
+# Plugin deployment
 deploy-plugin:
-	@echo "=========================================="
-	@echo "Deploying plugin: $(PLUGIN)"
-	@echo "=========================================="
-	@echo ""
-	@./scripts/deployment/deploy_plugin.sh $(PLUGIN)
+	@if [ -z "$(PLUGIN)" ]; then \
+		echo "Error: PLUGIN variable must be set. Usage: make deploy-plugin PLUGIN=<name>"; \
+		exit 1; \
+	fi
+	@$(AP) playbooks/deploy-plugin.yaml $(AP_FLAGS) -e plugin_name=$(PLUGIN)
 
-# Verify infrastructure
-verify:
-	@echo "Verifying infrastructure..."
-	@./scripts/verification/verify_infrastructure.sh
+# Convenience targets
+bootstrap:
+	@bash ./bootstrap.sh --global-vars $(GLOBAL_VARS) --certs-vars $(CERTS_VARS)
 
-# Clean up infrastructure
-clean:
-	@./scripts/cleanup/cleanup.sh
-
-# Verification targets
-verify-cluster:
-	@./scripts/verification/verify_cluster.sh
-
-verify-cleanup:
-	@./scripts/cleanup/verify_cleanup.sh
-
-# Helper targets
-generate-cluster-name:
-	@./scripts/setup/generate_cluster_name.sh
-
-setup-working-dir:
-	@./scripts/setup/setup_working_dir.sh
-
-collect-step-logs:
-	@./scripts/verification/collect_step_logs.sh step-logs
-
-preflight-checks:
-	@./scripts/setup/preflight_checks.sh
-
-# Artifact collection wrappers (use existing script)
-collect-artifacts-basic:
-	@./scripts/verification/collect_ci_artifacts.sh basic artifacts
-
-collect-artifacts-deployment:
-	@./scripts/verification/collect_ci_artifacts.sh deployment artifacts
-
-collect-artifacts-full:
-	@./scripts/verification/collect_ci_artifacts.sh full artifacts
-
-# Full CI flow for local testing
-ci-flow-connected:
-	@echo "=========================================="
-	@echo "Running full CI flow (connected mode)"
-	@echo "=========================================="
-	@echo ""
-	@$(MAKE) preflight-checks
-	@$(MAKE) setup-working-dir
-	@$(MAKE) environment
-	@$(MAKE) provision-landing-zone
-	@$(MAKE) install-enclave
-	@$(MAKE) deploy-cluster
-	@$(MAKE) verify-cluster
-	@echo ""
-	@echo "=========================================="
-	@echo "✅ CI flow complete!"
-	@echo "=========================================="
-
-ci-flow-disconnected:
-	@echo "Running full CI flow (disconnected mode)"
-	@ENCLAVE_DEPLOYMENT_MODE=disconnected $(MAKE) ci-flow-connected
+sync:
+	@bash ./sync.sh $(GLOBAL_VARS) $(CERTS_VARS)

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -3,9 +3,7 @@
 # Overrides deploy targets to use SSH-based scripts for remote Landing Zone execution
 # Adds CI-only infrastructure, validation, and image build targets
 
-include Makefile
-
-# CI Configuration (override LZ defaults)
+# CI Configuration (set before include so these defaults take precedence)
 DEV_SCRIPTS_PATH ?=
 WORKING_DIR ?= /opt/dev-scripts
 
@@ -18,6 +16,8 @@ CONFIG_NAME := config_$(ENCLAVE_CLUSTER_NAME).sh
 CI_IMAGE_NAME ?= quay.io/eerez/enclave-lab-ci
 CI_IMAGE_TAG ?= latest
 CI_IMAGE_FULL := $(CI_IMAGE_NAME):$(CI_IMAGE_TAG)
+
+include Makefile
 
 .PHONY: validate validate-shell validate-yaml validate-json-schema validate-ansible \
         validate-tags validate-makefile validate-plugins \
@@ -238,11 +238,11 @@ build-ci-image:
 
 push-ci-image:
 	@echo "Pushing CI image: $(CI_IMAGE_FULL)"
-	@if [ -z "$(QUAY_USER)" ] || [ -z "$(QUAY_TOKEN)" ]; then \
+	@if [ -z "$$QUAY_USER" ] || [ -z "$$QUAY_TOKEN" ]; then \
 		echo "Error: QUAY_USER and QUAY_TOKEN environment variables must be set"; \
 		exit 1; \
 	fi
-	@echo "$(QUAY_TOKEN)" | podman login quay.io -u "$(QUAY_USER)" --password-stdin
+	@echo "$$QUAY_TOKEN" | podman login quay.io -u "$$QUAY_USER" --password-stdin
 	podman push $(CI_IMAGE_FULL)
 	@echo "CI image pushed successfully: $(CI_IMAGE_FULL)"
 
@@ -288,6 +288,10 @@ environment:
 	@echo ""
 	@echo "Step 3: Creating infrastructure (VMs, networks, BMC)..."
 	@echo "  (Using lock to prevent conflicts with parallel runners)"
+	@if [ -z "$(DEV_SCRIPTS_PATH)" ]; then \
+		echo "Error: DEV_SCRIPTS_PATH is not set. Set it to the path of your dev-scripts installation."; \
+		exit 1; \
+	fi
 	@./scripts/utils/with_libvirt_lock.sh sh -c "cd $(DEV_SCRIPTS_PATH) && CONFIG=$(CONFIG_NAME) make infra_only && $(CURDIR)/scripts/infrastructure/configure_gpu_passthrough.sh"
 	@echo ""
 	@echo "Step 4: Verifying networks were created..."

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -1,0 +1,414 @@
+# Enclave Lab - CI Makefile
+# Not shipped in tarball
+# Overrides deploy targets to use SSH-based scripts for remote Landing Zone execution
+# Adds CI-only infrastructure, validation, and image build targets
+
+include Makefile
+
+# CI Configuration (override LZ defaults)
+DEV_SCRIPTS_PATH ?=
+WORKING_DIR ?= /opt/dev-scripts
+
+# Cluster name for parallel execution isolation (can be overridden)
+ENCLAVE_CLUSTER_NAME ?= enclave-test
+ENVIRONMENT_JSON := $(WORKING_DIR)/environment-$(ENCLAVE_CLUSTER_NAME).json
+CONFIG_NAME := config_$(ENCLAVE_CLUSTER_NAME).sh
+
+# CI Image
+CI_IMAGE_NAME ?= quay.io/eerez/enclave-lab-ci
+CI_IMAGE_TAG ?= latest
+CI_IMAGE_FULL := $(CI_IMAGE_NAME):$(CI_IMAGE_TAG)
+
+.PHONY: validate validate-shell validate-yaml validate-json-schema validate-ansible \
+        validate-tags validate-makefile validate-plugins \
+        build-ci-image push-ci-image test-ci-image build-push-ci-image \
+        deploy-cluster-pre-install-validate \
+        environment provision-landing-zone verify-landing-zone \
+        install-enclave verify-enclave-installation \
+        verify clean verify-cluster verify-cleanup \
+        generate-cluster-name setup-working-dir collect-step-logs \
+        preflight-checks collect-artifacts-basic collect-artifacts-deployment \
+        collect-artifacts-full ci-flow-connected ci-flow-disconnected
+
+# Override default help to show both LZ and CI targets
+help:
+	@echo "Enclave Lab - CI Makefile"
+	@echo ""
+	@echo "Landing Zone targets (from Makefile):"
+	@echo "  make -f Makefile.ci setup              - Run full setup (setup-env + setup-ansible)"
+	@echo "  make -f Makefile.ci setup-env          - Install system packages and dependencies"
+	@echo "  make -f Makefile.ci setup-ansible      - Install Ansible collections and roles"
+	@echo "  make -f Makefile.ci validate-config    - Validate configuration files"
+	@echo "  make -f Makefile.ci validate-schema    - Validate configuration against JSON schemas"
+	@echo "  make -f Makefile.ci bootstrap          - Bootstrap the Landing Zone"
+	@echo "  make -f Makefile.ci sync               - Sync configuration to the Landing Zone"
+	@echo ""
+	@echo "Validation targets (CI):"
+	@echo "  make -f Makefile.ci validate              - Run all validation checks"
+	@echo "  make -f Makefile.ci validate-shell        - Validate shell scripts with shellcheck"
+	@echo "  make -f Makefile.ci validate-yaml         - Validate YAML files with yamllint"
+	@echo "  make -f Makefile.ci validate-json-schema  - Validate JSON schema"
+	@echo "  make -f Makefile.ci validate-ansible      - Validate Ansible playbooks with ansible-lint"
+	@echo "  make -f Makefile.ci validate-tags         - Validate Ansible playbook tags"
+	@echo "  make -f Makefile.ci validate-makefile     - Validate Makefile syntax"
+	@echo "  make -f Makefile.ci validate-plugins      - Validate plugin directory structure"
+	@echo ""
+	@echo "CI Image targets:"
+	@echo "  make -f Makefile.ci build-ci-image        - Build CI container image locally"
+	@echo "  make -f Makefile.ci push-ci-image         - Push CI image to Quay.io"
+	@echo "  make -f Makefile.ci test-ci-image         - Test CI image locally"
+	@echo "  make -f Makefile.ci build-push-ci-image   - Build and push CI image"
+	@echo ""
+	@echo "CI Infrastructure targets:"
+	@echo "  make -f Makefile.ci environment                      - Create test infrastructure (VMs, networks, BMC emulation)"
+	@echo "  make -f Makefile.ci provision-landing-zone           - Provision Landing Zone VM with CentOS Stream 10"
+	@echo "  make -f Makefile.ci verify-landing-zone              - Verify Landing Zone VM is properly configured"
+	@echo "  make -f Makefile.ci install-enclave                  - Install Enclave Lab on Landing Zone VM"
+	@echo "  make -f Makefile.ci verify-enclave-installation      - Verify Enclave Lab installation"
+	@echo "  make -f Makefile.ci deploy-cluster                   - Deploy OpenShift cluster (all phases, via SSH)"
+	@echo "  make -f Makefile.ci verify                           - Verify infrastructure setup"
+	@echo "  make -f Makefile.ci clean                            - Clean up infrastructure"
+	@echo ""
+	@echo "CI Verification targets:"
+	@echo "  make -f Makefile.ci verify-cluster                   - Verify OpenShift cluster deployment"
+	@echo "  make -f Makefile.ci verify-cleanup                   - Verify infrastructure cleanup"
+	@echo ""
+	@echo "CI Helper targets:"
+	@echo "  make -f Makefile.ci generate-cluster-name            - Generate unique cluster name"
+	@echo "  make -f Makefile.ci setup-working-dir                - Setup cluster-specific working directory"
+	@echo "  make -f Makefile.ci collect-step-logs                - Collect logs from dev-scripts and cluster"
+	@echo "  make -f Makefile.ci preflight-checks                 - Run pre-flight environment checks"
+	@echo "  make -f Makefile.ci collect-artifacts-basic          - Collect basic artifacts"
+	@echo "  make -f Makefile.ci collect-artifacts-deployment     - Collect deployment artifacts"
+	@echo "  make -f Makefile.ci collect-artifacts-full           - Collect all artifacts"
+	@echo ""
+	@echo "Local CI Testing targets:"
+	@echo "  make -f Makefile.ci ci-flow-connected                - Run full CI flow locally (connected mode)"
+	@echo "  make -f Makefile.ci ci-flow-disconnected             - Run full CI flow locally (disconnected mode)"
+	@echo ""
+	@echo "Deploy individual phases (via SSH to Landing Zone):"
+	@echo "  make -f Makefile.ci deploy-cluster-prepare           - Phase 1: Download binaries and content"
+	@echo "  make -f Makefile.ci deploy-cluster-mirror            - Phase 2: Mirror registry setup (disconnected)"
+	@echo "  make -f Makefile.ci deploy-cluster-pre-install-validate - Validate servers are ready"
+	@echo "  make -f Makefile.ci deploy-cluster-install           - Phase 3: Deploy OpenShift cluster"
+	@echo "  make -f Makefile.ci deploy-cluster-post-install      - Phase 4: Cluster configuration"
+	@echo "  make -f Makefile.ci deploy-cluster-operators         - Phase 5: Install operators"
+	@echo "  make -f Makefile.ci deploy-cluster-day2              - Phase 6: Day-2 operations"
+	@echo "  make -f Makefile.ci deploy-cluster-discovery         - Phase 7: Configure hardware discovery"
+	@echo ""
+	@echo "Plugin deployment (via SSH to Landing Zone):"
+	@echo "  make -f Makefile.ci deploy-plugin PLUGIN=<name>      - Deploy a specific plugin"
+	@echo ""
+	@echo "Required configuration for CI targets:"
+	@echo "  DEV_SCRIPTS_PATH  - Path to dev-scripts installation (must be set)"
+	@echo ""
+	@echo "Optional configuration:"
+	@echo "  WORKING_DIR       - Working directory (default: /opt/dev-scripts)"
+	@echo ""
+	@echo "Current values:"
+	@echo "  DEV_SCRIPTS_PATH=$(DEV_SCRIPTS_PATH)"
+	@echo "  WORKING_DIR=$(WORKING_DIR)"
+	@echo "  BASE_WORKING_DIR=$(BASE_WORKING_DIR)"
+	@if [ -n "$(ENCLAVE_CLUSTER_NAME)" ]; then \
+		echo "  ENCLAVE_CLUSTER_NAME=$(ENCLAVE_CLUSTER_NAME)"; \
+	else \
+		echo "  ENCLAVE_CLUSTER_NAME=(will be auto-generated)"; \
+	fi
+	@echo ""
+	@echo "Example workflow (full deployment):"
+	@echo "  make -f Makefile.ci validate                # Validate code quality"
+	@echo "  export DEV_SCRIPTS_PATH=/path/to/dev-scripts"
+	@echo "  export BASE_WORKING_DIR=/opt/clusters"
+	@echo "  export CI_TOKEN=your-token"
+	@echo ""
+	@echo "  make -f Makefile.ci environment                # Step 1: Create infrastructure"
+	@echo "  make -f Makefile.ci provision-landing-zone     # Step 2: Install OS on Landing Zone"
+	@echo "  make -f Makefile.ci install-enclave            # Step 3: Install Enclave Lab"
+	@echo "  make -f Makefile.ci deploy-cluster             # Step 4: Deploy OpenShift (all phases)"
+	@echo ""
+	@echo "  Or run the complete flow in one command:"
+	@echo "  make -f Makefile.ci ci-flow-connected          # Runs all steps above automatically"
+	@echo ""
+	@echo "Requirements for CI targets:"
+	@echo "  - dev-scripts with infra_only target support"
+	@echo "  - libvirt installed and running"
+	@echo "  - Sufficient resources (64GB+ RAM recommended)"
+	@echo "  - CI_TOKEN environment variable set"
+
+# --- Override deploy targets to use SSH-based scripts ---
+
+deploy-cluster:
+	@echo "=========================================="
+	@echo "Deploying OpenShift Cluster with Enclave Lab"
+	@echo "=========================================="
+	@echo ""
+	@./scripts/deployment/deploy_cluster.sh
+
+deploy-cluster-prepare:
+	@echo "=========================================="
+	@echo "Phase 1: Prepare - Download binaries and content"
+	@echo "=========================================="
+	@echo ""
+	@./scripts/deployment/deploy_phase.sh 01-prepare.yaml
+
+deploy-cluster-mirror:
+	@echo "=========================================="
+	@echo "Phase 2: Mirror - Set up local registry (disconnected only)"
+	@echo "=========================================="
+	@echo ""
+	@./scripts/deployment/deploy_phase.sh 02-mirror.yaml
+
+deploy-cluster-pre-install-validate:
+	@echo "=========================================="
+	@echo "Pre-Install Validate - Check servers are ready"
+	@echo "=========================================="
+	@echo ""
+	@./scripts/deployment/deploy_phase.sh 03-deploy.yaml --tags pre-install-validate
+
+deploy-cluster-install:
+	@echo "=========================================="
+	@echo "Phase 3: Deploy - Deploy OpenShift cluster"
+	@echo "=========================================="
+	@echo ""
+	@./scripts/deployment/deploy_phase.sh 03-deploy.yaml
+
+deploy-cluster-post-install:
+	@echo "=========================================="
+	@echo "Phase 4: Post-Install - Cluster configuration"
+	@echo "=========================================="
+	@echo ""
+	@./scripts/deployment/deploy_phase.sh 04-post-install.yaml
+
+deploy-cluster-operators:
+	@echo "=========================================="
+	@echo "Phase 5: Operators - Install and configure operators"
+	@echo "=========================================="
+	@echo ""
+	@./scripts/deployment/deploy_phase.sh 05-operators.yaml
+
+deploy-cluster-day2:
+	@echo "=========================================="
+	@echo "Phase 6: Day-2 - Advanced features and policies"
+	@echo "=========================================="
+	@echo ""
+	@./scripts/deployment/deploy_phase.sh 06-day2.yaml
+
+deploy-cluster-discovery:
+	@echo "=========================================="
+	@echo "Phase 7: Configure Discovery - Hardware discovery (optional)"
+	@echo "=========================================="
+	@echo ""
+	@./scripts/deployment/deploy_phase.sh 07-configure-discovery.yaml
+
+deploy-plugin:
+	@./scripts/deployment/deploy_plugin.sh $(PLUGIN)
+
+# --- Validation targets (CI only) ---
+
+validate:
+	@./scripts/verification/validate.sh all
+
+validate-shell:
+	@./scripts/verification/validate.sh shell
+
+validate-yaml:
+	@./scripts/verification/validate.sh yaml
+
+validate-json-schema:
+	@./scripts/verification/validate.sh json-schema
+
+validate-ansible:
+	@./scripts/verification/validate.sh ansible
+
+validate-tags:
+	@./scripts/verification/validate.sh tags
+
+validate-makefile:
+	@./scripts/verification/validate.sh makefile
+
+validate-plugins:
+	@./scripts/verification/validate.sh plugins
+
+# --- CI Image targets ---
+
+build-ci-image:
+	@echo "Building CI image: $(CI_IMAGE_FULL)"
+	podman build -f .github/workflows/Dockerfile.ci -t $(CI_IMAGE_FULL) .
+	@echo "CI image built successfully: $(CI_IMAGE_FULL)"
+
+push-ci-image:
+	@echo "Pushing CI image: $(CI_IMAGE_FULL)"
+	@if [ -z "$(QUAY_USER)" ] || [ -z "$(QUAY_TOKEN)" ]; then \
+		echo "Error: QUAY_USER and QUAY_TOKEN environment variables must be set"; \
+		exit 1; \
+	fi
+	@echo "$(QUAY_TOKEN)" | podman login quay.io -u "$(QUAY_USER)" --password-stdin
+	podman push $(CI_IMAGE_FULL)
+	@echo "CI image pushed successfully: $(CI_IMAGE_FULL)"
+
+test-ci-image:
+	@echo "Testing CI image: $(CI_IMAGE_FULL)"
+	@echo ""
+	@echo "Test 1: Verify shellcheck is installed..."
+	@podman run --rm $(CI_IMAGE_FULL) shellcheck --version
+	@echo ""
+	@echo "Test 2: Verify yamllint is installed..."
+	@podman run --rm $(CI_IMAGE_FULL) yamllint --version
+	@echo ""
+	@echo "Test 3: Verify ansible-lint is installed..."
+	@podman run --rm $(CI_IMAGE_FULL) ansible-lint --version
+	@echo ""
+	@echo "Test 4: Verify ansible-core is installed..."
+	@podman run --rm $(CI_IMAGE_FULL) ansible --version
+	@echo ""
+	@echo "Test 5: Verify make is installed..."
+	@podman run --rm $(CI_IMAGE_FULL) make --version
+	@echo ""
+	@echo "Test 6: Verify docker CLI is installed..."
+	@podman run --rm $(CI_IMAGE_FULL) docker --version
+	@echo ""
+	@echo "All CI image tests passed!"
+
+build-push-ci-image: build-ci-image push-ci-image
+	@echo "CI image built and pushed successfully!"
+
+# --- CI Infrastructure targets ---
+
+# Create test infrastructure
+environment:
+	@echo "=========================================="
+	@echo "Creating Enclave test environment"
+	@echo "=========================================="
+	@echo ""
+	@echo "Step 1: Validating prerequisites..."
+	@./scripts/setup/validate_prerequisites.sh
+	@echo ""
+	@echo "Step 2: Configuring dev-scripts environment..."
+	@./scripts/setup/configure_devscripts.sh
+	@echo ""
+	@echo "Step 3: Creating infrastructure (VMs, networks, BMC)..."
+	@echo "  (Using lock to prevent conflicts with parallel runners)"
+	@./scripts/utils/with_libvirt_lock.sh sh -c "cd $(DEV_SCRIPTS_PATH) && CONFIG=$(CONFIG_NAME) make infra_only && $(CURDIR)/scripts/infrastructure/configure_gpu_passthrough.sh"
+	@echo ""
+	@echo "Step 4: Verifying networks were created..."
+	@./scripts/infrastructure/verify_networks.sh
+	@echo ""
+	@echo "Step 5: Starting BMC emulation (sushy-tools)..."
+	@./scripts/infrastructure/start_sushy_tools.sh
+	@echo ""
+	@echo "Step 6: Generating environment metadata..."
+	@./scripts/infrastructure/generate_environment_json.sh
+	@echo ""
+	@echo "Step 7: Verifying infrastructure..."
+	@$(MAKE) -f Makefile.ci verify
+	@echo ""
+	@echo "=========================================="
+	@echo "Environment creation complete!"
+	@echo "=========================================="
+
+# Provision Landing Zone VM with CentOS Stream 10
+provision-landing-zone:
+	@echo "=========================================="
+	@echo "Provisioning Landing Zone VM"
+	@echo "=========================================="
+	@echo ""
+	@./scripts/infrastructure/provision_landing_zone.sh
+	@echo ""
+	@echo "Verifying Landing Zone VM..."
+	@$(MAKE) -f Makefile.ci verify-landing-zone
+	@echo ""
+	@echo "=========================================="
+	@echo "Landing Zone VM provisioned!"
+	@echo "=========================================="
+
+# Verify Landing Zone VM
+verify-landing-zone:
+	@echo "=========================================="
+	@echo "Verifying Landing Zone VM"
+	@echo "=========================================="
+	@echo ""
+	@./scripts/verification/verify_landing_zone.sh
+
+# Install Enclave Lab on Landing Zone VM
+install-enclave:
+	@echo "=========================================="
+	@echo "Installing Enclave Lab on Landing Zone"
+	@echo "=========================================="
+	@echo ""
+	@./scripts/deployment/install_enclave.sh
+	@echo ""
+	@echo "Verifying Enclave Lab installation..."
+	@$(MAKE) -f Makefile.ci verify-enclave-installation
+	@echo ""
+	@echo "=========================================="
+	@echo "Enclave Lab installation complete!"
+	@echo "=========================================="
+
+# Verify Enclave Lab installation
+verify-enclave-installation:
+	@echo "=========================================="
+	@echo "Verifying Enclave Lab Installation"
+	@echo "=========================================="
+	@echo ""
+	@./scripts/verification/verify_enclave_installation.sh
+
+# Verify infrastructure
+verify:
+	@echo "Verifying infrastructure..."
+	@./scripts/verification/verify_infrastructure.sh
+
+# Clean up infrastructure
+clean:
+	@./scripts/cleanup/cleanup.sh
+
+# Verification targets
+verify-cluster:
+	@./scripts/verification/verify_cluster.sh
+
+verify-cleanup:
+	@./scripts/cleanup/verify_cleanup.sh
+
+# Helper targets
+generate-cluster-name:
+	@./scripts/setup/generate_cluster_name.sh
+
+setup-working-dir:
+	@./scripts/setup/setup_working_dir.sh
+
+collect-step-logs:
+	@./scripts/verification/collect_step_logs.sh step-logs
+
+preflight-checks:
+	@./scripts/setup/preflight_checks.sh
+
+# Artifact collection wrappers (use existing script)
+collect-artifacts-basic:
+	@./scripts/verification/collect_ci_artifacts.sh basic artifacts
+
+collect-artifacts-deployment:
+	@./scripts/verification/collect_ci_artifacts.sh deployment artifacts
+
+collect-artifacts-full:
+	@./scripts/verification/collect_ci_artifacts.sh full artifacts
+
+# Full CI flow for local testing
+ci-flow-connected:
+	@echo "=========================================="
+	@echo "Running full CI flow (connected mode)"
+	@echo "=========================================="
+	@echo ""
+	@$(MAKE) -f Makefile.ci preflight-checks
+	@$(MAKE) -f Makefile.ci setup-working-dir
+	@$(MAKE) -f Makefile.ci environment
+	@$(MAKE) -f Makefile.ci provision-landing-zone
+	@$(MAKE) -f Makefile.ci install-enclave
+	@$(MAKE) -f Makefile.ci deploy-cluster
+	@$(MAKE) -f Makefile.ci verify-cluster
+	@echo ""
+	@echo "=========================================="
+	@echo "CI flow complete!"
+	@echo "=========================================="
+
+ci-flow-disconnected:
+	@echo "Running full CI flow (disconnected mode)"
+	@ENCLAVE_DEPLOYMENT_MODE=disconnected $(MAKE) -f Makefile.ci ci-flow-connected

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -616,7 +616,33 @@ This ensures that the deployment continues running even if your SSH connection d
 
 ### Running Individual Phases
 
-You can run individual deployment phases using the modular playbooks:
+You can run individual deployment phases using `make`:
+
+```bash
+make deploy-cluster-prepare       # Phase 1: Download binaries and content
+make deploy-cluster-mirror        # Phase 2: Mirror registry (disconnected only)
+make deploy-cluster-pre-install-validate  # Validate servers are ready before install
+make deploy-cluster-install       # Phase 3: Deploy OpenShift cluster
+make deploy-cluster-post-install  # Phase 4: Post-install configuration
+make deploy-cluster-operators     # Phase 5: Install operators
+make deploy-cluster-day2          # Phase 6: Day-2 operations
+make deploy-cluster-discovery     # Phase 7: Hardware discovery
+
+# Deploy a single plugin
+make deploy-plugin PLUGIN=openshift-ai
+
+# Full deployment
+make deploy-cluster
+```
+
+Configuration can be customized via environment variables:
+
+```bash
+WORKING_DIR=/home/cloud-user make deploy-cluster
+DISCONNECTED=false make deploy-cluster    # Connected mode
+```
+
+Or use the raw `ansible-playbook` commands directly:
 
 ```bash
 # Phase 1: Download binaries and content (oc, RHCOS images, etc.)

--- a/scripts/verification/validate.sh
+++ b/scripts/verification/validate.sh
@@ -182,13 +182,25 @@ validate_tags() {
 validate_makefile() {
     print_header "Validating Makefile syntax"
 
+    local failed=0
+
     if make -n help >/dev/null 2>&1; then
         print_success "Makefile syntax is valid"
-        return 0
     else
         print_error "Makefile syntax validation failed"
-        return 1
+        failed=1
     fi
+
+    if [ -f Makefile.ci ]; then
+        if make -f Makefile.ci -n help >/dev/null 2>&1; then
+            print_success "Makefile.ci syntax is valid"
+        else
+            print_error "Makefile.ci syntax validation failed"
+            failed=1
+        fi
+    fi
+
+    return $failed
 }
 
 validate_plugins() {


### PR DESCRIPTION
## Summary

- Rewrite root `Makefile` as a Landing Zone client that calls `ansible-playbook` directly — no `scripts/` dependency, ships in the tarball
- Create `Makefile.ci` that includes `Makefile` and overrides deploy targets to use SSH-based scripts, plus all CI-only targets (validate, build-ci-image, environment, clean, etc.)
- Update all CI workflows (6 files) to use `make -f Makefile.ci`
- Exclude `Makefile.ci` from the tarball build and validation
- Add `deploy-cluster-pre-install-validate` target to both Makefiles for validating servers are ready before install (`--tags pre-install-validate` on `03-deploy.yaml`)
- Update `DEPLOYMENT_GUIDE.md` with `make` command equivalents (raw `ansible-playbook` commands preserved as alternative)
- Update `validate_makefile()` in `validate.sh` to lint both Makefiles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure**
  * CI and deployment workflows now use CI-specific make targets for consistent connected/disconnected runs and to restore CI orchestration and SSH-based deployment entrypoints.

* **Documentation**
  * Deployment guide updated with make-driven examples and environment-variable knobs for phase-by-phase and full deployments.

* **Chores**
  * Packaging/validation improved to exclude CI-only artifacts from released archives and to aggregate CI makefile validation results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->