### PR TITLE
Fix Quay DNS to use ingress VIP instead of router pod IP

### DIFF
--- a/operators/quay-operator/tasks.yaml
+++ b/operators/quay-operator/tasks.yaml
@@ -71,28 +71,13 @@
     file: "{{ playbook_dir }}/../plugins/{{ storage_plugin }}/tasks/quay.yaml"
   when: lookup('ansible.builtin.fileglob', playbook_dir ~ '/../plugins/' ~ storage_plugin ~ '/tasks/quay.yaml') | length > 0
 
-- name: Get router pod for Quay DNS
-  kubernetes.core.k8s_info:
-    kind: Pod
-    namespace: openshift-ingress
-    label_selectors:
-      - ingresscontroller.operator.openshift.io/deployment-ingresscontroller=default
-  register: quay_router_pods
-  retries: 10
-  delay: 6
-  until:
-    - quay_router_pods.resources | length > 0
-    - quay_router_pods.resources[0].status.podIP is defined
-    - quay_router_pods.resources[0].status.podIP != ''
-
-- name: Configure DNS for Quay route in /etc/hosts using router pod IP
+- name: Configure DNS for Quay route in /etc/hosts using ingress VIP
   ansible.builtin.lineinfile:
     path: /etc/hosts
-    line: "{{ quay_router_pods.resources[0].status.podIP }} registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}"
+    line: "{{ ingressVIP }} registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}"
     regexp: ".*registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}.*"
     state: present
   become: true
-  when: quay_router_pods.resources | length > 0
 
 - name: Wait for QuayRegistry to be available
   kubernetes.core.k8s_info:


### PR DESCRIPTION
## Summary

- Replace ephemeral router pod IP with stable ingress VIP for Quay registry `/etc/hosts` entry
- Remove the `Get router pod for Quay DNS` task that fetched a pod IP (changes on restart)
- Use `{{ ingressVIP }}` which is constant regardless of pod scheduling

The router pod IP is ephemeral — when a pod restarts it gets a new IP, leaving `/etc/hosts` stale and Quay unreachable. The ingress VIP is a virtual IP managed by MetalLB/keepalived that stays constant.

Fixes: gori-project/GoRI#852
Relates: gori-project/GoRI#834

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor

* Simplified registry endpoint configuration. Removed the process that discovers and monitors infrastructure components during setup. The registry hostname is now directly assigned using a Virtual IP address, streamlining deployment and reducing setup dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->