### PR TITLE
Increase Landing Zone VM to 16 vCPUs and 16 GB RAM

### DIFF
--- a/scripts/infrastructure/generate_environment_json.sh
+++ b/scripts/infrastructure/generate_environment_json.sh
@@ -219,8 +219,8 @@ cat >> "$OUTPUT_FILE" <<EOF
       "role": "landing_zone",
       "state": "${LZ_STATE}",
       "specs": {
-        "memory_mb": 8192,
-        "vcpus": 4,
+        "memory_mb": 16384,
+        "vcpus": 16,
         "disk_gb": 60
       },
       "networks": {

--- a/scripts/infrastructure/provision_landing_zone.sh
+++ b/scripts/infrastructure/provision_landing_zone.sh
@@ -292,8 +292,8 @@ info "✓ Disk prepared in pool"
 info "Creating Landing Zone VM with virt-install..."
 sudo virt-install \
     --name "$LZ_VM_NAME" \
-    --memory 8192 \
-    --vcpus 4 \
+    --memory 16384 \
+    --vcpus 16 \
     --disk vol=${POOL_NAME}/${LZ_VM_NAME}.qcow2,bus=virtio \
     --disk "${LZ_WORKING_DIR}/cloud-init.iso,device=cdrom,bus=sata" \
     --network network=${BMC_NETWORK_NAME} \


### PR DESCRIPTION
Increase LZ VM from 4 vCPUs / 8 GB RAM to 16 vCPUs / 16 GB RAM to prevent CPU saturation during oc-mirror with parallel Quay workers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased landing zone virtual machine resource allocation: memory raised to 16 GB and vCPU count increased to 16.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->