### PR TITLE
Fix sync.sh logging consistency

### DIFF
--- a/sync.sh
+++ b/sync.sh
@@ -7,6 +7,11 @@ getValue(){
         | jq -r $1
 }
 
+step_done(){
+    echo -e "\e[38;5;10m Done...\033[0m" | tee -a ${log}
+    date | tee -a ${log}
+}
+
 global_vars=${1:-config/global.yaml}
 certs_vars=${2:-config/certificates.yaml}
 workingDir=$(getValue .workingDir)
@@ -21,12 +26,12 @@ _cleanup(){
 
 
 echo " "
-echo " ██████╗░███████╗██████╗░  ██╗░░██╗░█████╗░████████╗"
-echo " ██╔══██╗██╔════╝██╔══██╗  ██║░░██║██╔══██╗╚══██╔══╝"
-echo " ██████╔╝█████╗░░██║░░██║  ███████║███████║░░░██║░░░"
-echo " ██╔══██╗██╔══╝░░██║░░██║  ██╔══██║██╔══██║░░░██║░░░"
-echo " ██║░░██║███████╗██████╔╝  ██║░░██║██║░░██║░░░██║░░░"
-echo " ╚═╝░░╚═╝╚══════╝╚═════╝░  ╚═╝░░╚═╝╚═╝░░╚═╝░░░╚═╝░░░"
+echo " ██████╗░███████╗██████╗░  ██╗░░██╗░█████╗░████████╗"
+echo " ██╔══██╗██╔════╝██╔══██╗  ██║░░██║██╔══██╗╚══██╔══╝"
+echo " ██████╔╝█████╗░░██║░░██║  ███████║███████║░░░██║░░░"
+echo " ██╔══██╗██╔══╝░░██║░░██║  ██╔══██║██╔══██║░░░██║░░░"
+echo " ██║░░██║███████╗██████╔╝  ██║░░██║██║░░██║░░░██║░░░"
+echo " ╚═╝░░╚═╝╚══════╝╚═════╝░  ╚═╝░░╚═╝╚═╝░░╚═╝░░░╚═╝░░░"
 echo " "
 echo "This script is designed to be re-run on demand "
 echo "NOTE: Some functions will reuse local caches   "
@@ -50,7 +55,7 @@ fi
 mkdir -p "$(dirname $log)"
 date > "$log"
 
-echo -p "Check Config .. " -n1 -s | tee -a ${log}
+echo "Check Config .. " | tee -a ${log}
 FList="ansible.cfg  bootstrap.sh  playbooks/main.yaml  playbooks/  \
         setup_ansible.sh  setup_env.sh $global_vars $certs_vars"
 for x in $FList; do
@@ -61,29 +66,29 @@ for x in $FList; do
     fi
 done
 
-echo -e "\e[38;5;10m Done...\033[0m"; date
+step_done
 
-echo -p "Validating Config .. " -n1 -s  | tee -a ${log}
+echo "Validating Config .. " | tee -a ${log}
     ansible-playbook playbooks/validation/validate-schema.yaml -e@$global_vars -e@$certs_vars --tags schema-validation 2>&1 | tee -a ${log}
     bash ./validations.sh --global-vars $global_vars --certs-vars $certs_vars 2>&1 | tee -a ${log}
-echo -e "\e[38;5;10m Done...\033[0m"; date
+step_done
 
-echo -p "Building local cache .. " -n1 -s
+echo "Building local cache .. " | tee -a ${log}
     ansible-playbook playbooks/02-mirror.yaml -e@$global_vars -e@$certs_vars --tags mirror-registry 2>&1 | tee -a ${log}
-echo -e "\e[38;5;10m Done...\033[0m"; date
+step_done
 
-echo -p "Quay disconnected .." -n1 -s
+echo "Quay disconnected .." | tee -a ${log}
     ansible-playbook playbooks/06-day2.yaml -e@$global_vars -e@$certs_vars --tags quay-disconnected 2>&1 | tee -a ${log}
-echo -e "\e[38;5;10m Done...\033[0m"; date
+step_done
 
-echo -p "Clair disconnected .." -n1 -s
+echo "Clair disconnected .." | tee -a ${log}
     ansible-playbook playbooks/06-day2.yaml -e@$global_vars -e@$certs_vars --tags clair-disconnected 2>&1 | tee -a ${log}
-echo -e "\e[38;5;10m Done...\033[0m"; date
+step_done
 
-echo -p "ACM ClusterImageSets .." -n1 -s
+echo "ACM ClusterImageSets .." | tee -a ${log}
     ansible-playbook playbooks/06-day2.yaml -e@$global_vars -e@$certs_vars --tags acm-cis 2>&1 | tee -a ${log}
-echo -e "\e[38;5;10m Done...\033[0m"; date
+step_done
 
-echo -p "OpenShift Pipelines .." -n1 -s
+echo "OpenShift Pipelines .." | tee -a ${log}
     ansible-playbook playbooks/06-day2.yaml -e@$global_vars -e@$certs_vars --tags openshift-pipelines 2>&1 | tee -a ${log}
-echo -e "\e[38;5;10m Done...\033[0m"; date
+step_done


### PR DESCRIPTION
Apply same logging fixes from `bootstrap.sh` (PR #224): add `step_done` function, replace invalid echo flags with plain echo, and pipe all step headers through tee for consistent log files.