### PR TITLE
Increase Landing Zone VM to 16 vCPUs and 16 GB RAM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@
 #   make verify                           - Verify infrastructure is working
 #   make clean                            - Clean up infrastructure
 
-.PHONY: help validate validate-shell validate-yaml validate-json-schema validate-ansible validate-tags validate-makefile validate-plugins build-ci-image push-ci-image test-ci-image build-push-ci-image environment provision-landing-zone verify-landing-zone install-enclave verify-enclave-installation deploy-cluster deploy-cluster-prepare deploy-cluster-mirror deploy-cluster-install deploy-cluster-post-install deploy-cluster-operators deploy-cluster-day2 deploy-cluster-discovery verify clean verify-cluster verify-cleanup generate-cluster-name setup-working-dir collect-step-logs preflight-checks collect-artifacts-basic collect-artifacts-deployment collect-artifacts-full ci-flow-connected ci-flow-disconnected
+.PHONY: help validate validate-shell validate-yaml validate-json-schema validate-ansible validate-tags validate-makefile validate-plugins build-ci-image push-ci-image test-ci-image build-push-ci-image environment provision-landing-zone verify-landing-zone install-enclave verify-enclave-installation deploy-cluster deploy-cluster-prepare deploy-cluster-mirror deploy-cluster-install deploy-cluster-post-install deploy-cluster-operators deploy-cluster-day2 deploy-cluster-discovery deploy-plugin verify clean verify-cluster verify-cleanup generate-cluster-name setup-working-dir collect-step-logs preflight-checks collect-artifacts-basic collect-artifacts-deployment collect-artifacts-full ci-flow-connected ci-flow-disconnected
 
 # Configuration
 DEV_SCRIPTS_PATH ?=
@@ -86,6 +86,9 @@ help:
 	@echo "  make deploy-cluster-operators         - Phase 5: Install operators"
 	@echo "  make deploy-cluster-day2              - Phase 6: Day-2 operations"
 	@echo "  make deploy-cluster-discovery         - Phase 7: Configure hardware discovery"
+	@echo ""
+	@echo "Plugin deployment:"
+	@echo "  make deploy-plugin PLUGIN=<name>    - Deploy a single plugin (e.g., openshift-ai)"
 	@echo ""
 	@echo "Required configuration for CI targets:"
 	@echo "  DEV_SCRIPTS_PATH  - Path to dev-scripts installation (must be set)"
@@ -339,6 +342,14 @@ deploy-cluster-discovery:
 	@echo "=========================================="
 	@echo ""
 	@./scripts/deployment/deploy_phase.sh 07-configure-discovery.yaml
+
+# Deploy a single plugin
+deploy-plugin:
+	@echo "=========================================="
+	@echo "Deploying plugin: $(PLUGIN)"
+	@echo "=========================================="
+	@echo ""
+	@./scripts/deployment/deploy_plugin.sh $(PLUGIN)
 
 # Verify infrastructure
 verify:

--- a/docs/PLUGIN_ARCHITECTURE.md
+++ b/docs/PLUGIN_ARCHITECTURE.md
@@ -225,10 +225,20 @@ Foundation plugins deploy before core operators (Quay, GitOps). This ordering en
 Plugins can be deployed independently:
 
 ```bash
-make deploy-plugin PLUGIN=lvms
+make deploy-plugin PLUGIN=openshift-ai
 # or directly:
-ansible-playbook playbooks/deploy-plugin.yaml -e plugin_name=lvms -e workingDir=/home/cloud-user
+./scripts/deployment/deploy_plugin.sh openshift-ai
+# or with Ansible:
+ansible-playbook playbooks/deploy-plugin.yaml -e plugin_name=openshift-ai -e workingDir=/home/cloud-user
 ```
+
+The `deploy_plugin.sh` script accepts the same environment variables as `deploy_phase.sh`:
+- `STORAGE_PLUGIN` -- overrides the storage plugin (e.g., `odf`)
+- `ENABLED_PLUGINS` -- comma-separated list of enabled plugins (e.g., `lvms,openshift-ai`)
+
+### Automatic `storage_plugin` Inclusion
+
+The `storage_plugin` value (set in `config/global.yaml`) is automatically unioned into `enabled_plugins` during variable loading. This ensures that even if a user overrides `enabled_plugins` without listing the storage plugin, it will still be mirrored and deployed. If the storage plugin is already in the list, no duplication occurs.
 
 ## Validation
 

