### PR TITLE
Increase postgres memory/cpu limits

### DIFF
--- a/plugins/odf/tasks/quay.yaml
+++ b/plugins/odf/tasks/quay.yaml
@@ -33,8 +33,8 @@
           overrides:
             resources:
               limits:
-                cpu: 500m
-                memory: 2Gi
+                cpu: 1
+                memory: 4Gi
               requests:
                 cpu: 500m
                 memory: 2Gi
@@ -43,8 +43,8 @@
           overrides:
             resources:
               limits:
-                cpu: 500m
-                memory: 2Gi
+                cpu: 1
+                memory: 4Gi
               requests:
                 cpu: 500m
                 memory: 2Gi


### PR DESCRIPTION
Fixes: https://github.com/gori-project/GoRI/issues/867

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced resource allocation for the Quay registry infrastructure to improve performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->