### PR TITLE
Trust Sovereign Core Root CA on hub to fix ACM spoke Unreachable state

### DIFF
--- a/operators/advanced-cluster-management/tasks.yaml
+++ b/operators/advanced-cluster-management/tasks.yaml
@@ -85,3 +85,10 @@
 - name: ACM ClusterImageSet reconciliation
   ansible.builtin.include_tasks:
     file: acm_cis.yaml
+
+- name: Trust custom Root CA in Hive for spoke cluster connections
+  ansible.builtin.include_tasks:
+    file: trust_hive_ca.yaml
+  when:
+    - sslCACertificate is defined
+    - sslCACertificate | length > 0

--- a/operators/advanced-cluster-management/trust_hive_ca.yaml
+++ b/operators/advanced-cluster-management/trust_hive_ca.yaml
@@ -1,0 +1,49 @@
+---
+- name: Read existing HiveConfig
+  kubernetes.core.k8s_info:
+    api_version: hive.openshift.io/v1
+    kind: HiveConfig
+    name: hive
+  register: r_hiveconfig
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until:
+    - r_hiveconfig is success
+    - r_hiveconfig.resources | length > 0
+
+- name: Create Secret with Root CA for Hive spoke cluster connections
+  no_log: true
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: custom-ca-for-hive
+        namespace: "{{ r_hiveconfig.resources[0].spec.targetNamespace | default('hive') }}"
+      type: Opaque
+      data:
+        ca.crt: "{{ sslCACertificate | b64encode }}"
+  register: r_hive_ca_secret
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_hive_ca_secret is success
+
+- name: Patch HiveConfig to trust the custom CA for spoke cluster connections
+  kubernetes.core.k8s:
+    state: patched
+    api_version: hive.openshift.io/v1
+    kind: HiveConfig
+    name: hive
+    merge_type: merge
+    definition:
+      spec:
+        additionalCertificateAuthoritiesSecretRef: "{{ merged_ca_refs }}"
+  vars:
+    existing_ca_refs: "{{ r_hiveconfig.resources[0].spec.additionalCertificateAuthoritiesSecretRef | default([]) }}"
+    already_present: "{{ existing_ca_refs | selectattr('name', 'equalto', 'custom-ca-for-hive') | list | length > 0 }}"
+    merged_ca_refs: "{{ existing_ca_refs if already_present else (existing_ca_refs + [{'name': 'custom-ca-for-hive'}]) }}"
+  register: r_patch_hiveconfig_ca
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_patch_hiveconfig_ca is success


### PR DESCRIPTION
When ClusterService distributes Root CA-signed TLS certs to spoke clusters,
Hive cannot verify spoke API servers because HiveConfig lacks the CA in
additionalCertificateAuthoritiesSecretRef. Unlike the hub's Proxy/cluster
trust (set automatically via additionalTrustBundle at install time), Hive
has its own CA verification path and must be configured independently.

Adds an Ansible task (trust_hive_ca.yaml) that reads the existing HiveConfig,
creates a Secret with the Root CA in open-cluster-management, and appends it
to additionalCertificateAuthoritiesSecretRef — preserving any pre-existing
CA refs. Conditional on sslCACertificate being defined.

https://redhat.atlassian.net/browse/MGMT-24002

https://github.com/gori-project/GoRI/issues/888

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for custom Root CA certificate trust in cluster connections
  * Custom CA configuration is conditionally applied when a certificate is provided
<!-- end of auto-generated comment: release notes by coderabbit.ai -->