### PR TITLE
MGMT-22946: Run mirror in two different phases

### DIFF
--- a/operators/quay-operator/quay_disconnected.yaml
+++ b/operators/quay-operator/quay_disconnected.yaml
@@ -6,10 +6,17 @@
   ansible.builtin.include_tasks:
     file: "../../playbooks/tasks/collect_plugin_registries.yaml"
 
-- name: Copy imagesetconfiguration to imagesetconfiguration.internal.yaml
-  ansible.builtin.copy:
-    src: "{{ workingDir }}/config/imagesetconfiguration.yaml"
-    dest: "{{ workingDir }}/config/imagesetconfiguration.internal.yaml"
+- name: Merge core and post imagesetconfiguration
+  vars:
+    imageset_core: "{{ lookup('file', workingDir ~ '/config/imagesetconfiguration-core.yaml') | from_yaml }}"
+    imageset_post: "{{ lookup('file', workingDir ~ '/config/imagesetconfiguration-post.yaml') | from_yaml }}"
+  set_fact:
+    imageset_internal: "{{ imageset_core | combine(imageset_post, recursive=True, list_merge='append') }}"
+
+- name: Write merged imagesetconfiguration to imagesetconfiguration.internal.yaml
+  copy:
+    content: "{{ imageset_internal | to_nice_yaml }}"
+    dest: "{{ workingDir}}/config/imagesetconfiguration.internal.yaml"
 
 - name: Replace registry.redhat.io with internal quay
   ansible.builtin.replace:

--- a/playbooks/02-mirror.yaml
+++ b/playbooks/02-mirror.yaml
@@ -5,14 +5,14 @@
 # Performs:
 # - Deploy local Quay registry (mirror-registry)
 # - Generate combined pull secret
-# - Run oc-mirror to mirror OpenShift images and operator catalogs
+# - Run oc-mirror to mirror OpenShift images and operator catalogs (split approach)
 # - Mirror additional images (Vault, ArgoCD, etc.)
 # - Mirror images to datacenter cache (optional)
 #
 # IMPORTANT: This phase requires significant disk space (~150GB+) and time (~30+ minutes)
 #
 # Usage:
-#   ansible-playbook playbooks/02-mirror.yaml -e workingDir=/home/cloud-user
+#   ansible-playbook playbooks/02-mirror.yaml -e workingDir=/home/cloud-user --tags mirror-registry
 #
 #   # Mirror images to datacenter cache
 #   ansible-playbook playbooks/02-mirror.yaml -e workingDir=/home/cloud-user --tags mirror-cache
@@ -58,9 +58,35 @@
         - mirror-registry
         - mirror-plugins
 
-    - name: Include tasks for mirror-registry
+    # Mirror registry setup
+    # This must run first as it sets up the registry and basic infrastructure
+    - name: Include tasks for mirror registry setup
       ansible.builtin.include_tasks:
         file: tasks/mirror_registry.yaml
         apply:
           tags: mirror-registry
       tags: mirror-registry
+
+    # Core installation mirror - only platform images needed for basic OpenShift installation
+    - name: Include tasks for core OpenShift installation mirroring
+      ansible.builtin.include_tasks:
+        file: tasks/mirror_registry_core.yaml
+        apply:
+          tags:
+            - mirror-registry
+            - mirror-registry-core
+      tags:
+        - mirror-registry
+        - mirror-registry-core
+
+    # Post-installation mirror - operators, additional images, and day-2 components
+    - name: Include tasks for post-installation mirroring (operators and additional images)
+      ansible.builtin.include_tasks:
+        file: tasks/mirror_registry_post.yaml
+        apply:
+          tags:
+            - mirror-registry
+            - mirror-registry-post
+      tags:
+        - mirror-registry
+        - mirror-registry-post

--- a/playbooks/05-operators.yaml
+++ b/playbooks/05-operators.yaml
@@ -30,6 +30,41 @@
         msg: "Installing operators in {{ 'disconnected' if (disconnected | default(true)) else 'connected' }} mode"
       tags: always
 
