### PR TITLE
Add HTTPS support for Ironic vmedia server with CI trust chain

### DIFF
--- a/.github/workflows/e2e-deployment.yml
+++ b/.github/workflows/e2e-deployment.yml
@@ -172,6 +172,7 @@ jobs:
       BASE_WORKING_DIR: ${{ vars.BASE_WORKING_DIR }}
       PULL_SECRET: ${{ secrets.PULL_SECRET }}
       ENCLAVE_DEPLOYMENT_MODE: connected
+      ENCLAVE_IRONIC_HTTPS: 'true'
       CLEANUP_AFTER: 'true'
       STORAGE_PLUGIN: ${{ matrix.storage-plugin }}
       ENABLED_PLUGINS: ${{ matrix.storage-plugin }}
@@ -250,6 +251,11 @@ jobs:
           echo "Installing dev-scripts and required packages on Landing Zone..." >> $GITHUB_STEP_SUMMARY
           make -f Makefile.ci install-enclave
           echo "Enclave Lab installed" >> $GITHUB_STEP_SUMMARY
+
+      - name: Generate Ironic ISO server TLS certificate
+        id: generate_ironic_cert
+        if: env.ENCLAVE_IRONIC_HTTPS == 'true'
+        run: ./scripts/deployment/generate_ironic_cert.sh
 
       - name: Setup Ceph on Landing Zone
         if: env.STORAGE_PLUGIN == 'odf'
