### PR TITLE
Unblock vllm images

### DIFF
--- a/plugins/openshift-ai/plugin.yaml
+++ b/plugins/openshift-ai/plugin.yaml
@@ -61,10 +61,6 @@ registries:
 blockedImages:
   - registry.redhat.io/quay/quay-builder-qemu-rhcos-rhel8
   - registry.redhat.io/quay/quay-builder-rhel8
-  - registry.redhat.io/rhaiis/vllm-cuda-rhel9
-  - registry.redhat.io/rhaiis/vllm-rocm-rhel9
-  - registry.redhat.io/rhaiis/vllm-spyre-rhel9
-  - registry.redhat.io/rhaiis/vllm-cpu-rhel9
   - registry.redhat.io/rhelai1/instructlab-nvidia-rhel9
   - registry.redhat.io/rhoai/odh-dashboard-rhel8
   - registry.redhat.io/rhoai/odh-dashboard-rhel9


### PR DESCRIPTION
It appears that the images used by RHOAI to serve LLMs are being blocked.

Unfortunately, I don’t yet have an environment where we can test plugin installation, so I haven’t been able to try this in practice, but I think it can be fixed by simply removing images from the list.

They seem to have been blocked in order to reduce build time in https://github.com/rh-ecosystem-edge/enclave/pull/121, but now that they have been split out as plugins, there should no longer be any impact on the core build time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Unblocked vLLM container images for CUDA, ROCm, SPYRE, and CPU architectures, expanding model deployment options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->