### PR TITLE
do not patch mce configmap for core plugins

### DIFF
--- a/playbooks/tasks/deploy_plugin.yaml
+++ b/playbooks/tasks/deploy_plugin.yaml
@@ -195,7 +195,7 @@
     plugin_registries_entries: "{{ plugin.registries }}"
   when:
     - plugin.registries is defined
-    - plugin.mirror | default('none') in ['core', 'plugin']
+    - plugin.mirror | default('none') == 'plugin'
     - disconnected | default(true) | bool
   tags: mirror
 


### PR DESCRIPTION
since core plugins are mirrored at the core, it shouldn't be expected that an MCE configmap patch is required.

this can work with #182