### PR TITLE
ci: expire PR tarball images after 7 days on Quay

### DIFF
--- a/.github/workflows/build-push-tarball.yml
+++ b/.github/workflows/build-push-tarball.yml
@@ -180,7 +180,11 @@ jobs:
       - name: Push tarball to Quay
         run: |
           set -euo pipefail
-          oras push quay.io/edge-infrastructure/enclave:${{ steps.meta.outputs.tag }} enclave.tar.gz:application/vnd.oci.image.layer.v1.tar+gzip
+          EXPIRE_FLAG=""
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            EXPIRE_FLAG="--annotation quay.expires-after=7d"
+          fi
+          oras push $EXPIRE_FLAG quay.io/edge-infrastructure/enclave:${{ steps.meta.outputs.tag }} enclave.tar.gz:application/vnd.oci.image.layer.v1.tar+gzip
           if [[ "${{ github.ref }}" == refs/heads/main ]]; then
             oras push quay.io/edge-infrastructure/enclave:latest enclave.tar.gz:application/vnd.oci.image.layer.v1.tar+gzip
           fi


### PR DESCRIPTION
Add quay.expires-after=7d annotation to oras push in PR context, matching the expiry pattern used in resolve-ci-image.yml. Main and tag pushes remain permanent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build workflow to automatically expire pull request artifacts after 7 days, improving storage efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->