### PR TITLE
schema: add discovery_hosts and SSL certificate variables

### DIFF
--- a/schemas/definitions.yaml
+++ b/schemas/definitions.yaml
@@ -58,4 +58,39 @@ definitions:
     type: string
     pattern: "^/"
     description: Path for backend storage
+  hostEntry:
+    type: object
+    description: Host entry for cluster or discovery nodes
+    properties:
+      bmcSystemId:
+        type: string
+        description: Redfish system ID path component, defaults to '1'
+      ipAddress:
+        "$ref": "#/definitions/ipv4Address"
+      macAddress:
+        "$ref": "#/definitions/macAddress"
+      mapInterfaces:
+        type: object
+        description: Interface mapping configuration
+      name:
+        "$ref": "#/definitions/nonEmptyString"
+      networkConfig:
+        type: object
+        description: Network configuration
+      redfish:
+        "$ref": "#/definitions/ipv4Address"
+      redfishPassword:
+        "$ref": "#/definitions/nonEmptyString"
+      redfishUser:
+        "$ref": "#/definitions/nonEmptyString"
+      rootDisk:
+        "$ref": "#/definitions/nonEmptyString"
+    required:
+      - ipAddress
+      - macAddress
+      - name
+      - redfish
+      - redfishPassword
+      - redfishUser
+      - rootDisk
 

--- a/schemas/variables.yaml
+++ b/schemas/variables.yaml
@@ -11,39 +11,7 @@ properties:
     maxItems: 3
     description: List of exactly 3 control plane nodes
     items:
-      type: object
-      properties:
-        bmcSystemId:
-          type: string
-          description: Redfish system ID path component, defaults to '1'
-        ipAddress:
-          "$ref": "#/definitions/ipv4Address"
-        macAddress:
-          "$ref": "#/definitions/macAddress"
-        mapInterfaces:
-          type: object
-          description: Interface mapping configuration
-        name:
-          "$ref": "#/definitions/nonEmptyString"
-        networkConfig:
-          type: object
-          description: Network configuration
-        redfish:
-          "$ref": "#/definitions/ipv4Address"
-        redfishPassword:
-          "$ref": "#/definitions/nonEmptyString"
-        redfishUser:
-          "$ref": "#/definitions/nonEmptyString"
-        rootDisk:
-          "$ref": "#/definitions/nonEmptyString"
-      required:
-        - ipAddress
-        - macAddress
-        - name
-        - redfish
-        - redfishPassword
-        - redfishUser
-        - rootDisk
+      "$ref": "#/definitions/hostEntry"
   apiVIP:
     "$ref": "#/definitions/ipv4Address"
   baseDomain:
@@ -70,6 +38,11 @@ properties:
     description: Network prefix length (subnet mask bits)
   disconnected:
     "$ref": "#/definitions/disconnected"
+  discovery_hosts:
+    type: array
+    description: List of discovery hosts for hardware discovery
+    items:
+      "$ref": "#/definitions/hostEntry"
   masterMaxPods:
     "$ref": "#/definitions/masterMaxPods"
   diskEncryption:
@@ -141,6 +114,21 @@ properties:
     "$ref": "#/definitions/ipv4Address"
   sshPubPath:
     "$ref": "#/definitions/nonEmptyString"
+  sslAPICertificateFullChain:
+    type: string
+    description: PEM-encoded full certificate chain for API server
+  sslAPICertificateKey:
+    type: string
+    description: PEM-encoded private key for API server certificate
+  sslCACertificate:
+    type: string
+    description: PEM-encoded root CA certificate
+  sslIngressCertificateFullChain:
+    type: string
+    description: PEM-encoded full certificate chain for ingress wildcard certificate
+  sslIngressCertificateKey:
+    type: string
+    description: PEM-encoded private key for ingress wildcard certificate
   workingDir:
     "$ref": "#/definitions/nonEmptyString"
 
@@ -179,3 +167,25 @@ allOf:
     then:
       required:
         - odfExternalConfig
+  - if:
+      properties:
+        sslAPICertificateFullChain:
+          type: string
+          minLength: 1
+      required:
+        - sslAPICertificateFullChain
+    then:
+      required:
+        - sslAPICertificateKey
+        - sslIngressCertificateFullChain
+        - sslIngressCertificateKey
+      properties:
+        sslAPICertificateKey:
+          type: string
+          minLength: 1
+        sslIngressCertificateFullChain:
+          type: string
+          minLength: 1
+        sslIngressCertificateKey:
+          type: string
+          minLength: 1

