### PR TITLE
add oc-mirror from landing zone to quay-enterprise in deploy plugin

### DIFF
--- a/playbooks/tasks/deploy_plugin.yaml
+++ b/playbooks/tasks/deploy_plugin.yaml
@@ -124,7 +124,7 @@
     - plugin.operators is defined
   tags: mirror
 
-- name: Run oc-mirror for plugin
+- name: Run oc-mirror for plugin (Landing Zone)
   ansible.builtin.shell: |
     {{ workingDir }}/bin/oc-mirror --v2 \
       --log-level {{ ocMirrorLogLevel }} \
@@ -142,6 +142,31 @@
   delay: 10
   register: r_plugin_mirror
   until: r_plugin_mirror is success
+  when:
+    - plugin.mirror | default('none') == 'plugin'
+    - disconnected | default(true) | bool
+  tags: mirror
+
+- name: Run oc-mirror for plugin (Quay Enterprise)
+  ansible.builtin.shell: |
+    {{ workingDir }}/bin/oc-mirror --v2 \
+      --log-level {{ ocMirrorLogLevel }} \
+      --authfile {{ workingDir }}/config/pull-secret.quay.json \
+      -c {{ workingDir }}/plugin-{{ plugin_name }}-imageset.yaml \
+      --workspace file://{{ workingDir }}/config/oc-mirror-workspace-quay \
+      docker://registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }} \
+      --dest-tls-verify=false \
+      --src-tls-verify=false \
+      --parallel-images 10 \
+      --parallel-layers {{ 1 if quayBackend == 'LocalStorage' else 10 }} \
+      --retry-times 10 \
+      --retry-delay 0 \
+      --image-timeout 40m0s \
+      > {{ workingDir }}/logs/oc-mirror-plugin-{{ plugin_name }}.progress.quay.$(date +%s).log 2>&1
+  retries: 10
+  delay: 10
+  register: r_oc_mirror_quay
+  until: r_oc_mirror_quay is succeeded
   when:
     - plugin.mirror | default('none') == 'plugin'
     - disconnected | default(true) | bool


### PR DESCRIPTION
seems we are only mirroring to the landing zone mirror registry.

this PR adds another oc-mirror call to mirror content from landing zone mirror registry to quay-enterprise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Extended plugin image mirroring to support Quay Enterprise registry with specialized configuration for authentication, TLS verification, and dynamic optimization based on storage backend.
  * Improved deployment task organization through naming updates for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->