### PR TITLE
extract catalog image and mirror logic from template to task

### DIFF
--- a/playbooks/tasks/deploy_plugin.yaml
+++ b/playbooks/tasks/deploy_plugin.yaml
@@ -114,6 +114,29 @@
   when: lookup('ansible.builtin.fileglob', plugin_dir ~ '/tasks/pre-validate.yaml') | length > 0
   tags: pre-validate
 
+- name: Set catalog image and mirror defaults
+  set_fact:
+    catalog_image: "{{ rh_operator_catalog }}:{{ rh_operator_catalog_version }}"
+    catalog_mirror: "{{ mirror_rh_operator_catalog }}-{{ plugin.name }}"
+    catalog_version: "{{ rh_operator_catalog_version }}"
+  when:
+    - plugin.mirror | default('none') == 'plugin'
+    - disconnected | default(true) | bool
+    - plugin.operators is defined
+  tags: mirror
+
+- name: Override variables for certified catalog
+  set_fact:
+    catalog_image: "{{ certified_operator_catalog }}:{{ certified_operator_catalog_version }}"
+    catalog_mirror: "{{ mirror_certified_rh_operator_catalog }}-{{ plugin.name }}"
+    catalog_version: "{{ certified_operator_catalog_version }}"
+  when:
+    - plugin.mirror | default('none') == 'plugin'
+    - disconnected | default(true) | bool
+    - plugin.operators is defined
+    - plugin.catalog | default("") == "certified"
+  tags: mirror
+
 - name: Template plugin imageset configuration
   ansible.builtin.template:
     src: "{{ playbook_dir }}/../templates/plugin-imageset.yaml.j2"

--- a/templates/plugin-imageset.yaml.j2
+++ b/templates/plugin-imageset.yaml.j2
@@ -1,16 +1,10 @@
-{% set catalog_image = rh_operator_catalog ~ ':' ~ rh_operator_catalog_version %}
-{% set catalog_mirror = mirror_rh_operator_catalog %}
-{% if (plugin.catalog | default("")) == "certified" %}
-{% set catalog_image = certified_operator_catalog ~ ':' ~ certified_operator_catalog_version %}
-{% set catalog_mirror = mirror_certified_rh_operator_catalog %}
-{% endif %}
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1
 mirror:
   operators:
     - catalog: {{ catalog_image }}
-      targetCatalog: redhat/{{ catalog_mirror ~ '-' ~ plugin.name }}
+      targetCatalog: redhat/{{ catalog_mirror }}
       packages:
 {% for operator in plugin.operators | default([]) %}
 {% set additional_operator_names = operator.csvNames if (operator.csvMirror | default(false) | bool) else [] %}


### PR DESCRIPTION
this will help expose how these variables are determined and will enable using them further down the flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved plugin mirroring configuration for disconnected environments by streamlining catalog variable handling.
  * Simplified catalog mirror naming logic for plugin mirror operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->