### PR TITLE
Fix htpasswd failure when ironic password contains trailing backslash

### DIFF
--- a/playbooks/tasks/deploy_ironic.yaml
+++ b/playbooks/tasks/deploy_ironic.yaml
@@ -13,7 +13,12 @@
     metal3_ironic_image: "{{ r_ironic_image.stdout }}"
 
 - name: Generate htpasswd hash for Ironic credentials
-  ansible.builtin.command: /usr/bin/htpasswd -nbB "{{ metal3_ironic_username }}" "{{ metal3_ironic_password }}"
+  ansible.builtin.command:
+    argv:
+      - /usr/bin/htpasswd
+      - -nbB
+      - "{{ metal3_ironic_username }}"
+      - "{{ metal3_ironic_password }}"
   register: r_htpasswd
   changed_when: false
   no_log: true


### PR DESCRIPTION
The `Generate htpasswd hash for Ironic credentials` task in `deploy_ironic.yaml` intermittently fails on CI runs with:
```
TASK [Generate htpasswd hash for Ironic credentials] ***************************
...
fatal: [localhost]: FAILED! => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": false}
```

This was observed on at least two different jobs in CI:
  - [E2E Disconnected](https://github.com/rh-ecosystem-edge/enclave/actions/runs/24019899340/job/70046650214) (Apr 6)
  - [E2E Connected](https://github.com/rh-ecosystem-edge/enclave/actions/runs/24327571190/job/71026049558) (Apr 13)

The ironic password is randomly generated with `chars=ascii_letters,digits,punctuation`. When the password ends with a backslash, Ansible's `command` module fails internally when parsing the string form:
```
  ValueError: No closing quotation
    File "/usr/lib64/python3.14/shlex.py", line 189, in read_token
      raise ValueError("No closing quotation")
```

The trailing `\` escapes the closing quote in the command string, causing `shlex.split()` to think the quoted argument never ends.

The PR switches `Generate htpasswd hash for Ironic credentials` task from string form to argv form in `ansible.builtin.command`.

MGMT-23796

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the reliability of credential handling in the Ironic deployment process through improved command execution methodology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->