--- a/test-fixtures/schemas/invalid/invalid-discovery-host-missing-field.yaml
+++ b/test-fixtures/schemas/invalid/invalid-discovery-host-missing-field.yaml
@@ -1,0 +1,50 @@
+---
+# Invalid fixture: discovery_hosts item missing required rootDisk field
+# Expected failure: variables schema requires rootDisk for each discovery_hosts item.
+workingDir: /home/enclave
+baseDomain: enclave-test.nodns.in
+clusterName: mgmt
+machineNetwork: 192.168.2.0/24
+apiVIP: 192.168.2.201
+ingressVIP: 192.168.2.202
+defaultDNS: 9.30.31.32
+defaultGateway: 192.168.2.10
+defaultPrefix: 24
+rendezvousIP: 192.168.2.24
+lzBmcIP: 100.64.1.10
+quayUser: admin
+quayPassword: password
+quayBackend: LocalStorage
+blockStorageBackend: lvms
+pullSecret: {"auths":{}}
+sshPubPath: /home/enclave/.ssh/id_rsa.pub
+discovery_hosts:
+  - name: discovery-host-01
+    macAddress: 0c:c4:7a:62:ff:01
+    ipAddress: 192.168.2.30
+    redfish: 192.168.1.201
+    redfishUser: admin
+    redfishPassword: password
+agent_hosts:
+  - name: mgmt-ctl01
+    macAddress: 0c:c4:7a:62:fe:ec
+    ipAddress: 192.168.2.24
+    redfish: 192.168.1.101
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl02
+    macAddress: 0c:c4:7a:62:fe:ed
+    ipAddress: 192.168.2.25
+    redfish: 192.168.1.102
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl03
+    macAddress: 0c:c4:7a:62:fe:ee
+    ipAddress: 192.168.2.26
+    redfish: 192.168.1.103
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+

--- a/test-fixtures/schemas/invalid/ssl-empty-key.yaml
+++ b/test-fixtures/schemas/invalid/ssl-empty-key.yaml
@@ -1,0 +1,57 @@
+---
+# Invalid fixture: sslAPICertificateFullChain present but sslAPICertificateKey is empty
+# Expected failure: variables schema requires sslAPICertificateKey to be non-empty
+# when sslAPICertificateFullChain is provided.
+workingDir: /home/enclave
+baseDomain: enclave-test.nodns.in
+clusterName: mgmt
+machineNetwork: 192.168.2.0/24
+apiVIP: 192.168.2.201
+ingressVIP: 192.168.2.202
+defaultDNS: 9.30.31.32
+defaultGateway: 192.168.2.10
+defaultPrefix: 24
+rendezvousIP: 192.168.2.24
+lzBmcIP: 100.64.1.10
+quayUser: admin
+quayPassword: password
+quayBackend: LocalStorage
+blockStorageBackend: lvms
+pullSecret: {"auths":{}}
+sshPubPath: /home/enclave/.ssh/id_rsa.pub
+sslAPICertificateFullChain: |
+  -----BEGIN CERTIFICATE-----
+  DUMMY_API_CERT_CHAIN
+  -----END CERTIFICATE-----
+sslAPICertificateKey: ""
+sslIngressCertificateFullChain: |
+  -----BEGIN CERTIFICATE-----
+  DUMMY_INGRESS_CERT_CHAIN
+  -----END CERTIFICATE-----
+sslIngressCertificateKey: |
+  -----BEGIN DUMMY KEY-----
+  DUMMY_INGRESS_KEY
+  -----END DUMMY KEY-----
+agent_hosts:
+  - name: mgmt-ctl01
+    macAddress: 0c:c4:7a:62:fe:ec
+    ipAddress: 192.168.2.24
+    redfish: 192.168.1.101
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl02
+    macAddress: 0c:c4:7a:62:fe:ed
+    ipAddress: 192.168.2.25
+    redfish: 192.168.1.102
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl03
+    macAddress: 0c:c4:7a:62:fe:ee
+    ipAddress: 192.168.2.26
+    redfish: 192.168.1.103
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+