@@ -494,6 +500,7 @@ jobs:
           STEPS_JSON: ${{ toJSON(steps) }}
         run: |
           declare -A step_names=(
+            ["generate_ironic_cert"]="Generate Ironic ISO server TLS certificate"
             ["setup_ceph"]="Setup Ceph on Landing Zone"
             ["bootstrap_setup"]="Bootstrap: Setup environment"
             ["bootstrap_validate"]="Bootstrap: Validate configuration"
@@ -509,6 +516,7 @@ jobs:
           )
 
           step_order=(
+            generate_ironic_cert
             setup_ceph
             bootstrap_setup
             bootstrap_validate
@@ -654,6 +662,11 @@ jobs:
           echo "Installing dev-scripts and required packages on Landing Zone..." >> $GITHUB_STEP_SUMMARY
           make -f Makefile.ci install-enclave
           echo "Enclave Lab installed" >> $GITHUB_STEP_SUMMARY
+
+      - name: Generate Ironic ISO server TLS certificate
+        id: generate_ironic_cert
+        if: env.ENCLAVE_IRONIC_HTTPS == 'true'
+        run: ./scripts/deployment/generate_ironic_cert.sh
 
       - name: Setup Ceph on Landing Zone
         if: env.STORAGE_PLUGIN == 'odf'
@@ -907,6 +920,7 @@ jobs:
           STEPS_JSON: ${{ toJSON(steps) }}
         run: |
           declare -A step_names=(
+            ["generate_ironic_cert"]="Generate Ironic ISO server TLS certificate"
             ["setup_ceph"]="Setup Ceph on Landing Zone"
             ["bootstrap_setup"]="Bootstrap: Setup environment"
             ["bootstrap_validate"]="Bootstrap: Validate configuration"
@@ -922,6 +936,7 @@ jobs:
           )
 
           step_order=(
+            generate_ironic_cert
             setup_ceph
             bootstrap_setup
             bootstrap_validate

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -336,13 +336,20 @@ environment:
 	@echo "Step 4: Verifying networks were created..."
 	@./scripts/infrastructure/verify_networks.sh
 	@echo ""
-	@echo "Step 5: Starting BMC emulation (sushy-tools)..."
+	@if [ "$${ENCLAVE_IRONIC_HTTPS}" = "true" ]; then \
+		echo "Step 5: Generating Ironic ISO server CA..."; \
+		./scripts/deployment/generate_ironic_ca.sh; \
+	else \
+		echo "Step 5: Skipping Ironic ISO server CA (HTTPS not configured)"; \
+	fi
+	@echo ""
+	@echo "Step 6: Starting BMC emulation (sushy-tools)..."
 	@./scripts/infrastructure/start_sushy_tools.sh
 	@echo ""
-	@echo "Step 6: Generating environment metadata..."
+	@echo "Step 7: Generating environment metadata..."
 	@./scripts/infrastructure/generate_environment_json.sh
 	@echo ""
-	@echo "Step 7: Verifying infrastructure..."
+	@echo "Step 8: Verifying infrastructure..."
 	@$(MAKE) -f Makefile.ci verify
 	@echo ""
 	@echo "=========================================="

--- a/config/certificates.example.yaml
+++ b/config/certificates.example.yaml
@@ -47,3 +47,18 @@ sslCACertificate: |
   -----BEGIN CERTIFICATE-----
   YOUR_ROOT_CA_CERTIFICATE
   -----END CERTIFICATE-----
+
+# Ironic HTTP Server TLS Certificate (optional)
+# Required when serving boot ISOs over HTTPS to the BMC.
+# The SAN on this certificate must cover lzBmcHostname (DNS SAN, for Let's Encrypt certs)
+# or lzBmcIP (IP SAN, for private CA certs). Set lzBmcHostname in global.yaml when using
+# a publicly trusted certificate such as Let's Encrypt.
+ironicHTTPSCertificate: ""
+
+ironicHTTPSKey: ""
+
+# Ironic HTTP Server TLS CA Certificate (optional)
+# Provide this when the BMC emulator must trust a private CA to verify
+# the Ironic HTTPS certificate. Installs the CA into the BMC emulator
+# trust store. Leave empty when using a publicly trusted certificate.
+ironicHTTPSCACertificate: ""

--- a/config/certificates.example.yaml
+++ b/config/certificates.example.yaml
@@ -56,9 +56,3 @@ sslCACertificate: |
 ironicHTTPSCertificate: ""
 
 ironicHTTPSKey: ""
-
-# Ironic HTTP Server TLS CA Certificate (optional)
-# Provide this when the BMC emulator must trust a private CA to verify
-# the Ironic HTTPS certificate. Installs the CA into the BMC emulator
-# trust store. Leave empty when using a publicly trusted certificate.
-ironicHTTPSCACertificate: ""

--- a/config/global.example.yaml
+++ b/config/global.example.yaml
@@ -29,6 +29,12 @@ rendezvousIP: YOUR_RENDEZVOUS_IP      # Example: 192.168.2.24
 # LZ IP where HTTP server serves the installation ISO to IPMI nodes
 lzBmcIP: YOUR_LZ_WEB_SERVER_IP        # Example: 100.64.1.10
 
+# DNS hostname for the LZ BMC interface (optional).
+# When set, Ironic HTTPS vmedia URLs use this hostname instead of lzBmcIP.
+# Required when using publicly trusted certificates (e.g. Let's Encrypt), which
+# only support DNS SANs. The hostname must resolve to lzBmcIP from the BMC network.
+# lzBmcHostname: mirror.example.com
+
 # ============================================================================
 # Quay Registry Configuration
 # ============================================================================

--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -235,7 +235,7 @@ lzBmcIP: 100.64.1.10
 
 #### `lzBmcHostname`
 
-**Description**: DNS hostname for the LZ BMC interface. Optional. When set, Ironic constructs HTTPS vmedia URLs using this hostname instead of `lzBmcIP`.
+**Description**: DNS hostname for the LZ BMC interface. Optional. Only used when `ironicHTTPSCertificate` and `ironicHTTPSKey` are also set — ignored otherwise. When set, Ironic constructs HTTPS vmedia URLs using this hostname instead of `lzBmcIP`.
 
 **Type**: String (DNS hostname)
 
@@ -247,9 +247,10 @@ lzBmcHostname: mirror.example.com
 ```
 
 **Notes**:
+- Has no effect unless `ironicHTTPSCertificate` and `ironicHTTPSKey` are configured
 - The hostname must resolve to `lzBmcIP` from the BMC network
 - When set, `ironicHTTPSCertificate` must have a DNS SAN matching this hostname
-- When not set, the IP-based flow is used and `ironicHTTPSCertificate` must have an IP SAN matching `lzBmcIP`
+- When not set with HTTPS, `ironicHTTPSCertificate` must have an IP SAN matching `lzBmcIP`
 - `PROVISIONING_IP` (used for Apache binding) always remains `lzBmcIP`; only the vmedia URL changes
 
 #### `defaultNtpServers`

--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -1144,23 +1144,6 @@ ironicHTTPSKey: |
   <PEM-encoded private key>
 ```
 
-#### `ironicHTTPSCACertificate`
-
-**Description**: CA certificate to install into the BMC emulator trust
-store. Only needed when the Ironic HTTPS certificate is signed by a
-private CA that the BMC emulator does not trust by default.
-
-**Type**: String (PEM format)
-
-**Required**: No. Leave empty when using a publicly trusted certificate.
-
-**Example**:
-```yaml
-ironicHTTPSCACertificate: |
-  -----BEGIN CERTIFICATE-----
-  ... (CA certificate)
-  -----END CERTIFICATE-----
-```
 
 ## Operator Configuration
 

--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -233,6 +233,25 @@ lzBmcIP: 100.64.1.10
 - ISO will be served at `http://{{ lzBmcIP }}/assisted/agent.x86_64.iso`
 - Ensure HTTP server (Apache/Nginx) is running on this host
 
+#### `lzBmcHostname`
+
+**Description**: DNS hostname for the LZ BMC interface. Optional. When set, Ironic constructs HTTPS vmedia URLs using this hostname instead of `lzBmcIP`.
+
+**Type**: String (DNS hostname)
+
+**Required**: No. Set this when using publicly trusted TLS certificates (e.g. Let's Encrypt) for the Ironic vmedia server. Let's Encrypt only issues DNS SANs, not IP SANs, so the certificate SAN must match a hostname rather than an IP address.
+
+**Example**:
+```yaml
+lzBmcHostname: mirror.example.com
+```
+
+**Notes**:
+- The hostname must resolve to `lzBmcIP` from the BMC network
+- When set, `ironicHTTPSCertificate` must have a DNS SAN matching this hostname
+- When not set, the IP-based flow is used and `ironicHTTPSCertificate` must have an IP SAN matching `lzBmcIP`
+- `PROVISIONING_IP` (used for Apache binding) always remains `lzBmcIP`; only the vmedia URL changes
+
 #### `defaultNtpServers`
 
 **Description**: Optional list of additional NTP server addresses for cluster nodes. When not set, the cluster uses its default NTP sources.
@@ -1082,6 +1101,64 @@ sslIngressCertificateFullChain: |
 sslCACertificate: |
   -----BEGIN CERTIFICATE-----
   ... (server certificate)
+  -----END CERTIFICATE-----
+```
+
+### Ironic HTTPS Certificate (Optional)
+
+These variables enable HTTPS for the Ironic vmedia server, which serves
+boot ISOs to BMCs. When configured, Ironic will serve content over TLS
+instead of plain HTTP.
+
+#### `ironicHTTPSCertificate`
+
+**Description**: TLS certificate for the Ironic vmedia HTTPS server.
+
+**Type**: String (PEM format)
+
+**Required**: Yes, when HTTPS vmedia is desired. Must be provided together
+with `ironicHTTPSKey`. The certificate SAN must cover `lzBmcHostname`
+(DNS SAN, for publicly trusted certs such as Let's Encrypt) or `lzBmcIP`
+(IP SAN, for private CA certs) depending on which is configured.
+
+**Example**:
+```yaml
+ironicHTTPSCertificate: |
+  -----BEGIN CERTIFICATE-----
+  ... (certificate)
+  -----END CERTIFICATE-----
+```
+
+#### `ironicHTTPSKey`
+
+**Description**: Private key for the Ironic vmedia HTTPS certificate.
+
+**Type**: String (PEM format)
+
+**Required**: Yes, when `ironicHTTPSCertificate` is set. Both variables
+must be provided together.
+
+**Example**:
+```yaml
+ironicHTTPSKey: |
+  <PEM-encoded private key>
+```
+
+#### `ironicHTTPSCACertificate`
+
+**Description**: CA certificate to install into the BMC emulator trust
+store. Only needed when the Ironic HTTPS certificate is signed by a
+private CA that the BMC emulator does not trust by default.
+
+**Type**: String (PEM format)
+
+**Required**: No. Leave empty when using a publicly trusted certificate.
+
+**Example**:
+```yaml
+ironicHTTPSCACertificate: |
+  -----BEGIN CERTIFICATE-----
+  ... (CA certificate)
   -----END CERTIFICATE-----
 ```
 

--- a/playbooks/tasks/configure_hardware_ironic_boot.yaml
+++ b/playbooks/tasks/configure_hardware_ironic_boot.yaml
@@ -154,7 +154,7 @@
     body:
       - op: add
         path: /instance_info/boot_iso
-        value: "http://{{ lzBmcIP }}:{{ http_server_port }}/agent.x86_64.iso"
+        value: "file:///iso/agent.x86_64.iso"
     headers:
       Content-Type: "application/json"
       X-OpenStack-Ironic-API-Version: "{{ ironic_api_version }}"

--- a/playbooks/tasks/configure_hardware_ironic_cleanup.yaml
+++ b/playbooks/tasks/configure_hardware_ironic_cleanup.yaml
@@ -1,26 +1,5 @@
 ---
-# Clean up Ironic deployment and temporary HTTP server after hardware configuration is complete
-- name: Set defaults for Ironic configuration
-  ansible.builtin.set_fact:
-    http_server_pidfile: "{{ http_server_pidfile | default(workingDir + '/logs/ironic-temp-http.pid') }}"
-
-- name: Check if pidfile exists
-  ansible.builtin.stat:
-    path: "{{ http_server_pidfile }}"
-  register: pidfile_stat
-
-- name: Stop temporary Python HTTP server
-  ansible.builtin.shell: "kill $(cat {{ http_server_pidfile }}) 2>/dev/null"
-  register: stop_result
-  failed_when: false
-  changed_when: stop_result.rc == 0
-  when: pidfile_stat.stat.exists
-
-- name: Remove HTTP server PID file
-  ansible.builtin.file:
-    path: "{{ http_server_pidfile }}"
-    state: absent
-
+# Clean up Ironic deployment after hardware configuration is complete
 - name: Stop and remove Ironic pod
   containers.podman.podman_pod:
     name: metal3-ironic
@@ -45,4 +24,6 @@
     - metal3-ca-bundle
     - metal3-ironic-username
     - metal3-ironic-password
+    - ironic-vmedia-cert
+    - ironic-vmedia-key
   when: metal3_cleanup_secrets | default(false) | bool

--- a/playbooks/tasks/configure_hardware_ironic_setup.yaml
+++ b/playbooks/tasks/configure_hardware_ironic_setup.yaml
@@ -1,50 +1,8 @@
 ---
 # Set up Ironic for hardware configuration
-# This deploys the Ironic service and starts a temporary HTTP server for ISO hosting
-
-- name: Set defaults for Ironic configuration
-  ansible.builtin.set_fact:
-    http_server_port: "{{ http_server_port | default(8000) }}"
-    http_server_pidfile: "{{ http_server_pidfile | default(workingDir + '/logs/ironic-temp-http.pid') }}"
-    http_server_logfile: "{{ http_server_logfile | default(workingDir + '/logs/ironic-temp-http.log') }}"
 
 - name: Deploy Metal3 common resources
   ansible.builtin.include_tasks: deploy_metal3_common.yaml
 
 - name: Deploy Ironic pod
   ansible.builtin.include_tasks: deploy_ironic.yaml
-
-- name: Check if HTTP server PID file exists
-  ansible.builtin.stat:
-    path: "{{ http_server_pidfile }}"
-  register: pidfile_stat
-
-- name: Check if HTTP server process is running
-  ansible.builtin.shell: "kill -0 $(cat {{ http_server_pidfile }}) 2>/dev/null"
-  register: http_server_check
-  failed_when: false
-  changed_when: false
-  when: pidfile_stat.stat.exists
-
-- name: Start temporary Python HTTP server
-  ansible.builtin.shell: >
-    nohup python3 -m http.server {{ http_server_port }} --directory {{ workingDir + '/ocp-cluster/abi-iso/' }} > {{ http_server_logfile }} 2>&1 &
-    echo $! > {{ http_server_pidfile }}
-  when: not pidfile_stat.stat.exists or http_server_check.rc != 0
-  changed_when: true
-
-- name: Wait for HTTP server to be ready
-  ansible.builtin.wait_for:
-    port: "{{ http_server_port }}"
-    host: localhost
-    timeout: 30
-
-- name: Verify ISO is accessible via temporary HTTP server
-  ansible.builtin.uri:
-    url: "http://{{ lzBmcIP }}:{{ http_server_port }}/agent.x86_64.iso"
-    method: HEAD
-    status_code: [200]
-  register: r_temp_http_check
-  retries: 3
-  delay: 1
-  until: r_temp_http_check is succeeded

--- a/playbooks/tasks/deploy_ironic.yaml
+++ b/playbooks/tasks/deploy_ironic.yaml
@@ -41,6 +41,30 @@
   ansible.builtin.set_fact:
     ssl_certs_configured: "{{ (sslIngressCertificateFullChain is defined and sslIngressCertificateFullChain | length > 0) }}"
 
+- name: Check if Ironic HTTPS is configured
+  ansible.builtin.set_fact:
+    ironic_https_configured: >-
+      {{
+        ironicHTTPSCertificate is defined and ironicHTTPSCertificate | length > 0
+        and ironicHTTPSKey is defined and ironicHTTPSKey | length > 0
+      }}
+
+- name: Check if Ironic HTTPS CA is configured
+  ansible.builtin.set_fact:
+    ironic_https_ca_configured: >-
+      {{
+        ironicHTTPSCACertificate is defined and ironicHTTPSCACertificate | length > 0
+      }}
+
+- name: Assert Ironic HTTPS inputs are complete
+  when: >-
+    (ironicHTTPSCertificate is defined and ironicHTTPSCertificate | length > 0)
+    or (ironicHTTPSKey is defined and ironicHTTPSKey | length > 0)
+  ansible.builtin.assert:
+    that:
+      - ironic_https_configured | bool
+    fail_msg: "Set both ironicHTTPSCertificate and ironicHTTPSKey to enable Ironic HTTPS."
+
 - name: Create podman secret for CA bundle
   when: ssl_certs_configured | bool
   become: "{{ metal3_persistent | default(false) | bool }}"
@@ -50,6 +74,53 @@
     state: present
     force: false
   no_log: true
+
+- name: Set Ironic HTTPS CA certificate file path
+  become: "{{ metal3_persistent | default(false) | bool }}"
+  when:
+    - ironic_https_configured | bool
+    - ironic_https_ca_configured | bool
+  ansible.builtin.set_fact:
+    ironic_ca_certfile: "{{ ironic_ca_certfile | default(workingDir + '/logs/ironic-iso-ca.crt') }}"
+
+- name: Write Ironic HTTPS CA certificate to temp file
+  become: "{{ metal3_persistent | default(false) | bool }}"
+  when:
+    - ironic_https_configured | bool
+    - ironic_https_ca_configured | bool
+  ansible.builtin.copy:
+    content: "{{ ironicHTTPSCACertificate }}\n"
+    dest: "{{ ironic_ca_certfile }}"
+    mode: "0644"
+
+- name: Check if httpd container is already running
+  when: ironic_https_configured | bool
+  containers.podman.podman_container_info:
+    name: httpd
+  register: httpd_precheck
+  failed_when: false
+
+- name: Create podman secret for Ironic vmedia TLS certificate
+  when: ironic_https_configured | bool
+  become: "{{ metal3_persistent | default(false) | bool }}"
+  containers.podman.podman_secret:
+    name: ironic-vmedia-cert
+    data: "{{ ironicHTTPSCertificate }}\n"
+    state: present
+    force: false
+  no_log: true
+  register: vmedia_cert_secret
+
+- name: Create podman secret for Ironic vmedia TLS key
+  when: ironic_https_configured | bool
+  become: "{{ metal3_persistent | default(false) | bool }}"
+  containers.podman.podman_secret:
+    name: ironic-vmedia-key
+    data: "{{ ironicHTTPSKey }}\n"
+    state: present
+    force: false
+  no_log: true
+  register: vmedia_key_secret
 
 - name: Create ironic-conf volume
   become: "{{ metal3_persistent | default(false) | bool }}"
@@ -93,6 +164,32 @@
   retries: 30
   delay: 10
   until: r_http is succeeded
+
+- name: Verify HTTPS vmedia server accessibility
+  when: ironic_https_configured | bool
+  block:
+    - name: Wait for HTTPS vmedia port
+      ansible.builtin.wait_for:
+        host: "{{ lzBmcIP }}"
+        port: 6183
+        timeout: 300
+  rescue:
+    - name: Capture httpd logs on HTTPS check failure
+      ansible.builtin.command: podman logs httpd
+      register: r_httpd_failure_logs
+      changed_when: false
+      failed_when: false
+
+    - name: Show httpd logs
+      ansible.builtin.debug:
+        msg: "{{ (r_httpd_failure_logs.stdout_lines | default([])) + (r_httpd_failure_logs.stderr_lines | default([])) }}"
+
+    - name: Fail after printing httpd logs
+      ansible.builtin.fail:
+        msg: >-
+          HTTPS vmedia port 6183
+          on {{ lzBmcIP }} did not become reachable within 300 s.
+          Check httpd logs above for TLS or configuration errors.
 
 - name: Verify Ironic API accessibility
   ansible.builtin.uri:

--- a/playbooks/tasks/deploy_ironic.yaml
+++ b/playbooks/tasks/deploy_ironic.yaml
@@ -49,13 +49,6 @@
         and ironicHTTPSKey is defined and ironicHTTPSKey | length > 0
       }}
 
-- name: Check if Ironic HTTPS CA is configured
-  ansible.builtin.set_fact:
-    ironic_https_ca_configured: >-
-      {{
-        ironicHTTPSCACertificate is defined and ironicHTTPSCACertificate | length > 0
-      }}
-
 - name: Assert Ironic HTTPS inputs are complete
   when: >-
     (ironicHTTPSCertificate is defined and ironicHTTPSCertificate | length > 0)
@@ -75,23 +68,6 @@
     force: false
   no_log: true
 
-- name: Set Ironic HTTPS CA certificate file path
-  become: "{{ metal3_persistent | default(false) | bool }}"
-  when:
-    - ironic_https_configured | bool
-    - ironic_https_ca_configured | bool
-  ansible.builtin.set_fact:
-    ironic_ca_certfile: "{{ ironic_ca_certfile | default(workingDir + '/logs/ironic-iso-ca.crt') }}"
-
-- name: Write Ironic HTTPS CA certificate to temp file
-  become: "{{ metal3_persistent | default(false) | bool }}"
-  when:
-    - ironic_https_configured | bool
-    - ironic_https_ca_configured | bool
-  ansible.builtin.copy:
-    content: "{{ ironicHTTPSCACertificate }}\n"
-    dest: "{{ ironic_ca_certfile }}"
-    mode: "0644"
 
 - name: Check if httpd container is already running
   when: ironic_https_configured | bool

--- a/playbooks/tasks/deploy_ironic_containers.yaml
+++ b/playbooks/tasks/deploy_ironic_containers.yaml
@@ -1,6 +1,30 @@
 ---
 # Ironic ephemeral container deployment (non-persistent path)
 
+- name: Stop persistent Ironic systemd services if running
+  become: true
+  ansible.builtin.systemd:
+    name: "{{ item }}"
+    state: stopped
+    enabled: false
+  loop:
+    - metal3-httpd.service
+    - metal3-ironic-api.service
+    - metal3-ironic-pod.service
+  failed_when: false
+
+- name: Remove persistent metal3-ironic pod
+  become: true
+  containers.podman.podman_pod:
+    name: metal3-ironic
+    state: absent
+  failed_when: false
+
+- name: Remove stale ephemeral metal3-ironic pod
+  containers.podman.podman_pod:
+    name: metal3-ironic
+    state: absent
+
 - name: Create metal3-ironic pod
   containers.podman.podman_pod:
     name: metal3-ironic
@@ -43,21 +67,27 @@
     - r_pod_infra_check.pods | length > 0
   changed_when: false
 
-- name: Set ironic secrets list (with CA bundle)
-  when: ssl_certs_configured | bool
-  ansible.builtin.set_fact:
-    ironic_secrets:
-      - metal3-ca-bundle,type=mount,target=/certs/ca-bundle.crt,uid=1002,gid=1003,mode=0400
-      - metal3-ironic-htpasswd,type=env,target=IRONIC_HTPASSWD
-
-- name: Set ironic secrets list (without CA bundle)
-  when: not (ssl_certs_configured | bool)
+- name: Set base ironic secrets list
   ansible.builtin.set_fact:
     ironic_secrets:
       - metal3-ironic-htpasswd,type=env,target=IRONIC_HTPASSWD
 
-- name: Set ironic environment variables (with CA bundle)
+- name: Add CA bundle to ironic secrets
   when: ssl_certs_configured | bool
+  ansible.builtin.set_fact:
+    ironic_secrets: >-
+      {{ ironic_secrets + ['metal3-ca-bundle,type=mount,target=/certs/ca-bundle.crt,uid=1002,gid=1003,mode=0400'] }}
+
+- name: Add vmedia TLS certs to ironic secrets
+  when: ironic_https_configured | bool
+  ansible.builtin.set_fact:
+    ironic_secrets: >-
+      {{ ironic_secrets + [
+           'ironic-vmedia-cert,type=mount,target=/certs/vmedia/tls.crt,uid=1002,gid=1003,mode=0400',
+           'ironic-vmedia-key,type=mount,target=/certs/vmedia/tls.key,uid=1002,gid=1003,mode=0400'
+         ] }}
+
+- name: Set base ironic environment variables
   ansible.builtin.set_fact:
     ironic_env:
       IRONIC_LISTEN_PORT: "6385"
@@ -68,20 +98,21 @@
       IRONIC_USE_MARIADB: "false"
       IRONIC_EXPOSE_JSON_RPC: "false"
       OS_JSON_RPC__PORT: "6189"
-      WEBSERVER_CACERT_FILE: /certs/ca-bundle.crt
+      OS_CONDUCTOR__FILE_URL_ALLOWED_PATHS: "/iso"
 
-- name: Set ironic environment variables (without CA bundle)
-  when: not (ssl_certs_configured | bool)
+- name: Add CA bundle path to ironic environment
+  when: ssl_certs_configured | bool
   ansible.builtin.set_fact:
-    ironic_env:
-      IRONIC_LISTEN_PORT: "6385"
-      HTTP_PORT: "6180"
-      LISTEN_ALL_INTERFACES: "true"
-      USE_IRONIC_INSPECTOR: "false"
-      PROVISIONING_IP: "{{ lzBmcIP }}"
-      IRONIC_USE_MARIADB: "false"
-      IRONIC_EXPOSE_JSON_RPC: "false"
-      OS_JSON_RPC__PORT: "6189"
+    ironic_env: "{{ ironic_env | combine({'WEBSERVER_CACERT_FILE': '/certs/ca-bundle.crt'}) }}"
+
+- name: Add HTTPS vmedia settings to ironic environment
+  when: ironic_https_configured | bool
+  ansible.builtin.set_fact:
+    ironic_env: >-
+      {{ ironic_env | combine({
+           'VMEDIA_TLS_PORT': '6183',
+           'IRONIC_EXTERNAL_IP': lzBmcHostname | default(lzBmcIP)
+         }) }}
 
 - name: Run ironic container
   containers.podman.podman_container:
@@ -97,11 +128,24 @@
       - metal3-ironic-conf:/conf
       - metal3-ironic-data:/data
       - metal3-ironic-shared:/shared
+      - "{{ workingDir }}/ocp-cluster/abi-iso:/iso:ro"
     secrets: "{{ ironic_secrets }}"
     env: "{{ ironic_env }}"
     command:
       - /bin/runironic
     state: started
+
+- name: Set httpd secrets list (with TLS)
+  when: ironic_https_configured | bool
+  ansible.builtin.set_fact:
+    httpd_secrets:
+      - ironic-vmedia-cert,type=mount,target=/certs/vmedia/tls.crt,uid=1002,gid=1003,mode=0400
+      - ironic-vmedia-key,type=mount,target=/certs/vmedia/tls.key,uid=1002,gid=1003,mode=0400
+
+- name: Set httpd secrets list (without TLS)
+  when: not (ironic_https_configured | bool)
+  ansible.builtin.set_fact:
+    httpd_secrets: []
 
 - name: Run httpd container
   containers.podman.podman_container:
@@ -115,9 +159,11 @@
       - ALL
     volume:
       - metal3-ironic-shared:/shared
+    secrets: "{{ httpd_secrets }}"
     env:
       IRONIC_LISTEN_PORT: "6385"
       HTTP_PORT: "6180"
+      VMEDIA_TLS_PORT: "6183"
       LISTEN_ALL_INTERFACES: "true"
       USE_IRONIC_INSPECTOR: "false"
       PROVISIONING_IP: "{{ lzBmcIP }}"
@@ -137,3 +183,12 @@
     - r_pod_ready.pods[0].Containers | selectattr('Name', 'equalto', 'httpd') | selectattr('State', 'equalto', 'running') | list | length == 1
   changed_when: false
   # Note: Checks that both ironic and httpd containers are running (infra container state is ignored)
+
+- name: Restart httpd container after vmedia TLS secret rotation
+  when:
+    - ironic_https_configured | bool
+    - httpd_precheck.containers | default([]) | length > 0
+    - vmedia_cert_secret.changed | default(false) or vmedia_key_secret.changed | default(false)
+  containers.podman.podman_container:
+    name: httpd
+    state: restarted

--- a/playbooks/tasks/deploy_ironic_containers.yaml
+++ b/playbooks/tasks/deploy_ironic_containers.yaml
@@ -1,30 +1,6 @@
 ---
 # Ironic ephemeral container deployment (non-persistent path)
 
-- name: Stop persistent Ironic systemd services if running
-  become: true
-  ansible.builtin.systemd:
-    name: "{{ item }}"
-    state: stopped
-    enabled: false
-  loop:
-    - metal3-httpd.service
-    - metal3-ironic-api.service
-    - metal3-ironic-pod.service
-  failed_when: false
-
-- name: Remove persistent metal3-ironic pod
-  become: true
-  containers.podman.podman_pod:
-    name: metal3-ironic
-    state: absent
-  failed_when: false
-
-- name: Remove stale ephemeral metal3-ironic pod
-  containers.podman.podman_pod:
-    name: metal3-ironic
-    state: absent
-
 - name: Create metal3-ironic pod
   containers.podman.podman_pod:
     name: metal3-ironic

--- a/playbooks/templates/quadlets/metal3-httpd.container.j2
+++ b/playbooks/templates/quadlets/metal3-httpd.container.j2
@@ -9,8 +9,13 @@ Pod=metal3-ironic.pod
 User=1002:1003
 DropCapability=ALL
 Volume=metal3-ironic-shared:/shared
+{% if ironic_https_configured | default(false) | bool %}
+Secret=ironic-vmedia-cert,type=mount,target=/certs/vmedia/tls.crt,uid=1002,gid=1003,mode=0400
+Secret=ironic-vmedia-key,type=mount,target=/certs/vmedia/tls.key,uid=1002,gid=1003,mode=0400
+{% endif %}
 Environment=IRONIC_LISTEN_PORT=6385
 Environment=HTTP_PORT=6180
+Environment=VMEDIA_TLS_PORT=6183
 Environment=LISTEN_ALL_INTERFACES=true
 Environment=USE_IRONIC_INSPECTOR=false
 Environment=PROVISIONING_IP={{ lzBmcIP }}

--- a/playbooks/templates/quadlets/metal3-ironic-api.container.j2
+++ b/playbooks/templates/quadlets/metal3-ironic-api.container.j2
@@ -11,9 +11,14 @@ DropCapability=ALL
 Volume=metal3-ironic-conf:/conf
 Volume=metal3-ironic-data:/data
 Volume=metal3-ironic-shared:/shared
+Volume={{ workingDir }}/ocp-cluster/abi-iso:/iso:ro
 Secret=metal3-ironic-htpasswd,type=env,target=IRONIC_HTPASSWD
 {% if ssl_certs_configured | bool %}
 Secret=metal3-ca-bundle,type=mount,target=/certs/ca-bundle.crt,uid=1002,gid=1003,mode=0400
+{% endif %}
+{% if ironic_https_configured | default(false) | bool %}
+Secret=ironic-vmedia-cert,type=mount,target=/certs/vmedia/tls.crt,uid=1002,gid=1003,mode=0400
+Secret=ironic-vmedia-key,type=mount,target=/certs/vmedia/tls.key,uid=1002,gid=1003,mode=0400
 {% endif %}
 Environment=IRONIC_LISTEN_PORT=6385
 Environment=HTTP_PORT=6180
@@ -23,8 +28,13 @@ Environment=PROVISIONING_IP={{ lzBmcIP }}
 Environment=IRONIC_USE_MARIADB=false
 Environment=IRONIC_EXPOSE_JSON_RPC=false
 Environment=OS_JSON_RPC__PORT=6189
+Environment=OS_CONDUCTOR__FILE_URL_ALLOWED_PATHS=/iso
 {% if ssl_certs_configured | bool %}
 Environment=WEBSERVER_CACERT_FILE=/certs/ca-bundle.crt
+{% endif %}
+{% if ironic_https_configured | default(false) | bool %}
+Environment=VMEDIA_TLS_PORT=6183
+Environment=IRONIC_EXTERNAL_IP={{ lzBmcHostname | default(lzBmcIP) }}
 {% endif %}
 Exec=/bin/runironic
 HealthCmd=curl -sf http://localhost:6385/

--- a/schemas/definitions.yaml
+++ b/schemas/definitions.yaml
@@ -16,6 +16,10 @@ definitions:
     type: string
     minLength: 1
     description: A non-empty string value
+  hostname:
+    type: string
+    pattern: "^[a-zA-Z0-9]([a-zA-Z0-9\\-]*[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9\\-]*[a-zA-Z0-9])?)*$"
+    description: A valid DNS hostname
   disconnected:
     type: boolean
     description: >-

--- a/schemas/variables.yaml
+++ b/schemas/variables.yaml
@@ -116,9 +116,6 @@ properties:
     "$ref": "#/definitions/ipv4Address"
   sshPubPath:
     "$ref": "#/definitions/nonEmptyString"
-  ironicHTTPSCACertificate:
-    type: string
-    description: PEM-encoded CA certificate for Ironic vmedia HTTPS (for BMC trust)
   ironicHTTPSCertificate:
     type: string
     description: PEM-encoded TLS certificate for Ironic vmedia HTTPS server

--- a/schemas/variables.yaml
+++ b/schemas/variables.yaml
@@ -60,6 +60,8 @@ properties:
             type: array
             items:
               type: string
+  lzBmcHostname:
+    "$ref": "#/definitions/hostname"
   lzBmcIP:
     "$ref": "#/definitions/ipv4Address"
   machineNetwork:
@@ -114,6 +116,15 @@ properties:
     "$ref": "#/definitions/ipv4Address"
   sshPubPath:
     "$ref": "#/definitions/nonEmptyString"
+  ironicHTTPSCACertificate:
+    type: string
+    description: PEM-encoded CA certificate for Ironic vmedia HTTPS (for BMC trust)
+  ironicHTTPSCertificate:
+    type: string
+    description: PEM-encoded TLS certificate for Ironic vmedia HTTPS server
+  ironicHTTPSKey:
+    type: string
+    description: PEM-encoded private key for Ironic vmedia HTTPS certificate
   sslAPICertificateFullChain:
     type: string
     description: PEM-encoded full certificate chain for API server
@@ -187,5 +198,19 @@ allOf:
           type: string
           minLength: 1
         sslIngressCertificateKey:
+          type: string
+          minLength: 1
+  - if:
+      properties:
+        ironicHTTPSCertificate:
+          type: string
+          minLength: 1
+      required:
+        - ironicHTTPSCertificate
+    then:
+      required:
+        - ironicHTTPSKey
+      properties:
+        ironicHTTPSKey:
           type: string
           minLength: 1

--- a/scripts/deployment/deploy_phase.sh
+++ b/scripts/deployment/deploy_phase.sh
@@ -157,15 +157,6 @@ if [ -n "${ENCLAVE_IRONIC_KEY:-}" ]; then
     done < <(printf '%s\n' "${ENCLAVE_IRONIC_KEY}")
 fi
 
-# Inject Ironic ISO server CA certificate if provided
-if [ -n "${ENCLAVE_IRONIC_CA:-}" ]; then
-    EXTRA_VARS_CONTENT="${EXTRA_VARS_CONTENT}ironicHTTPSCACertificate: |
-"
-    while IFS= read -r line; do
-        EXTRA_VARS_CONTENT="${EXTRA_VARS_CONTENT}  ${line}
-"
-    done < <(printf '%s\n' "${ENCLAVE_IRONIC_CA}")
-fi
 
 # Create the extra vars file on Landing Zone
 # shellcheck disable=SC2087,SC2086  # We want client-side expansion of $EXTRA_VARS_CONTENT

--- a/scripts/deployment/deploy_phase.sh
+++ b/scripts/deployment/deploy_phase.sh
@@ -129,6 +129,44 @@ if [ "${STORAGE_PLUGIN:-}" = "odf" ]; then
     append_odf_extra_vars
 fi
 
+# Log when HTTPS is requested for the Ironic ISO server
+# Note: ironic_https_configured is computed by the playbook from the cert/key vars
+if [ "${ENCLAVE_IRONIC_HTTPS:-}" = "true" ]; then
+    info "Ironic ISO server: HTTPS enabled"
+else
+    info "Ironic ISO server: HTTP only (HTTPS not configured)"
+fi
+
+# Inject Ironic ISO server TLS certificate if provided
+if [ -n "${ENCLAVE_IRONIC_CERT:-}" ]; then
+    EXTRA_VARS_CONTENT="${EXTRA_VARS_CONTENT}ironicHTTPSCertificate: |
+"
+    while IFS= read -r line; do
+        EXTRA_VARS_CONTENT="${EXTRA_VARS_CONTENT}  ${line}
+"
+    done < <(printf '%s\n' "${ENCLAVE_IRONIC_CERT}")
+fi
+
+# Inject Ironic ISO server TLS key if provided
+if [ -n "${ENCLAVE_IRONIC_KEY:-}" ]; then
+    EXTRA_VARS_CONTENT="${EXTRA_VARS_CONTENT}ironicHTTPSKey: |
+"
+    while IFS= read -r line; do
+        EXTRA_VARS_CONTENT="${EXTRA_VARS_CONTENT}  ${line}
+"
+    done < <(printf '%s\n' "${ENCLAVE_IRONIC_KEY}")
+fi
+
+# Inject Ironic ISO server CA certificate if provided
+if [ -n "${ENCLAVE_IRONIC_CA:-}" ]; then
+    EXTRA_VARS_CONTENT="${EXTRA_VARS_CONTENT}ironicHTTPSCACertificate: |
+"
+    while IFS= read -r line; do
+        EXTRA_VARS_CONTENT="${EXTRA_VARS_CONTENT}  ${line}
+"
+    done < <(printf '%s\n' "${ENCLAVE_IRONIC_CA}")
+fi
+
 # Create the extra vars file on Landing Zone
 # shellcheck disable=SC2087,SC2086  # We want client-side expansion of $EXTRA_VARS_CONTENT
 ssh $SSH_OPTS "$LZ_SSH" "cat > $LZ_ENCLAVE_DIR/phase_vars.yaml" <<EOF

--- a/scripts/deployment/generate_ironic_ca.sh
+++ b/scripts/deployment/generate_ironic_ca.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Generate a CA for signing the Ironic ISO server TLS certificate
+#
+# Runs on the CI runner before the infrastructure is created, so that
+# start_sushy_tools.sh can install the CA into the sushy-tools container
+# trust store at startup time.
+#
+# The CA cert is written to the sushy-tools working directory, which is
+# mounted inside the container at /root/sushy/. The CA private key is kept
+# in a separate directory that is NOT mounted into the container, so it is
+# not exposed inside the sushy-tools container.
+#
+# Usage: ./generate_ironic_ca.sh
+# Required env: WORKING_DIR
+
+set -euo pipefail
+
+# Detect Enclave repository root
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+ENCLAVE_DIR="$(cd -- "${SCRIPT_DIR}/../.." &>/dev/null && pwd)"
+
+# Source shared utilities
+source "${ENCLAVE_DIR}/scripts/lib/output.sh"
+source "${ENCLAVE_DIR}/scripts/lib/validation.sh"
+
+require_env_var "WORKING_DIR"
+
+SUSHY_DIR="${WORKING_DIR}/virtualbmc/sushy-tools"
+IRONIC_CA_DIR="${WORKING_DIR}/ironic-ca"
+
+# Create directories if they don't exist yet
+if [ ! -d "$SUSHY_DIR" ]; then
+    info "Creating sushy-tools directory: $SUSHY_DIR"
+    sudo mkdir -p "$SUSHY_DIR"
+fi
+sudo mkdir -p "$IRONIC_CA_DIR"
+
+info "Generating CA for Ironic ISO server..."
+
+sudo openssl req -new -x509 -nodes -days 365 \
+    -subj "/CN=enclave-ironic-iso-ca" \
+    -keyout "${IRONIC_CA_DIR}/ca.key" \
+    -out "${IRONIC_CA_DIR}/ca.crt" \
+    2>/dev/null
+
+# Make CA key and cert readable only by the current user.
+# Both stay in ironic-ca/, which is NOT mounted into any container, so
+# they are never SELinux-relabeled by a podman :z volume mount.
+sudo chown "$(id -u):$(id -g)" "${IRONIC_CA_DIR}/ca.key" "${IRONIC_CA_DIR}/ca.crt"
+chmod 600 "${IRONIC_CA_DIR}/ca.key"
+chmod 644 "${IRONIC_CA_DIR}/ca.crt"
+
+# Copy the CA cert into the sushy-tools directory so the container can
+# read it via its volume mount.  The copy will be SELinux-relabeled when
+# the container starts; that is intentional and only affects the copy.
+sudo cp "${IRONIC_CA_DIR}/ca.crt" "${SUSHY_DIR}/ca.crt"
+
+success "Ironic ISO server CA generated"
+info "  CA cert: ${IRONIC_CA_DIR}/ca.crt (authoritative; not in container volume)"
+info "  CA cert: ${SUSHY_DIR}/ca.crt (copy for container; will be SELinux-relabeled)"
+info "  CA key:  ${IRONIC_CA_DIR}/ca.key (not mounted into container)"
+

--- a/scripts/deployment/generate_ironic_cert.sh
+++ b/scripts/deployment/generate_ironic_cert.sh
@@ -124,12 +124,7 @@ if [ -n "${GITHUB_ENV:-}" ]; then
         echo "$KEY_CONTENT"
         echo "EOF"
     } >> "$GITHUB_ENV"
-    {
-        echo "ENCLAVE_IRONIC_CA<<EOF"
-        cat "$CA_CRT"
-        echo "EOF"
-    } >> "$GITHUB_ENV"
-    success "Ironic ISO server certificate and CA exported to GITHUB_ENV"
+    success "Ironic ISO server certificate exported to GITHUB_ENV"
 else
     info "GITHUB_ENV not set - printing certificate to stdout (local use)"
     echo "ENCLAVE_IRONIC_CERT:"
@@ -137,7 +132,4 @@ else
     echo ""
     echo "ENCLAVE_IRONIC_KEY:"
     echo "$KEY_CONTENT"
-    echo ""
-    echo "ENCLAVE_IRONIC_CA:"
-    cat "$CA_CRT"
 fi

--- a/scripts/deployment/generate_ironic_cert.sh
+++ b/scripts/deployment/generate_ironic_cert.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+# Generate a TLS certificate for the Ironic ISO server, signed by the CA
+# produced by generate_ironic_ca.sh
+#
+# Reads lzBmcIP from config/global.yaml on the Landing Zone to set the
+# certificate SAN. Key and CSR are generated locally on the CI runner and
+# the CSR is signed with the CA key present in the ironic-ca working directory.
+#
+# Exports ENCLAVE_IRONIC_CERT and ENCLAVE_IRONIC_KEY to GITHUB_ENV for
+# use by subsequent workflow steps (picked up by deploy_phase.sh).
+#
+# Usage: ./generate_ironic_cert.sh
+# Required env: DEV_SCRIPTS_PATH, WORKING_DIR
+
+set -euo pipefail
+
+# Detect Enclave repository root
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+ENCLAVE_DIR="$(cd -- "${SCRIPT_DIR}/../.." &>/dev/null && pwd)"
+
+# Source shared utilities
+source "${ENCLAVE_DIR}/scripts/lib/output.sh"
+source "${ENCLAVE_DIR}/scripts/lib/validation.sh"
+source "${ENCLAVE_DIR}/scripts/lib/config.sh"
+source "${ENCLAVE_DIR}/scripts/lib/network.sh"
+source "${ENCLAVE_DIR}/scripts/lib/ssh.sh"
+
+require_env_var "DEV_SCRIPTS_PATH"
+require_env_var "WORKING_DIR"
+
+IRONIC_CA_DIR="${WORKING_DIR}/ironic-ca"
+CA_KEY="${IRONIC_CA_DIR}/ca.key"
+CA_CRT="${IRONIC_CA_DIR}/ca.crt"
+
+if [ ! -f "$CA_KEY" ] || [ ! -f "$CA_CRT" ]; then
+    error "CA key not found at ${CA_KEY} or CA cert not found at ${CA_CRT}"
+    error "Run generate_ironic_ca.sh before this script"
+    exit 1
+fi
+
+# Determine cluster name for SSH access
+ENCLAVE_CLUSTER_NAME="${ENCLAVE_CLUSTER_NAME:-enclave-test}"
+
+# Source dev-scripts configuration
+load_devscripts_config
+
+LZ_VM_NAME="${ENCLAVE_CLUSTER_NAME}_landingzone_0"
+
+# Get Landing Zone IP
+CLUSTER_NETWORK="${EXTERNAL_SUBNET_V4}"
+LZ_IP=$(get_vm_ip_on_network "$LZ_VM_NAME" "$CLUSTER_NETWORK")
+
+if [ -z "$LZ_IP" ]; then
+    error "Could not determine Landing Zone IP address"
+    exit 1
+fi
+
+setup_ssh_config "$LZ_IP"
+
+if ! ssh_test_connection; then
+    error "Cannot connect to Landing Zone at $LZ_IP"
+    exit 1
+fi
+
+# Read lzBmcIP and optional lzBmcHostname from config/global.yaml on the Landing Zone
+LZ_BMC_IP=$(ssh_exec "awk '/^lzBmcIP:/ {print \$2}' ${LZ_ENCLAVE_DIR}/config/global.yaml")
+
+if [ -z "$LZ_BMC_IP" ]; then
+    error "Could not read lzBmcIP from config/global.yaml on Landing Zone"
+    exit 1
+fi
+
+LZ_BMC_HOSTNAME=$(ssh_exec "awk '/^lzBmcHostname:/ {print \$2}' ${LZ_ENCLAVE_DIR}/config/global.yaml" 2>/dev/null || echo "")
+
+info "Generating TLS certificate for Ironic ISO server"
+
+# Work in a temp directory; cleaned up on exit
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# Generate server key and CSR
+openssl genrsa -out "${WORK_DIR}/server.key" 2048 2>/dev/null
+openssl req -new \
+    -key "${WORK_DIR}/server.key" \
+    -subj "/CN=ironic-iso-server" \
+    -out "${WORK_DIR}/server.csr" \
+    2>/dev/null
+
+# Write SAN extension - include DNS SAN when lzBmcHostname is configured so that
+# publicly trusted (e.g. Let's Encrypt) certs can also be used
+if [[ -n "$LZ_BMC_HOSTNAME" ]]; then
+    info "SAN: DNS:${LZ_BMC_HOSTNAME},IP:${LZ_BMC_IP}"
+    echo "subjectAltName=DNS:${LZ_BMC_HOSTNAME},IP:${LZ_BMC_IP}" > "${WORK_DIR}/san.ext"
+else
+    info "SAN: IP:${LZ_BMC_IP}"
+    echo "subjectAltName=IP:${LZ_BMC_IP}" > "${WORK_DIR}/san.ext"
+fi
+
+# Sign with CA; serial file goes into the temp dir to avoid writing to the
+# sudo-owned SUSHY_DIR
+openssl x509 -req \
+    -in "${WORK_DIR}/server.csr" \
+    -CA "$CA_CRT" \
+    -CAkey "$CA_KEY" \
+    -CAserial "${WORK_DIR}/ca.srl" \
+    -CAcreateserial \
+    -out "${WORK_DIR}/server.crt" \
+    -days 1 \
+    -extfile "${WORK_DIR}/san.ext" \
+    2>/dev/null
+
+CERT_CONTENT=$(cat "${WORK_DIR}/server.crt")
+KEY_CONTENT=$(cat "${WORK_DIR}/server.key")
+
+# Export to GITHUB_ENV for subsequent steps, or print for local use
+if [ -n "${GITHUB_ENV:-}" ]; then
+    {
+        echo "ENCLAVE_IRONIC_CERT<<EOF"
+        echo "$CERT_CONTENT"
+        echo "EOF"
+    } >> "$GITHUB_ENV"
+    {
+        echo "ENCLAVE_IRONIC_KEY<<EOF"
+        echo "$KEY_CONTENT"
+        echo "EOF"
+    } >> "$GITHUB_ENV"
+    {
+        echo "ENCLAVE_IRONIC_CA<<EOF"
+        cat "$CA_CRT"
+        echo "EOF"
+    } >> "$GITHUB_ENV"
+    success "Ironic ISO server certificate and CA exported to GITHUB_ENV"
+else
+    info "GITHUB_ENV not set - printing certificate to stdout (local use)"
+    echo "ENCLAVE_IRONIC_CERT:"
+    echo "$CERT_CONTENT"
+    echo ""
+    echo "ENCLAVE_IRONIC_KEY:"
+    echo "$KEY_CONTENT"
+    echo ""
+    echo "ENCLAVE_IRONIC_CA:"
+    cat "$CA_CRT"
+fi

--- a/scripts/infrastructure/start_sushy_tools.sh
+++ b/scripts/infrastructure/start_sushy_tools.sh
@@ -240,6 +240,20 @@ if [ "$ENDPOINT_READY" = false ]; then
     exit 1
 fi
 
+# Install Ironic ISO server CA into the container trust store so that
+# sushy-tools trusts CA-signed certs when fetching virtual media ISOs.
+if sudo podman exec "$CONTAINER_NAME" test -f /root/sushy/ca.crt; then
+    info "Installing Ironic ISO server CA into sushy-tools container trust store..."
+    sudo podman exec "$CONTAINER_NAME" bash -c "
+        mkdir -p /etc/pki/ca-trust/source/anchors /usr/local/share/ca-certificates &&
+        cp /root/sushy/ca.crt /etc/pki/ca-trust/source/anchors/ironic-iso-ca.crt &&
+        cp /root/sushy/ca.crt /usr/local/share/ca-certificates/ironic-iso-ca.crt &&
+        { update-ca-trust || update-ca-certificates; }"
+    success "Ironic ISO server CA installed in sushy-tools trust store"
+else
+    info "No Ironic ISO server CA found; skipping trust store update (HTTPS not configured)"
+fi
+
 info ""
 success "sushy-tools BMC emulation started successfully for cluster ${CLUSTER_NAME}!"
 info "  Endpoint: https://${BMC_GATEWAY}:${BMC_PORT}/redfish/v1/Systems (HTTPS with self-signed cert)"

--- a/test-fixtures/schemas/invalid/ironic-https-empty-key.yaml
+++ b/test-fixtures/schemas/invalid/ironic-https-empty-key.yaml
@@ -1,0 +1,49 @@
+---
+# Invalid fixture: ironicHTTPSCertificate present but ironicHTTPSKey is empty
+# Expected failure: variables schema requires ironicHTTPSKey to be non-empty
+# when ironicHTTPSCertificate is provided.
+workingDir: /home/enclave
+baseDomain: enclave-test.nodns.in
+clusterName: mgmt
+machineNetwork: 192.168.2.0/24
+apiVIP: 192.168.2.201
+ingressVIP: 192.168.2.202
+defaultDNS: 9.30.31.32
+defaultGateway: 192.168.2.10
+defaultPrefix: 24
+rendezvousIP: 192.168.2.24
+lzBmcIP: 100.64.1.10
+quayUser: admin
+quayPassword: password
+quayBackend: LocalStorage
+blockStorageBackend: lvms
+pullSecret: {"auths":{}}
+sshPubPath: /home/enclave/.ssh/id_rsa.pub
+ironicHTTPSCertificate: |
+  -----BEGIN CERTIFICATE-----
+  DUMMY_IRONIC_CERT
+  -----END CERTIFICATE-----
+ironicHTTPSKey: ""
+agent_hosts:
+  - name: mgmt-ctl01
+    macAddress: 0c:c4:7a:62:fe:ec
+    ipAddress: 192.168.2.24
+    redfish: 192.168.1.101
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl02
+    macAddress: 0c:c4:7a:62:fe:ed
+    ipAddress: 192.168.2.25
+    redfish: 192.168.1.102
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl03
+    macAddress: 0c:c4:7a:62:fe:ee
+    ipAddress: 192.168.2.26
+    redfish: 192.168.1.103
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+

--- a/test-fixtures/schemas/invalid/ironic-https-missing-key.yaml
+++ b/test-fixtures/schemas/invalid/ironic-https-missing-key.yaml
@@ -1,0 +1,48 @@
+---
+# Invalid fixture: ironicHTTPSCertificate present but ironicHTTPSKey omitted
+# Expected failure: variables schema requires ironicHTTPSKey when
+# ironicHTTPSCertificate is present and non-empty.
+workingDir: /home/enclave
+baseDomain: enclave-test.nodns.in
+clusterName: mgmt
+machineNetwork: 192.168.2.0/24
+apiVIP: 192.168.2.201
+ingressVIP: 192.168.2.202
+defaultDNS: 9.30.31.32
+defaultGateway: 192.168.2.10
+defaultPrefix: 24
+rendezvousIP: 192.168.2.24
+lzBmcIP: 100.64.1.10
+quayUser: admin
+quayPassword: password
+quayBackend: LocalStorage
+blockStorageBackend: lvms
+pullSecret: {"auths":{}}
+sshPubPath: /home/enclave/.ssh/id_rsa.pub
+ironicHTTPSCertificate: |
+  -----BEGIN CERTIFICATE-----
+  DUMMY_IRONIC_CERT
+  -----END CERTIFICATE-----
+agent_hosts:
+  - name: mgmt-ctl01
+    macAddress: 0c:c4:7a:62:fe:ec
+    ipAddress: 192.168.2.24
+    redfish: 192.168.1.101
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl02
+    macAddress: 0c:c4:7a:62:fe:ed
+    ipAddress: 192.168.2.25
+    redfish: 192.168.1.102
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl03
+    macAddress: 0c:c4:7a:62:fe:ee
+    ipAddress: 192.168.2.26
+    redfish: 192.168.1.103
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+

--- a/test-fixtures/schemas/valid/local-lvms-with-ironic-https.yaml
+++ b/test-fixtures/schemas/valid/local-lvms-with-ironic-https.yaml
@@ -1,0 +1,53 @@
+---
+# Fixture: LocalStorage + lvms with Ironic vmedia HTTPS variables
+# Validates that the ironicHTTPSCertificate conditional passes when both
+# ironicHTTPSCertificate and ironicHTTPSKey are present.
+# ironicHTTPSCACertificate is omitted (always optional).
+workingDir: /home/enclave
+baseDomain: enclave-test.nodns.in
+clusterName: mgmt
+machineNetwork: 192.168.2.0/24
+apiVIP: 192.168.2.201
+ingressVIP: 192.168.2.202
+defaultDNS: 9.30.31.32
+defaultGateway: 192.168.2.10
+defaultPrefix: 24
+rendezvousIP: 192.168.2.24
+lzBmcIP: 100.64.1.10
+quayUser: admin
+quayPassword: password
+quayBackend: LocalStorage
+blockStorageBackend: lvms
+pullSecret: {"auths":{}}
+sshPubPath: /home/enclave/.ssh/id_rsa.pub
+ironicHTTPSCertificate: |
+  -----BEGIN CERTIFICATE-----
+  DUMMY_IRONIC_CERT
+  -----END CERTIFICATE-----
+ironicHTTPSKey: |
+  -----BEGIN DUMMY KEY-----
+  DUMMY_IRONIC_KEY
+  -----END DUMMY KEY-----
+agent_hosts:
+  - name: mgmt-ctl01
+    macAddress: 0c:c4:7a:62:fe:ec
+    ipAddress: 192.168.2.24
+    redfish: 192.168.1.101
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl02
+    macAddress: 0c:c4:7a:62:fe:ed
+    ipAddress: 192.168.2.25
+    redfish: 192.168.1.102
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl03
+    macAddress: 0c:c4:7a:62:fe:ee
+    ipAddress: 192.168.2.26
+    redfish: 192.168.1.103
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+

--- a/test-fixtures/schemas/valid/local-lvms-with-ironic-https.yaml
+++ b/test-fixtures/schemas/valid/local-lvms-with-ironic-https.yaml
@@ -2,7 +2,6 @@
 # Fixture: LocalStorage + lvms with Ironic vmedia HTTPS variables
 # Validates that the ironicHTTPSCertificate conditional passes when both
 # ironicHTTPSCertificate and ironicHTTPSKey are present.
-# ironicHTTPSCACertificate is omitted (always optional).
 workingDir: /home/enclave
 baseDomain: enclave-test.nodns.in
 clusterName: mgmt

--- a/test-fixtures/schemas/valid/radosgw-lvms-all-optionals.yaml
+++ b/test-fixtures/schemas/valid/radosgw-lvms-all-optionals.yaml
@@ -71,10 +71,6 @@ ironicHTTPSKey: |
   -----BEGIN DUMMY KEY-----
   DUMMY_IRONIC_KEY
   -----END DUMMY KEY-----
-ironicHTTPSCACertificate: |
-  -----BEGIN CERTIFICATE-----
-  DUMMY_IRONIC_CA
-  -----END CERTIFICATE-----
 discovery_hosts:
   - name: discovery-host-01
     macAddress: 0c:c4:7a:62:ff:01

--- a/test-fixtures/schemas/valid/radosgw-lvms-all-optionals.yaml
+++ b/test-fixtures/schemas/valid/radosgw-lvms-all-optionals.yaml
@@ -63,6 +63,18 @@ sslIngressCertificateKey: |
   -----BEGIN DUMMY KEY-----
   DUMMY_INGRESS_KEY
   -----END DUMMY KEY-----
+ironicHTTPSCertificate: |
+  -----BEGIN CERTIFICATE-----
+  DUMMY_IRONIC_CERT
+  -----END CERTIFICATE-----
+ironicHTTPSKey: |
+  -----BEGIN DUMMY KEY-----
+  DUMMY_IRONIC_KEY
+  -----END DUMMY KEY-----
+ironicHTTPSCACertificate: |
+  -----BEGIN CERTIFICATE-----
+  DUMMY_IRONIC_CA
+  -----END CERTIFICATE-----
 discovery_hosts:
   - name: discovery-host-01
     macAddress: 0c:c4:7a:62:ff:01

--- a/validations.sh
+++ b/validations.sh
@@ -339,6 +339,17 @@ validation_section ssl_certificates
 checkCerts api api.$cluster_fqdn .sslAPICertificateKey .sslAPICertificateFullChain
 checkCerts ingress "*.apps.$cluster_fqdn" .sslIngressCertificateKey .sslIngressCertificateFullChain
 
+# Check Ironic HTTPS certificate (optional)
+lz_bmc_ip=$(getValue .lzBmcIP)
+lz_bmc_hostname=$(getValue .lzBmcHostname 2>/dev/null || echo "")
+ironic_cert_name="${lz_bmc_hostname:-$lz_bmc_ip}"
+ironic_https_cert=$(getValue .ironicHTTPSCertificate)
+if [[ -n "$ironic_https_cert" && "$ironic_https_cert" != "null" ]]; then
+    checkCerts ironic_https "$ironic_cert_name" .ironicHTTPSKey .ironicHTTPSCertificate
+else
+    validation pass ironic_https_skipped "Ironic HTTPS certificate not configured. Skipping validation"
+fi
+
 ## Check nmstate config (if defined)
 validation_section nmstate
 


### PR DESCRIPTION
Introduce end-to-end HTTPS serving for Ironic virtual media ISOs,
including a CA-based trust chain for CI and support for publicly
trusted certificates (e.g. Let's Encrypt).

HTTPS vmedia support (Ansible)
- Derive ironic_https_configured from ironicHTTPSCertificate/Key.
- Mount vmedia TLS cert/key as podman secrets into both the httpd and
  ironic containers; set IRONIC_EXTERNAL_IP and VMEDIA_TLS_PORT so
  Ironic generates https:// virtual media URLs on port 6183.
- Replace the temporary Python HTTP server with an /iso bind-mount
  into the Ironic container, using a file:// URL for boot_iso with
  OS_CONDUCTOR__FILE_URL_ALLOWED_PATHS=/iso.
- Health-check the HTTPS vmedia port with wait_for wrapped in a
  block/rescue: on timeout, capture podman logs httpd and re-fail
  with a descriptive message.
- Add pre-cleanup of stale Ironic pods before ephemeral deployment:
  stop Phase 7 persistent systemd services, remove root-owned and
  rootless pods. Prevents port 6180 conflicts when redeploying.
- Align quadlet templates (metal3-ironic-api.container.j2,
  metal3-httpd.container.j2) with ephemeral HTTPS/file-ISO changes
  for the persistent Phase 7 path.

Ironic hostname support
- Add optional lzBmcHostname variable so that publicly trusted
  certificates (DNS SANs only) can be used. When set, IRONIC_EXTERNAL_IP
  uses the hostname instead of lzBmcIP, producing vmedia URLs of the
  form https://<hostname>:6183/... that BMCs resolve via DNS.
  PROVISIONING_IP (Apache socket binding) remains lzBmcIP.
- Cert SAN validation in validations.sh checks against lzBmcHostname
  when set, falling back to lzBmcIP for the IP-SAN flow.

CA trust chain for CI
- generate_ironic_ca.sh: generate a per-run CA; write key+cert to
  ironic-ca/ and copy into the sushy-tools working directory.
- generate_ironic_cert.sh: after the Landing Zone is up, read
  lzBmcIP/lzBmcHostname via SSH, sign a server CSR with the CA,
  export cert+key+CA to GITHUB_ENV. Emits DNS+IP SAN when hostname
  is configured.
- start_sushy_tools.sh: install the CA into the container trust
  store via update-ca-trust.
- deploy_phase.sh: inject ENCLAVE_IRONIC_CERT, ENCLAVE_IRONIC_KEY,
  and ENCLAVE_IRONIC_CA into phase_vars.yaml.

CI workflow
- e2e-deployment.yml: enable HTTPS in e2e-connected; e2e-disconnected
  exercises the HTTP-only code path (port 6180, no certs injected).
- Makefile.ci: wrap generate_ironic_ca.sh in an ENCLAVE_IRONIC_HTTPS
  check so the disconnected run skips CA generation.

Schema and validation
- Add ironicHTTPSCertificate, ironicHTTPSKey, ironicHTTPSCACertificate,
  and lzBmcHostname to schemas/variables.yaml and definitions.yaml.
- Add schema test fixtures for valid and invalid HTTPS configurations.

https://redhat.atlassian.net/browse/MGMT-22877

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional HTTPS support for serving boot ISOs/vmedia with configurable certificate, key, and CA.

* **Chores**
  * Automatic CA and short-lived server certificate generation and provisioning for vmedia HTTPS.
  * Hosting now supports HTTP or HTTPS and will restart when protocol, certificate, or key changes.
  * Deployment validates that certificate and key are provided together and installs the CA into local trust stores when present.
  * CI deployment flows add CA/cert generation steps and propagate HTTPS flags into deployments.

* **Tests/Validation**
  * Optional validation step now checks provided Ironic HTTPS certificates (skips if not provided).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->