### PR TITLE
Support RHEL 10 Landing Zone image in CI

### DIFF
--- a/.github/workflows/e2e-deployment.yml
+++ b/.github/workflows/e2e-deployment.yml
@@ -137,6 +137,7 @@ jobs:
       ENABLED_PLUGINS: ${{ github.event.inputs.storage-plugin || 'lvms' }}
       OPENSHIFT_CI: "true"
       ENCLAVE_ENABLE_GPU_PASSTHROUGH: "false"
+      LZ_OS_VARIANT: ${{ vars.LZ_OS_VARIANT }}
 
     steps:
       - name: Checkout code
@@ -190,10 +191,15 @@ jobs:
           echo "Infrastructure created" >> $GITHUB_STEP_SUMMARY
 
       - name: Provision Landing Zone
+        env:
+          LZ_CLOUD_IMAGE_URL: ${{ vars.LZ_CLOUD_IMAGE_URL }}
+          LZ_CLOUD_IMAGE_NAME: ${{ vars.LZ_CLOUD_IMAGE_NAME }}
+          LZ_RHSM_ORG: ${{ secrets.LZ_RHSM_ORG }}
+          LZ_RHSM_ACTIVATION_KEY: ${{ secrets.LZ_RHSM_ACTIVATION_KEY }}
         run: |
           echo "## Provisioning Landing Zone" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Installing CentOS Stream and configuring Landing Zone VM..." >> $GITHUB_STEP_SUMMARY
+          echo "Installing ${LZ_OS_VARIANT:-centos-stream10} on Landing Zone VM..." >> $GITHUB_STEP_SUMMARY
           make -f Makefile.ci provision-landing-zone
           echo "Landing Zone provisioned" >> $GITHUB_STEP_SUMMARY
 
@@ -529,6 +535,7 @@ jobs:
       ENABLED_PLUGINS: ${{ github.event.inputs.storage-plugin || 'lvms' }}
       OPENSHIFT_CI: "true"
       ENCLAVE_ENABLE_GPU_PASSTHROUGH: "false"
+      LZ_OS_VARIANT: ${{ vars.LZ_OS_VARIANT }}
 
     steps:
       - name: Checkout code
@@ -582,10 +589,15 @@ jobs:
           echo "Infrastructure created" >> $GITHUB_STEP_SUMMARY
 
       - name: Provision Landing Zone
+        env:
+          LZ_CLOUD_IMAGE_URL: ${{ vars.LZ_CLOUD_IMAGE_URL }}
+          LZ_CLOUD_IMAGE_NAME: ${{ vars.LZ_CLOUD_IMAGE_NAME }}
+          LZ_RHSM_ORG: ${{ secrets.LZ_RHSM_ORG }}
+          LZ_RHSM_ACTIVATION_KEY: ${{ secrets.LZ_RHSM_ACTIVATION_KEY }}
         run: |
           echo "## Provisioning Landing Zone" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Installing CentOS Stream and configuring Landing Zone VM..." >> $GITHUB_STEP_SUMMARY
+          echo "Installing ${LZ_OS_VARIANT:-centos-stream10} on Landing Zone VM..." >> $GITHUB_STEP_SUMMARY
           make -f Makefile.ci provision-landing-zone
           echo "Landing Zone provisioned" >> $GITHUB_STEP_SUMMARY
 

--- a/scripts/infrastructure/provision_landing_zone.sh
+++ b/scripts/infrastructure/provision_landing_zone.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
-# Provision Landing Zone VM with CentOS Stream 10
+# Provision Landing Zone VM (CentOS Stream 10 or RHEL 10)
 #
 # This script provisions the existing Landing Zone VM (created by dev-scripts)
-# with CentOS Stream 10 cloud image and configures it for Enclave Lab deployment.
+# with a configurable cloud image (CentOS Stream 10 by default, or RHEL 10)
+# and configures it for Enclave Lab deployment.
 
 set -euo pipefail
 
@@ -31,8 +32,9 @@ CLUSTER_NAME="${CLUSTER_NAME:-enclave-test}"
 LZ_VM_NAME="${CLUSTER_NAME}_landingzone_0"
 ensure_working_dir
 LZ_WORKING_DIR="${WORKING_DIR}/landing-zone/${CLUSTER_NAME}"
