### PR TITLE
Skip IDMS/ITMS when applying plugin mirror manifests to avoid control…

### DIFF
--- a/playbooks/tasks/deploy_plugin.yaml
+++ b/playbooks/tasks/deploy_plugin.yaml
@@ -147,11 +147,11 @@
     - disconnected | default(true) | bool
   tags: mirror
 
-- name: Apply updated mirror manifests to cluster
+- name: Apply updated CatalogSource manifests to cluster (skip IDMS/ITMS to avoid node reboots)
   ansible.builtin.shell: |
-    {{ workingDir }}/bin/oc apply \
-      -f {{ workingDir }}/config/oc-mirror-workspace/working-dir/cluster-resources/ \
-      --server-side --force-conflicts
+    find {{ workingDir }}/config/oc-mirror-workspace/working-dir/cluster-resources/ \
+      -name '*.yaml' ! -name 'idms-*' ! -name 'itms-*' \
+      -exec {{ workingDir }}/bin/oc apply --server-side --force-conflicts -f {} +
   environment:
     KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
   when:


### PR DESCRIPTION
The problem is in deploy_plugin.yaml:150-154. When a plugin with mirror: plugin runs, oc-mirror generates files in the shared             
  cluster-resources/ directory. The original code applies everything in that directory:
                                                                                                                                            
  oc apply -f cluster-resources/ --server-side --force-conflicts                                                                            
                                                                                                                                            
  That includes IDMS/ITMS files (idms-oc-mirror.yaml, itms-oc-mirror.yaml). When those get applied to the hub, MCO detects the image mirror 
  configuration change, generates new MachineConfigs, and rolls them out — which reboots nodes including control plane.                     
                                                                                                                                            
  But the hub doesn't need the updated IDMS/ITMS at all. The plugins set installOperators: false, so no plugin operator images are pulled on
   the hub. The only thing the hub needs from cluster-resources/ is the CatalogSource updates, so ACM can reference the mirrored operator
  catalogs when deploying to spoke clusters.                                                                                                
                                                            
  The fix uses find to apply only non-IDMS/ITMS files:                                                                                      
   
  find cluster-resources/ -name '*.yaml' ! -name 'idms-*' ! -name 'itms-*' \                                                                
    -exec oc apply --server-side --force-conflicts -f {} +                                                                                  
   
  This skips idms-*.yaml and itms-*.yaml, applying only CatalogSource and other manifests that don't trigger MCO rolling updates