+    - name: Validate enabled plugin requirements
+      ansible.builtin.include_tasks:
+        file: tasks/validate_enabled_plugins.yaml
+        apply:
+          tags:
+            - foundation-plugins
+            - operators
+      tags:
+        - foundation-plugins
+        - operators
+
+    - name: Wait for the async task mirror_registry_post (operators and additional images)
+      when: disconnected | default(true) | bool
+      ansible.builtin.include_tasks:
+        file: tasks/wait_operator_mirror.yaml
+        apply:
+          tags:
+            - foundation-plugins
+            - operators
+      tags:
+        - foundation-plugins
+        - operators
+
+    - name: Configure mirror for operators and additional images
+      when: disconnected | default(true) | bool
+      ansible.builtin.include_tasks:
+        file: tasks/configure_mirror_post.yaml
+        apply:
+          tags:
+            - foundation-plugins
+            - operators
+      tags:
+        - foundation-plugins
+        - operators
+
     - name: Disable default operator catalog sources
       when: disconnected | default(true) | bool
       ansible.builtin.command: |

--- a/playbooks/tasks/configure_mirror_post.yaml
+++ b/playbooks/tasks/configure_mirror_post.yaml
@@ -1,0 +1,53 @@
+---
+- name: Pause MachineConfigPool to prevent immediate churn
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: machineconfiguration.openshift.io/v1
+      kind: MachineConfigPool
+      metadata:
+        name: master
+      spec:
+        paused: true
+
+- name: Apply mirroring and catalog resources
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  kubernetes.core.k8s:
+    state: present
+    src: "{{ workingDir }}/config/oc-mirror-workspace-post/working-dir/cluster-resources/{{ item }}"
+  loop:
+    - idms-oc-mirror.yaml
+    - itms-oc-mirror.yaml
+    - cs-redhat-operator-index-v4-20.yaml
+
+- name: Unpause MachineConfigPools to trigger a single update cycle
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: machineconfiguration.openshift.io/v1
+      kind: MachineConfigPool
+      metadata:
+        name: master
+      spec:
+        paused: false
+
+- name: Wait for MCO to acknowledge the change (Avoid the race condition)
+  ansible.builtin.pause:
+    seconds: 20
+
+- name: Wait for MachineConfigPools to finish updating (In-Place)
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  kubernetes.core.k8s_info:
+    api_version: machineconfiguration.openshift.io/v1
+    kind: MachineConfigPool
+    name: master
+  register: mcp_status
+  until:
+    - mcp_status.resources[0].status.updatedMachineCount == mcp_status.resources[0].status.machineCount
+    - mcp_status.resources[0].status.degradedMachineCount == 0
+  retries: 60
+  delay: 30

--- a/playbooks/tasks/configure_ocp_abi.yaml
+++ b/playbooks/tasks/configure_ocp_abi.yaml
@@ -55,7 +55,6 @@
     - idms-oc-mirror.yaml
     - itms-oc-mirror.yaml
     - signature-configmap.yaml
-    - cs-redhat-operator-index-v4-20.yaml
 
 - name: Enable diskEncryption if set
   when: diskEncryption | default(false) == true

--- a/playbooks/tasks/mirror_cache.yaml
+++ b/playbooks/tasks/mirror_cache.yaml
@@ -29,22 +29,17 @@
     src: ../../templates/imagesetconfiguration.yaml.j2
     dest: "{{ workingDir }}/config/imagesetconfiguration-cache.yaml"
 
-- name: Change oc-mirror permissions
-  ansible.builtin.file:
-    path: "{{ workingDir }}/bin/oc-mirror"
-    mode: "0755"
-
 - name: Start oc-mirror process
