### PR TITLE
fixes for plugins catalogsources - custom per-plugin catalogsource

### DIFF
--- a/files/catalogsource-configuration/10-policy.yaml.j2
+++ b/files/catalogsource-configuration/10-policy.yaml.j2
@@ -43,15 +43,3 @@ spec:
             spec:
               image: registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/redhat/redhat-operator-index:v{{ short_version_dot }}
               sourceType: grpc
-
-        - complianceType: mustonlyhave
-          metadataComplianceType: musthave
-          objectDefinition:
-            apiVersion: operators.coreos.com/v1alpha1
-            kind: CatalogSource
-            metadata:
-              name: {{ mirror_certified_rh_operator_catalog }}
-              namespace: openshift-marketplace
-            spec:
-              image: registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/redhat/certified-operator-index:v{{ short_version_dot }}
-              sourceType: grpc

--- a/playbooks/tasks/deploy_plugin.yaml
+++ b/playbooks/tasks/deploy_plugin.yaml
@@ -206,7 +206,7 @@
 - name: Replace upstream catalog with LZ registry in internal plugin imageset
   ansible.builtin.replace:
     path: "{{ workingDir }}/plugin-{{ plugin_name }}-imageset.internal.yaml"
-    regexp: 'catalog: registry.redhat.io/redhat/{{ certified_operator_catalog if (plugin.catalog | default("")) == "certified" else rh_operator_catalog }}'
+    regexp: 'catalog: {{ certified_operator_catalog if (plugin.catalog | default("")) == "certified" else rh_operator_catalog }}'
     replace: 'catalog: {{ quayHostname }}:8443/redhat/{{ mirror_certified_rh_operator_catalog if (plugin.catalog | default("")) == "certified" else mirror_rh_operator_catalog ~ "-" ~ plugin.name }}'
   when:
     - plugin.mirror | default('none') == 'plugin'

--- a/playbooks/tasks/deploy_plugin.yaml
+++ b/playbooks/tasks/deploy_plugin.yaml
@@ -206,8 +206,8 @@
 - name: Replace upstream catalog with LZ registry in internal plugin imageset
   ansible.builtin.replace:
     path: "{{ workingDir }}/plugin-{{ plugin_name }}-imageset.internal.yaml"
-    regexp: 'catalog: registry.redhat.io'
-    replace: "catalog: {{ quayHostname }}:8443"
+    regexp: 'catalog: registry.redhat.io/redhat/{{ certified_operator_catalog if (plugin.catalog | default("")) == "certified" else rh_operator_catalog }}'
+    replace: 'catalog: {{ quayHostname }}:8443/redhat/{{ mirror_certified_rh_operator_catalog if (plugin.catalog | default("")) == "certified" else mirror_rh_operator_catalog ~ "-" ~ plugin.name }}'
   when:
     - plugin.mirror | default('none') == 'plugin'
     - disconnected | default(true) | bool

--- a/playbooks/tasks/deploy_plugin.yaml
+++ b/playbooks/tasks/deploy_plugin.yaml
@@ -207,7 +207,7 @@
   ansible.builtin.replace:
     path: "{{ workingDir }}/plugin-{{ plugin_name }}-imageset.internal.yaml"
     regexp: 'catalog: {{ certified_operator_catalog if (plugin.catalog | default("")) == "certified" else rh_operator_catalog }}'
-    replace: 'catalog: {{ quayHostname }}:8443/redhat/{{ mirror_certified_rh_operator_catalog if (plugin.catalog | default("")) == "certified" else mirror_rh_operator_catalog ~ "-" ~ plugin.name }}'
+    replace: 'catalog: {{ quayHostname }}:8443/redhat/{{ (mirror_certified_rh_operator_catalog if (plugin.catalog | default("")) == "certified" else mirror_rh_operator_catalog) ~ "-" ~ plugin.name }}'
   when:
     - plugin.mirror | default('none') == 'plugin'
     - disconnected | default(true) | bool

--- a/plugins/nvidia-gpu/files/09-policy-catalogsource.yaml.j2
+++ b/plugins/nvidia-gpu/files/09-policy-catalogsource.yaml.j2
@@ -31,7 +31,7 @@ spec:
               name: {{ mirror_certified_rh_operator_catalog }}-nvidia-gpu
               namespace: openshift-marketplace
             spec:
-              image: registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/redhat/{{ mirror_certified_rh_operator_catalog }}-nvidia-gpu:v{{ short_version_dot }}
+              image: registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/redhat/{{ mirror_certified_rh_operator_catalog }}-nvidia-gpu:{{ certified_operator_catalog_version }}
               sourceType: grpc
         - complianceType: musthave
           metadataComplianceType: musthave