-CLOUD_IMAGE_URL="https://cloud.centos.org/centos/10-stream/x86_64/images/CentOS-Stream-GenericCloud-10-latest.x86_64.qcow2"
-CLOUD_IMAGE_NAME="centos-stream-10-cloud.qcow2"
+CLOUD_IMAGE_URL="${LZ_CLOUD_IMAGE_URL:-https://cloud.centos.org/centos/10-stream/x86_64/images/CentOS-Stream-GenericCloud-10-latest.x86_64.qcow2}"
+CLOUD_IMAGE_NAME="${LZ_CLOUD_IMAGE_NAME:-centos-stream-10-cloud.qcow2}"
+OS_VARIANT="${LZ_OS_VARIANT:-centos-stream10}"
 # Use cluster-specific storage pool for isolation in parallel execution
 # Each cluster gets its own pool in its dedicated working directory
 POOL_NAME="${CLUSTER_NAME}"
@@ -75,13 +77,17 @@ info "Creating working directory: $LZ_WORKING_DIR"
 sudo mkdir -p "$LZ_WORKING_DIR"
 sudo chown $USER:$USER "$LZ_WORKING_DIR"
 
-# Download CentOS Stream 10 cloud image
+# Download cloud image
 if [ ! -f "${LZ_WORKING_DIR}/${CLOUD_IMAGE_NAME}" ]; then