-  ansible.builtin.shell: >
-    {{ workingDir }}/bin/oc-mirror --v2
-    --log-level {{ ocMirrorLogLevel }}
-    --authfile {{ workingDir }}/config/pull-secret-cache.json
-    --dest-tls-verify=false
-    -c {{ workingDir }}/config/imagesetconfiguration-cache.yaml
-    --workspace file://{{ workingDir }}/config/oc-mirror-cache-workspace
-    --parallel-images 10 --parallel-layers 10
-    --retry-times 10 --retry-delay 0
-    docker://{{ dc_cache_address }}
+  ansible.builtin.shell: |
+    {{ workingDir }}/bin/oc-mirror --v2 \
+    --log-level {{ ocMirrorLogLevel }} \
+    --authfile {{ workingDir }}/config/pull-secret-cache.json \
+    --dest-tls-verify=false \
+    -c {{ workingDir }}/config/imagesetconfiguration-cache.yaml \
+    --workspace file://{{ workingDir }}/config/oc-mirror-cache-workspace \
+    --parallel-images 10 --parallel-layers 10 \
+    --retry-times 10 --retry-delay 0 \
+    docker://{{ dc_cache_address }} \
     > {{ workingDir }}/logs/oc-mirror-cache.progress.$(date +%s).log 2>&1
   retries: 5
   delay: 10

--- a/playbooks/tasks/mirror_registry.yaml
+++ b/playbooks/tasks/mirror_registry.yaml
@@ -14,6 +14,11 @@
         {{ workingDir }}/bin/mirror-registry  install --quayHostname "{{ quayHostname }}" --quayRoot {{ workingDir }}/data --initPassword "{{ quayPassword }}" --initUser "{{ quayUser }}"
       register: r_mirror_registry
 
+- name: Change oc-mirror permissions
+  ansible.builtin.file:
+    path: "{{ workingDir }}/bin/oc-mirror"
+    mode: "0755"
+
 - name: Generate pull secret for internal mirror
   no_log: true
   ansible.builtin.set_fact:
@@ -35,31 +40,3 @@
   ansible.builtin.copy:
     content: "{{ pullSecretInternal }}"
     dest: "{{ workingDir }}/config/pull-secret.internal.json"
-
-- name: Copy imagesetconfiguration.yaml
-  ansible.builtin.template:
-    src: ../../templates/imagesetconfiguration.yaml.j2
-    dest: "{{ workingDir }}/config/imagesetconfiguration.yaml"
-
-- name: Change oc-mirror permissions
-  ansible.builtin.file:
-    path: "{{ workingDir }}/bin/oc-mirror"
-    mode: "0755"
-
-- name: Start oc-mirror process
-  ansible.builtin.shell: >
-    {{ workingDir }}/bin/oc-mirror --v2
-    {{ '--dry-run' if (mirror_dry_run | default(false) | bool) else '' }}
-    --log-level {{ ocMirrorLogLevel }}
-    --authfile {{ pullSecretPath }}
-    --dest-tls-verify=false
-    -c {{ workingDir }}/config/imagesetconfiguration.yaml
-    --workspace file://{{ workingDir }}/config/oc-mirror-workspace
-    --parallel-images 10 --parallel-layers 10
-    --retry-times 10 --retry-delay 0
-    docker://{{ quayHostname }}:8443
-    > {{ workingDir }}/logs/oc-mirror.progress.$(date +%s).log 2>&1
-  retries: "{{ 1 if (mirror_dry_run | default(false) | bool) else 10 }}"
-  delay: "{{ 0 if (mirror_dry_run | default(false) | bool) else 10 }}"
-  register: r_oc_mirror
-  until: r_oc_mirror is success

--- a/playbooks/tasks/mirror_registry_core.yaml
+++ b/playbooks/tasks/mirror_registry_core.yaml
@@ -1,0 +1,23 @@
+---
+- name: Copy core imagesetconfiguration.yaml
+  ansible.builtin.template:
+    src: ../../templates/imagesetconfiguration-core.yaml.j2
+    dest: "{{ workingDir }}/config/imagesetconfiguration-core.yaml"
+
+- name: Mirror core OpenShift installation images
+  ansible.builtin.shell: |
+    {{ workingDir }}/bin/oc-mirror --v2 \
+    {{ '--dry-run' if (mirror_dry_run | default(false) | bool) else '' }} \
+    --log-level {{ ocMirrorLogLevel }} \
+    --authfile {{ pullSecretPath }} \
+    --dest-tls-verify=false \
+    -c {{ workingDir }}/config/imagesetconfiguration-core.yaml \
+    --workspace file://{{ workingDir }}/config/oc-mirror-workspace \
+    --parallel-images 10 --parallel-layers 10 \
+    --retry-times 10 --retry-delay 0 \
+    docker://{{ quayHostname }}:8443 \
+    > {{ workingDir }}/logs/oc-mirror-core.progress.$(date +%s).log 2>&1
+  retries: "{{ 1 if (mirror_dry_run | default(false) | bool) else 10 }}"
+  delay: "{{ 0 if (mirror_dry_run | default(false) | bool) else 10 }}"
+  register: r_oc_mirror_core
+  until: r_oc_mirror_core is success