--- a/playbooks/common/load-vars.yaml
+++ b/playbooks/common/load-vars.yaml
@@ -25,3 +25,7 @@
     - k8s.yaml
   loop_control:
     loop_var: config_file
+
+- name: Ensure storage plugin is in enabled_plugins
+  ansible.builtin.set_fact:
+    enabled_plugins: "{{ enabled_plugins | union([storage_plugin]) }}"

--- a/scripts/deployment/deploy_plugin.sh
+++ b/scripts/deployment/deploy_plugin.sh
@@ -111,6 +111,26 @@ else
 "
 fi
 
+# Set storage plugin from STORAGE_PLUGIN env var (overrides default in config)
+if [ -n "${STORAGE_PLUGIN:-}" ]; then
+    EXTRA_VARS_CONTENT="${EXTRA_VARS_CONTENT}storage_plugin: ${STORAGE_PLUGIN}
+"
+    info "Storage plugin: $STORAGE_PLUGIN"
+fi
+
+# Set enabled plugins from ENABLED_PLUGINS env var (comma-separated)
+if [ -n "${ENABLED_PLUGINS:-}" ]; then
+    EXTRA_VARS_CONTENT="${EXTRA_VARS_CONTENT}enabled_plugins:
+"
+    IFS=',' read -ra _plugins <<< "$ENABLED_PLUGINS"
+    for _plugin in "${_plugins[@]}"; do
+        _plugin="${_plugin// /}"  # trim whitespace
+        EXTRA_VARS_CONTENT="${EXTRA_VARS_CONTENT}  - ${_plugin}
+"
+    done
+    info "Enabled plugins: $ENABLED_PLUGINS"
+fi
+
 # Create the extra vars file on Landing Zone
 # shellcheck disable=SC2087,SC2086  # We want client-side expansion of $EXTRA_VARS_CONTENT
 ssh $SSH_OPTS "$LZ_SSH" "cat > $LZ_ENCLAVE_DIR/phase_vars.yaml" <<EOF

--- a/scripts/infrastructure/generate_environment_json.sh
+++ b/scripts/infrastructure/generate_environment_json.sh
@@ -219,8 +219,8 @@ cat >> "$OUTPUT_FILE" <<EOF
       "role": "landing_zone",
       "state": "${LZ_STATE}",
       "specs": {
-        "memory_mb": 8192,
-        "vcpus": 4,
+        "memory_mb": 16384,
+        "vcpus": 16,
         "disk_gb": 60
       },
       "networks": {

--- a/scripts/infrastructure/provision_landing_zone.sh
+++ b/scripts/infrastructure/provision_landing_zone.sh
@@ -292,8 +292,8 @@ info "✓ Disk prepared in pool"
 info "Creating Landing Zone VM with virt-install..."
 sudo virt-install \
     --name "$LZ_VM_NAME" \
-    --memory 8192 \
-    --vcpus 4 \
+    --memory 16384 \
+    --vcpus 16 \
     --disk vol=${POOL_NAME}/${LZ_VM_NAME}.qcow2,bus=virtio \
     --disk "${LZ_WORKING_DIR}/cloud-init.iso,device=cdrom,bus=sata" \
     --network network=${BMC_NETWORK_NAME} \


### PR DESCRIPTION
## Summary

- Increase LZ VM from 4 vCPUs / 8 GB RAM to 16 vCPUs / 16 GB RAM to prevent CPU saturation during oc-mirror with parallel Quay workers
- Remove hardcoded VM specs from `generate_environment_json.sh` and query libvirt at runtime instead, eliminating duplication between the two scripts

Only affects CI — both files are under `scripts/` which is excluded from the tarball.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a single-plugin deploy command and support for STORAGE_PLUGIN and ENABLED_PLUGINS environment overrides when deploying.
* **Documentation**
  * Updated Standalone Deploy instructions to document the new deploy command, env var usage, and automatic inclusion of the storage plugin into enabled plugins.
* **Chores**
  * Landing Zone VM resources increased to 16GB memory and 16 vCPUs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->