--- a/plugins/nvidia-gpu/files/09-policy-catalogsource.yaml.j2
+++ b/plugins/nvidia-gpu/files/09-policy-catalogsource.yaml.j2
@@ -1,0 +1,46 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+  name: nvidia-gpu-catalogsource
+  namespace: openshift-acm-policies
+spec:
+  disabled: false
+  remediationAction: inform
+  policy-templates:
+  - objectDefinition:
+      apiVersion: policy.open-cluster-management.io/v1
+      kind: ConfigurationPolicy
+      metadata:
+        name: nvidia-gpu-catalogsource
+      spec:
+        evaluationInterval:
+          compliant: 5m
+          noncompliant: 45s
+        object-templates:
+        # Create custom CatalogSource for the plugin
+        - complianceType: mustonlyhave
+          metadataComplianceType: musthave
+          objectDefinition:
+            apiVersion: operators.coreos.com/v1alpha1
+            kind: CatalogSource
+            metadata:
+              name: {{ mirror_certified_rh_operator_catalog }}-nvidia-gpu
+              namespace: openshift-marketplace
+            spec:
+              image: registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/redhat/{{ mirror_certified_rh_operator_catalog }}-nvidia-gpu:v{{ short_version_dot }}
+              sourceType: grpc
+        - complianceType: musthave
+          metadataComplianceType: musthave
+          objectDefinition:
+            apiVersion: operators.coreos.com/v1alpha1
+            kind: CatalogSource
+            metadata:
+              name: {{ mirror_rh_operator_catalog }}-nvidia-gpu
+              namespace: openshift-marketplace
+            status:
+              connectionState:
+                lastObservedState: READY

--- a/plugins/nvidia-gpu/files/09-policy-catalogsource.yaml.j2
+++ b/plugins/nvidia-gpu/files/09-policy-catalogsource.yaml.j2
@@ -9,7 +9,7 @@ metadata:
   namespace: openshift-acm-policies
 spec:
   disabled: false
-  remediationAction: inform
+  remediationAction: enforce
   policy-templates:
   - objectDefinition:
       apiVersion: policy.open-cluster-management.io/v1
@@ -39,7 +39,7 @@ spec:
             apiVersion: operators.coreos.com/v1alpha1
             kind: CatalogSource
             metadata:
-              name: {{ mirror_rh_operator_catalog }}-nvidia-gpu
+              name: {{ mirror_certified_rh_operator_catalog }}-nvidia-gpu
               namespace: openshift-marketplace
             status:
               connectionState:

--- a/plugins/nvidia-gpu/files/10-policy.yaml.j2
+++ b/plugins/nvidia-gpu/files/10-policy.yaml.j2
@@ -8,6 +8,12 @@ metadata:
   name: nvidia-gpu-configuration
   namespace: openshift-acm-policies
 spec:
+  dependencies:
+  - apiVersion: policy.open-cluster-management.io/v1
+    compliance: Compliant
+    kind: Policy
+    name: nvidia-gpu-catalogsource
+    namespace: openshift-acm-policies
   disabled: false
   remediationAction: enforce
   policy-templates:
@@ -52,7 +58,7 @@ spec:
               channel: v25.10
               installPlanApproval: Automatic
               name: gpu-operator-certified
-              source: {{ mirror_certified_rh_operator_catalog }}
+              source: {{ mirror_certified_rh_operator_catalog }}-nvidia-gpu
               sourceNamespace: openshift-marketplace
         # Create ClusterPolicy Instance
         - complianceType: mustonlyhave

--- a/plugins/nvidia-gpu/files/30-placementbinding.yaml
+++ b/plugins/nvidia-gpu/files/30-placementbinding.yaml
@@ -10,4 +10,7 @@ placementRef:
 subjects:
 - apiGroup: policy.open-cluster-management.io
   kind: Policy
+  name: nvidia-gpu-catalogsource
+- apiGroup: policy.open-cluster-management.io
+  kind: Policy
   name: nvidia-gpu-configuration

--- a/plugins/nvidia-gpu/tasks/deploy.yaml
+++ b/plugins/nvidia-gpu/tasks/deploy.yaml
@@ -9,6 +9,18 @@
   delay: "{{ k8s_delay }}"
   until: r_namespace_model_config is success
 
+- name: Create ACM Policy for Model CatalogSources
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  kubernetes.core.k8s:
+    state: present
+    namespace: openshift-acm-policies
+    definition: "{{ lookup('ansible.builtin.template', plugin_dir ~ '/files/09-policy-catalogsource.yaml.j2') | from_yaml }}"
+  register: r_acm_policy_model_catalogsources
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_acm_policy_model_catalogsources is success
+
 - name: Create ACM Policy for Model configuration
   environment:
     KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"

