### PR TITLE
Make GPU passthrough opt-in in CI workflows

### DIFF
--- a/.github/workflows/disconnected-dry-run.yml
+++ b/.github/workflows/disconnected-dry-run.yml
@@ -52,6 +52,7 @@ jobs:
       ENCLAVE_DEPLOYMENT_MODE: disconnected
       ENCLAVE_MIRROR_DRY_RUN: "true"
       OPENSHIFT_CI: "true"
+      ENCLAVE_ENABLE_GPU_PASSTHROUGH: "false"
 
     steps:
       - name: Checkout code

--- a/.github/workflows/e2e-deployment.yml
+++ b/.github/workflows/e2e-deployment.yml
@@ -136,6 +136,7 @@ jobs:
       STORAGE_PLUGIN: ${{ github.event.inputs.storage-plugin || 'lvms' }}
       ENABLED_PLUGINS: ${{ github.event.inputs.storage-plugin || 'lvms' }}
       OPENSHIFT_CI: "true"
+      ENCLAVE_ENABLE_GPU_PASSTHROUGH: "false"
 
     steps:
       - name: Checkout code
@@ -506,6 +507,7 @@ jobs:
       STORAGE_PLUGIN: ${{ github.event.inputs.storage-plugin || 'lvms' }}
       ENABLED_PLUGINS: ${{ github.event.inputs.storage-plugin || 'lvms' }}
       OPENSHIFT_CI: "true"
+      ENCLAVE_ENABLE_GPU_PASSTHROUGH: "false"
 
     steps:
       - name: Checkout code

--- a/.github/workflows/infra-verify.yml
+++ b/.github/workflows/infra-verify.yml
@@ -25,6 +25,7 @@ jobs:
       PULL_SECRET: ${{ secrets.PULL_SECRET }}
       # Bypass CI_TOKEN requirement (we only use dev-scripts for infra, not cluster install)
       OPENSHIFT_CI: "true"
+      ENCLAVE_ENABLE_GPU_PASSTHROUGH: "false"
 
     steps:
       - name: Checkout code

--- a/playbooks/03-deploy.yaml
+++ b/playbooks/03-deploy.yaml
@@ -59,13 +59,6 @@
           tags: hardware
       tags: hardware
 
-    - name: Pre-install validate plugins
-      ansible.builtin.include_tasks:
-        file: tasks/pre_install_validate_plugins.yaml
-        apply:
-          tags: pre-install-validate
-      tags: pre-install-validate
-
     - name: Wait for all hosts to reach active state
       loop: "{{ agent_hosts }}"
       loop_control:
@@ -75,6 +68,13 @@
         apply:
           tags: hardware
       tags: hardware
+
+    - name: Pre-install validate plugins
+      ansible.builtin.include_tasks:
+        file: tasks/pre_install_validate_plugins.yaml
+        apply:
+          tags: pre-install-validate
+      tags: pre-install-validate
 
     - name: Wait for deployment
       ansible.builtin.include_tasks:

--- a/playbooks/tasks/pre_install_validate_plugins.yaml
+++ b/playbooks/tasks/pre_install_validate_plugins.yaml
@@ -13,7 +13,7 @@
 # explicitly before any delegated tasks.
 - name: Wait for rendezvous node to become reachable
   ansible.builtin.wait_for_connection:
-    timeout: 900
+    timeout: 600
     sleep: 10
   delegate_to: rendezvous
 

--- a/scripts/infrastructure/configure_gpu_passthrough.sh
+++ b/scripts/infrastructure/configure_gpu_passthrough.sh
@@ -4,7 +4,8 @@
 # This script auto-detects an NVIDIA GPU on the host and attaches it
 # to the first master VM via PCI passthrough. It is designed to be
 # called as part of `make environment` and exits silently (exit 0)
-# when no GPU or no IOMMU is available.
+# when ENCLAVE_ENABLE_GPU_PASSTHROUGH is not set to "true", no GPU
+# is detected, or no IOMMU is available.
 #
 # Prerequisites (manual, one-time on GPU host):
 #   1. BIOS: VT-d (Intel) or AMD-Vi must be enabled
@@ -24,6 +25,17 @@ source "${ENCLAVE_DIR}/scripts/lib/config.sh"
 source "${ENCLAVE_DIR}/scripts/lib/common.sh"
 
 load_devscripts_config
+
+# GPU passthrough is opt-in via ENCLAVE_ENABLE_GPU_PASSTHROUGH=true.
+# When disabled (default), the script exits early and no GPU is attached.
+# Set this env var in CI workflow env blocks or export it before running
+# `make environment` to enable GPU passthrough for a specific job.
+if [ "${ENCLAVE_ENABLE_GPU_PASSTHROUGH:-false}" != "true" ]; then
+    info "GPU passthrough not enabled (set ENCLAVE_ENABLE_GPU_PASSTHROUGH=true to enable)"
+    exit 0
+fi
+
+info "GPU passthrough enabled (ENCLAVE_ENABLE_GPU_PASSTHROUGH=true)"
 
 if [ -z "${CLUSTER_NAME:-}" ]; then
     error "CLUSTER_NAME not set after loading config"
@@ -65,13 +77,29 @@ BUS=$(echo "$GPU_PCI_ADDRESS" | cut -d: -f2)
 SLOT=$(echo "$GPU_PCI_ADDRESS" | cut -d: -f3 | cut -d. -f1)
 FUNC=$(echo "$GPU_PCI_ADDRESS" | cut -d: -f3 | cut -d. -f2)
 
-VM_NAME="${CLUSTER_NAME}_master_0"
+# Check if the GPU is already assigned to another VM (running or defined).
+# A physical GPU can only be passed through to one VM at a time, so when
+# multiple OCP deployments share the same host, only the first one gets it.
+# This prevents subsequent cluster deployment failures but only one deployment
+# will hold the GPU.
+# We check all VMs (not just running) because the GPU is attached via --config
+# before the VM starts, so parallel jobs would both see it as available.
+mapfile -t _all_vms < <(sudo virsh list --all --name)
+GPU_IN_USE_BY=
+for vm in "${_all_vms[@]}"; do
+    [ -z "$vm" ] && continue
+    if sudo virsh dumpxml "$vm" 2>/dev/null | grep -q "bus='0x${BUS}'.*slot='0x${SLOT}'.*function='0x${FUNC}'"; then
+        GPU_IN_USE_BY="$vm"
+        break
+    fi
+done
 
-# Check if GPU is already attached (idempotency)
-if sudo virsh dumpxml "$VM_NAME" 2>/dev/null | grep -q "bus='0x${BUS}'.*slot='0x${SLOT}'.*function='0x${FUNC}'"; then
-    info "GPU already attached to $VM_NAME, skipping"
+if [ -n "$GPU_IN_USE_BY" ]; then
+    warning "GPU $GPU_PCI_ADDRESS is already in use by VM '$GPU_IN_USE_BY', skipping passthrough"
     exit 0
 fi
+
+VM_NAME="${CLUSTER_NAME}_master_0"
 
 info "Attaching GPU to VM: $VM_NAME"
 


### PR DESCRIPTION
GPU passthrough now requires `ENCLAVE_ENABLE_GPU_PASSTHROUGH=true`, preventing PCI conflicts when multiple CI jobs share a GPU host.
Also adds a check to skip passthrough when the GPU is already held by another VM.
Moves pre-install plugin validation after Ironic wait so deploy failures are caught early, and reduces the
rendezvous wait timeout from 900s to 600s accordingly.

MGMT-23797