### PR TITLE
e2e-deployment: fix invalid GITHUB_OUTPUT format when multiple artifacts match

### DIFF
--- a/.github/workflows/e2e-deployment.yml
+++ b/.github/workflows/e2e-deployment.yml
@@ -337,7 +337,7 @@ jobs:
           for attempt in 1 2 3 4 5; do
             sleep $((attempt * 2))
             ARTIFACT_ID=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts \
-              --jq '.artifacts[] | select(.name == "e2e-connected-${{ env.ENCLAVE_CLUSTER_NAME }}-${{ github.run_id }}") | .id')
+              --jq '[.artifacts[] | select(.name == "e2e-connected-${{ env.ENCLAVE_CLUSTER_NAME }}-${{ github.run_id }}")] | sort_by(.created_at) | last // empty | .id')
             if [ -n "$ARTIFACT_ID" ]; then
               break
             fi
@@ -728,7 +728,7 @@ jobs:
           for attempt in 1 2 3 4 5; do
             sleep $((attempt * 2))
             ARTIFACT_ID=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts \
-              --jq '.artifacts[] | select(.name == "e2e-disconnected-${{ env.ENCLAVE_CLUSTER_NAME }}-${{ github.run_id }}") | .id')
+              --jq '[.artifacts[] | select(.name == "e2e-disconnected-${{ env.ENCLAVE_CLUSTER_NAME }}-${{ github.run_id }}")] | sort_by(.created_at) | last // empty | .id')
             if [ -n "$ARTIFACT_ID" ]; then
               break
             fi


### PR DESCRIPTION
If the artifact upload ran more than once (retries/reruns), the gh api jq query returned multiple IDs on separate lines. The embedded newline in ARTIFACT_ID caused GITHUB_OUTPUT to receive a bare number on its own line, which the runner rejected as "Invalid format".

Use sort_by(.created_at) | last to explicitly select the most recent artifact instead of relying on API ordering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced e2e deployment workflow to select the most recently created artifact instead of the first matching artifact, ensuring consistent and up-to-date deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->