### PR TITLE
increase number of limit of Pods per node to 500

### DIFF
--- a/config/global.example.yaml
+++ b/config/global.example.yaml
@@ -94,6 +94,9 @@ storage_plugin: lvms
 # Disconnected mode (default: true, set to false for connected deployments)
 # disconnected: false
 
+# Configure High Density Pod Limits for ABI (default: 500)
+# masterMaxPods: 250
+
 # Encrypt installation partition with TPM v2 (default: false, set to true to enable)
 # diskEncryption: true
 

--- a/defaults/deployment.yaml
+++ b/defaults/deployment.yaml
@@ -2,6 +2,9 @@
 # Default deployment mode. Override in config/global.yaml to deploy in connected mode.
 disconnected: true
 
+# Configure High Density Pod Limits for ABI. Override in config/global.yaml.
+masterMaxPods: 500
+
 # Default disk encryption setting. Override in config/global.yaml to enable TPM v2 encryption.
 diskEncryption: false
 

--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -1206,6 +1206,7 @@ lzBmcIP: 100.64.1.10
 
 # OpenShift Deployment Configuration (optional — uncomment only to override defaults)
 # disconnected: false  # Default: true (set to false for connected deployments)
+# masterMaxPods: 250 # Default: 500
 # diskEncryption: true  # Default: false (set to true to enable TPM v2 encryption)
 # ocMirrorLogLevel: debug  # Default: info
 # defaultNtpServers:  # No additional servers by default

--- a/playbooks/tasks/configure_ocp_abi.yaml
+++ b/playbooks/tasks/configure_ocp_abi.yaml
@@ -46,6 +46,22 @@
     src: "../../templates/agent-config.yaml.j2"
     dest: "{{ workingDir }}/ocp-cluster/agent-config.yaml"
 
+- name: Create KubeletConfig manifest for master max pods
+  ansible.builtin.copy:
+    dest: "{{ install_dir }}/openshift/99-worker-max-pods.yaml"
+    content: |
+      apiVersion: machineconfiguration.openshift.io/v1
+      kind: KubeletConfig
+      metadata:
+        name: set-master-max-pods
+      spec:
+        machineConfigPoolSelector:
+          matchLabels:
+            pools.operator.machineconfiguration.openshift.io/master: ""
+        kubeletConfig:
+          maxPods: {{ masterMaxPods }}
+    mode: '0644'
+
 - name: Copy custom manifests from mirror registry to the ABI directory
   when: disconnected | default(true)
   ansible.builtin.copy:

--- a/playbooks/tasks/configure_ocp_abi.yaml
+++ b/playbooks/tasks/configure_ocp_abi.yaml
@@ -48,7 +48,7 @@
 
 - name: Create KubeletConfig manifest for master max pods
   ansible.builtin.copy:
-    dest: "{{ workingDir }}/ocp-cluster/openshift/99-worker-max-pods.yaml"
+    dest: "{{ workingDir }}/ocp-cluster/openshift/99-master-max-pods.yaml"
     content: |
       apiVersion: machineconfiguration.openshift.io/v1
       kind: KubeletConfig

--- a/playbooks/tasks/configure_ocp_abi.yaml
+++ b/playbooks/tasks/configure_ocp_abi.yaml
@@ -48,7 +48,7 @@
 
 - name: Create KubeletConfig manifest for master max pods
   ansible.builtin.copy:
-    dest: "{{ install_dir }}/openshift/99-worker-max-pods.yaml"
+    dest: "{{ workingDir }}/ocp-cluster/openshift/99-worker-max-pods.yaml"
     content: |
       apiVersion: machineconfiguration.openshift.io/v1
       kind: KubeletConfig

--- a/playbooks/tasks/wait_for_deployment.yaml
+++ b/playbooks/tasks/wait_for_deployment.yaml
@@ -25,6 +25,8 @@
 - name: Verify pod Capacity on all master nodes
   block:
     - name: Wait for KubeletConfig to be recognized by the cluster
+      environment:
+        KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
       kubernetes.core.k8s_info:
         kind: KubeletConfig
         name: set-master-max-pods
@@ -36,6 +38,8 @@
         - kubeconfig_status.resources | length > 0
 
     - name: Wait until master nodes report expected maxPods
+      environment:
+        KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
       kubernetes.core.k8s_info:
         kind: Node
         label_selectors:

--- a/playbooks/tasks/wait_for_deployment.yaml
+++ b/playbooks/tasks/wait_for_deployment.yaml
@@ -31,7 +31,9 @@
       register: kubeconfig_status
       retries: "{{ k8s_retries }}"
       delay: "{{ k8s_delay }}"
-      until: kubeconfig_status.resources | length > 0
+      until:
+        - kubeconfig_status.resources is defined
+        - kubeconfig_status.resources | length > 0
 
     - name: Get master node capacities
       kubernetes.core.k8s_info:

--- a/playbooks/tasks/wait_for_deployment.yaml
+++ b/playbooks/tasks/wait_for_deployment.yaml
@@ -21,3 +21,31 @@
 - name: Cleanup Ironic
   ansible.builtin.include_tasks:
     file: tasks/configure_hardware_ironic_cleanup.yaml
