### PR TITLE
do not apply updated mirror manifests to cluster if operators should not be installed

### DIFF
--- a/playbooks/tasks/deploy_plugin.yaml
+++ b/playbooks/tasks/deploy_plugin.yaml
@@ -286,6 +286,7 @@
         KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
   when:
     - plugin.mirror | default('none') == 'plugin'
+    - plugin.installOperators | default(true)
     - disconnected | default(true) | bool
     - r_plugin_mirror_quay is defined
     - r_plugin_mirror_quay is success


### PR DESCRIPTION
same as #244 but for section added in #248

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Refined plugin mirror deployment to require operator installation to be enabled as a prerequisite condition, ensuring mirrors are applied only when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->