### PR TITLE
[MGMT-23811] enable build-push-tarball github action for 0-rc branch

### DIFF
--- a/.github/workflows/build-push-tarball.yml
+++ b/.github/workflows/build-push-tarball.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - 0-rc
     tags:
       - '*'
   pull_request:
@@ -71,6 +72,12 @@ jobs:
           registry: quay.io
           username: ${{ secrets.QUAY_USER }}
           password: ${{ secrets.QUAY_TOKEN }}
+
+      - name: Exit if image exists
+        run: |
+          if oras manifest fetch quay.io/edge-infrastructure/enclave:${{ steps.meta.outputs.tag }} > /dev/null 2>&1; then
+            exit 0
+          fi
 
       - name: Build tarball
         run: |


### PR DESCRIPTION
part of https://redhat.atlassian.net/browse/MGMT-23811

this PR enables the github actions that are enabled for main.

while these changes have no effect in main, we want to have 0-rc as similar as possible to main. this is why we are adding 0-rc in main. this will allow us to have 0-rc cleanly track main while we get it started.