### PR TITLE
MGMT-23792: Remove rootfs download and serving

### DIFF
--- a/defaults/content_images.yaml
+++ b/defaults/content_images.yaml
@@ -1,8 +1,5 @@
 ---
 content_images:
-  imgs:
-    - url: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.20/4.20.0/rhcos-4.20.0-x86_64-live-rootfs.x86_64.img"
-      checksum: "sha256:4d2e74921d95d4132b12d1088693a1b93b556a7846f93c4a6d6af32cecd10d2c"
   isos:
     - url: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.20/4.20.0/rhcos-4.20.0-x86_64-live-iso.x86_64.iso"
       checksum: "sha256:7a47d0c7a9bf5edb143d52809e793af2d74731567b95d91c6225171a1c49b5ab"

--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -1133,7 +1133,7 @@ Core operators are defined in `defaults/operators.yaml`. Plugin operators are de
 
 Content configuration is stored in the `defaults/` directory:
 - `defaults/control_binaries.yaml` - Binary downloads (oc, helm, mirror-registry, oc-mirror)
-- `defaults/content_images.yaml` - RHCOS images and ISOs
+- `defaults/content_images.yaml` - RHCOS ISO images
 
 ### Control Binaries
 
@@ -1186,17 +1186,13 @@ control_binaries:
 **Example**:
 ```yaml
 content_images:
-  imgs:
-    - url: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.19/4.19.10/rhcos-4.19.10-x86_64-live-rootfs.x86_64.img"
-      checksum: "sha256:4d2e74921d95d4132b12d1088693a1b93b556a7846f93c4a6d6af32cecd10d2c"
   isos:
     - url: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.19/4.19.10/rhcos-4.19.10-x86_64-live-iso.x86_64.iso"
       checksum: "sha256:7a47d0c7a9bf5edb143d52809e793af2d74731567b95d91c6225171a1c49b5ab"
 ```
 
 **Fields**:
-- `imgs`: List of rootfs images (used by agent-based installer)
-- `isos`: List of ISO images (used for traditional installation)
+- `isos`: List of ISO images (used for cluster deployment)
 
 **Notes**:
 - Version should match OCP version

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -447,12 +447,9 @@ control_binaries:
     checksum: "sha256:..."
 ```
 
-**`defaults/content_images.yaml`** - Content images (RHCOS ISO and rootfs):
+**`defaults/content_images.yaml`** - RHCOS ISO images:
 ```yaml
 content_images:
-  imgs:
-    - url: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.19/4.19.10/rhcos-4.19.10-x86_64-live-rootfs.x86_64.img"
-      checksum: "sha256:..."
   isos:
     - url: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.19/4.19.10/rhcos-4.19.10-x86_64-live-iso.x86_64.iso"
       checksum: "sha256:..."

--- a/operators/multicluster-engine/tasks.yaml
+++ b/operators/multicluster-engine/tasks.yaml
@@ -328,7 +328,6 @@
         osImages:
         - cpuArchitecture: x86_64
           openshiftVersion: "4.20"
-          rootFSUrl: "http://{{ quayHostname }}/rhcos-4.20.0-x86_64-live-rootfs.x86_64.img"
           url: "http://{{ quayHostname }}/rhcos-4.20.0-x86_64-live-iso.x86_64.iso"
           version: 9.6.20251023-0
   register: r_agentserviceconfig

--- a/playbooks/tasks/download_content.yaml
+++ b/playbooks/tasks/download_content.yaml
@@ -1,20 +1,10 @@
 ---
-- name: Download live rootfs images
+- name: Download RHCOS live ISOs
   become: true
   ansible.builtin.get_url:
-    url: "{{ rootfs_img.url }}"
-    dest: "/var/www/html/{{ (rootfs_img.url | ansible.builtin.split('/'))[-1] }}"
-    checksum: "{{ rootfs_img.checksum }}"
-  loop: "{{ content_images.imgs }}"
-  loop_control:
-    loop_var: rootfs_img
-
-- name: Download live rootfs isos
-  become: true
-  ansible.builtin.get_url:
-    url: "{{ rootfs_iso.url }}"
-    dest: "/var/www/html/{{ (rootfs_iso.url | ansible.builtin.split('/'))[-1] }}"
-    checksum: "{{ rootfs_iso.checksum }}"
+    url: "{{ iso_item.url }}"
+    dest: "/var/www/html/{{ (iso_item.url | ansible.builtin.split('/'))[-1] }}"
+    checksum: "{{ iso_item.checksum }}"
   loop: "{{ content_images.isos }}"
   loop_control:
-    loop_var: rootfs_iso
+    loop_var: iso_item

--- a/schemas/content_images.yaml
+++ b/schemas/content_images.yaml
@@ -7,25 +7,8 @@ additionalProperties: false
 properties:
   content_images:
     type: object
-    description: URLs and checksums for RHCOS images.
+    description: URLs and checksums for RHCOS ISO images.
     properties:
-      imgs:
-        type: array
-        description: List of rootfs images (used by agent-based installer).
-        items:
-          type: object
-          required:
-          - url
-          - checksum
-          properties:
-            url:
-              type: string
-              description: URL to download the rootfs image.
-            checksum:
-              type: string
-              description: SHA256 checksum for the image.
-              pattern: "^sha256:[0-9a-f]{64}$"
-          additionalProperties: false
       isos:
         type: array
         description: List of ISO images (used for traditional installation).


### PR DESCRIPTION
The rootfs URL has not been required in the AgentServiceConfig OSImages list in a long time. This is because the rootfs is always served from the image service full ISO content directly rather than requiring a separate stored artifact.

Supplying that URL was the only reason this image was downloaded and served so that can all just be removed. This saves time, complexity, and space (especially if many versions will eventually be configured).

Resolves https://redhat.atlassian.net/browse/MGMT-23792

For reference, the requirement for rootFSURL was removed several years ago in https://github.com/openshift/assisted-image-service/pull/83

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Removed rootfs image configuration; system now exclusively handles RHCOS ISO images for deployments.

* **Documentation**
  * Updated configuration and deployment guides to reflect removal of rootfs image support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->