### PR TITLE
extract odf quay task resources to plugin defaults

### DIFF
--- a/plugins/odf/plugin.yaml
+++ b/plugins/odf/plugin.yaml
@@ -42,6 +42,25 @@ requires:
 defaults:
   odfDefaults:
     defaultStorageClass: true
+  components:
+    postgres:
+      overrides:
+        resources:
+          limits:
+            cpu: 1
+            memory: 4Gi
+          requests:
+            cpu: 500m
+            memory: 2Gi
+    clairpostgres:
+      overrides:
+        resources:
+          limits:
+            cpu: 1
+            memory: 4Gi
+          requests:
+            cpu: 500m
+            memory: 2Gi
 
 registries:
   - location: "registry.redhat.io/odf4"

--- a/plugins/odf/tasks/quay.yaml
+++ b/plugins/odf/tasks/quay.yaml
@@ -31,23 +31,11 @@
         - kind: postgres
           managed: true
           overrides:
-            resources:
-              limits:
-                cpu: 1
-                memory: 4Gi
-              requests:
-                cpu: 500m
-                memory: 2Gi
+            resources: "{{ components.postgres.overrides.resources }}"
         - kind: clairpostgres
           managed: true
           overrides:
-            resources:
-              limits:
-                cpu: 1
-                memory: 4Gi
-              requests:
-                cpu: 500m
-                memory: 2Gi
+            resources: "{{ components.clairpostgres.overrides.resources }}"
   retries: 60
   delay: 10
   register: r_quay


### PR DESCRIPTION
extract the resources section of the quay components as required by odf plugin to the plugin file.

the defaults are later used to template the task and apply the required values.

this approach enables and signals a consumer to get involved in setting the values should they choose to, via the plugin file which is the interface to the functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default resource configuration for Postgres components with standardized CPU (1 limit / 500m request) and memory (4Gi limit / 2Gi request) allocations.
  * Migrated resource specifications to use templated configuration values for improved consistency and manageability across deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->