### PR TITLE
bump quay-operator to 3.15.4

### DIFF
--- a/defaults/operators.yaml
+++ b/defaults/operators.yaml
@@ -2,7 +2,7 @@
 operators:
 
   - name: quay-operator
-    version: 3.15.3
+    version: 3.15.4
     channel: stable-3.15
     init_version: 3.15.0
     namespace: quay-enterprise


### PR DESCRIPTION
part of https://github.com/gori-project/GoRI/issues/314

bump quay-operator version to 3.15.4 to include https://github.com/quay/quay-operator/pull/1134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated quay-operator to version 3.15.4

<!-- end of auto-generated comment: release notes by coderabbit.ai -->