### PR TITLE
extract supported runtime hosts to global config

### DIFF
--- a/.github/workflows/disconnected-dry-run.yml
+++ b/.github/workflows/disconnected-dry-run.yml
@@ -50,6 +50,7 @@ jobs:
       BASE_WORKING_DIR: ${{ vars.BASE_WORKING_DIR }}
       PULL_SECRET: ${{ secrets.PULL_SECRET }}
       ENCLAVE_DEPLOYMENT_MODE: disconnected
+      ENCLAVE_SUPPORTED_RUNTIME_HOSTS: '["centos:centos:10"]'
       ENCLAVE_MIRROR_DRY_RUN: "true"
       OPENSHIFT_CI: "true"
       ENCLAVE_ENABLE_GPU_PASSTHROUGH: "false"

--- a/.github/workflows/e2e-deployment.yml
+++ b/.github/workflows/e2e-deployment.yml
@@ -132,6 +132,7 @@ jobs:
       BASE_WORKING_DIR: ${{ vars.BASE_WORKING_DIR }}
       PULL_SECRET: ${{ secrets.PULL_SECRET }}
       ENCLAVE_DEPLOYMENT_MODE: connected
+      ENCLAVE_SUPPORTED_RUNTIME_HOSTS: '["centos:centos:10"]'
       CLEANUP_AFTER: 'true'
       STORAGE_PLUGIN: ${{ github.event.inputs.storage-plugin || 'lvms' }}
       ENABLED_PLUGINS: ${{ github.event.inputs.storage-plugin || 'lvms' }}
@@ -524,6 +525,7 @@ jobs:
       BASE_WORKING_DIR: ${{ vars.BASE_WORKING_DIR }}
       PULL_SECRET: ${{ secrets.PULL_SECRET }}
       ENCLAVE_DEPLOYMENT_MODE: disconnected
+      ENCLAVE_SUPPORTED_RUNTIME_HOSTS: '["centos:centos:10"]'
       CLEANUP_AFTER: 'true'
       STORAGE_PLUGIN: ${{ github.event.inputs.storage-plugin || 'lvms' }}
       ENABLED_PLUGINS: ${{ github.event.inputs.storage-plugin || 'lvms' }}

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -138,6 +138,18 @@ elif [ "$(getValue .disconnected 2>/dev/null)" = "false" ]; then
     is_disconnected=false
 fi
 
+# Determine supported runtime hosts: env var takes precedence, then config file
+supported_runtime_hosts=$(getValue .supportedRuntimeHosts | jq -r '
+    if . == null or . == [] then 
+        "redhat:enterprise_linux:10" 
+    else 
+        join("|") 
+    end')
+if [ -n "$ENCLAVE_SUPPORTED_RUNTIME_HOSTS" ]; then
+    supported_runtime_hosts=$(echo $ENCLAVE_SUPPORTED_RUNTIME_HOSTS | jq -r 'join("|")')
+fi
+
+
 EXTRA_VARS=""
 if [ "$is_disconnected" = false ]; then
     # Use --extra-vars= with JSON to pass boolean false (not string "false")
@@ -184,7 +196,7 @@ step_setup() {
     echo 'Runtime Host:' | tee -a ${log}
     cat /etc/redhat-release | tee -a ${log}
     echo ' - '
-    if ! [[ $(</etc/os-release) =~ CPE_NAME=\"cpe:/o:(redhat:enterprise_linux|centos:centos):10(\.?.*)?\" ]]; then
+    if ! [[ $(</etc/os-release) =~ CPE_NAME=\"cpe:/o:($supported_runtime_hosts)(\.?.*)?\" ]]; then
         echo "RHEL 10 / CentOS Stream 10 Check Failed"
         exit 1
     fi

--- a/config/global.example.yaml
+++ b/config/global.example.yaml
@@ -94,6 +94,10 @@ storage_plugin: lvms
 # Disconnected mode (default: true, set to false for connected deployments)
 # disconnected: false
 
+# Supported Runtime Hosts (default: ["redhat:enterprise_linux:10"])
+# supportedRuntimeHosts:
+#   - redhat:enterprise_linux:10
+
 # Configure High Density Pod Limits for ABI (default: 500)
 # masterMaxPods: 250
 

--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -1206,6 +1206,8 @@ lzBmcIP: 100.64.1.10
 
 # OpenShift Deployment Configuration (optional — uncomment only to override defaults)
 # disconnected: false  # Default: true (set to false for connected deployments)
+# supportedRuntimeHosts:
+#   - redhat:enterprise_linux:10
 # masterMaxPods: 250 # Default: 500
 # diskEncryption: true  # Default: false (set to true to enable TPM v2 encryption)
 # ocMirrorLogLevel: debug  # Default: info

--- a/schemas/definitions.yaml
+++ b/schemas/definitions.yaml
@@ -21,6 +21,11 @@ definitions:
     description: >-
       Whether the deployment is disconnected (air-gapped). Default: true.
       Set to false for connected deployments.
+  supportedRuntimeHosts:
+    type: array
+    description: "Supported Runtime Hosts (default: ['redhat:enterprise_linux:10'])"
+    items:
+      type: string
   masterMaxPods:
     type: integer
     minimum: 1

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -242,6 +242,7 @@ Common environment variables used across scripts:
 | `WORKING_DIR` | Cluster working directory |
 | `BASE_WORKING_DIR` | Base directory for all clusters |
 | `ENCLAVE_DEPLOYMENT_MODE` | Deployment mode: `connected` or `disconnected` |
+| `ENCLAVE_SUPPORTED_RUNTIME_HOSTS` | Supported Runtime Hosts |
 | `ENCLAVE_SUBNET_ID` | Allocated subnet ID (for parallel CI) |
 | `ENCLAVE_BMC_NETWORK` | BMC network CIDR (e.g., `100.64.3.0/24`) |
 | `ENCLAVE_CLUSTER_NETWORK` | Cluster network CIDR (e.g., `192.168.3.0/24`) |


### PR DESCRIPTION
default to rhel 10, but leave option for consumers to define anything else. a possible alternative for #271

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `supportedRuntimeHosts` configuration option, configurable via config files or the `ENCLAVE_SUPPORTED_RUNTIME_HOSTS` environment variable, with a default value of `redhat:enterprise_linux:10`.

* **Documentation**
  * Updated configuration reference and examples to document the new `supportedRuntimeHosts` setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->