### PR TITLE
Fix stale references and trim bloat in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The Red Hat Sovereign Enclave (RHSE) is an optionally disconnected, infrastructu
 
 RHSE provisions and maintains a local point of management (including ACM and Quay) with controls on the ingress of software and related artifacts into the environment.
 
-This is an Open Source project. Contributions are welcome! (Contribution guide coming soon)
+This is an Open Source project. Contributions are welcome! See the [Contributing](#contributing) section below.
 
 Check [Topo.png](docs/Topo.png) for expected hardware setup and [ArchMap.png](docs/ArchMap.png) for intended deployment model.
 
@@ -44,7 +44,7 @@ make deploy-cluster
 
 **With custom vars file:**
 ```bash
-VARS_FILE=config/custom-global.yaml make deploy-cluster
+GLOBAL_VARS=config/custom-global.yaml make deploy-cluster
 ```
 
 **Common use cases:**
@@ -60,10 +60,10 @@ cp config/global.yaml config/dev-global.yaml
 vim config/dev-global.yaml  # Modify as needed
 
 # Deploy with custom vars
-VARS_FILE=config/dev-global.yaml make deploy-cluster
+GLOBAL_VARS=config/dev-global.yaml make deploy-cluster
 ```
 
-**Note:** The custom vars file must be relative to the enclave directory on the Landing Zone (e.g., `config/custom-global.yaml`). If you need to use an absolute path, set `VARS_FILE=/absolute/path/to/global.yaml`.
+**Note:** The custom vars file must be relative to the enclave directory on the Landing Zone (e.g., `config/custom-global.yaml`). If you need to use an absolute path, set `GLOBAL_VARS=/absolute/path/to/global.yaml`.
 
 ### Deployment Modes
 
@@ -80,7 +80,9 @@ Skips mirror registry setup for faster deployments in environments with internet
 
 **Usage:**
 ```bash
-ENCLAVE_DEPLOYMENT_MODE=connected make deploy-cluster
+make deploy-cluster-connected
+# or equivalently:
+DISCONNECTED=false make deploy-cluster
 ```
 
 **What happens:**
@@ -105,8 +107,7 @@ Full air-gapped deployment with local mirror registry for production environment
 **Usage:**
 ```bash
 make deploy-cluster
-# or explicitly:
-ENCLAVE_DEPLOYMENT_MODE=disconnected make deploy-cluster
+# Disconnected is the default (DISCONNECTED=true)
 ```
 
 **What happens:**
@@ -139,52 +140,16 @@ Comprehensive documentation is available in the `docs/` folder:
 
 ### Make Targets Reference
 
-#### Validation Targets
-```bash
-make validate              # Run all validation checks
-make validate-shell        # Validate shell scripts with shellcheck
-make validate-yaml         # Validate YAML files with yamllint
-make validate-ansible      # Validate Ansible playbooks with ansible-lint
-make validate-makefile     # Validate Makefile syntax
-```
+There are two Makefiles:
+- **`Makefile`** — runs directly on the Landing Zone (deploy, bootstrap, sync)
+- **`Makefile.ci`** — CI infrastructure and validation targets (use `make -f Makefile.ci <target>`)
 
-#### Infrastructure Targets
+#### Landing Zone Targets (`Makefile`)
+
 ```bash
-make environment                     # Create test infrastructure
-make provision-landing-zone          # Provision Landing Zone VM
-make verify-landing-zone             # Verify Landing Zone VM configuration
-make install-enclave                 # Install Enclave Lab
-make verify-enclave-installation     # Verify Enclave Lab installation
+# Deployment
 make deploy-cluster                  # Deploy OpenShift cluster (all phases)
-make verify                          # Verify infrastructure setup
-make clean                           # Clean up all infrastructure
-```
-
-#### Verification Targets
-```bash
-make verify-cluster                  # Verify OpenShift cluster deployment
-make verify-cleanup                  # Verify infrastructure cleanup
-```
-
-#### Helper Targets
-```bash
-make generate-cluster-name           # Generate unique cluster name (auto-called)
-make setup-working-dir               # Setup cluster-specific working directory
-make collect-step-logs               # Collect logs from dev-scripts and cluster
-make preflight-checks                # Run pre-flight environment checks
-make collect-artifacts-basic         # Collect basic artifacts
-make collect-artifacts-deployment    # Collect deployment artifacts
-make collect-artifacts-full          # Collect all artifacts
-```
-
-#### Local CI Testing Targets
-```bash
-make ci-flow-connected               # Run full CI flow locally (connected mode)
-make ci-flow-disconnected            # Run full CI flow locally (disconnected mode)
-```
-
-#### Deploy Individual Phases (for granular control)
-```bash
+make deploy-cluster-connected        # Deploy in connected mode (DISCONNECTED=false)
 make deploy-cluster-prepare          # Phase 1: Download binaries
 make deploy-cluster-mirror           # Phase 2: Mirror registry (disconnected)
 make deploy-cluster-install          # Phase 3: Deploy cluster
@@ -192,6 +157,43 @@ make deploy-cluster-post-install     # Phase 4: Cluster configuration
 make deploy-cluster-operators        # Phase 5: Install operators
 make deploy-cluster-day2             # Phase 6: Day-2 operations
 make deploy-cluster-discovery        # Phase 7: Configure hardware discovery
+make deploy-plugin PLUGIN=<name>     # Deploy a single plugin
+
+# Setup & utilities
+make bootstrap                       # Bootstrap the Landing Zone
+make sync                            # Sync configuration
+make setup                           # Install system packages and Ansible deps
+make validate-config                 # Validate configuration files
+make validate-schema                 # Validate configuration against JSON schemas
+```
+
+#### CI Targets (`Makefile.ci`)
+
+```bash
+# Validation
+make -f Makefile.ci validate              # Run all validation checks
+make -f Makefile.ci validate-shell        # Validate shell scripts with shellcheck
+make -f Makefile.ci validate-yaml         # Validate YAML files with yamllint
+make -f Makefile.ci validate-ansible      # Validate Ansible playbooks with ansible-lint
+make -f Makefile.ci validate-makefile     # Validate Makefile syntax
+
+# Infrastructure
+make -f Makefile.ci environment                     # Create test infrastructure
+make -f Makefile.ci provision-landing-zone          # Provision Landing Zone VM
+make -f Makefile.ci install-enclave                 # Install Enclave Lab
+make -f Makefile.ci clean                           # Clean up all infrastructure
+
+# Verification
+make -f Makefile.ci verify-cluster                  # Verify OpenShift cluster deployment
+make -f Makefile.ci verify-cleanup                  # Verify infrastructure cleanup
+
+# Full CI flows
+make -f Makefile.ci ci-flow-connected               # Run full CI flow locally (connected)
+make -f Makefile.ci ci-flow-disconnected            # Run full CI flow locally (disconnected)
+
+# Helpers
+make -f Makefile.ci collect-artifacts-full          # Collect all artifacts
+make -f Makefile.ci preflight-checks                # Run pre-flight environment checks
 ```
 
 ### Common Testing Workflows
@@ -268,7 +270,7 @@ make provision-landing-zone
 **Connected Mode (Recommended for Development):**
 ```bash
 # No mirroring, uses upstream registries
-ENCLAVE_DEPLOYMENT_MODE=connected make install-enclave
+DISCONNECTED=false make install-enclave
 ```
 
 **Disconnected Mode (Production Validation):**
@@ -295,7 +297,7 @@ make environment
 make provision-landing-zone
 
 # 3. Install Enclave Lab - Choose mode:
-ENCLAVE_DEPLOYMENT_MODE=connected make install-enclave  # Connected mode
+DISCONNECTED=false make install-enclave  # Connected mode
 # OR
 make install-enclave  # Disconnected mode
 
@@ -306,233 +308,27 @@ make deploy-cluster
 make clean
 ```
 
-### Component-Specific Testing
-
-#### Test Only Validation
-```bash
-# All validators
-make validate
-
-# Individual validators
-make validate-shell      # Only shell scripts
-make validate-yaml       # Only YAML files
-make validate-ansible    # Only Ansible playbooks
-make validate-makefile   # Only Makefile syntax
-```
-
-#### Test Only Infrastructure
-```bash
-# Create infrastructure and stop
-make environment
-
-# Manual verification
-virsh list --all              # Check VMs created
-virsh net-list               # Check networks active
-curl http://100.64.1.1:8000/redfish/v1/Systems  # Check BMC emulation
-```
-
-#### Test Only Landing Zone
-```bash
-# Assumes infrastructure exists from 'make environment'
-make provision-landing-zone
-
-# Manual verification
-ssh cloud-user@<landing-zone-ip>
-# Check: CentOS Stream 10, podman installed, network configured
-```
-
-#### Test Only Enclave Installation
-```bash
-# Assumes Landing Zone is provisioned
-make install-enclave
-make verify-enclave-installation
-
-# Manual verification
-ssh cloud-user@<landing-zone-ip>
-ls -la /home/cloud-user/enclave
-cat /home/cloud-user/enclave/config/global.yaml
-cat /home/cloud-user/enclave/config/certificates.yaml
-cat /home/cloud-user/enclave/config/cloud_infra.yaml
-```
-
-#### Test Only Cluster Deployment
-```bash
-# Assumes Enclave Lab is installed
-make deploy-cluster
-
-# Monitor progress
-ssh cloud-user@<landing-zone-ip>
-tail -f /home/cloud-user/enclave/deployment.log
-```
-
-### Troubleshooting Local Tests
-
-**Infrastructure creation fails:**
-```bash
-# Check dev-scripts path
-echo $DEV_SCRIPTS_PATH
-ls -la $DEV_SCRIPTS_PATH
-
-# Check libvirt
-sudo systemctl status libvirtd
-virsh list --all
-
-# Check resources
-free -h  # Need 64GB+ RAM
-df -h    # Need 100GB+ disk
-```
-
-**Landing Zone provisioning fails:**
-```bash
-# Check VM state
-virsh list --all | grep landingzone
-
-# Check console
-virsh console enclave-test_landingzone_0
-
-# Check logs on Landing Zone
-ssh cloud-user@<ip> journalctl -xef
-```
-
-**Enclave installation fails:**
-```bash
-# Check Landing Zone connectivity
-ping <landing-zone-ip>
-ssh cloud-user@<landing-zone-ip>
-
-# Check installation logs
-make verify-enclave-installation
-
-# Re-run with fresh state
-ssh cloud-user@<landing-zone-ip>
-rm -rf /home/cloud-user/enclave
-# Then re-run: make install-enclave
-```
-
-**Cluster deployment fails:**
-```bash
-# Check deployment logs
-ssh cloud-user@<landing-zone-ip>
-tail -100 /home/cloud-user/enclave/deployment.log
-
-# Check cluster state
-ssh cloud-user@<landing-zone-ip>
-export KUBECONFIG=/home/cloud-user/enclave/auth/kubeconfig
-oc get nodes
-oc get co  # Cluster operators
-```
-
-**Cleanup issues:**
-```bash
-# Force cleanup
-make clean
-
-# Manual cleanup if needed
-cd $DEV_SCRIPTS_PATH
-CONFIG=config_enclave.sh make clean
-
-# Nuclear option (removes everything)
-virsh list --all | grep enclave-test | awk '{print $2}' | xargs -I {} virsh destroy {}
-virsh list --all | grep enclave-test | awk '{print $2}' | xargs -I {} virsh undefine {}
-```
-
-### Development Best Practices
-
-✅ **DO:**
-- Run `make validate` before every commit
-- Test in connected mode for faster iteration during development
-- Use disconnected mode for final validation before PR
-- Clean up infrastructure regularly to free resources
-- Check logs when tests fail before asking for help
-- Test your changes in isolation first
-
-❌ **DON'T:**
-- Skip validation (CI will catch it anyway)
-- Commit without testing locally
-- Leave infrastructure running when not in use
-- Test in disconnected mode for every small change
-- Forget to set required environment variables
-
-**Typical Development Cycle:**
-1. Make code changes
-2. Run `make validate` ✅
-3. Test specific component if needed
-4. Commit and push
-5. GitHub Actions validates automatically
+For component-specific testing, troubleshooting, and development best practices, see [Local Testing Guide](docs/LOCAL_TESTING.md).
 
 ## Continuous Integration
 
-Enclave Lab uses GitHub Actions for automated testing and validation with four main workflows. All CI workflows use the same Makefile targets that you can run locally, ensuring consistency between local testing and CI.
+GitHub Actions workflows:
 
-### Available Workflows
+1. **PR Validation** (automatic) — shellcheck, yamllint, ansible-lint, Makefile syntax. Test locally: `make -f Makefile.ci validate`
+2. **Infrastructure Verification** (manual / `test-infra` label) — infra setup without full cluster deploy
+3. **E2E Connected Mode** (manual / `test-e2e` label / weekly) — full end-to-end cluster deployment
+4. **Cleanup** (manual / weekly) — infrastructure teardown
 
-#### 1. PR Validation (Automatic)
+The `main` branch requires passing PR validation, code review approval, and an up-to-date branch.
 
-Every pull request automatically runs:
-- ✅ Shell script validation (shellcheck)
-- ✅ YAML linting (yamllint)
-- ✅ Ansible playbook validation (ansible-lint)
-- ✅ Makefile syntax checking
+Pull requests are automatically reviewed by [CodeRabbit AI](https://coderabbit.ai) for security and code quality.
 
 **Test locally before pushing:**
 ```bash
 make validate
 ```
 
-Runs on GitHub-hosted runners for fast feedback.
-
-#### 2. Infrastructure Verification (Manual/Label)
-
-Tests infrastructure setup without full cluster deployment:
-- Create test infrastructure
-- Provision Landing Zone
-- Install Enclave Lab (connected mode)
-- Verify installation
-
-**Trigger**: Manual or add `test-infra` label to PR
-
-#### 3. E2E Deployment (Automatic/Scheduled/Manual)
-
-Full end-to-end cluster deployment testing in both connected and disconnected modes:
-- Two parallel jobs: connected and disconnected
-- Complete infrastructure setup per mode
-- Deploy OpenShift cluster (with mirror registry for disconnected)
-- Verify cluster health
-- Collect artifacts, Slack notifications on nightly runs
-
-**Trigger**: Automatic on PR, nightly schedule (03:00 UTC daily), or manual dispatch
-
-#### 4. Cleanup (Manual/Scheduled)
-
-Infrastructure cleanup and maintenance:
-- Standard: Clean Enclave infrastructure
-- Deep: Force remove stuck resources
-- Full: Complete reset
-
-**Trigger**: Manual or weekly schedule (Sunday 4 AM UTC)
-
-### CI Documentation
-
-For detailed information about using and troubleshooting CI workflows:
-- **[CI Workflows Guide](docs/CI_WORKFLOWS.md)**: How to use each workflow
-- **[CI Runner Setup](docs/CI_RUNNER_SETUP.md)**: Self-hosted runner configuration
-- **[CI Troubleshooting](docs/CI_TROUBLESHOOTING.md)**: Common issues and solutions
-
-### Branch Protection
-
-The `main` branch is protected and requires:
-- ✅ PR validation checks to pass
-- ✅ Code review approval
-- ✅ Up-to-date branch with main
-
-### Automated Code Review
-
-Pull requests are automatically reviewed by [CodeRabbit AI](https://coderabbit.ai) for:
-- JIRA task ID validation in PR titles and commits
-- Security checks (credentials, hardcoded paths, secrets)
-- Best practices and code quality
-
-CodeRabbit provides inline suggestions and auto-generates JIRA issue links in PR summaries.
+For details see **[CI Workflows Guide](docs/CI_WORKFLOWS.md)** and **[CI Runner Setup](docs/CI_RUNNER_SETUP.md)**.
 
 ## Architecture
 

--- a/config/README.md
+++ b/config/README.md
@@ -32,6 +32,10 @@ Contains cloud infrastructure configuration, including the list of worker nodes 
 - These files contain sensitive credentials and private keys
 - The `.gitignore` is configured to exclude them
 
+## Storage Operators
+
+Storage operators (LVMS, ODF) are configured via the plugin system. See `docs/PLUGIN_ARCHITECTURE.md`.
+
 ## Getting Help
 - See `docs/DEPLOYMENT_GUIDE.md` for step-by-step deployment instructions
 - See `docs/CONFIGURATION_REFERENCE.md` for detailed parameter documentation

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -49,14 +49,23 @@ The following Red Hat operators are automatically installed and configured:
 
 | Operator | Namespace | Purpose |
 |----------|-----------|---------|
-| **LVMS Operator** | `openshift-storage` | Provides local volume management and storage |
 | **Quay Operator** | `quay-enterprise` | Container registry management |
+| **Multicluster Engine** | `multicluster-engine` | Cluster lifecycle management |
 | **Advanced Cluster Management** | `open-cluster-management` | Multi-cluster management |
-| **OpenShift GitOps** | `openshift-operators` | GitOps workflow management (ArgoCD) |
-| **OpenShift Pipelines** | `openshift-operators` | CI/CD pipeline automation |
-| **NetObserv Operator** | `openshift-operators` | Network observability |
+| **Cincinnati Operator** | `openshift-update-service` | Update service for cluster upgrades |
+| **OpenShift GitOps** | `openshift-gitops-operator` | GitOps workflow management (ArgoCD) |
+| **OpenShift Pipelines** | `openshift-pipelines` | CI/CD pipeline automation |
+| **NetObserv Operator** | `openshift-netobserv-operator` | Network observability |
+| **Cluster Logging** | `openshift-logging` | Cluster log collection and forwarding |
+| **Loki Operator** | `openshift-operators-redhat` | Log storage backend |
 | **Red Hat OADP** | `openshift-oadp` | Backup and restore operations |
 | **OpenShift Cert Manager** | `cert-manager-operator` | Certificate management |
+| **Cluster Observability** | `openshift-cluster-observability-operator` | Monitoring and observability |
+| **External Secrets Operator** | `external-secrets-operator` | External secrets management |
+| **Compliance Operator** | `openshift-compliance` | Compliance scanning and remediation |
+| **MetalLB Operator** | `metallb-system` | Load balancer for bare metal |
+
+**Note:** Storage operators (LVMS, ODF) and addon operators (e.g., OpenShift AI) are managed via the plugin system, not through the core operator list. See [Plugin Architecture](PLUGIN_ARCHITECTURE.md).
 
 ### 4. Post-Install Configuration
 
@@ -137,92 +146,55 @@ Configuration is split across multiple files for better organization:
 **Default configuration files** (in `defaults/` directory):
 - `defaults/operators.yaml` - General cluster operators
 - `defaults/platforms.yaml` - Available OpenShift versions
-- `defaults/storage_operators.yaml` - Storage operators (ODF, LVMS)
+- `defaults/deployment.yaml` - Deployment behavior defaults
+- `defaults/k8s.yaml` - Kubernetes resource defaults
 - `defaults/control_binaries.yaml` - Binary URLs and checksums (oc, helm, etc.)
 - `defaults/content_images.yaml` - RHCOS images and ISOs
 - `defaults/catalogs.yaml` - Operator catalog source name mappings
 - `defaults/mirror_registry.yaml` - Quay hostname and CA path defaults
 - `defaults/quay_operator.yaml` - Quay feature flags and backend storage defaults
-- `defaults/lvms_operator.yaml` - LVMS device selector defaults
+
+**Note:** Storage operators (LVMS, ODF) are configured via the plugin system in `plugins/<name>/plugin.yaml`. See [Plugin Architecture](PLUGIN_ARCHITECTURE.md).
 
 All configuration files in the `defaults/` directory are automatically loaded by the phase playbooks at runtime.
 
 ## Deployment Workflow
 
-The deployment follows this sequence (defined in `playbooks/main-disconnected.yaml`):
+The deployment is split into seven phase playbooks (orchestrated by `playbooks/main.yaml`):
 
+```text
+Phase 1: Prepare (01-prepare.yaml)
+  Download binaries and RHCOS content
+         ↓
+Phase 2: Mirror (02-mirror.yaml)          ← disconnected only
+  Deploy mirror registry, mirror images
+         ↓
+Phase 3: Deploy (03-deploy.yaml)
+  Generate ISO, boot servers via Redfish, wait for cluster install
+         ↓
+Phase 4: Post-Install (04-post-install.yaml)
+  Apply SSL certificates, configure registry, cluster settings
+         ↓
+Phase 5: Operators (05-operators.yaml)
+  Install and configure cluster operators
+         ↓
+Phase 6: Day-2 (06-day2.yaml)
+  Clair, ACM policies, model config, plugin deployment
+         ↓
+Phase 7: Discovery (07-configure-discovery.yaml)
+  Configure hardware discovery for additional nodes
 ```
-1. Download Content (RHCOS images)
-   ↓
-2. Download Control Binaries (oc, helm, etc.)
-   ↓
-3. Mirror Registry Setup
-   ↓
-4. OCP ABI Configuration (ISO generation)
-   ↓
-5. Hardware Configuration (Redfish boot)
-   ↓
-6. Wait for Deployment (cluster installation)
-   ↓
-7. Operator Installation
-   ↓
-8. Post-Install Configuration
-```
 
-### Step-by-Step Process
+### Bootstrap
 
-1. **Bootstrap** (`bootstrap.sh`):
-   - Validates configuration
-   - Sets up environment
-   - Downloads dependencies
-   - Builds local cache
+Before running the deployment phases, run `bootstrap.sh` to:
+- Validate configuration
+- Install system packages and Ansible dependencies
+- Set up the environment
 
-2. **Download Content** (`download-content` tag):
-   - Downloads RHCOS live rootfs images
-   - Downloads RHCOS live ISOs
-   - Files are stored in `/var/www/html/`
+### Phase Details
 
-3. **Download Control Binaries** (`download-control-binaries` tag):
-   - Creates necessary directories (`bin/`, `dist/`, `config/`, `logs/`)
-   - Downloads and extracts OpenShift CLI (`oc`)
-   - Downloads Helm CLI
-   - Downloads and extracts mirror-registry
-   - Downloads and extracts oc-mirror
-
-4. **Mirror Registry** (`mirror-registry` tag):
-   - Deploys Quay registry container
-   - Configures pull secrets
-   - Mirrors OpenShift and operator images
-
-5. **OCP ABI Configuration** (`configure-abi` tag):
-   - Generates SSH keys
-   - Extracts `openshift-install` binary
-   - Creates `install-config.yaml` and `agent-config.yaml`
-   - Generates installation ISO
-   - Serves ISO via HTTP
-
-6. **Hardware Configuration** (`hardware` tag):
-   - Ejects existing virtual media
-   - Mounts ISO via Redfish
-   - Configures UEFI boot
-   - Reboots servers
-
-7. **Wait for Deployment** (`wait-deployment` tag):
-   - Waits for bootstrap completion
-   - Waits for installation completion
-   - Disables default operator catalogs
-
-8. **Operator Installation** (`operators` tag):
-   - Creates namespaces
-   - Creates OperatorGroups
-   - Creates Subscriptions
-   - Waits for CSV installation
-   - Applies operator-specific configurations
-
-9. **Post-Install Configuration** (`post-install-config` tag):
-   - Applies SSL certificates to API server
-   - Applies SSL certificates to Ingress
-   - Configures registry settings
+See the [Running Individual Phases](#running-individual-phases) section for the exact `make` and `ansible-playbook` commands for each phase.
 
 ## Configuration Examples
 
@@ -382,42 +354,48 @@ Operators are configured in `defaults/operators.yaml`:
 
 ```yaml
 operators:
+  # Container Registry
+  - name: quay-operator
+    channel: stable-3.15
+    namespace: quay-enterprise
+    source: cs-redhat-operator-index-v4-20
+
   # Advanced Cluster Management
   - name: advanced-cluster-management
     channel: release-2.15
     namespace: open-cluster-management
-    source: cs-redhat-operator-index-v4-19
+    source: cs-redhat-operator-index-v4-20
 
   # OpenShift GitOps (ArgoCD)
   - name: openshift-gitops-operator
-    channel: latest
-    namespace: openshift-operators
-    source: cs-redhat-operator-index-v4-19
+    channel: gitops-1.19
+    namespace: openshift-gitops-operator
+    source: cs-redhat-operator-index-v4-20
 
   # OpenShift Pipelines (Tekton)
   - name: openshift-pipelines-operator-rh
-    channel: latest
-    namespace: openshift-operators
-    source: cs-redhat-operator-index-v4-19
+    channel: pipelines-1.20
+    namespace: openshift-pipelines
+    source: cs-redhat-operator-index-v4-20
 
   # Network Observability
   - name: netobserv-operator
     channel: stable
-    namespace: openshift-operators
-    source: cs-redhat-operator-index-v4-19
+    namespace: openshift-netobserv-operator
+    source: cs-redhat-operator-index-v4-20
 
   # Backup and Restore
   - name: redhat-oadp-operator
     channel: stable
     namespace: openshift-oadp
-    source: cs-redhat-operator-index-v4-19
+    source: cs-redhat-operator-index-v4-20
 
   # Certificate Manager
   - name: openshift-cert-manager-operator
     channel: stable-v1
     namespace: cert-manager-operator
-    source: cs-redhat-operator-index-v4-19
-  [...]
+    source: cs-redhat-operator-index-v4-20
+  # ... and more (see defaults/operators.yaml for full list)
 ```
 
 ### SSL Certificate Configuration
@@ -657,7 +635,8 @@ ansible-playbook playbooks/03-deploy.yaml -e workingDir=/home/cloud-user
 # Phase 4: Post-install configuration (cluster config, secrets, certificates)
 ansible-playbook playbooks/04-post-install.yaml -e workingDir=/home/cloud-user
 
-# Phase 5: Install and configure operators (LVMS, ODF, Quay, etc.)
+# Phase 5: Install and configure operators (Quay, ACM, GitOps, etc.)
+# Note: Storage operators (LVMS, ODF) are deployed via the plugin system in this phase
 ansible-playbook playbooks/05-operators.yaml -e workingDir=/home/cloud-user
 
 # Phase 6: Day-2 operations (Clair, ACM policies, model config)
@@ -672,7 +651,7 @@ ansible-playbook playbooks/main.yaml -e workingDir=/home/cloud-user
 
 ## Troubleshooting
 
-For diagnostic log collection, see the [Log Collection Tool](../lz-gather-logs/README.md).
+For diagnostic log collection, see the [Log Collection Tool](../scripts/diagnostics/README.md).
 
 ### Common Issues
 


### PR DESCRIPTION
## Summary

- **DEPLOYMENT_GUIDE.md**: Fix deleted default file references (`storage_operators.yaml`, `lvms_operator.yaml` → `deployment.yaml`, `k8s.yaml`), rewrite workflow section for 7-phase playbook structure, update operator table to full 15-operator list from `defaults/operators.yaml`, fix broken diagnostics link, add plugin-managed storage notes
- **README.md**: Fix `VARS_FILE` → `GLOBAL_VARS`, fix `ENCLAVE_DEPLOYMENT_MODE` → `DISCONNECTED`/`deploy-cluster-connected`, remove broken `CI_TROUBLESHOOTING.md` link, remove JIRA references from CodeRabbit section, group make targets under `Makefile`/`Makefile.ci` headings, trim ~200 lines of duplicated testing/troubleshooting content replaced with link to `LOCAL_TESTING.md`
- **config/README.md**: Add note that storage operators (LVMS/ODF) are plugin-managed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated deployment docs: use GLOBAL_VARS, DISCONNECTED is now default, and connected mode uses explicit Make targets
  * Refactored Make targets docs into two entrypoints (landing zone vs CI) and added helper targets (deploy-plugin, bootstrap, sync, setup, validate-*)
  * Reorganized Deployment Guide with phase-based playbooks, refreshed operator inventory/namespaces, and plugin-managed storage operators
  * Consolidated local testing and CI workflow docs with clearer navigation and shorter CI workflow descriptions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->