### PR TITLE
Add retries to Clair vulnerability data export

### DIFF
--- a/operators/quay-operator/clair_disconnected.yaml
+++ b/operators/quay-operator/clair_disconnected.yaml
@@ -24,6 +24,10 @@
 - name: Export vulnerability data on Landing Zone
   ansible.builtin.shell: |
     {{ workingDir }}/bin/clairctl --config {{ workingDir }}/data/clair/config.yaml export-updaters {{ workingDir }}/data/clair/updates.json.gz
+  register: r_clair_export
+  retries: 3
+  delay: 30
+  until: r_clair_export is success
 
 - name: Ensure directory /var/www/html/clair/
   become: true


### PR DESCRIPTION
## Summary

- Add retries (3 attempts, 30s delay) to `clairctl export-updaters` task in `clair_disconnected.yaml`
- The export can be OOM-killed (exit code 137) under memory pressure; retries handle transient failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Clair vulnerability export reliability with automatic retry logic, allowing up to 3 attempts with 30-second intervals between retries to ensure successful completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->