### PR TITLE
Remove unneeded Quay DNS /etc/hosts entry

### DIFF
--- a/operators/quay-operator/tasks.yaml
+++ b/operators/quay-operator/tasks.yaml
@@ -71,14 +71,6 @@
     file: "{{ playbook_dir }}/../plugins/{{ storage_plugin }}/tasks/quay.yaml"
   when: lookup('ansible.builtin.fileglob', playbook_dir ~ '/../plugins/' ~ storage_plugin ~ '/tasks/quay.yaml') | length > 0
 
-- name: Configure DNS for Quay route in /etc/hosts using ingress VIP
-  ansible.builtin.lineinfile:
-    path: /etc/hosts
-    line: "{{ ingressVIP }} registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}"
-    regexp: ".*registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}.*"
-    state: present
-  become: true
-
 - name: Wait for QuayRegistry to be available
   kubernetes.core.k8s_info:
     api_version: quay.redhat.com/v1


### PR DESCRIPTION
The Quay route DNS entry in `/etc/hosts` was inadvertently reintroduced after the commit 5555b35. DNS for all cluster endpoints, including Quay, is handled via external DNS server, and for CI via libvirt network dnsmasq (`virsh net-update`) configured in `install_enclave.sh`.

MGMT-23781

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unnecessary hosts file configuration step from the Quay operator deployment process, streamlining the setup workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->