### PR TITLE
Enable OAuth token generation without UI access in Quay Ansible setup  (#207)

### DIFF
--- a/defaults/quay_operator.yaml
+++ b/defaults/quay_operator.yaml
@@ -15,3 +15,12 @@ quayBackendRGWDefaults:
   minimum_chunk_size_mb: 100
   maximum_chunk_size_mb: 500
   server_side_assembly: true
+
+# OAuth application configuration
+# Enable automatic OAuth application creation during initial setup
+quayOAuthApp:
+  enabled: true
+  name: "default-application"
+  organization: "default-org"
+  redirect_uri: "http://localhost:8080/callback"
+  scopes: "repo:read repo:write repo:admin repo:create user:read"

--- a/operators/quay-operator/oauth_setup.yaml
+++ b/operators/quay-operator/oauth_setup.yaml
@@ -1,0 +1,204 @@
+---
+# OAuth Application Setup for Quay
+#
+# Prerequisites:
+#   - quay_initial_token must be defined
+#   - QuayRegistry must be available
+#   - Initial user must be created
+#
+# This file sets the following variables:
+#   - quay_oauth_client_id
+#   - quay_oauth_client_secret
+#   - quay_oauth_token
+
+- name: Create Quay organization for OAuth application
+  no_log: true
+  ansible.builtin.uri:
+    url: "https://registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/api/v1/organization/"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ quay_initial_token }}"
+      Content-Type: application/json
+    validate_certs: false
+    return_content: yes
+    status_code:
+      - 200
+      - 201
+      - 400
+    body_format: json
+    body:
+      name: "{{ quayOAuthApp.organization }}"
+      email: "{{ quayUser }}@{{ baseDomain }}"
+  register: r_quay_org
+  retries: 3
+  delay: 5
+  when:
+    - quay_initial_token is defined
+    - quay_initial_token | length > 0
+  until:
+    - r_quay_org is defined
+    - r_quay_org.status in [200, 201, 400]
+
+- name: Create OAuth application
+  no_log: true
+  ansible.builtin.uri:
+    url: "https://registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/api/v1/organization/{{ quayOAuthApp.organization }}/applications"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ quay_initial_token }}"
+      Content-Type: application/json
+    validate_certs: false
+    return_content: yes
+    status_code:
+      - 200
+      - 201
+    body_format: json
+    body:
+      name: "{{ quayOAuthApp.name }}"
+      redirect_uri: "{{ quayOAuthApp.redirect_uri }}"
+      description: "Automated OAuth application for Enclave operations"
+  register: r_quay_oauth_app
+  retries: 5
+  delay: 10
+  when:
+    - quay_initial_token is defined
+    - quay_initial_token | length > 0
+  until:
+    - r_quay_oauth_app is defined
+    - r_quay_oauth_app.status in [200, 201]
+
+- name: Extract OAuth application credentials from create response
+  no_log: true
+  ansible.builtin.set_fact:
+    quay_oauth_client_id: "{{ r_quay_oauth_app.json.client_id }}"
+    quay_oauth_client_secret: "{{ r_quay_oauth_app.json.client_secret }}"
+  when:
+    - r_quay_oauth_app is defined
+    - r_quay_oauth_app is not skipped
+    - r_quay_oauth_app.status is defined
+    - r_quay_oauth_app.status in [200, 201]
+    - r_quay_oauth_app.json.client_id is defined
+    - r_quay_oauth_app.json.client_secret is defined
+
+- name: Get current quay-app Deployment state before config update
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: registry-quay-app
+    namespace: quay-enterprise
+  register: r_quay_app_deployment_before
+
+- name: Store current deployment generation and replica count
+  ansible.builtin.set_fact:
+    quay_app_generation_before: "{{ r_quay_app_deployment_before.resources[0].metadata.generation | default(0) }}"
+    quay_app_replicas: "{{ r_quay_app_deployment_before.resources[0].spec.replicas | default(1) }}"
+  when:
+    - r_quay_app_deployment_before.resources is defined
+    - r_quay_app_deployment_before.resources | length > 0
+
+- name: Update quay-config Secret with OAuth client ID whitelist
+  no_log: true
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('template', 'templates/quay-config-secret.yaml.j2') | from_yaml }}"
+  vars:
+    oauth_client_ids:
+      - "{{ quay_oauth_client_id }}"
+  register: r_quay_config_secret_oauth
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  when:
+    - quay_oauth_client_id is defined
+    - quay_oauth_client_id | length > 0
+  until: r_quay_config_secret_oauth is success
+
+- name: Wait for quay-app Deployment rolling update to complete
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: registry-quay-app
+    namespace: quay-enterprise
+  register: r_quay_app_deployment
+  retries: 60
+  delay: 10
+  when:
+    - r_quay_config_secret_oauth is changed
+  until:
+    - r_quay_app_deployment.resources is defined
+    - r_quay_app_deployment.resources | length > 0
+    - r_quay_app_deployment.resources[0].status is defined
+    - r_quay_app_deployment.resources[0].status.observedGeneration is defined
+    - r_quay_app_deployment.resources[0].status.observedGeneration == r_quay_app_deployment.resources[0].metadata.generation
+    - r_quay_app_deployment.resources[0].metadata.generation | default(0) > (quay_app_generation_before | int)
+    - r_quay_app_deployment.resources[0].status.updatedReplicas | default(0) == (quay_app_replicas | int)
+    - r_quay_app_deployment.resources[0].status.readyReplicas | default(0) == (quay_app_replicas | int)
+    - r_quay_app_deployment.resources[0].status.availableReplicas | default(0) == (quay_app_replicas | int)
+    - r_quay_app_deployment.resources[0].status.unavailableReplicas | default(0) == 0
+
+- name: Generate OAuth application token
+  no_log: true
+  ansible.builtin.uri:
+    url: "https://registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/oauth/authorizeapp"
+    method: POST
+    url_username: "{{ quayUser }}"
+    url_password: "{{ quayPassword }}"
+    force_basic_auth: yes
+    validate_certs: false
+    follow_redirects: none
+    status_code:
+      - 302
+      - 303
+    body_format: form-urlencoded
+    body:
+      response_type: token
+      client_id: "{{ quay_oauth_client_id }}"
+      redirect_uri: "{{ quayOAuthApp.redirect_uri }}"
+      scope: "{{ quayOAuthApp.scopes }}"
+  register: r_quay_oauth_token
+  retries: 5
+  delay: 10
+  when:
+    - quay_oauth_client_id is defined
+    - quay_oauth_client_id | length > 0
+  until:
+    - r_quay_oauth_token is defined
+    - r_quay_oauth_token.status in [302, 303]
+
+- name: Extract OAuth token from Location header
+  no_log: true
+  ansible.builtin.set_fact:
+    quay_oauth_token: "{{ r_quay_oauth_token.location | regex_search('#access_token=([^&]+)', '\\1') | first }}"
+  when:
+    - r_quay_oauth_token is defined
+    - r_quay_oauth_token is not skipped
+    - r_quay_oauth_token.status is defined
+    - r_quay_oauth_token.location is defined
+
+- name: Store OAuth application credentials in Kubernetes Secret
+  no_log: true
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: quay-oauth-credentials
+        namespace: quay-enterprise
+        labels:
+          app: quay
+          component: oauth
+      type: Opaque
+      stringData:
+        client-id: "{{ quay_oauth_client_id }}"
+        client-secret: "{{ quay_oauth_client_secret }}"
+        access-token: "{{ quay_oauth_token }}"
+        application-name: "{{ quayOAuthApp.name }}"
+        redirect-uri: "{{ quayOAuthApp.redirect_uri }}"
+        scopes: "{{ quayOAuthApp.scopes }}"
+  when:
+    - quay_oauth_client_id is defined
+    - quay_oauth_token is defined
+  register: r_quay_oauth_secret
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_quay_oauth_secret is success

