### PR TITLE
[e2e-deployment] add run id to artifact name

### DIFF
--- a/.github/workflows/e2e-deployment.yml
+++ b/.github/workflows/e2e-deployment.yml
@@ -323,7 +323,7 @@ jobs:
         id: upload_artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-connected-${{ env.ENCLAVE_CLUSTER_NAME }}
+          name: e2e-connected-${{ env.ENCLAVE_CLUSTER_NAME }}-${{ github.run_id }}
           path: artifacts/
           retention-days: 7
           if-no-files-found: warn
@@ -336,7 +336,7 @@ jobs:
           for attempt in 1 2 3 4 5; do
             sleep $((attempt * 2))
             ARTIFACT_ID=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts \
-              --jq '.artifacts[] | select(.name == "e2e-connected-${{ env.ENCLAVE_CLUSTER_NAME }}") | .id')
+              --jq '.artifacts[] | select(.name == "e2e-connected-${{ env.ENCLAVE_CLUSTER_NAME }}-${{ github.run_id }}") | .id')
             if [ -n "$ARTIFACT_ID" ]; then
               break
             fi
@@ -713,7 +713,7 @@ jobs:
         id: upload_artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-disconnected-${{ env.ENCLAVE_CLUSTER_NAME }}
+          name: e2e-disconnected-${{ env.ENCLAVE_CLUSTER_NAME }}-${{ github.run_id }}
           path: artifacts/
           retention-days: 7
           if-no-files-found: warn
@@ -726,7 +726,7 @@ jobs:
           for attempt in 1 2 3 4 5; do
             sleep $((attempt * 2))
             ARTIFACT_ID=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts \
-              --jq '.artifacts[] | select(.name == "e2e-disconnected-${{ env.ENCLAVE_CLUSTER_NAME }}") | .id')
+              --jq '.artifacts[] | select(.name == "e2e-disconnected-${{ env.ENCLAVE_CLUSTER_NAME }}-${{ github.run_id }}") | .id')
             if [ -n "$ARTIFACT_ID" ]; then
               break
             fi


### PR DESCRIPTION
when re-running the e2e jobs there will be multiple artifacts with the same name. with this PR the name will be different per run.

failure example: https://github.com/rh-ecosystem-edge/enclave/actions/runs/24300889730/job/70964776152
```
Error: Unable to process file command 'output' successfully.
Error: Invalid format '6391318096'
```
gh api call:
```
$ gh api repos/rh-ecosystem-edge/enclave/actions/runs/24300889730/artifacts --jq '.artifacts[] | select(.name == "e2e-connected-eci-a6c53998") | .id'
6392501463
6391318096
```
it returns the artifact ids from 2 runs:
1. https://github.com/rh-ecosystem-edge/enclave/actions/runs/24300889730/job/70953963515
2. https://github.com/rh-ecosystem-edge/enclave/actions/runs/24300889730/job/70964776152