### PR TITLE
Remove opm utility

### DIFF
--- a/defaults/control_binaries.yaml
+++ b/defaults/control_binaries.yaml
@@ -15,6 +15,3 @@ control_binaries:
   clairctl:
     url: "https://github.com/quay/clair/releases/download/v4.8.0/clairctl-linux-amd64"
     checksum: "sha256:eec1311f5e68165b49c8b4d024c83fc46285bdca2f37e756becf21d534551434"
-  opm:
-    url: "https://mirror.openshift.com/pub/openshift-v4/clients/opm/4.6.1/opm-linux-4.6.1.tar.gz"
-    checksum: "sha256:d59b6b8d5bf3d0445179ef3d4ddc944fdfa81abdea6637d04e55a6a5299f6ab7"

--- a/playbooks/tasks/download_control_binaries.yaml
+++ b/playbooks/tasks/download_control_binaries.yaml
@@ -68,4 +68,3 @@
     dest: "{{ workingDir }}/bin/clairctl"
     checksum: "{{ control_binaries.clairctl.checksum }}"
     mode: "0750"
-

--- a/playbooks/tasks/download_control_binaries.yaml
+++ b/playbooks/tasks/download_control_binaries.yaml
@@ -69,14 +69,3 @@
     checksum: "{{ control_binaries.clairctl.checksum }}"
     mode: "0750"
 
-- name: Download opm - CLI to interact with operator-registry and build indexes of operator content
-  ansible.builtin.get_url:
-    url: "{{ control_binaries.opm.url }}"
-    dest: "{{ workingDir }}/dist/opm.tar.gz"
-    checksum: "{{ control_binaries.opm.checksum }}"
-
-- name: Unarchive opm.tar.gz to {{ workingDir }}/bin/
-  ansible.builtin.unarchive:
-    src: "{{ workingDir }}/dist/opm.tar.gz"
-    dest: "{{ workingDir }}/bin/"
-    remote_src: true

--- a/schemas/control_binaries.yaml
+++ b/schemas/control_binaries.yaml
@@ -79,20 +79,6 @@ properties:
         - url
         - checksum
         additionalProperties: false
-      opm:
-        type: object
-        properties:
-          url:
-            type: string
-            description: URL to download opm binary.
-          checksum:
-            type: string
-            description: SHA256 checksum for the binary.
-            pattern: "^sha256:[0-9a-f]{64}$"
-        required:
-        - url
-        - checksum
-        additionalProperties: false
     additionalProperties: false
 required:
 - control_binaries


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the `opm` (OpenShift Package Manager) binary from the control binaries configuration and its automated download/installation, so `opm` will no longer be managed or provided by the release's control binaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->