--- a/plugins/openshift-ai/files/09-policy-catalogsource.yaml.j2
+++ b/plugins/openshift-ai/files/09-policy-catalogsource.yaml.j2
@@ -9,7 +9,7 @@ metadata:
   namespace: openshift-acm-policies
 spec:
   disabled: false
-  remediationAction: inform
+  remediationAction: enforce
   policy-templates:
   - objectDefinition:
       apiVersion: policy.open-cluster-management.io/v1

--- a/plugins/openshift-ai/files/09-policy-catalogsource.yaml.j2
+++ b/plugins/openshift-ai/files/09-policy-catalogsource.yaml.j2
@@ -31,7 +31,7 @@ spec:
               name: {{ mirror_rh_operator_catalog }}-openshift-ai
               namespace: openshift-marketplace
             spec:
-              image: registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/redhat/{{ mirror_rh_operator_catalog }}-openshift-ai:v{{ short_version_dot }}
+              image: registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/redhat/{{ mirror_rh_operator_catalog }}-openshift-ai:{{ rh_operator_catalog_version }}
               sourceType: grpc
         - complianceType: musthave
           metadataComplianceType: musthave

--- a/plugins/openshift-ai/files/09-policy-catalogsource.yaml.j2
+++ b/plugins/openshift-ai/files/09-policy-catalogsource.yaml.j2
@@ -1,0 +1,62 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+  name: model-catalogsources
+  namespace: openshift-acm-policies
+spec:
+  disabled: false
+  remediationAction: inform
+  policy-templates:
+  - objectDefinition:
+      apiVersion: policy.open-cluster-management.io/v1
+      kind: ConfigurationPolicy
+      metadata:
+        name: model-catalogsources
+      spec:
+        evaluationInterval:
+          compliant: 5m
+          noncompliant: 45s
+        object-templates:
+        # Create custom CatalogSource for the plugin
+        - complianceType: mustonlyhave
+          metadataComplianceType: musthave
+          objectDefinition:
+            apiVersion: operators.coreos.com/v1alpha1
+            kind: CatalogSource
+            metadata:
+              name: {{ mirror_rh_operator_catalog }}-openshift-ai
+              namespace: openshift-marketplace
+            spec:
+              image: registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/redhat/{{ mirror_rh_operator_catalog }}-openshift-ai:v{{ short_version_dot }}
+              sourceType: grpc
+        - complianceType: musthave
+          metadataComplianceType: musthave
+          objectDefinition:
+            apiVersion: operators.coreos.com/v1alpha1
+            kind: CatalogSource
+            metadata:
+              name: {{ mirror_rh_operator_catalog }}-openshift-ai
+              namespace: openshift-marketplace
+            status:
+              connectionState:
+                lastObservedState: READY
+        # the ingress-operator creates a servicemeshoperator3 Subscription
+        # with source: redhat-operators, which doesn't exist in disconnected mode.
+        # The ingress-operator actively manages the subscription spec and overwrites any
+        # changes, so instead of fighting it we create a CatalogSource alias that makes
+        # the existing subscription resolve to the mirrored catalog.
+        - complianceType: mustonlyhave
+          metadataComplianceType: musthave
+          objectDefinition:
+            apiVersion: operators.coreos.com/v1alpha1
+            kind: CatalogSource
+            metadata:
+              name: redhat-operators
+              namespace: openshift-marketplace
+            spec:
+              image: registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/redhat/{{ mirror_rh_operator_catalog }}-openshift-ai:v{{ short_version_dot }}
+              sourceType: grpc

--- a/plugins/openshift-ai/files/09-policy-catalogsource.yaml.j2
+++ b/plugins/openshift-ai/files/09-policy-catalogsource.yaml.j2
@@ -58,7 +58,7 @@ spec:
               name: redhat-operators
               namespace: openshift-marketplace
             spec:
-              image: registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/redhat/{{ mirror_rh_operator_catalog }}-openshift-ai:v{{ short_version_dot }}
+              image: registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/redhat/{{ mirror_rh_operator_catalog }}-openshift-ai:{{ rh_operator_catalog_version }}
               sourceType: grpc
         - complianceType: musthave
           metadataComplianceType: musthave

--- a/plugins/openshift-ai/files/09-policy-catalogsource.yaml.j2
+++ b/plugins/openshift-ai/files/09-policy-catalogsource.yaml.j2
@@ -60,3 +60,14 @@ spec:
             spec:
               image: registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/redhat/{{ mirror_rh_operator_catalog }}-openshift-ai:v{{ short_version_dot }}
               sourceType: grpc
