### PR TITLE
retry Extract ISO from machine-os-images container

### DIFF
--- a/playbooks/tasks/download_content_single_version.yaml
+++ b/playbooks/tasks/download_content_single_version.yaml
@@ -30,6 +30,10 @@
           {{ machine_os_image.stdout }}
           --path /coreos/coreos-x86_64.iso:{{ temp_extract_dir.path }}/
       changed_when: true
+      register: iso_extraction
+      retries: "{{ k8s_retries }}"
+      delay: "{{ k8s_delay }}"
+      until: iso_extraction is success
 
     - name: Move ISO to final location with version-specific name
       become: true


### PR DESCRIPTION
handle intermittent failures such as https://github.com/rh-ecosystem-edge/enclave/actions/runs/24382428494/job/71208716270

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced reliability of ISO extraction process with improved retry and polling mechanisms, ensuring more consistent content download completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->