### PR TITLE
mirror servicemeshoperato3 from version 3.1.0

### DIFF
--- a/plugins/openshift-ai/plugin.yaml
+++ b/plugins/openshift-ai/plugin.yaml
@@ -36,7 +36,7 @@ operators:
   - name: servicemeshoperator3
     version: 3.2.2
     channel: stable
-    init_version: 3.2.2
+    init_version: 3.1.0
 
 installOperators: false
 


### PR DESCRIPTION
openshift-ingress insists on this version. adding mirroring for more version to have one less thing operators fight about.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated operator initialization version configuration to ensure proper deployment compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->