### PR TITLE
Makefile.ci: pass ENCLAVE_CLUSTER_NAME and WORKING_DIR to verify-cluster

### DIFF
--- a/Makefile.ci
+++ b/Makefile.ci
@@ -387,7 +387,7 @@ clean:
 
 # Verification targets
 verify-cluster:
-	@./scripts/verification/verify_cluster.sh
+	@ENCLAVE_CLUSTER_NAME=$(ENCLAVE_CLUSTER_NAME) WORKING_DIR=$(WORKING_DIR) ./scripts/verification/verify_cluster.sh
 
 verify-cleanup:
 	@./scripts/cleanup/verify_cleanup.sh


### PR DESCRIPTION
Make variables are not exported to recipe shells by default, so verify_cluster.sh failed with ENCLAVE_CLUSTER_NAME must be set when invoked via make -f Makefile.ci verify-cluster. Prefix the script with the same variables the Makefile already defines so verification runs without requiring a manual export.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cluster verification process in CI to explicitly pass required environment variables during script execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->