### PR TITLE
[proposal] set ai plugins mirror to core as a workaround to avoid node restarts

### DIFF
--- a/plugins/nvidia-gpu/plugin.yaml
+++ b/plugins/nvidia-gpu/plugin.yaml
@@ -2,7 +2,7 @@
 name: nvidia-gpu
 type: addon
 order: 110
-mirror: plugin
+mirror: core
 
 catalog: certified
 operators:

--- a/plugins/openshift-ai/plugin.yaml
+++ b/plugins/openshift-ai/plugin.yaml
@@ -2,7 +2,7 @@
 name: openshift-ai
 type: addon
 order: 100
-mirror: plugin
+mirror: core
 
 operators:
   - name: nfd


### PR DESCRIPTION
this PR is a possible work around for individual mirroring (which causes node restarts).

by setting mirror to core we force mirroring to happen in a single iteration, avoiding additional IDMS/ITMS updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reconfigured NVIDIA GPU and OpenShift AI add-on distribution to use the core mirror channel instead of the plugin channel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->