--- a/operators/quay-operator/tasks.yaml
+++ b/operators/quay-operator/tasks.yaml
@@ -1,66 +1,11 @@
+# Create initial quay-config Secret with empty OAuth whitelist
 - name: Create or update quay-config Secret
   no_log: true
   kubernetes.core.k8s:
     state: present
-    definition:
-      apiVersion: v1
-      kind: Secret
-      metadata:
-        name: quay-config
-        namespace: quay-enterprise
-      type: Opaque
-      stringData:
-        config.yaml: |
-          ALLOW_PULLS_WITHOUT_STRICT_LOGGING: false
-          AUTHENTICATION_TYPE: Database
-          DEFAULT_TAG_EXPIRATION: 2w
-          FEATURE_USER_INITIALIZE: true
-          SUPER_USERS:
-            - quayadmin
-          BROWSER_API_CALLS_XHR_ONLY: false
-          FEATURE_USER_CREATION: false
-          CREATE_NAMESPACE_ON_PUSH: true
-          DISTRIBUTED_STORAGE_CONFIG:
-            local_us:
-              - {{ quayBackend }}
-              - {{ ((quayBackendDefaults
-                   | combine(quayBackendRGWDefaults)
-                   | combine(quayBackendRGWConfiguration))
-                   if quayBackend == 'RadosGWStorage'
-                   else (quayBackendDefaults
-                   | combine(quayBackendLocalStorageConfiguration | default({})))
-                   if quayBackend == 'LocalStorage'
-                   else quayBackendDefaults)
-                   | to_yaml }}
-          DISTRIBUTED_STORAGE_DEFAULT_LOCATIONS:
-            - local_us
-
-          ENTERPRISE_LOGO_URL: /static/img/RH_Logo_Quay_Black_UX-horizontal.svg
-          FEATURE_BUILD_SUPPORT: false
-          FEATURE_DIRECT_LOGIN: true
-          FEATURE_MAILING: false
-          REGISTRY_TITLE: Red Hat Quay
-          REGISTRY_TITLE_SHORT: Red Hat Quay
-          SETUP_COMPLETE: true
-          TAG_EXPIRATION_OPTIONS:
-            - 2w
-          TEAM_RESYNC_STALE_TIME: 60m
-          TESTING: false
-          FEATURE_PROXY_STORAGE: {{ quayFeatureProxyStorage | bool | lower }}
-          FEATURE_QUOTA_MANAGEMENT: {{ quayFeatureQuotaManagement | bool | lower }}
-          MAXIMUM_LAYER_SIZE: {{ quayMaximumLayerSize }}
-        clair-config.yaml: |
-          indexer:
-            airgap: true
-            scanner:
-              repo:
-                rhel-repository-scanner:
-                  repo2cpe_mapping_file: "/data/repository-to-cpe.json"
-              package:
-                rhel_containerscanner:
-                  name2repos_mapping_file: "/data/container-name-repos-map.json"
-          matcher:
-            disable_updaters: true
+    definition: "{{ lookup('template', 'templates/quay-config-secret.yaml.j2') | from_yaml }}"
+  vars:
+    oauth_client_ids: []
   register: r_quay_config_secret
   retries: "{{ k8s_retries }}"
   delay: "{{ k8s_delay }}"