+        - complianceType: musthave
+          metadataComplianceType: musthave
+          objectDefinition:
+            apiVersion: operators.coreos.com/v1alpha1
+            kind: CatalogSource
+            metadata:
+              name: redhat-operators
+              namespace: openshift-marketplace
+            status:
+              connectionState:
+                lastObservedState: READY

--- a/plugins/openshift-ai/files/10-policy-operators.yaml.j2
+++ b/plugins/openshift-ai/files/10-policy-operators.yaml.j2
@@ -8,6 +8,12 @@ metadata:
   name: model-prerequisites
   namespace: openshift-acm-policies
 spec:
+  dependencies:
+  - apiVersion: policy.open-cluster-management.io/v1
+    compliance: Compliant
+    kind: Policy
+    name: model-catalogsources
+    namespace: openshift-acm-policies
   disabled: false
   remediationAction: enforce
   policy-templates:
@@ -52,7 +58,7 @@ spec:
               channel: stable
               installPlanApproval: Automatic
               name: nfd
-              source: {{ mirror_rh_operator_catalog }}
+              source: {{ mirror_rh_operator_catalog }}-openshift-ai
               sourceNamespace: openshift-marketplace
         # Create NodeFeatureDiscovery Instance
         - complianceType: mustonlyhave
@@ -206,7 +212,7 @@ spec:
               channel: stable-v1.18
               installPlanApproval: Automatic
               name: openshift-cert-manager-operator
-              source: {{ mirror_rh_operator_catalog }}
+              source: {{ mirror_rh_operator_catalog }}-openshift-ai
               sourceNamespace: openshift-marketplace
         # Install Service Mesh Operator
         - complianceType: mustonlyhave
@@ -221,7 +227,7 @@ spec:
               channel: stable
               installPlanApproval: Automatic
               name: servicemeshoperator3
-              source: {{ mirror_rh_operator_catalog }}
+              source: {{ mirror_rh_operator_catalog }}-openshift-ai
               sourceNamespace: openshift-marketplace
 
         # Install Red Hat Connectivity Link (RHCL)
@@ -237,7 +243,7 @@ spec:
               channel: stable
               installPlanApproval: Automatic
               name: rhcl-operator
-              source: {{ mirror_rh_operator_catalog }}
+              source: {{ mirror_rh_operator_catalog }}-openshift-ai
               sourceNamespace: openshift-marketplace
         # Install Leader Worker Set Operator
         - complianceType: mustonlyhave
@@ -270,7 +276,7 @@ spec:
               channel: stable-v1.0
               installPlanApproval: Automatic
               name: leader-worker-set
-              source: {{ mirror_rh_operator_catalog }}
+              source: {{ mirror_rh_operator_catalog }}-openshift-ai
               sourceNamespace: openshift-marketplace
         # Install Red Hat OpenShift AI
         - complianceType: mustonlyhave
@@ -300,6 +306,6 @@ spec:
             spec:
               channel: fast-3.x
               name: rhods-operator
-              source: {{ mirror_rh_operator_catalog }}
+              source: {{ mirror_rh_operator_catalog }}-openshift-ai
               sourceNamespace: openshift-marketplace
               installPlanApproval: Automatic

--- a/plugins/openshift-ai/files/10-policy-operators.yaml.j2
+++ b/plugins/openshift-ai/files/10-policy-operators.yaml.j2
@@ -209,10 +209,10 @@ spec:
               name: openshift-cert-manager-operator
               namespace: cert-manager-operator
             spec:
-              channel: stable-v1.18
+              channel: stable-v1
               installPlanApproval: Automatic
               name: openshift-cert-manager-operator
-              source: {{ mirror_rh_operator_catalog }}-openshift-ai
+              source: {{ mirror_rh_operator_catalog }}
               sourceNamespace: openshift-marketplace
         # Install Service Mesh Operator
         - complianceType: mustonlyhave

--- a/plugins/openshift-ai/files/10-policy-operators.yaml.j2
+++ b/plugins/openshift-ai/files/10-policy-operators.yaml.j2
@@ -278,6 +278,17 @@ spec:
               name: leader-worker-set
               source: {{ mirror_rh_operator_catalog }}-openshift-ai
               sourceNamespace: openshift-marketplace
