### PR TITLE
servicemeshoperator3 alias catalogsource

### DIFF
--- a/plugins/openshift-ai/files/10-policy-operators.yaml.j2
+++ b/plugins/openshift-ai/files/10-policy-operators.yaml.j2
@@ -209,6 +209,22 @@ spec:
               source: {{ mirror_rh_operator_catalog }}
               sourceNamespace: openshift-marketplace
         # Install Service Mesh Operator
+        # the ingress-operator creates a servicemeshoperator3 Subscription
+        # with source: redhat-operators, which doesn't exist in disconnected mode.
+        # The ingress-operator actively manages the subscription spec and overwrites any
+        # changes, so instead of fighting it we create a CatalogSource alias that makes
+        # the existing subscription resolve to the mirrored catalog.
+        - complianceType: mustonlyhave
+          metadataComplianceType: musthave
+          objectDefinition:
+            apiVersion: operators.coreos.com/v1alpha1
+            kind: CatalogSource
+            metadata:
+              name: redhat-operators
+              namespace: openshift-marketplace
+            spec:
+              image: registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/redhat/{{ mirror_rh_operator_catalog }}-openshift-ai:v{{ short_version_dot }}
+              sourceType: grpc
         - complianceType: mustonlyhave
           metadataComplianceType: musthave
           objectDefinition:


### PR DESCRIPTION
When the openshift-ai plugin is enabled, the ACM Policy creates the servicemeshoperator3 Subscription with the correct mirror catalog source (mirror-redhat-operators). However, immediately after the Policy applies this configuration, another controller (ingress-operator) overwrites the source field back to redhat-operators. This causes the Subscription to fail in disconnected environments because the redhat-operators CatalogSource does not exist.

depends on #259