--- a/test-fixtures/schemas/invalid/ssl-missing-key.yaml
+++ b/test-fixtures/schemas/invalid/ssl-missing-key.yaml
@@ -1,0 +1,49 @@
+---
+# Invalid fixture: sslAPICertificateFullChain present but sslAPICertificateKey omitted
+# Expected failure: variables schema requires sslAPICertificateKey,
+# sslIngressCertificateFullChain, and sslIngressCertificateKey when
+# sslAPICertificateFullChain is present and non-empty.
+workingDir: /home/enclave
+baseDomain: enclave-test.nodns.in
+clusterName: mgmt
+machineNetwork: 192.168.2.0/24
+apiVIP: 192.168.2.201
+ingressVIP: 192.168.2.202
+defaultDNS: 9.30.31.32
+defaultGateway: 192.168.2.10
+defaultPrefix: 24
+rendezvousIP: 192.168.2.24
+lzBmcIP: 100.64.1.10
+quayUser: admin
+quayPassword: password
+quayBackend: LocalStorage
+blockStorageBackend: lvms
+pullSecret: {"auths":{}}
+sshPubPath: /home/enclave/.ssh/id_rsa.pub
+sslAPICertificateFullChain: |
+  -----BEGIN CERTIFICATE-----
+  DUMMY_API_CERT_CHAIN
+  -----END CERTIFICATE-----
+agent_hosts:
+  - name: mgmt-ctl01
+    macAddress: 0c:c4:7a:62:fe:ec
+    ipAddress: 192.168.2.24
+    redfish: 192.168.1.101
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl02
+    macAddress: 0c:c4:7a:62:fe:ed
+    ipAddress: 192.168.2.25
+    redfish: 192.168.1.102
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl03
+    macAddress: 0c:c4:7a:62:fe:ee
+    ipAddress: 192.168.2.26
+    redfish: 192.168.1.103
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+

--- a/test-fixtures/schemas/valid/local-lvms-with-discovery.yaml
+++ b/test-fixtures/schemas/valid/local-lvms-with-discovery.yaml
@@ -1,0 +1,51 @@
+---
+# Fixture: LocalStorage + lvms with discovery_hosts
+# Validates discovery_hosts with one host entry. No SSL vars.
+workingDir: /home/enclave
+baseDomain: enclave-test.nodns.in
+clusterName: mgmt
+machineNetwork: 192.168.2.0/24
+apiVIP: 192.168.2.201
+ingressVIP: 192.168.2.202
+defaultDNS: 9.30.31.32
+defaultGateway: 192.168.2.10
+defaultPrefix: 24
+rendezvousIP: 192.168.2.24
+lzBmcIP: 100.64.1.10
+quayUser: admin
+quayPassword: password
+quayBackend: LocalStorage
+blockStorageBackend: lvms
+pullSecret: {"auths":{}}
+sshPubPath: /home/enclave/.ssh/id_rsa.pub
+discovery_hosts:
+  - name: discovery-host-01
+    macAddress: 0c:c4:7a:62:ff:01
+    ipAddress: 192.168.2.30
+    redfish: 192.168.1.201
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+agent_hosts:
+  - name: mgmt-ctl01
+    macAddress: 0c:c4:7a:62:fe:ec
+    ipAddress: 192.168.2.24
+    redfish: 192.168.1.101
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl02
+    macAddress: 0c:c4:7a:62:fe:ed
+    ipAddress: 192.168.2.25
+    redfish: 192.168.1.102
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl03
+    macAddress: 0c:c4:7a:62:fe:ee
+    ipAddress: 192.168.2.26
+    redfish: 192.168.1.103
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+

--- a/test-fixtures/schemas/valid/local-lvms-with-ssl.yaml
+++ b/test-fixtures/schemas/valid/local-lvms-with-ssl.yaml
@@ -1,0 +1,60 @@
+---
+# Fixture: LocalStorage + lvms with SSL certificate variables
+# Validates that the SSL conditional passes when all 4 required SSL vars are present.
+# sslCACertificate is omitted (always optional).
+workingDir: /home/enclave
+baseDomain: enclave-test.nodns.in
+clusterName: mgmt
+machineNetwork: 192.168.2.0/24
+apiVIP: 192.168.2.201
+ingressVIP: 192.168.2.202
+defaultDNS: 9.30.31.32
+defaultGateway: 192.168.2.10
+defaultPrefix: 24
+rendezvousIP: 192.168.2.24
+lzBmcIP: 100.64.1.10
+quayUser: admin
+quayPassword: password
+quayBackend: LocalStorage
+blockStorageBackend: lvms
+pullSecret: {"auths":{}}
+sshPubPath: /home/enclave/.ssh/id_rsa.pub
+sslAPICertificateFullChain: |
+  -----BEGIN CERTIFICATE-----
+  DUMMY_API_CERT_CHAIN
+  -----END CERTIFICATE-----
+sslAPICertificateKey: |
+  -----BEGIN DUMMY KEY-----
+  DUMMY_API_KEY
+  -----END DUMMY KEY-----
+sslIngressCertificateFullChain: |
+  -----BEGIN CERTIFICATE-----
+  DUMMY_INGRESS_CERT_CHAIN
+  -----END CERTIFICATE-----
+sslIngressCertificateKey: |
+  -----BEGIN DUMMY KEY-----
+  DUMMY_INGRESS_KEY
+  -----END DUMMY KEY-----
+agent_hosts:
+  - name: mgmt-ctl01
+    macAddress: 0c:c4:7a:62:fe:ec
+    ipAddress: 192.168.2.24
+    redfish: 192.168.1.101
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl02
+    macAddress: 0c:c4:7a:62:fe:ed
+    ipAddress: 192.168.2.25
+    redfish: 192.168.1.102
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl03
+    macAddress: 0c:c4:7a:62:fe:ee
+    ipAddress: 192.168.2.26
+    redfish: 192.168.1.103
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+