+        - complianceType: mustonlyhave
+          metadataComplianceType: musthave
+          objectDefinition:
+            apiVersion: operator.openshift.io/v1
+            kind: LeaderWorkerSetOperator
+            metadata:
+              name: cluster
+            spec:
+              logLevel: Normal
+              operatorLogLevel: Normal
+              managementState: Managed
         # Install Red Hat OpenShift AI
         - complianceType: mustonlyhave
           metadataComplianceType: musthave

--- a/plugins/openshift-ai/files/30-placementbinding.yaml
+++ b/plugins/openshift-ai/files/30-placementbinding.yaml
@@ -10,6 +10,9 @@ placementRef:
 subjects:
 - apiGroup: policy.open-cluster-management.io
   kind: Policy
+  name: model-catalogsources
+- apiGroup: policy.open-cluster-management.io
+  kind: Policy
   name: model-prerequisites
 - apiGroup: policy.open-cluster-management.io
   kind: Policy

--- a/plugins/openshift-ai/plugin.yaml
+++ b/plugins/openshift-ai/plugin.yaml
@@ -36,7 +36,7 @@ operators:
   - name: servicemeshoperator3
     version: 3.2.2
     channel: stable
-    init_version: 3.2.2
+    init_version: 3.1.0
 
 installOperators: false
 

--- a/plugins/openshift-ai/tasks/deploy.yaml
+++ b/plugins/openshift-ai/tasks/deploy.yaml
@@ -9,6 +9,18 @@
   delay: "{{ k8s_delay }}"
   until: r_namespace_model_config is success
 
+- name: Create ACM Policy for Model CatalogSources
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  kubernetes.core.k8s:
+    state: present
+    namespace: openshift-acm-policies
+    definition: "{{ lookup('ansible.builtin.template', plugin_dir ~ '/files/09-policy-catalogsource.yaml.j2') | from_yaml }}"
+  register: r_acm_policy_model_catalogsources
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_acm_policy_model_catalogsources is success
+
 - name: Create ACM Policy for Model prerequisites
   environment:
     KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"

--- a/templates/plugin-imageset.yaml.j2
+++ b/templates/plugin-imageset.yaml.j2
@@ -1,6 +1,8 @@
 {% set catalog_image = rh_operator_catalog ~ ':' ~ rh_operator_catalog_version %}
+{% set catalog_mirror = mirror_rh_operator_catalog %}
 {% if (plugin.catalog | default("")) == "certified" %}
 {% set catalog_image = certified_operator_catalog ~ ':' ~ certified_operator_catalog_version %}
+{% set catalog_mirror = mirror_certified_rh_operator_catalog %}
 {% endif %}
 ---
 kind: ImageSetConfiguration
@@ -8,6 +10,7 @@ apiVersion: mirror.openshift.io/v2alpha1
 mirror:
   operators:
     - catalog: {{ catalog_image }}
+      targetCatalog: {{ catalog_mirror ~ '-' ~ plugin.name }}
       packages:
 {% for operator in plugin.operators | default([]) %}
 {% set additional_operator_names = operator.csvNames if (operator.csvMirror | default(false) | bool) else [] %}

--- a/templates/plugin-imageset.yaml.j2
+++ b/templates/plugin-imageset.yaml.j2
@@ -10,7 +10,7 @@ apiVersion: mirror.openshift.io/v2alpha1
 mirror:
   operators:
     - catalog: {{ catalog_image }}
-      targetCatalog: {{ catalog_mirror ~ '-' ~ plugin.name }}
+      targetCatalog: redhat/{{ catalog_mirror ~ '-' ~ plugin.name }}
       packages:
 {% for operator in plugin.operators | default([]) %}
 {% set additional_operator_names = operator.csvNames if (operator.csvMirror | default(false) | bool) else [] %}


### PR DESCRIPTION
this PR adds:
- plugin mirror to custom per-plugin catalogs
- catalgsource resources for each plugin with the custom per-plugin catalog name and image
- usage of the custom per-plugin catalogs in the plugins tasks (when deploying operators via acm policies)
- a policy dependency on a new policy that applies the catalogsource and verifies it is ready
- servicemeshoperator3 version and catalogsource fixes/hacks

related to:
- https://github.com/gori-project/GoRI/issues/883
- https://github.com/gori-project/GoRI/issues/884
- https://github.com/gori-project/GoRI/issues/885

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added policies to provision mirrored operator catalog sources for NVIDIA GPU and OpenShift AI and enforce their READY state before installation.
  * Made operator installation policies explicitly depend on the corresponding catalog-source policies and updated placement bindings to include them.

* **Chores**
  * Updated deployment tasks, subscription sources, and image set templates to target mirrored catalog names per plugin type.
  * Removed an outdated catalog-source entry for a previously referenced certified catalog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->