### PR TITLE
bump quay-operator to 3.17.1

### DIFF
--- a/defaults/operators.yaml
+++ b/defaults/operators.yaml
@@ -2,9 +2,9 @@
 operators:
 
   - name: quay-operator
-    version: 3.15.3
-    channel: stable-3.15
-    init_version: 3.15.0
+    version: 3.17.1
+    channel: stable-3.17
+    init_version: 3.17.1
     namespace: quay-enterprise
 
   - name: multicluster-engine

--- a/operators/quay-operator/clair_validations.yaml
+++ b/operators/quay-operator/clair_validations.yaml
@@ -1,0 +1,45 @@
+---
+- name: Get the name of the first Clair pod
+  kubernetes.core.k8s_info:
+    kind: Pod
+    namespace: quay-enterprise
+    label_selectors:
+      - quay-component=clair-app
+  register: clair_pods
+
+- name: Set clair pod name fact
+  ansible.builtin.set_fact:
+    clair_pod_name: "{{ clair_pods.resources[0].metadata.name }}"
+
+- name: Check for repository-to-cpe.json in the pod
+  kubernetes.core.k8s_exec:
+    namespace: quay-enterprise
+    pod: "{{ clair_pod_name }}"
+    command: ls /data/repository-to-cpe.json
+  register: cpe_file_check
+
+- name: Check for container-name-repos-map.json in the pod
+  kubernetes.core.k8s_exec:
+    namespace: quay-enterprise
+    pod: "{{ clair_pod_name }}"
+    command: ls /data/container-name-repos-map.json
+  register: repo_map_check
+
+- name: Fail if files are missing
+  fail:
+    msg: "Required CPE mapping files are missing from /data in pod {{ clair_pod_name }}"
+  when: cpe_file_check.rc != 0 or repo_map_check.rc != 0
+
+- name: Validate that Clair postgres config Secret exists
+  kubernetes.core.k8s_info:
+    kind: Secret
+    name: clairpostgres-config-secret
+    namespace: quay-enterprise
+  register: clair_postgres_config_secret
+
+- name: Fail if Secret is missing
+  ansible.builtin.assert:
+    that:
+      - clair_postgres_config_secret.resources | length > 0
+    fail_msg: "Validation Failed: Secret clairpostgres-config-secret was not found in namespace quay-enterprise."
+    success_msg: "Validation Passed: Secret clairpostgres-config-secret is present in namespace quay-enterprise."

--- a/operators/quay-operator/tasks.yaml
+++ b/operators/quay-operator/tasks.yaml
@@ -173,3 +173,7 @@
   when: disconnected | default(true)
   ansible.builtin.include_tasks:
     file: quay_disconnected_start.yaml
+
+- name: Clair validations
+  ansible.builtin.include_tasks:
+    file: clair_validations.yaml


### PR DESCRIPTION
we need a quay version that includes:
1. CPE files
```
$ podman run -it --entrypoint /bin/ls registry.redhat.io/quay/clair-rhel9:v3.17.1 -lah /data
total 2.9M
drwxr-xr-x. 1 root root  102 Apr  6 14:34 .
dr-xr-xr-x. 1 root root   24 Apr  9 08:56 ..
-rw-r--r--. 1 root root 101K Apr  6 14:31 container-name-repos-map.json
-rw-r--r--. 1 root root 2.8M Apr  6 14:31 repository-to-cpe.json
```
2. clair postgres config secret.

both are included in 3.17.1 and missing from 3.15 (current version).

this PR also includes validations for both issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Quay operator to version 3.17.1 (channel moved to stable-3.17).

* **New Features / Improvements**
  * Added validation during disconnected/oc-mirror setup to verify Clair data files and required Clair database secret, failing early with clear messages if checks fail.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/enclave/pull/220?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->