### PR TITLE
Prevent GPU operator daemonsets from scheduling on control plane nodes

### DIFF
--- a/playbooks/tasks/deploy_plugin.yaml
+++ b/playbooks/tasks/deploy_plugin.yaml
@@ -147,11 +147,11 @@
     - disconnected | default(true) | bool
   tags: mirror
 
-- name: Apply updated mirror manifests to cluster
+- name: Apply updated CatalogSource manifests to cluster (skip IDMS/ITMS to avoid node reboots)
   ansible.builtin.shell: |
-    {{ workingDir }}/bin/oc apply \
-      -f {{ workingDir }}/config/oc-mirror-workspace/working-dir/cluster-resources/ \
-      --server-side --force-conflicts
+    find {{ workingDir }}/config/oc-mirror-workspace/working-dir/cluster-resources/ \
+      -name '*.yaml' ! -name 'idms-*' ! -name 'itms-*' \
+      -exec {{ workingDir }}/bin/oc apply --server-side --force-conflicts -f {} +
   environment:
     KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
   when:


### PR DESCRIPTION
Add nodeAffinity to the ClusterPolicy daemonsets section to exclude nodes with the control-plane role. This prevents GPU driver installation from triggering control plane node restarts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Configuration Updates**
  * Updated NVIDIA GPU plugin policy to restrict GPU component scheduling to non-control-plane nodes, ensuring proper resource allocation across the cluster infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->