@@ -111,6 +56,72 @@
   until:
     - r_quay_user is defined
     - r_quay_user.status | default(0) == 200 or r_quay_user.json.message | default("") == "Cannot initialize user in a non-empty database"
+
+- name: Extract initial user access token from initialize response
+  no_log: true
+  ansible.builtin.set_fact:
+    quay_initial_token: "{{ r_quay_user.json.access_token }}"
+  when:
+    - r_quay_user.status == 200
+    - r_quay_user.json.access_token is defined
+    - r_quay_user.json.access_token | length > 0
+
+- name: Store initial user token in Kubernetes Secret
+  no_log: true
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: quay-initial-user-token
+        namespace: quay-enterprise
+        labels:
+          app: quay
+          component: initial-user
+      type: Opaque
+      stringData:
+        username: "{{ quayUser }}"
+        access-token: "{{ quay_initial_token }}"
+  when:
+    - quay_initial_token is defined
+    - quay_initial_token | length > 0
+  register: r_quay_initial_user_secret
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_quay_initial_user_secret is success
+
+- name: Read stored initial user token Secret
+  no_log: true
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    name: quay-initial-user-token
+    namespace: quay-enterprise
+  register: r_quay_initial_user_secret_info
+  when:
+    - quay_initial_token is not defined or quay_initial_token | length == 0
+
+- name: Extract initial user access token from Kubernetes Secret
+  no_log: true
+  ansible.builtin.set_fact:
+    quay_initial_token: "{{ r_quay_initial_user_secret_info.resources[0].data['access-token'] | b64decode }}"
+  when:
+    - quay_initial_token is not defined or quay_initial_token | length == 0
+    - r_quay_initial_user_secret_info.resources is defined
+    - r_quay_initial_user_secret_info.resources | length > 0
+    - r_quay_initial_user_secret_info.resources[0].data is defined
+    - r_quay_initial_user_secret_info.resources[0].data['access-token'] is defined
+
+# Configure OAuth application (organization, app, token generation)
+# This is extracted to a separate file for better maintainability
+- name: Configure OAuth application for Quay
+  ansible.builtin.include_tasks:
+    file: oauth_setup.yaml
+  when:
+    - quayOAuthApp.enabled | default(true)
+    - quay_initial_token is defined
+    - quay_initial_token | length > 0
 
 - name: Generate pull secret for internal mirror
   no_log: true