+
+- name: Verify pod Capacity on all master nodes
+  block:
+    - name: Wait for KubeletConfig to be recognized by the cluster
+      kubernetes.core.k8s_info:
+        kind: KubeletConfig
+        name: set-master-max-pods
+      register: kubeconfig_status
+      retries: "{{ k8s_retries }}"
+      delay: "{{ k8s_delay }}"
+      until: kubeconfig_status.resources | length > 0
+
+    - name: Get master node capacities
+      kubernetes.core.k8s_info:
+        kind: Node
+        label_selectors:
+          - pools.operator.machineconfiguration.openshift.io/master
+      register: master_nodes
+
+    - name: Assert that all master nodes report the correct maxPods
+      ansible.builtin.assert:
+        that:
+          - item.status.capacity.pods == {{ masterMaxPods }}
+        fail_msg: "Node {{ item.metadata.name }} reports {{ item.status.capacity.pods }} pods, expected {{ masterMaxPods }}"
+        success_msg: "Node {{ item.metadata.name }} correctly reports {{ masterMaxPods }} pods."
+      loop: "{{ master_nodes.resources }}"
+      loop_control:
+        label: "{{ item.metadata.name }}"

--- a/playbooks/tasks/wait_for_deployment.yaml
+++ b/playbooks/tasks/wait_for_deployment.yaml
@@ -35,17 +35,29 @@
         - kubeconfig_status.resources is defined
         - kubeconfig_status.resources | length > 0
 
-    - name: Get master node capacities
+    - name: Wait until master nodes report expected maxPods
       kubernetes.core.k8s_info:
         kind: Node
         label_selectors:
-          - pools.operator.machineconfiguration.openshift.io/master
+          - node-role.kubernetes.io/master
       register: master_nodes
+      retries: "{{ k8s_retries }}"
+      delay: "{{ k8s_delay }}"
+      until:
+        - master_nodes.resources is defined
+        - master_nodes.resources | length > 0
+        - (master_nodes.resources | map(attribute='status.capacity.pods') | map('int') | list | unique) == [masterMaxPods | int]
+
+    - name: Ensure master nodes were discovered
+      ansible.builtin.assert:
+        that:
+          - master_nodes.resources | length > 0
+        fail_msg: "No master nodes matched the selector; cannot validate maxPods."
 
     - name: Assert that all master nodes report the correct maxPods
       ansible.builtin.assert:
         that:
-          - item.status.capacity.pods == {{ masterMaxPods }}
+          - (item.status.capacity.pods | int) == (masterMaxPods | int)
         fail_msg: "Node {{ item.metadata.name }} reports {{ item.status.capacity.pods }} pods, expected {{ masterMaxPods }}"
         success_msg: "Node {{ item.metadata.name }} correctly reports {{ masterMaxPods }} pods."
       loop: "{{ master_nodes.resources }}"

--- a/schemas/definitions.yaml
+++ b/schemas/definitions.yaml
@@ -23,6 +23,7 @@ definitions:
       Set to false for connected deployments.
   masterMaxPods:
     type: integer
+    minimum: 1
     description: >-
       Configure High Density Pod Limits for ABI. Default: 500.
   diskEncryption:

--- a/schemas/definitions.yaml
+++ b/schemas/definitions.yaml
@@ -21,6 +21,10 @@ definitions:
     description: >-
       Whether the deployment is disconnected (air-gapped). Default: true.
       Set to false for connected deployments.
+  masterMaxPods:
+    type: integer
+    description: >-
+      Configure High Density Pod Limits for ABI. Default: 500.
   diskEncryption:
     type: boolean
     description: >-

--- a/schemas/deployment.yaml
+++ b/schemas/deployment.yaml
@@ -7,6 +7,8 @@ additionalProperties: false
 properties:
   disconnected:
     "$ref": "#/definitions/disconnected"
+  masterMaxPods:
+    "$ref": "#/definitions/masterMaxPods"
   diskEncryption:
     "$ref": "#/definitions/diskEncryption"
   ocMirrorLogLevel:
@@ -33,6 +35,7 @@ properties:
 
 required:
   - disconnected
+  - masterMaxPods
   - diskEncryption
   - ocMirrorLogLevel
   - pullSecretPath

--- a/schemas/fixtures/valid/radosgw-lvms-all-optionals.yaml
+++ b/schemas/fixtures/valid/radosgw-lvms-all-optionals.yaml
@@ -14,6 +14,7 @@ defaultPrefix: 24
 rendezvousIP: 192.168.2.24
 lzBmcIP: 100.64.1.10
 disconnected: false
+masterMaxPods: 250
 diskEncryption: true
 ocMirrorLogLevel: trace
 defaultNtpServers:

--- a/schemas/variables.yaml
+++ b/schemas/variables.yaml
@@ -70,6 +70,8 @@ properties:
     description: Network prefix length (subnet mask bits)
   disconnected:
     "$ref": "#/definitions/disconnected"
+  masterMaxPods:
+    "$ref": "#/definitions/masterMaxPods"
   diskEncryption:
     "$ref": "#/definitions/diskEncryption"
   ingressVIP:


### PR DESCRIPTION
this PR adds a KubeletConfig resource to the agent based installation (placing a file in the `{{ workingDir }}/ocp-cluster/openshift` dir does the trick).

this enables provisioning the cluster with the max pod customization built in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `masterMaxPods` configuration parameter to control high-density pod limits on master nodes (default: 500).
  * Automated deployment and verification of pod capacity settings via OpenShift MachineConfig.

* **Documentation**
  * Updated configuration reference with the new `masterMaxPods` parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->