### PR TITLE
Increase k8s retry defaults and CatalogSource timeout

### DIFF
--- a/defaults/k8s.yaml
+++ b/defaults/k8s.yaml
@@ -1,5 +1,5 @@
 ---
 # Retry settings for kubernetes.core.k8s state: present/absent/patched calls.
 # These are internal defaults and are not meant to be overridden by the user.
-k8s_retries: 6
-k8s_delay: 5
+k8s_retries: 12
+k8s_delay: 10

--- a/playbooks/tasks/deploy_plugin.yaml
+++ b/playbooks/tasks/deploy_plugin.yaml
@@ -169,8 +169,8 @@
   environment:
     KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
   register: r_catalog_sources
-  retries: "{{ k8s_retries }}"
-  delay: "{{ k8s_delay }}"
+  retries: 24
+  delay: 10
   until: >-
     r_catalog_sources.resources | default([])
     | selectattr('status', 'defined')


### PR DESCRIPTION
Raise default k8s_retries from 6 to 12 and k8s_delay from 5s to 10s (30s → 2min total) to better handle API server pressure during deployment when many resources are created simultaneously.

For the CatalogSource readiness check after plugin mirroring, use explicit 24×10s (4min) since CatalogSources can remain in TRANSIENT_FAILURE for several minutes after oc-mirror applies new catalog images.

Fixes: https://github.com/gori-project/GoRI/issues/862

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Kubernetes operation resilience by increasing retry attempts and delays for plugin deployment tasks and CatalogSource readiness checks, reducing timeout failures during cluster operations and improving reliability when waiting for cluster resources to reach the desired state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->