--- a/operators/quay-operator/templates/quay-config-secret.yaml.j2
+++ b/operators/quay-operator/templates/quay-config-secret.yaml.j2
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: quay-config
+  namespace: quay-enterprise
+type: Opaque
+stringData:
+  config.yaml: |
+    ALLOW_PULLS_WITHOUT_STRICT_LOGGING: false
+    AUTHENTICATION_TYPE: Database
+    DEFAULT_TAG_EXPIRATION: 2w
+    FEATURE_USER_INITIALIZE: true
+    SUPER_USERS:
+      - quayadmin
+    BROWSER_API_CALLS_XHR_ONLY: false
+    FEATURE_USER_CREATION: false
+    CREATE_NAMESPACE_ON_PUSH: true
+    DISTRIBUTED_STORAGE_CONFIG:
+      local_us:
+        - {{ quayBackend }}
+        - {{ ((quayBackendDefaults
+             | combine(quayBackendRGWDefaults)
+             | combine(quayBackendRGWConfiguration))
+             if quayBackend == 'RadosGWStorage'
+             else (quayBackendDefaults
+             | combine(quayBackendLocalStorageConfiguration | default({})))
+             if quayBackend == 'LocalStorage'
+             else quayBackendDefaults)
+             | to_nice_yaml(indent=2, width=50000) | indent(10) }}
+    DISTRIBUTED_STORAGE_DEFAULT_LOCATIONS:
+      - local_us
+
+    ENTERPRISE_LOGO_URL: /static/img/RH_Logo_Quay_Black_UX-horizontal.svg
+    FEATURE_BUILD_SUPPORT: false
+    FEATURE_DIRECT_LOGIN: true
+    FEATURE_MAILING: false
+    REGISTRY_TITLE: Red Hat Quay
+    REGISTRY_TITLE_SHORT: Red Hat Quay
+    SETUP_COMPLETE: true
+    TAG_EXPIRATION_OPTIONS:
+      - 2w
+    TEAM_RESYNC_STALE_TIME: 60m
+    TESTING: false
+    FEATURE_PROXY_STORAGE: {{ quayFeatureProxyStorage | bool | lower }}
+    FEATURE_QUOTA_MANAGEMENT: {{ quayFeatureQuotaManagement | bool | lower }}
+    MAXIMUM_LAYER_SIZE: {{ quayMaximumLayerSize }}
+    DIRECT_OAUTH_CLIENTID_WHITELIST:
+{% if oauth_client_ids | default([]) | length > 0 %}
+{% for client_id in oauth_client_ids %}
+      - "{{ client_id }}"
+{% endfor %}
+{% else %}
+      []
+{% endif %}
+  clair-config.yaml: |
+    indexer:
+      airgap: true
+      scanner:
+        repo:
+          rhel-repository-scanner:
+            repo2cpe_mapping_file: "/data/repository-to-cpe.json"
+        package:
+          rhel_containerscanner:
+            name2repos_mapping_file: "/data/container-name-repos-map.json"
+    matcher:
+      disable_updaters: true

--- a/schemas/quay_operator.yaml
+++ b/schemas/quay_operator.yaml
@@ -45,6 +45,39 @@ properties:
       - minimum_chunk_size_mb
       - maximum_chunk_size_mb
       - server_side_assembly
+  quayOAuthApp:
+    type: object
+    description: OAuth application configuration for Quay
+    additionalProperties: false
+    properties:
+      enabled:
+        type: boolean
+        description: Enable automatic OAuth application creation during initial setup
+      name:
+        type: string
+        description: Name of the OAuth application
+      organization:
+        type: string
+        description: Organization name for OAuth application
+        pattern: "^[a-z0-9]+(?:[._-][a-z0-9]+)*$"
+      redirect_uri:
+        type: string
+        description: Redirect URI for OAuth application
+        pattern: "^https?://.+"
+      scopes:
+        type: string
+        description: Space-separated list of OAuth scopes
+    allOf:
+      - if:
+          properties:
+            enabled:
+              const: true
+        then:
+          required:
+            - name
+            - organization
+            - redirect_uri
+            - scopes
 
 required:
   - quayFeatureProxyStorage


### PR DESCRIPTION

* feat: add OAuth application creation and management for Quay operator

* feat: add organization support for OAuth application creation

* refactor(quay-oauth-token): extract OAuth setup tasks to separate file

* feat(quay-oauth-token): handle existing OAuth app credentials retrieval

* refactor(quay-oauth-token): make OAuth app configuration conditionally required

* refactor(quay-oauth-token): remove conflict handling for OAuth app creation

---------

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OAuth application configuration and automatic setup support for Quay deployments
  * New configuration options for OAuth app parameters including name, organization, redirect URI, and scopes
  * OAuth credentials are securely stored and managed within the system

<!-- end of auto-generated comment: release notes by coderabbit.ai -->