--- a/playbooks/tasks/mirror_registry_post.yaml
+++ b/playbooks/tasks/mirror_registry_post.yaml
@@ -1,0 +1,40 @@
+---
+- name: Copy post-installation imagesetconfiguration.yaml
+  ansible.builtin.template:
+    src: ../../templates/imagesetconfiguration-post.yaml.j2
+    dest: "{{ workingDir }}/config/imagesetconfiguration-post.yaml"
+
+- name: Mirror post-installation operators and additional images
+  ansible.builtin.shell: |
+    _retry=1
+    _max_retries={{ 1 if (mirror_dry_run | default(false) | bool) else 10 }}
+    _delay={{ 0 if (mirror_dry_run | default(false) | bool) else 10 }}
+    until {{ workingDir }}/bin/oc-mirror --v2 \
+      {{ '--dry-run' if (mirror_dry_run | default(false) | bool) else '' }} \
+      --log-level {{ ocMirrorLogLevel }} \
+      --authfile {{ pullSecretPath }} \
+      --dest-tls-verify=false \
+      -c {{ workingDir }}/config/imagesetconfiguration-post.yaml \
+      --workspace file://{{ workingDir }}/config/oc-mirror-workspace-post \
+      --parallel-images 10 --parallel-layers 10 \
+      --retry-times 10 --retry-delay 0 \
+      docker://{{ quayHostname }}:8443 \
+      > {{ workingDir }}/logs/oc-mirror-post.progress.$(date +%s).log 2>&1
+    do
+      if [ $_retry -ge $_max_retries ]; then
+        echo "Max retries reached"
+        exit 1
+      fi
+      echo "Some images failed to mirror. Retrying ($_retry of $_max_retries)"
+      _retry=$((_retry+1))
+      sleep $_delay
+    done
+  register: r_oc_mirror_post
+  # Async run
+  async: 14400 # 4 hours timeout
+  poll: 0      # Start immediately, don't wait
+
+- name: Save async job ID for later reference
+  ansible.builtin.copy:
+    content: "{{ r_oc_mirror_post.ansible_job_id }}"
+    dest: "{{ workingDir }}/logs/operator-mirror.async_job_id"

