### PR TITLE
[WIP] Add Podman health checks to ironic, httpd, and baremetal-operator containers

### DIFF
--- a/playbooks/tasks/deploy_bmo.yaml
+++ b/playbooks/tasks/deploy_bmo.yaml
@@ -58,10 +58,15 @@
       - /baremetal-operator
       - --webhook-port=0
       - --metrics-addr=0
-      - --health-addr=0
+      - --health-addr=:9440
       - --dev
       - --enable-leader-election=false
     state: started
+    healthcheck: "bash -c 'echo > /dev/tcp/localhost/9440'"
+    healthcheck_interval: 30s
+    healthcheck_timeout: 10s
+    healthcheck_retries: 3
+    healthcheck_start_period: 60s
 
 - name: Wait for baremetal-operator container to be running
   containers.podman.podman_container_info:
@@ -74,6 +79,17 @@
     r_bmo_ready.containers[0].State.Status == 'running'
   changed_when: false
 
+- name: Wait for baremetal-operator health check to pass
+  containers.podman.podman_container_info:
+    name: baremetal-operator
+  register: r_bmo_health
+  retries: 30
+  delay: 10
+  until:
+    - r_bmo_health.containers | length > 0
+    - r_bmo_health.containers[0].State.Health.Status | default('starting') == 'healthy'
+  changed_when: false
+
 - name: Display baremetal-operator container status
   containers.podman.podman_container_info:
     name: baremetal-operator
@@ -81,5 +97,5 @@
 
 - name: Show baremetal-operator status
   ansible.builtin.debug:
-    msg: "Container: {{ r_bmo_status.containers[0].Name }} | State: {{ r_bmo_status.containers[0].State.Status }}"
+    msg: "Container: {{ r_bmo_status.containers[0].Name }} | State: {{ r_bmo_status.containers[0].State.Status }} | Health: {{ r_bmo_status.containers[0].State.Health.Status | default('N/A') }}"
   when: r_bmo_status.containers | length > 0

--- a/playbooks/tasks/deploy_ironic.yaml
+++ b/playbooks/tasks/deploy_ironic.yaml
@@ -160,6 +160,11 @@
     command:
       - /bin/runironic
     state: started
+    healthcheck: "python3 -c \"import socket; s=socket.create_connection(('localhost', 6385), 5); s.close()\""
+    healthcheck_interval: 30s
+    healthcheck_timeout: 10s
+    healthcheck_retries: 3
+    healthcheck_start_period: 60s
 
 - name: Run httpd container
   containers.podman.podman_container:
@@ -182,6 +187,11 @@
     command:
       - /bin/runhttpd
     state: started
+    healthcheck: "python3 -c \"import socket; s=socket.create_connection(('localhost', 6180), 5); s.close()\""
+    healthcheck_interval: 30s
+    healthcheck_timeout: 10s
+    healthcheck_retries: 3
+    healthcheck_start_period: 60s
 
 - name: Wait for metal3-ironic pod and containers to be running
   containers.podman.podman_pod_info:
@@ -195,6 +205,28 @@
     - r_pod_ready.pods[0].Containers | selectattr('Name', 'equalto', 'httpd') | selectattr('State', 'equalto', 'running') | list | length == 1
   changed_when: false
   # Note: Checks that both ironic and httpd containers are running (infra container state is ignored)
+
+- name: Wait for ironic container health check to pass
+  containers.podman.podman_container_info:
+    name: ironic
+  register: r_ironic_health
+  retries: 30
+  delay: 10
+  until:
+    - r_ironic_health.containers | length > 0
+    - r_ironic_health.containers[0].State.Health.Status | default('starting') == 'healthy'
+  changed_when: false
+
+- name: Wait for httpd container health check to pass
+  containers.podman.podman_container_info:
+    name: httpd
+  register: r_httpd_health
+  retries: 30
+  delay: 10
+  until:
+    - r_httpd_health.containers | length > 0
+    - r_httpd_health.containers[0].State.Health.Status | default('starting') == 'healthy'
+  changed_when: false
 
 - name: Verify HTTP server accessibility
   ansible.builtin.uri:


### PR DESCRIPTION
Use TCP connect checks (python3 socket for ironic/httpd, bash /dev/tcp for BMO) with 60s start period to account for initialization. Enable BMO health endpoint on port 9440. Add wait tasks to ensure containers are healthy before proceeding.


Assisted-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented automated health checks for baremetal-operator and Ironic container services during deployment

* **Improvements**
  * Extended deployment workflow to include container health status verification with automatic polling
  * Enhanced deployment status reporting to display container health information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->