### PR TITLE
Revert "bump quay-operator to 3.15.4"

### DIFF
--- a/defaults/operators.yaml
+++ b/defaults/operators.yaml
@@ -2,7 +2,7 @@
 operators:
 
   - name: quay-operator
-    version: 3.15.4
+    version: 3.15.3
     channel: stable-3.15
     init_version: 3.15.0
     namespace: quay-enterprise


### PR DESCRIPTION
Reverts rh-ecosystem-edge/enclave#217

3.15.4 does not have CPE files:
```
$ podman run -it --entrypoint /bin/ls registry.redhat.io/quay/clair-rhel8:v3.15.4 -lah /data
ls: cannot access '/data': No such file or directory
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Quay Operator component version configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->