-    info "Downloading CentOS Stream 10 cloud image..."
-    wget -nv -O "${LZ_WORKING_DIR}/${CLOUD_IMAGE_NAME}" "$CLOUD_IMAGE_URL"
+    info "Downloading cloud image: ${CLOUD_IMAGE_NAME}..."
+    if [[ "$CLOUD_IMAGE_URL" == file://* ]]; then
+        cp "${CLOUD_IMAGE_URL#file://}" "${LZ_WORKING_DIR}/${CLOUD_IMAGE_NAME}"
+    else
+        wget -nv -O "${LZ_WORKING_DIR}/${CLOUD_IMAGE_NAME}" "$CLOUD_IMAGE_URL"
+    fi
     info "✓ Cloud image downloaded"
 else
-    info "Cloud image already exists, skipping download"
+    info "Cloud image already cached: ${CLOUD_IMAGE_NAME}"
 fi
 
 # Create cloud-init configuration
@@ -127,6 +133,17 @@ disable_root: true
 final_message: "Enclave Landing Zone VM is ready. Time: \$UPTIME"
 EOF
 
+# Conditionally add RHSM subscription for RHEL images
+if [ -n "${LZ_RHSM_ORG:-}" ] && [ -n "${LZ_RHSM_ACTIVATION_KEY:-}" ]; then
+    info "Adding RHSM subscription to cloud-init configuration..."
+    cat >> "${LZ_WORKING_DIR}/user-data" <<RHSM_EOF
+
+rh_subscription:
+  activation-key: "${LZ_RHSM_ACTIVATION_KEY}"
+  org: "${LZ_RHSM_ORG}"
+RHSM_EOF
+fi
+
 # Note: Skipping network-config - let cloud-init use DHCP from libvirt networks
 # This ensures the VM gets network connectivity quickly
 # Static IPs can be configured later if needed via Task 3
@@ -140,6 +157,9 @@ sudo genisoimage -output "${LZ_WORKING_DIR}/cloud-init.iso" \
     "${LZ_WORKING_DIR}/user-data" \
     "${LZ_WORKING_DIR}/meta-data" 2>&1 | grep -v "Warning: creating filesystem"
 info "✓ cloud-init ISO created"
+
+# Remove cloud-init files that may contain RHSM credentials
+rm -f "${LZ_WORKING_DIR}/user-data" "${LZ_WORKING_DIR}/meta-data"
 
 # Stop and remove existing VM if it exists
 if sudo virsh list --all | grep -q "$LZ_VM_NAME"; then
@@ -299,7 +319,7 @@ sudo virt-install \
     --network network=${BMC_NETWORK_NAME} \
     --network network=${CLUSTER_NETWORK_NAME} \
     --boot hd,cdrom \
-    --os-variant centos-stream10 \
+    --os-variant "$OS_VARIANT" \
     --graphics vnc \
     --noautoconsole \
     --import

--- a/scripts/infrastructure/provision_landing_zone.sh
+++ b/scripts/infrastructure/provision_landing_zone.sh
@@ -34,6 +34,7 @@ ensure_working_dir
 LZ_WORKING_DIR="${WORKING_DIR}/landing-zone/${CLUSTER_NAME}"
 CLOUD_IMAGE_URL="${LZ_CLOUD_IMAGE_URL:-https://cloud.centos.org/centos/10-stream/x86_64/images/CentOS-Stream-GenericCloud-10-latest.x86_64.qcow2}"
 CLOUD_IMAGE_NAME="${LZ_CLOUD_IMAGE_NAME:-centos-stream-10-cloud.qcow2}"
+CLOUD_IMAGE_CACHE_DIR="${LZ_CLOUD_IMAGE_CACHE_DIR:-/opt/images}"
 OS_VARIANT="${LZ_OS_VARIANT:-centos-stream10}"
 # Use cluster-specific storage pool for isolation in parallel execution
 # Each cluster gets its own pool in its dedicated working directory
@@ -77,18 +78,19 @@ info "Creating working directory: $LZ_WORKING_DIR"
 sudo mkdir -p "$LZ_WORKING_DIR"
 sudo chown $USER:$USER "$LZ_WORKING_DIR"
 
-# Download cloud image
-if [ ! -f "${LZ_WORKING_DIR}/${CLOUD_IMAGE_NAME}" ]; then
-    info "Downloading cloud image: ${CLOUD_IMAGE_NAME}..."
-    if [[ "$CLOUD_IMAGE_URL" == file://* ]]; then
-        cp "${CLOUD_IMAGE_URL#file://}" "${LZ_WORKING_DIR}/${CLOUD_IMAGE_NAME}"
-    else
-        wget -nv -O "${LZ_WORKING_DIR}/${CLOUD_IMAGE_NAME}" "$CLOUD_IMAGE_URL"
-    fi
-    info "✓ Cloud image downloaded"
+# Copy cloud image from cache or download
+# Each job gets its own copy to avoid I/O conflicts during parallel execution
+if [ -f "${CLOUD_IMAGE_CACHE_DIR}/${CLOUD_IMAGE_NAME}" ]; then
+    info "Copying cloud image from cache: ${CLOUD_IMAGE_CACHE_DIR}/${CLOUD_IMAGE_NAME}"
+    cp "${CLOUD_IMAGE_CACHE_DIR}/${CLOUD_IMAGE_NAME}" "${LZ_WORKING_DIR}/${CLOUD_IMAGE_NAME}"
+elif [[ "$CLOUD_IMAGE_URL" == file://* ]]; then
+    info "Copying cloud image from ${CLOUD_IMAGE_URL}..."
+    cp "${CLOUD_IMAGE_URL#file://}" "${LZ_WORKING_DIR}/${CLOUD_IMAGE_NAME}"
 else
-    info "Cloud image already cached: ${CLOUD_IMAGE_NAME}"
+    info "Downloading cloud image: ${CLOUD_IMAGE_NAME}..."
+    wget -nv -O "${LZ_WORKING_DIR}/${CLOUD_IMAGE_NAME}" "$CLOUD_IMAGE_URL"
 fi
+info "✓ Cloud image ready"
 
 # Create cloud-init configuration
 info "Creating cloud-init configuration..."
@@ -302,6 +304,9 @@ fi
 # 1000GB: extra headroom for full release mirror and OLM catalogs in disconnected env
 info "Resizing disk to ${LZ_DISK_SIZE}..."
 sudo qemu-img resize "${POOL_PATH}/${LZ_VM_NAME}.qcow2" "$LZ_DISK_SIZE"
+
+# Remove working copy of cloud image to free disk space
+rm -f "${LZ_WORKING_DIR}/${CLOUD_IMAGE_NAME}"
 
 # Refresh pool so libvirt sees the new volume
 info "Refreshing libvirt pool..."


### PR DESCRIPTION
## Summary

- Make `provision_landing_zone.sh` configurable via env vars (`LZ_CLOUD_IMAGE_URL`, `LZ_CLOUD_IMAGE_NAME`, `LZ_OS_VARIANT`) so CI can use RHEL 10 instead of CentOS Stream 10
- Add conditional RHSM registration via `LZ_RHSM_ORG` + `LZ_RHSM_ACTIVATION_KEY` (cloud-init `rh_subscription` module)
- Pass new vars/secrets through both E2E workflow jobs
- Default behavior without env vars remains CentOS Stream 10 (no change for local dev)

## Manual setup required

Configure in GitHub repo Settings > Secrets and variables > Actions:

**Variables:**
- `LZ_CLOUD_IMAGE_URL` — `file:///opt/images/rhel-10-cloud.qcow2` (pre-downloaded to runner)
- `LZ_CLOUD_IMAGE_NAME` — `rhel-10-cloud.qcow2`
- `LZ_OS_VARIANT` — `rhel10.0`

**Secrets:**
- `LZ_RHSM_ORG` — Red Hat organization ID
- `LZ_RHSM_ACTIVATION_KEY` — RHSM activation key for unattended registration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployment workflow now supports configurable cloud images and selectable OS variants for provisioning (replacing a hardcoded OS).
  * Provisioning accepts local image sources or downloads, reports cached images, stages images from a configurable cache, and cleans per-run temporary files to free space and avoid credential leftovers.
  * Red Hat subscription details are attached conditionally when credentials are provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->