### PR TITLE
add github action to mirror main to 0-rc

### DIFF
--- a/.github/workflows/mirror-main-0-rc.yml
+++ b/.github/workflows/mirror-main-0-rc.yml
@@ -1,0 +1,28 @@
+# A temporary action to mirror main to 0-rc
+# Useful until main and 0-rc diverge
+name: Mirror main to 0-rc
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: mirror-main-0-rc
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  mirror-branch:
+    runs-on: [self-hosted, pr-validation]
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      SHA: ${{ github.sha }}
+    
+    steps:
+      - name: Sync 0-rc with main
+        run: |
+          gh api -X PATCH repos/$REPO/git/refs/heads/0-rc -f sha="$SHA"


### PR DESCRIPTION
part of https://redhat.atlassian.net/browse/MGMT-23811

we want to initialize 0-rc to start kicking the tires, but for now it should be a mirror of main.
that is until we decide to merge something into main that should not go to 0-rc, at which point we will remove this github action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated branch synchronization: every push to main now automatically updates the 0-rc branch to the same commit, with concurrency control to cancel overlapping syncs so only the latest update is applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->