--- a/playbooks/tasks/wait_operator_mirror.yaml
+++ b/playbooks/tasks/wait_operator_mirror.yaml
@@ -1,0 +1,77 @@
+---
+- name: Check if async job ID file exists
+  when: async_job_id is not defined
+  ansible.builtin.stat:
+    path: "{{ workingDir }}/logs/operator-mirror.async_job_id"
+  register: async_job_id_file_stat
+
+- name: Read async job ID from file
+  when:
+    - async_job_id is not defined
+    - async_job_id_file_stat.stat.exists
+  ansible.builtin.slurp:
+    src: "{{ workingDir }}/logs/operator-mirror.async_job_id"
+  register: async_job_id_file_content
+
+- name: Set async job ID from file
+  when:
+    - async_job_id is not defined
+    - async_job_id_file_stat.stat.exists
+    - async_job_id_file_content.content is defined
+  ansible.builtin.set_fact:
+    async_job_id: "{{ async_job_id_file_content.content | b64decode | trim }}"
+
+- name: Get async job ID from user input or fail
+  when: async_job_id is not defined
+  ansible.builtin.fail:
+    msg: |
+      No async job ID found. Please either:
+      1. Provide the async job ID with: -e async_job_id=<JOB_ID>
+      2. Run 02-mirror.yaml first to generate the job ID file
+
+      The job ID was displayed when you ran 02-mirror.yaml
+
+- name: Wait for operator mirroring async task to complete
+  when: async_job_id is defined
+  ansible.builtin.async_status:
+    jid: "{{ async_job_id }}"
+  register: operator_mirror_result
+  until: operator_mirror_result.finished
+  retries: 480  # 4 hours maximum (480 * 30 seconds)
+  delay: 30
+
+- name: Display operator mirroring results
+  when: async_job_id is defined
+  ansible.builtin.debug:
+    msg: |
+      Operator mirroring async task has completed.
+      Status: {{ 'Success' if operator_mirror_result.rc == 0 else 'Failed' }}
+      Exit code: {{ operator_mirror_result.rc | default('unknown') }}
+      Duration: {{ operator_mirror_result.delta | default('unknown') }}
+
+- name: Show operator mirroring output on failure
+  when:
+    - async_job_id is defined
+    - operator_mirror_result.rc != 0
+  ansible.builtin.debug:
+    msg: |
+      Operator mirroring failed with output:
+      STDOUT: {{ operator_mirror_result.stdout | default('none') }}
+      STDERR: {{ operator_mirror_result.stderr | default('none') }}
+
+- name: Fail if operator mirroring failed
+  when:
+    - async_job_id is defined
+    - operator_mirror_result.rc != 0
+  ansible.builtin.fail:
+    msg: "Operator mirroring failed with exit code {{ operator_mirror_result.rc }}"
+
+- name: Clean up async job ID file on success
+  when:
+    - async_job_id is defined
+    - operator_mirror_result.rc == 0
+    - async_job_id_file_stat.stat.exists is defined
+    - async_job_id_file_stat.stat.exists
+  ansible.builtin.file:
+    path: "{{ workingDir }}/logs/operator-mirror.async_job_id"
+    state: absent

--- a/playbooks/wait_operator_mirror.yaml
+++ b/playbooks/wait_operator_mirror.yaml
@@ -1,0 +1,31 @@
+---
+# Wait for mirror of operator and additional images
+#
+# The mirror of operator images and additional images is now performed in an async way
+# This playbook will run the tasks needed to wait for that async task to finish
+#
+# Usage:
+#   ansible-playbook playbooks/wait_operator_mirror.yaml -e workingDir=/home/cloud-user
+
+- name: Wait operator mirror
+  hosts: localhost
+  gather_facts: false
+  environment:
+    PATH: "{{ workingDir }}/bin:{{ lookup('env', 'PATH') }}"
+  tasks:
+    - name: Load common variables
+      ansible.builtin.include_tasks:
+        file: common/load-vars.yaml
+        apply:
+          tags: always
+      tags: always
+
+    - name: Display operator installation mode
+      ansible.builtin.debug:
+        msg: "Installing operators in {{ 'disconnected' if (disconnected | default(true)) else 'connected' }} mode"
+      tags: always
+
+    - name: Wait for the async task mirror_registry_post
+      when: disconnected | default(true) | bool
+      ansible.builtin.include_tasks:
+        file: tasks/wait_operator_mirror.yaml

