### PR TITLE
Wait for cert-manager webhook before continuing deployment

### DIFF
--- a/operators/openshift-cert-manager-operator/tasks.yaml
+++ b/operators/openshift-cert-manager-operator/tasks.yaml
@@ -35,3 +35,18 @@
             requests:
               cpu: 20m
               memory: 32Mi
+
+- name: Wait for cert-manager webhook to be available
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: cert-manager-webhook
+    namespace: cert-manager
+  register: r_cert_manager_webhook
+  retries: 60
+  delay: 10
+  until:
+    - r_cert_manager_webhook.resources is defined
+    - r_cert_manager_webhook.resources | length > 0
+    - r_cert_manager_webhook.resources[0].status.availableReplicas is defined
+    - r_cert_manager_webhook.resources[0].status.availableReplicas >= 3


### PR DESCRIPTION
The cert-manager webhook pods may not be ready when subsequent steps try to create cert-manager resources, causing "connection refused" errors.
Add a readiness check after the CertManager resource patch to wait for all webhook replicas to be available.

MGMT-23860

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cert-manager operator stability by adding a readiness check for the webhook deployment that waits for the component to become fully available (ensuring expected replica availability) before proceeding, reducing failed or premature deployment steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->