### PR TITLE
Add auto-fallback to plugin mirroring for standalone foundation plugin deployment

### DIFF
--- a/playbooks/tasks/deploy_plugin.yaml
+++ b/playbooks/tasks/deploy_plugin.yaml
@@ -45,6 +45,43 @@
     msg: "Deploying plugin '{{ plugin.name }}' (type={{ plugin.type }}, order={{ plugin.order | default('unset') }}, mirror={{ plugin_mirror | default(false) | bool }})"
   tags: always
 
+# Auto-fallback: when deploying a foundation plugin standalone (plugin_mirror=true)
+# or in the core pipeline, check whether its CatalogSource already exists.
+# If not, enable mirroring so the plugin's operators are mirrored on the spot.
+- name: Check if plugin CatalogSource already exists
+  kubernetes.core.k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: CatalogSource
+    name: "{{ plugin.operators[0].source }}"
+    namespace: openshift-marketplace
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  register: r_catalog_check
+  when:
+    - not (plugin_mirror | default(false) | bool)
+    - disconnected | default(true) | bool
+    - plugin.operators is defined and plugin.operators | length > 0
+  tags: always
+
+- name: Auto-enable plugin mirroring (CatalogSource not found)
+  ansible.builtin.set_fact:
+    plugin_mirror: true
+    _plugin_mirror_auto: true
+  when:
+    - not (plugin_mirror | default(false) | bool)
+    - disconnected | default(true) | bool
+    - r_catalog_check is defined
+    - r_catalog_check.resources | default([]) | length == 0
+  tags: always
+
+- name: Report auto-enabled plugin mirroring
+  ansible.builtin.debug:
+    msg: >-
+      Plugin '{{ plugin.name }}': CatalogSource '{{ plugin.operators[0].source }}'
+      not found. Auto-enabling plugin mirroring.
+  when: _plugin_mirror_auto | default(false)
+  tags: always
+
 # Dynamically set each key in plugin.defaults as an Ansible fact.
 # The dict2items loop is required because set_fact needs explicit key: value
 # pairs — the free-form `set_fact: "{{ dict }}"` renders to a string and


### PR DESCRIPTION
## Problem

Foundation plugins like ODF have `mirror: core`, meaning their operators are expected to be mirrored during Phase 2 alongside platform images. When a user deploys with a different storage plugin (e.g. LVMS) and later wants to add ODF via `make deploy-plugin PLUGIN=odf`, it fails because:

1. ODF operators were never mirrored - ODF wasn't in `enabled_plugins` during Phase 2
2. `deploy_plugin.yaml` skips all mirror tasks for `mirror: core` plugins, assuming the operators are already available

## Solution

`deploy_plugin.yaml` now detects at runtime whether a `mirror: core` plugin's CatalogSource actually exists on the cluster. If it doesn't, it automatically falls back to `mirror: plugin` behavior - mirroring the operators on the spot and overriding the operator source to point at the newly created CatalogSource.

This is fully transparent: `make deploy-plugin PLUGIN=odf` just works regardless of whether the operators were mirrored earlier.

### What changed

- Introduced `_effective_mirror` variable that starts as `plugin.mirror` and gets overridden to `plugin` when the expected CatalogSource is missing
- Replaced all `plugin.mirror` condition checks with `_effective_mirror`
- After fallback mirroring, discovers the oc-mirror-generated CatalogSource name and updates `plugin.operators[*].source` so Subscriptions point at the correct source

### What stays unchanged

- All `plugin.yaml` descriptors (ODF keeps `type: foundation`, `mirror: core`)
- Phase 2 mirroring behavior (`collect_core_plugin_operators.yaml`)
- `configure_operator.yaml`, `deploy_plugin.sh`, Makefile, plugin schemas

### Edge cases

- **Normal pipeline run**: CatalogSource exists → `_effective_mirror` stays `core` → no mirror tasks → idempotent
- **Connected mode**: `disconnected: false` → all mirror/CatalogSource checks skipped → works unchanged
- **Re-run after standalone deploy**: CatalogSource now exists → no fallback → idempotent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin deployment for disconnected environments by automatically enabling plugin mirroring when the operator source is not found in the marketplace.
  * Ensures consistent mirroring/installation behavior when upstream CatalogSource is missing.
  * Adds a debug message to surface when mirroring is auto-enabled for transparency during deployment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/enclave/pull/288?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->