### PR TITLE
do not apply updated mirror manifests to cluster

### DIFF
--- a/playbooks/tasks/deploy_plugin.yaml
+++ b/playbooks/tasks/deploy_plugin.yaml
@@ -147,43 +147,6 @@
     - disconnected | default(true) | bool
   tags: mirror
 
-- name: Apply updated mirror manifests to cluster
-  ansible.builtin.shell: |
-    {{ workingDir }}/bin/oc apply \
-      -f {{ workingDir }}/config/oc-mirror-workspace/working-dir/cluster-resources/ \
-      --server-side --force-conflicts
-  environment:
-    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
-  when:
-    - plugin.mirror | default('none') == 'plugin'
-    - disconnected | default(true) | bool
-    - r_plugin_mirror is defined
-    - r_plugin_mirror is success
-  tags: mirror
-
-- name: Wait for updated CatalogSource to be ready
-  kubernetes.core.k8s_info:
-    api_version: operators.coreos.com/v1alpha1
-    kind: CatalogSource
-    namespace: openshift-marketplace
-  environment:
-    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
-  register: r_catalog_sources
-  retries: 24
-  delay: 10
-  until: >-
-    r_catalog_sources.resources | default([])
-    | selectattr('status', 'defined')
-    | selectattr('status.connectionState', 'defined')
-    | selectattr('status.connectionState.lastObservedState', 'equalto', 'READY')
-    | list | length >= (r_catalog_sources.resources | length)
-  when:
-    - plugin.mirror | default('none') == 'plugin'
-    - disconnected | default(true) | bool
-    - r_plugin_mirror is defined
-    - r_plugin_mirror is success
-  tags: mirror
-
 - name: Patch MCE custom-registries with plugin entries
   ansible.builtin.include_tasks:
     file: tasks/patch_mce_registries.yaml


### PR DESCRIPTION
when `mirror: plugin` the content is not expected to land in management cluster, hence updating cluster resources is not needed.
when `mirror: core` the content is expected to exist already.

hence, this PR removes the entire section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed automatic cluster manifest application and resource verification steps from the plugin deployment workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->