--- a/test-fixtures/schemas/valid/radosgw-lvms-all-optionals.yaml
+++ b/test-fixtures/schemas/valid/radosgw-lvms-all-optionals.yaml
@@ -1,7 +1,8 @@
 ---
 # Fixture: RadosGWStorage + lvms with all optional fields set
 # Exercises: disconnected, diskEncryption, ocMirrorLogLevel, defaultNtpServers,
-# lvmsConfig, bmcSystemId, and all optional quayBackendRGWConfiguration overrides.
+# lvmsConfig, bmcSystemId, all optional quayBackendRGWConfiguration overrides,
+# discovery_hosts (with bmcSystemId), and all SSL certificate variables.
 workingDir: /home/enclave
 baseDomain: enclave-test.nodns.in
 clusterName: mgmt
@@ -42,6 +43,42 @@ lvmsConfig:
       - /dev/disk/by-path/pci-0000:00:11.4-ata-3.0
 pullSecret: {"auths":{}}
 sshPubPath: /home/enclave/.ssh/id_rsa.pub
+sslAPICertificateFullChain: |
+  -----BEGIN CERTIFICATE-----
+  DUMMY_API_CERT_CHAIN
+  -----END CERTIFICATE-----
+sslAPICertificateKey: |
+  -----BEGIN DUMMY KEY-----
+  DUMMY_API_KEY
+  -----END DUMMY KEY-----
+sslCACertificate: |
+  -----BEGIN CERTIFICATE-----
+  DUMMY_CA_CERT
+  -----END CERTIFICATE-----
+sslIngressCertificateFullChain: |
+  -----BEGIN CERTIFICATE-----
+  DUMMY_INGRESS_CERT_CHAIN
+  -----END CERTIFICATE-----
+sslIngressCertificateKey: |
+  -----BEGIN DUMMY KEY-----
+  DUMMY_INGRESS_KEY
+  -----END DUMMY KEY-----
+discovery_hosts:
+  - name: discovery-host-01
+    macAddress: 0c:c4:7a:62:ff:01
+    ipAddress: 192.168.2.30
+    redfish: 192.168.1.201
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+    bmcSystemId: "2"
+  - name: discovery-host-02
+    macAddress: 0c:c4:7a:62:ff:02
+    ipAddress: 192.168.2.31
+    redfish: 192.168.1.202
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
 agent_hosts:
   - name: mgmt-ctl01
     macAddress: 0c:c4:7a:62:fe:ec


### PR DESCRIPTION
Add 6 missing variables to the variables schema:
- discovery_hosts: optional array of hardware discovery hosts, with the same item structure as agent_hosts (no minItems/maxItems constraint)
- sslAPICertificateFullChain, sslAPICertificateKey, sslCACertificate, sslIngressCertificateFullChain, sslIngressCertificateKey: optional PEM-encoded SSL certificate strings

Add a conditional allOf rule: when sslAPICertificateFullChain is present and non-empty, sslAPICertificateKey, sslIngressCertificateFullChain, and sslIngressCertificateKey are all required. sslCACertificate remains unconditionally optional (uses default('') in playbooks).

Add fixture files to cover the new schema paths, extract the shared host item schema into a reusable hostEntry definition, and fix the fixture discovery path in variables_schema_validation.yaml.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for discovery hosts configuration alongside existing agent hosts
  * Added SSL/TLS certificate configuration options for API and ingress endpoints
  * Implemented validation to require matching key and certificate pairs when SSL configurations are provided
<!-- end of auto-generated comment: release notes by coderabbit.ai -->