### PR TITLE
plugin custom catalogsource mirroring

### DIFF
--- a/plugins/nvidia-gpu/files/10-policy.yaml.j2
+++ b/plugins/nvidia-gpu/files/10-policy.yaml.j2
@@ -21,6 +21,18 @@ spec:
           compliant: 2h
           noncompliant: 45s
         object-templates:
+        # Create custom CatalogSource for the plugin
+        - complianceType: mustonlyhave
+          metadataComplianceType: musthave
+          objectDefinition:
+            apiVersion: operators.coreos.com/v1alpha1
+            kind: CatalogSource
+            metadata:
+              name: {{ mirror_certified_rh_operator_catalog }}-nvidia-gpu
+              namespace: openshift-marketplace
+            spec:
+              image: registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/redhat/{{ mirror_certified_rh_operator_catalog }}-nvidia-gpu:v{{ short_version_dot }}
+              sourceType: grpc
         # Install NVIDIA GPU Operator
         - complianceType: mustonlyhave
           metadataComplianceType: musthave
@@ -52,7 +64,7 @@ spec:
               channel: v25.10
               installPlanApproval: Automatic
               name: gpu-operator-certified
-              source: {{ mirror_certified_rh_operator_catalog }}
+              source: {{ mirror_certified_rh_operator_catalog }}-nvidia-gpu
               sourceNamespace: openshift-marketplace
         # Create ClusterPolicy Instance
         - complianceType: mustonlyhave

--- a/plugins/openshift-ai/files/10-policy-operators.yaml.j2
+++ b/plugins/openshift-ai/files/10-policy-operators.yaml.j2
@@ -21,6 +21,18 @@ spec:
           compliant: 2h
           noncompliant: 45s
         object-templates:
+        # Create custom CatalogSource for the plugin
+        - complianceType: mustonlyhave
+          metadataComplianceType: musthave
+          objectDefinition:
+            apiVersion: operators.coreos.com/v1alpha1
+            kind: CatalogSource
+            metadata:
+              name: {{ mirror_rh_operator_catalog }}-openshift-ai
+              namespace: openshift-marketplace
+            spec:
+              image: registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/redhat/{{ mirror_rh_operator_catalog }}-openshift-ai:v{{ short_version_dot }}
+              sourceType: grpc
         # Install Node Feature Discovery (NFD) Operator
         - complianceType: mustonlyhave
           metadataComplianceType: musthave
@@ -52,7 +64,7 @@ spec:
               channel: stable
               installPlanApproval: Automatic
               name: nfd
-              source: {{ mirror_rh_operator_catalog }}
+              source: {{ mirror_rh_operator_catalog }}-openshift-ai
               sourceNamespace: openshift-marketplace
         # Create NodeFeatureDiscovery Instance
         - complianceType: mustonlyhave
@@ -206,7 +218,7 @@ spec:
               channel: stable-v1.18
               installPlanApproval: Automatic
               name: openshift-cert-manager-operator
-              source: {{ mirror_rh_operator_catalog }}
+              source: {{ mirror_rh_operator_catalog }}-openshift-ai
               sourceNamespace: openshift-marketplace
         # Install Service Mesh Operator
         - complianceType: mustonlyhave
@@ -221,7 +233,7 @@ spec:
               channel: stable
               installPlanApproval: Automatic
               name: servicemeshoperator3
-              source: {{ mirror_rh_operator_catalog }}
+              source: {{ mirror_rh_operator_catalog }}-openshift-ai
               sourceNamespace: openshift-marketplace
 
         # Install Red Hat Connectivity Link (RHCL)
@@ -237,7 +249,7 @@ spec:
               channel: stable
               installPlanApproval: Automatic
               name: rhcl-operator
-              source: {{ mirror_rh_operator_catalog }}
+              source: {{ mirror_rh_operator_catalog }}-openshift-ai
               sourceNamespace: openshift-marketplace
         # Install Leader Worker Set Operator
         - complianceType: mustonlyhave
@@ -270,7 +282,7 @@ spec:
               channel: stable-v1.0
               installPlanApproval: Automatic
               name: leader-worker-set
-              source: {{ mirror_rh_operator_catalog }}
+              source: {{ mirror_rh_operator_catalog }}-openshift-ai
               sourceNamespace: openshift-marketplace
         # Install Red Hat OpenShift AI
         - complianceType: mustonlyhave
@@ -300,6 +312,6 @@ spec:
             spec:
               channel: fast-3.x
               name: rhods-operator
-              source: {{ mirror_rh_operator_catalog }}
+              source: {{ mirror_rh_operator_catalog }}-openshift-ai
               sourceNamespace: openshift-marketplace
               installPlanApproval: Automatic

--- a/templates/plugin-imageset.yaml.j2
+++ b/templates/plugin-imageset.yaml.j2
@@ -1,6 +1,8 @@
 {% set catalog_image = rh_operator_catalog ~ ':' ~ rh_operator_catalog_version %}
+{% set catalog_mirror = mirror_rh_operator_catalog %}
 {% if (plugin.catalog | default("")) == "certified" %}
 {% set catalog_image = certified_operator_catalog ~ ':' ~ certified_operator_catalog_version %}
+{% set catalog_mirror = mirror_certified_rh_operator_catalog %}
 {% endif %}
 ---
 kind: ImageSetConfiguration
@@ -8,6 +10,7 @@ apiVersion: mirror.openshift.io/v2alpha1
 mirror:
   operators:
     - catalog: {{ catalog_image }}
+      targetCatalog: {{ catalog_mirror ~ '-' ~ plugin.name }}
       packages:
 {% for operator in plugin.operators | default([]) %}
 {% set additional_operator_names = operator.csvNames if (operator.csvMirror | default(false) | bool) else [] %}


### PR DESCRIPTION
this PR is an idea to mirror each plugin to a custom catalog. with custom catalogs we do not worry about mirror overrides.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated operator catalogs for NVIDIA GPU and OpenShift AI operators, enabling isolated operator sourcing and management
  * Operators now source from plugin-specific catalogs rather than shared catalogs
  * Enhanced catalog configuration and operator deployment flexibility for improved cluster operator management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->