### PR TITLE
do not apply updated mirror manifests to cluster if operators should not be installed

### DIFF
--- a/playbooks/tasks/deploy_plugin.yaml
+++ b/playbooks/tasks/deploy_plugin.yaml
@@ -156,6 +156,7 @@
     KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
   when:
     - plugin.mirror | default('none') == 'plugin'
+    - plugin.installOperators | default(true)
     - disconnected | default(true) | bool
     - r_plugin_mirror is defined
     - r_plugin_mirror is success
@@ -179,6 +180,7 @@
     | list | length >= (r_catalog_sources.resources | length)
   when:
     - plugin.mirror | default('none') == 'plugin'
+    - plugin.installOperators | default(true)
     - disconnected | default(true) | bool
     - r_plugin_mirror is defined
     - r_plugin_mirror is success


### PR DESCRIPTION
if operators should not be installed, they shouldn't be applied to IDMS/ITMS on the management cluster.

- https://github.com/rh-ecosystem-edge/enclave/blob/7204790fc9bfaf9f5aa1a501e6f622d415e41c1d/plugins/openshift-ai/plugin.yaml#L41
- https://github.com/rh-ecosystem-edge/enclave/blob/7204790fc9bfaf9f5aa1a501e6f622d415e41c1d/plugins/nvidia-gpu/plugin.yaml#L14