--- a/scripts/verification/validate.sh
+++ b/scripts/verification/validate.sh
@@ -126,7 +126,9 @@ validate_tags() {
     local tag_tests=(
         "playbooks/01-prepare.yaml:download-content:Download content"
         "playbooks/01-prepare.yaml:download-control-binaries:Download control binaries"
-        "playbooks/02-mirror.yaml:mirror-registry:Include tasks for mirror-registry"
+        "playbooks/02-mirror.yaml:mirror-registry:Include tasks for mirror registry setup"
+        "playbooks/02-mirror.yaml:mirror-registry-core:Include tasks for core OpenShift installation mirroring"
+        "playbooks/02-mirror.yaml:mirror-registry-post:Include tasks for post-installation mirroring (operators and additional images)"
         "playbooks/03-deploy.yaml:configure-abi:Include tasks for OCP ABI"
         "playbooks/03-deploy.yaml:hardware:Configure and boot hosts via Ironic"
         "playbooks/03-deploy.yaml:wait-deployment:Wait for deployment"

--- a/templates/imagesetconfiguration-core.yaml.j2
+++ b/templates/imagesetconfiguration-core.yaml.j2
@@ -1,0 +1,31 @@
+---
+kind: ImageSetConfiguration
+apiVersion: mirror.openshift.io/v2alpha1
+mirror:
+  platform:
+    channels:
+{% set channels = {} %}
+{% for v in openshift_versions %}
+{%   set channel_name = 'stable-' + v.version.split('.')[:2] | join('.') %}
+{%   set patch = v.version.split('.')[2] | int %}
+{%   if channel_name not in channels %}
+{%     set _ = channels.update({channel_name: {'min_patch': patch, 'min_ver': v.version, 'max_patch': patch, 'max_ver': v.version}}) %}
+{%   else %}
+{%     if patch < channels[channel_name]['min_patch'] %}
+{%       set _ = channels[channel_name].update({'min_patch': patch, 'min_ver': v.version}) %}
+{%     endif %}
+{%     if patch > channels[channel_name]['max_patch'] %}
+{%       set _ = channels[channel_name].update({'max_patch': patch, 'max_ver': v.version}) %}
+{%     endif %}
+{%   endif %}
+{% endfor %}
+{% for channel_name, data in channels.items() %}
+      - name: {{ channel_name }}
+        minVersion: {{ data.min_ver }}
+        maxVersion: {{ data.max_ver }}
+{% endfor %}
+    graph: true
+
+  blockedImages:
+    - name: registry.redhat.io/quay/quay-builder-qemu-rhcos-rhel8
+    - name: registry.redhat.io/quay/quay-builder-rhel8

--- a/templates/imagesetconfiguration-post.yaml.j2
+++ b/templates/imagesetconfiguration-post.yaml.j2
@@ -1,0 +1,35 @@
+---
+kind: ImageSetConfiguration
+apiVersion: mirror.openshift.io/v2alpha1
+mirror:
+  operators:
+    - catalog: {{ rh_operator_catalog }}:{{ rh_operator_catalog_version }}
+      packages:
+        # KubeVirt for virtualization workloads
+        - name: kubevirt-hyperconverged
+{% for operator in operators + (_core_plugin_operators | default([])) %}
+{% set additional_operator_names = operator.csvNames if (operator.csvMirror | default(false) | bool) else [] %}
+{% for operator_name in [operator.name] + additional_operator_names %}
+        - name: {{ operator_name }}
+          defaultChannel: {{ operator.channel }}
+          channels:
+            - name: {{ operator.channel }}
+              minVersion: {{ operator.init_version }}
+              maxVersion: {{ operator.version }}
+{% endfor %}
+{% for pkg in operator.extraMirrorPackages | default([]) %}
+        - name: {{ pkg }}
+{% endfor %}
+{% endfor %}
+
+  additionalImages:
+    - name: registry.redhat.io/ubi8/ubi:latest
+    - name: quay.io/argoproj/argocd:v2.2.2
+    - name: registry.connect.redhat.com/hashicorp/vault-csi-provider:1.6.0-ubi
+    - name: registry.connect.redhat.com/hashicorp/vault-enterprise:1.20.4-ent-ubi
+    - name: registry.connect.redhat.com/hashicorp/vault-k8s:1.7.0-ubi
+    - name: registry.connect.redhat.com/hashicorp/vault:1.20.4-ubi
+
+  blockedImages:
+    - name: registry.redhat.io/quay/quay-builder-qemu-rhcos-rhel8
+    - name: registry.redhat.io/quay/quay-builder-rhel8


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Split OpenShift mirroring into separate core and post-installation stages for improved orchestration and performance.
  * Asynchronous operator mirroring for disconnected installations with dedicated completion polling mechanism.

* **Refactor**
  * Enhanced task orchestration with improved tagging for selective execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->