### PR TITLE
Add OSAC plugin skeleton and E2E CI workflow

### DIFF
--- a/.github/workflows/e2e-deployment.yml
+++ b/.github/workflows/e2e-deployment.yml
@@ -61,6 +61,7 @@ permissions:
 jobs:
   check-e2e-needed:
     name: Check if E2E should run
+    if: false #TODO: remove before merge
     runs-on: [self-hosted, pr-validation]
     timeout-minutes: 5
     outputs:

--- a/.github/workflows/e2e-osac-plugin.yml
+++ b/.github/workflows/e2e-osac-plugin.yml
@@ -1,0 +1,381 @@
+name: E2E OSAC Plugin
+
+on:
+  workflow_dispatch:
+    inputs:
+      skip-cleanup:
+        description: 'Skip cleanup after deployment (leave infrastructure running)'
+        required: false
+        type: boolean
+        default: false
+      send-slack-notification:
+        description: 'Send Slack notification on completion'
+        required: false
+        type: boolean
+        default: false
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'plugins/osac/**'
+      - '.github/workflows/e2e-osac-plugin.yml'
+
+permissions:
+  contents: read
+  checks: write
+
+concurrency:
+  group: e2e-osac-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  e2e-osac:
+    name: E2E OSAC Plugin (Connected)
+    runs-on: [self-hosted, enclave-large]
+    timeout-minutes: 240
+
+    env:
+      DEV_SCRIPTS_PATH: ${{ vars.DEV_SCRIPTS_PATH }}
+      BASE_WORKING_DIR: ${{ vars.BASE_WORKING_DIR }}
+      PULL_SECRET: ${{ secrets.PULL_SECRET }}
+      ENCLAVE_DEPLOYMENT_MODE: connected
+      ENCLAVE_HEAVY_WORKLOAD: "true"
+      CLEANUP_AFTER: 'true'
+      STORAGE_PLUGIN: lvms
+      ENABLED_PLUGINS: lvms
+      OPENSHIFT_CI: "true"
+      ENCLAVE_ENABLE_GPU_PASSTHROUGH: "false"
+      LZ_OS_VARIANT: ${{ vars.LZ_OS_VARIANT }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Generate unique cluster name
+        uses: ./.github/actions/setup-cluster-name
+        with:
+          naming-strategy: hash
+          prefix: osac
+          run-id: ${{ github.run_id }}
+
+      - name: Setup cluster-specific working directory
+        run: |
+          make -f Makefile.ci setup-working-dir
+          echo "WORKING_DIR=$(cat /tmp/working_dir)" >> $GITHUB_ENV
+
+      - name: Workflow information
+        run: |
+          echo "## E2E OSAC Plugin - Connected Mode" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Started at**: $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_STEP_SUMMARY
+          echo "**Cluster name**: $ENCLAVE_CLUSTER_NAME" >> $GITHUB_STEP_SUMMARY
+          echo "**Trigger**: ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+      - name: Pre-flight checks
+        uses: ./.github/actions/preflight-checks
+        with:
+          title: E2E OSAC Plugin
+          check-pull-secret: 'true'
+          check-system-resources: 'true'
+          check-libvirt: 'true'
+
+      - name: Allocate unique subnet for cluster
+        uses: ./.github/actions/allocate-subnet
+
+      - name: Create infrastructure
+        env:
+          WORKING_DIR: ${{ env.WORKING_DIR }}
+        run: |
+          echo "## Creating Infrastructure" >> $GITHUB_STEP_SUMMARY
+          make -f Makefile.ci environment
+          echo "Infrastructure created" >> $GITHUB_STEP_SUMMARY
+
+      - name: Provision Landing Zone
+        env:
+          LZ_CLOUD_IMAGE_URL: ${{ vars.LZ_CLOUD_IMAGE_URL }}
+          LZ_CLOUD_IMAGE_NAME: ${{ vars.LZ_CLOUD_IMAGE_NAME }}
+          LZ_RHSM_ORG: ${{ secrets.LZ_RHSM_ORG }}
+          LZ_RHSM_ACTIVATION_KEY: ${{ secrets.LZ_RHSM_ACTIVATION_KEY }}
+        run: |
+          echo "## Provisioning Landing Zone" >> $GITHUB_STEP_SUMMARY
+          make -f Makefile.ci provision-landing-zone
+          echo "Landing Zone provisioned" >> $GITHUB_STEP_SUMMARY
+
+      - name: Install Enclave Lab
+        run: |
+          echo "## Installing Enclave Lab" >> $GITHUB_STEP_SUMMARY
+          make -f Makefile.ci install-enclave
+          echo "Enclave Lab installed" >> $GITHUB_STEP_SUMMARY
+
+      - name: Bootstrap - Setup environment
+        id: bootstrap_setup
+        run: |
+          echo "## Bootstrap: Setup" >> $GITHUB_STEP_SUMMARY
+          make -f Makefile.ci deploy-cluster-setup
+          echo "Setup complete" >> $GITHUB_STEP_SUMMARY
+
+      - name: Bootstrap - Validate configuration
+        id: bootstrap_validate
+        run: |
+          echo "## Bootstrap: Validate" >> $GITHUB_STEP_SUMMARY
+          make -f Makefile.ci deploy-cluster-validate
+          echo "Validation complete" >> $GITHUB_STEP_SUMMARY
+
+      - name: Bootstrap - Download content
+        id: bootstrap_download_content
+        run: |
+          echo "## Bootstrap: Download Content" >> $GITHUB_STEP_SUMMARY
+          make -f Makefile.ci deploy-cluster-prepare
+          echo "Download complete" >> $GITHUB_STEP_SUMMARY
+
+      - name: Bootstrap - Build local cache
+        id: bootstrap_build_cache
+        run: |
+          echo "## Bootstrap: Build Cache" >> $GITHUB_STEP_SUMMARY
+          make -f Makefile.ci deploy-cluster-mirror
+          echo "Cache build complete" >> $GITHUB_STEP_SUMMARY
+
+      - name: Bootstrap - Acquire hardware
+        id: bootstrap_acquire_hardware
+        run: |
+          echo "## Bootstrap: Acquire Hardware" >> $GITHUB_STEP_SUMMARY
+          make -f Makefile.ci deploy-cluster-acquire-hardware
+          echo "Hardware acquired" >> $GITHUB_STEP_SUMMARY
+
+      - name: Bootstrap - Deploy cluster
+        id: bootstrap_deploy
+        run: |
+          echo "## Bootstrap: Deploy Cluster" >> $GITHUB_STEP_SUMMARY
+          make -f Makefile.ci deploy-cluster-install
+          echo "Cluster deployed" >> $GITHUB_STEP_SUMMARY
+
+      - name: Bootstrap - Post-install
+        id: bootstrap_post_install
+        run: |
+          echo "## Bootstrap: Post-Install" >> $GITHUB_STEP_SUMMARY
+          make -f Makefile.ci deploy-cluster-post-install
+          echo "Post-install complete" >> $GITHUB_STEP_SUMMARY
+
+      - name: Bootstrap - Operators
+        id: bootstrap_operators
+        run: |
+          echo "## Bootstrap: Operators" >> $GITHUB_STEP_SUMMARY
+          make -f Makefile.ci deploy-cluster-operators
+          echo "Operators installed" >> $GITHUB_STEP_SUMMARY
+
+      - name: Deploy AAP license to Landing Zone
+        run: |
+          AAP_LICENSE_FILE="${DEV_SCRIPTS_PATH}/aap-license.zip"
+          if [ ! -f "$AAP_LICENSE_FILE" ]; then
+            echo "AAP license not found at $AAP_LICENSE_FILE"
+            exit 1
+          fi
+          LZ_IP=$(./scripts/utils/get_landing_zone_ip.sh)
+          SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10"
+          scp $SSH_OPTS "$AAP_LICENSE_FILE" cloud-user@${LZ_IP}:/tmp/aap-license.zip
+
+      - name: Deploy OSAC plugin
+        id: deploy_osac
+        run: |
+          echo "## Deploy OSAC Plugin" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          make -f Makefile.ci deploy-plugin PLUGIN=osac
+          echo "OSAC plugin deployed" >> $GITHUB_STEP_SUMMARY
+
+      - name: Verify cluster deployment
+        if: success()
+        id: verify_cluster
+        run: make -f Makefile.ci verify-cluster
+
+      - name: Collect artifacts
+        if: always()
+        uses: ./.github/actions/collect-artifacts
+        with:
+          artifact-type: deployment
+          output-directory: artifacts
+
+      - name: Collect full diagnostics on failure
+        if: failure()
+        run: |
+          echo "## Collecting Full Diagnostics (failure)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if ! ./scripts/verification/collect_ci_artifacts.sh full artifacts 2>&1 | tee artifact-collection-full.log; then
+            echo "Full artifact collection failed; continuing with must-gather" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          LZ_IP=$(./scripts/utils/get_landing_zone_ip.sh)
+          if [ -n "$LZ_IP" ]; then
+            SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10"
+
+            if ssh $SSH_OPTS cloud-user@$LZ_IP "test -f /home/cloud-user/enclave/scripts/diagnostics/gather.sh" 2>/dev/null; then
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "### Running must-gather..." >> $GITHUB_STEP_SUMMARY
+
+              mkdir -p artifacts/must-gather
+              GATHER_OUT=$(ssh $SSH_OPTS cloud-user@$LZ_IP \
+                "cd /home/cloud-user/enclave/scripts/diagnostics && \
+                 export KUBECONFIG=/home/cloud-user/ocp-cluster/auth/kubeconfig && \
+                 GITHUB_RUN_ID='${{ github.run_id }}' ./gather.sh --must-gather=full ../../config/global.yaml 2>&1" || true)
+              echo "$GATHER_OUT" >> artifacts/must-gather/gather-output.txt
+
+              scp $SSH_OPTS "cloud-user@${LZ_IP}:/home/cloud-user/enclave/scripts/diagnostics/lz-logs-*.tar.gz" artifacts/must-gather/ 2>/dev/null || true
+              scp $SSH_OPTS "cloud-user@${LZ_IP}:/home/cloud-user/enclave/scripts/diagnostics/cluster-logs-*.tar.gz" artifacts/must-gather/ 2>/dev/null || true
+
+              if ls artifacts/must-gather/*-logs-*.tar.gz 1>/dev/null 2>&1; then
+                echo "Collected must-gather archives" >> $GITHUB_STEP_SUMMARY
+              else
+                echo "Must-gather failed (see must-gather/gather-output.txt)" >> $GITHUB_STEP_SUMMARY
+              fi
+            fi
+          fi
+
+      - name: Upload artifacts
+        if: always()
+        id: upload_artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-osac-${{ env.ENCLAVE_CLUSTER_NAME }}-${{ github.run_id }}
+          path: artifacts/
+          retention-days: 7
+          if-no-files-found: warn
+
+      - name: Get artifact download URL
+        if: always()
+        id: artifact_url
+        run: |
+          ARTIFACT_ID=""
+          for attempt in 1 2 3 4 5; do
+            sleep $((attempt * 2))
+            ARTIFACT_ID=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts \
+              --jq '[.artifacts[] | select(.name == "e2e-osac-${{ env.ENCLAVE_CLUSTER_NAME }}-${{ github.run_id }}")] | sort_by(.created_at) | last // empty | .id')
+            if [ -n "$ARTIFACT_ID" ]; then
+              break
+            fi
+          done
+
+          if [ -n "$ARTIFACT_ID" ]; then
+            ARTIFACT_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${ARTIFACT_ID}"
+            echo "ARTIFACT_URL=${ARTIFACT_URL}" >> $GITHUB_OUTPUT
+          else
+            echo "ARTIFACT_URL=" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Cleanup infrastructure
+        if: always() && (github.event_name != 'workflow_dispatch' || inputs.skip-cleanup != true)
+        run: |
+          echo "## Cleanup Infrastructure" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Removing infrastructure for cluster: $ENCLAVE_CLUSTER_NAME" >> $GITHUB_STEP_SUMMARY
+
+          mkdir -p cleanup-logs
+
+          set +e
+          make -f Makefile.ci clean 2>&1 | tee cleanup-logs/cleanup.log
+          CLEANUP_EXIT_CODE=$?
+          set -e
+
+          if grep -q "WARNING:" cleanup-logs/cleanup.log; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Cleanup completed with warnings:" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            grep "WARNING:" cleanup-logs/cleanup.log >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          elif [ $CLEANUP_EXIT_CODE -eq 0 ]; then
+            echo "Infrastructure cleaned up successfully" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "Cleanup completed with errors (exit code: $CLEANUP_EXIT_CODE)" >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Cleanup skipped notice
+        if: always() && github.event_name == 'workflow_dispatch' && inputs.skip-cleanup == true
+        run: |
+          echo "## Cleanup Skipped" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Infrastructure cleanup was skipped as requested." >> $GITHUB_STEP_SUMMARY
+          echo "**Cluster name**: $ENCLAVE_CLUSTER_NAME" >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload post-cleanup artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: post-cleanup-osac-${{ github.run_id }}
+          path: cleanup-logs/
+          retention-days: 7
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "---" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "## Deployment Summary" >> $GITHUB_STEP_SUMMARY
+          echo "- **Mode**: Connected" >> $GITHUB_STEP_SUMMARY
+          echo "- **Plugin**: osac" >> $GITHUB_STEP_SUMMARY
+          echo "- **Cluster**: $ENCLAVE_CLUSTER_NAME" >> $GITHUB_STEP_SUMMARY
+          echo "- **Branch**: ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Commit**: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Triggered by**: @${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Completed at**: $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_STEP_SUMMARY
+          echo "- **Status**: ${{ job.status }}" >> $GITHUB_STEP_SUMMARY
+
+      - name: Determine failed step
+        if: failure()
+        id: failed_step
+        env:
+          STEPS_JSON: ${{ toJSON(steps) }}
+        run: |
+          declare -A step_names=(
+            ["bootstrap_setup"]="Bootstrap: Setup environment"
+            ["bootstrap_validate"]="Bootstrap: Validate configuration"
+            ["bootstrap_download_content"]="Bootstrap: Download content"
+            ["bootstrap_build_cache"]="Bootstrap: Build local cache"
+            ["bootstrap_acquire_hardware"]="Bootstrap: Acquire hardware"
+            ["bootstrap_deploy"]="Bootstrap: Deploy cluster"
+            ["bootstrap_post_install"]="Bootstrap: Post-install"
+            ["bootstrap_operators"]="Bootstrap: Operators"
+            ["deploy_osac"]="Deploy OSAC plugin"
+            ["verify_cluster"]="Verify cluster deployment"
+          )
+
+          step_order=(
+            bootstrap_setup
+            bootstrap_validate
+            bootstrap_download_content
+            bootstrap_build_cache
+            bootstrap_acquire_hardware
+            bootstrap_deploy
+            bootstrap_post_install
+            bootstrap_operators
+            deploy_osac
+            verify_cluster
+          )
+
+          FAILED_STEP=""
+          for step_id in "${step_order[@]}"; do
+            outcome=$(printf '%s' "$STEPS_JSON" | jq -r --arg id "$step_id" '.[$id].outcome // "skipped"')
+            if [ "$outcome" == "failure" ]; then
+              FAILED_STEP="${step_names[$step_id]}"
+              break
+            fi
+          done
+
+          if [ -n "$FAILED_STEP" ]; then
+            echo "FAILED_STEP=$FAILED_STEP" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Notify Slack
+        if: always() && inputs.send-slack-notification == true
+        uses: ./.github/actions/notify-slack
+        with:
+          status: ${{ job.status }}
+          workflow-name: E2E OSAC Plugin
+          cluster-name: ${{ env.ENCLAVE_CLUSTER_NAME }}
+          slack-webhook-urls: ${{ secrets.SLACK_WEBHOOK_URLS }}
+          workflow-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          branch-name: ${{ github.ref_name }}
+          commit-sha: ${{ github.sha }}
+          failed-step: ${{ steps.failed_step.outputs.FAILED_STEP }}
+          artifact-url: ${{ steps.artifact_url.outputs.ARTIFACT_URL }}

--- a/plugins/osac/files/aap.yaml.j2
+++ b/plugins/osac/files/aap.yaml.j2
@@ -1,0 +1,19 @@
+---
+apiVersion: aap.ansible.com/v1alpha1
+kind: AnsibleAutomationPlatform
+metadata:
+  name: {{ osac_aap.name }}
+  namespace: {{ osac_aap.ns }}
+spec:
+  controller:
+    disabled: {{ osac_aap.controller_disabled }}
+  eda:
+    disabled: {{ osac_aap.eda_disabled }}
+  hub:
+    disabled: {{ osac_aap.hub_disabled }}
+  image_pull_policy: {{ osac_aap.image_pull_policy }}
+  lightspeed:
+    disabled: {{ osac_aap.lightspeed_disabled }}
+  no_log: {{ osac_aap.no_log }}
+  redis_mode: {{ osac_aap.redis_mode }}
+  route_tls_termination_mechanism: {{ osac_aap.route_tls_termination }}

--- a/plugins/osac/files/ca-issuer.yaml
+++ b/plugins/osac/files/ca-issuer.yaml
@@ -1,0 +1,50 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+# Self-signed issuer for creating the CA certificate
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: cert-manager
+spec:
+  selfSigned: {}
+
+---
+# CA Certificate that will be used by the ClusterIssuer
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: default-ca-cert
+  namespace: cert-manager
+spec:
+  isCA: true
+  commonName: default-ca
+  secretName: default-ca
+  privateKey:
+    algorithm: RSA
+    size: 4096
+  issuerRef:
+    name: selfsigned-issuer
+    kind: Issuer
+
+---
+# ClusterIssuer that uses the CA certificate
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: default-ca
+spec:
+  ca:
+    secretName: default-ca

--- a/plugins/osac/files/keycloak.yaml
+++ b/plugins/osac/files/keycloak.yaml
@@ -1,0 +1,3389 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: keycloak
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: keycloak-database
+  namespace: keycloak
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: keycloak-database
+  namespace: keycloak
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: keycloak-database
+  namespace: keycloak
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: keycloak-database
+subjects:
+- kind: ServiceAccount
+  name: keycloak-database
+  namespace: keycloak
+---
+apiVersion: v1
+data:
+  access.conf: |
+    #
+    # Copyright (c) 2025 Red Hat Inc.
+    #
+    # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+    # the License. You may obtain a copy of the License at
+    #
+    #   http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+    # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+    # specific language governing permissions and limitations under the License.
+    #
+
+    # This is needed by the scripts that setup the database.
+    local all all peer
+
+    # For any other user we only allow access with certificates.
+    hostssl all all 0.0.0.0/0 cert
+    hostssl all all ::0/0 cert
+kind: ConfigMap
+metadata:
+  name: keycloak-db-access-config-b88tb82fkh
+  namespace: keycloak
+---
+apiVersion: v1
+data:
+  server.conf: |
+    #
+    # Copyright (c) 2025 Red Hat Inc.
+    #
+    # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+    # the License. You may obtain a copy of the License at
+    #
+    #   http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+    # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+    # specific language governing permissions and limitations under the License.
+    #
+
+    # Enable TLS:
+    ssl = on
+    ssl_ca_file = '/secrets/cert/ca.crt'
+    ssl_cert_file = '/secrets/cert/tls.crt'
+    ssl_key_file = '/secrets/cert/tls.key'
+
+    # Use our custom access file:
+    hba_file = '/config/access/access.conf'
+kind: ConfigMap
+metadata:
+  name: keycloak-db-server-config-6mtfcgkhfc
+  namespace: keycloak
+---
+apiVersion: v1
+data:
+  set-passwords.sh: |
+    #!/bin/bash
+    set -e
+
+    echo "Waiting for Keycloak to be ready..."
+    until curl -k -s https://keycloak:443/realms/osac > /dev/null 2>&1; do
+      sleep 5
+    done
+    echo "Keycloak is ready!"
+
+    # Function to set password
+    set_password() {
+      local username=$1
+      local password=$2
+
+      # Get admin token
+      TOKEN=$(curl -k -s -X POST https://keycloak:443/realms/master/protocol/openid-connect/token \
+        -H 'Content-Type: application/x-www-form-urlencoded' \
+        -d 'grant_type=password' \
+        -d 'client_id=admin-cli' \
+        -d 'username=admin' \
+        -d 'password=admin' 2>/dev/null | grep -o '"access_token":"[^"]*"' | cut -d'"' -f4)
+
+      if [ -z "$TOKEN" ]; then
+        echo "Could not get admin token"
+        return 1
+      fi
+
+      # Get user ID
+      USER_ID=$(curl -k -s -X GET "https://keycloak:443/admin/realms/osac/users?username=$username" \
+        -H "Authorization: Bearer $TOKEN" 2>/dev/null | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+
+      if [ -z "$USER_ID" ]; then
+        echo "Could not find user: $username"
+        return 1
+      fi
+
+      # Set password
+      curl -k -s -X PUT "https://keycloak:443/admin/realms/osac/users/$USER_ID/reset-password" \
+        -H "Authorization: Bearer $TOKEN" \
+        -H "Content-Type: application/json" \
+        -d "{\"type\":\"password\",\"value\":\"$password\",\"temporary\":false}" 2>/dev/null
+
+      echo "✓ Set password for $username"
+    }
+
+    # Set all passwords
+    echo "Setting passwords for all tenant users..."
+    set_password "tenant1_admin" "foobar"
+    set_password "tenant1_user" "foobar"
+    set_password "tenant2_admin" "foobar"
+    set_password "tenant2_user" "foobar"
+    set_password "twotenant" "foobar"
+    set_password "my_user" "foobar"
+    set_password "your_user" "foobar"
+
+    echo "✓ All passwords set to 'foobar'"
+kind: ConfigMap
+metadata:
+  name: keycloak-password-setup
+  namespace: keycloak
+---
+apiVersion: v1
+data:
+  realm.json: |
+    {
+      "id": "01e6c34f-6906-4907-9cbd-2dec7a6a0e1d",
+      "realm": "osac",
+      "notBefore": 0,
+      "defaultSignatureAlgorithm": "RS256",
+      "revokeRefreshToken": false,
+      "refreshTokenMaxReuse": 0,
+      "accessTokenLifespan": 300,
+      "accessTokenLifespanForImplicitFlow": 900,
+      "ssoSessionIdleTimeout": 1800,
+      "ssoSessionMaxLifespan": 36000,
+      "ssoSessionIdleTimeoutRememberMe": 0,
+      "ssoSessionMaxLifespanRememberMe": 0,
+      "offlineSessionIdleTimeout": 2592000,
+      "offlineSessionMaxLifespanEnabled": false,
+      "offlineSessionMaxLifespan": 5184000,
+      "clientSessionIdleTimeout": 0,
+      "clientSessionMaxLifespan": 0,
+      "clientOfflineSessionIdleTimeout": 0,
+      "clientOfflineSessionMaxLifespan": 0,
+      "accessCodeLifespan": 60,
+      "accessCodeLifespanUserAction": 300,
+      "accessCodeLifespanLogin": 1800,
+      "actionTokenGeneratedByAdminLifespan": 43200,
+      "actionTokenGeneratedByUserLifespan": 300,
+      "oauth2DeviceCodeLifespan": 600,
+      "oauth2DevicePollingInterval": 5,
+      "enabled": true,
+      "sslRequired": "external",
+      "registrationAllowed": false,
+      "registrationEmailAsUsername": false,
+      "rememberMe": false,
+      "verifyEmail": false,
+      "loginWithEmailAllowed": true,
+      "duplicateEmailsAllowed": false,
+      "resetPasswordAllowed": false,
+      "editUsernameAllowed": false,
+      "bruteForceProtected": false,
+      "permanentLockout": false,
+      "maxTemporaryLockouts": 0,
+      "bruteForceStrategy": "MULTIPLE",
+      "maxFailureWaitSeconds": 900,
+      "minimumQuickLoginWaitSeconds": 60,
+      "waitIncrementSeconds": 60,
+      "quickLoginCheckMilliSeconds": 1000,
+      "maxDeltaTimeSeconds": 43200,
+      "failureFactor": 30,
+      "roles": {
+        "realm": [
+          {
+            "id": "ecc55bff-3667-427d-9326-764d76d99483",
+            "name": "uma_authorization",
+            "description": "${role_uma_authorization}",
+            "composite": false,
+            "clientRole": false,
+            "containerId": "01e6c34f-6906-4907-9cbd-2dec7a6a0e1d",
+            "attributes": {}
+          },
+          {
+            "id": "69723bdf-7a37-471a-ae8d-d8fda6d0d119",
+            "name": "default-roles-my realm",
+            "description": "${role_default-roles}",
+            "composite": true,
+            "composites": {
+              "realm": [
+                "offline_access",
+                "uma_authorization"
+              ],
+              "client": {
+                "account": [
+                  "view-profile",
+                  "manage-account"
+                ]
+              }
+            },
+            "clientRole": false,
+            "containerId": "01e6c34f-6906-4907-9cbd-2dec7a6a0e1d",
+            "attributes": {}
+          },
+          {
+            "id": "d0263b33-127a-41cc-a359-ce581f8f3fae",
+            "name": "offline_access",
+            "description": "${role_offline-access}",
+            "composite": false,
+            "clientRole": false,
+            "containerId": "01e6c34f-6906-4907-9cbd-2dec7a6a0e1d",
+            "attributes": {}
+          },
+          {
+            "id": "a1b2c3d4-e5f6-7890-abcd-900000000003",
+            "name": "tenant-admin",
+            "description": "Tenant administrator role with elevated privileges",
+            "composite": false,
+            "clientRole": false,
+            "containerId": "01e6c34f-6906-4907-9cbd-2dec7a6a0e1d",
+            "attributes": {}
+          }
+        ],
+        "client": {
+          "osac-cli": [],
+          "realm-management": [
+            {
+              "id": "6a539c7b-9c68-499a-8eaf-ac1f5cca678b",
+              "name": "query-groups",
+              "description": "${role_query-groups}",
+              "composite": false,
+              "clientRole": true,
+              "containerId": "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+              "attributes": {}
+            },
+            {
+              "id": "d57bf948-75ab-41a6-ba57-63acea7fec96",
+              "name": "view-identity-providers",
+              "description": "${role_view-identity-providers}",
+              "composite": false,
+              "clientRole": true,
+              "containerId": "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+              "attributes": {}
+            },
+            {
+              "id": "8fba07c4-f659-4ccc-8416-a6d6f64fa6da",
+              "name": "manage-clients",
+              "description": "${role_manage-clients}",
+              "composite": false,
+              "clientRole": true,
+              "containerId": "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+              "attributes": {}
+            },
+            {
+              "id": "c5dd177c-82a5-4cea-bbe2-2f434deeda5d",
+              "name": "query-clients",
+              "description": "${role_query-clients}",
+              "composite": false,
+              "clientRole": true,
+              "containerId": "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+              "attributes": {}
+            },
+            {
+              "id": "5b3da028-41c7-4c83-b310-276fe1eea7a0",
+              "name": "realm-admin",
+              "description": "${role_realm-admin}",
+              "composite": true,
+              "composites": {
+                "client": {
+                  "realm-management": [
+                    "query-groups",
+                    "view-identity-providers",
+                    "manage-clients",
+                    "query-clients",
+                    "view-users",
+                    "impersonation",
+                    "manage-identity-providers",
+                    "manage-realm",
+                    "view-clients",
+                    "view-realm",
+                    "manage-events",
+                    "query-users",
+                    "manage-users",
+                    "create-client",
+                    "view-events",
+                    "manage-authorization",
+                    "view-authorization",
+                    "query-realms"
+                  ]
+                }
+              },
+              "clientRole": true,
+              "containerId": "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+              "attributes": {}
+            },
+            {
+              "id": "ec2e4475-05c8-46c3-808a-9ed58d5da015",
+              "name": "view-users",
+              "description": "${role_view-users}",
+              "composite": true,
+              "composites": {
+                "client": {
+                  "realm-management": [
+                    "query-groups",
+                    "query-users"
+                  ]
+                }
+              },
+              "clientRole": true,
+              "containerId": "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+              "attributes": {}
+            },
+            {
+              "id": "7ad226c6-f4b8-43d8-a7fe-30eb2daf61cf",
+              "name": "impersonation",
+              "description": "${role_impersonation}",
+              "composite": false,
+              "clientRole": true,
+              "containerId": "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+              "attributes": {}
+            },
+            {
+              "id": "b2a448e4-7469-4153-93a6-dcc7136e2ce8",
+              "name": "manage-identity-providers",
+              "description": "${role_manage-identity-providers}",
+              "composite": false,
+              "clientRole": true,
+              "containerId": "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+              "attributes": {}
+            },
+            {
+              "id": "ffd09670-3d1c-4cef-b408-6f650a6a22b2",
+              "name": "manage-realm",
+              "description": "${role_manage-realm}",
+              "composite": false,
+              "clientRole": true,
+              "containerId": "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+              "attributes": {}
+            },
+            {
+              "id": "9ca3d3d0-caa6-400e-b92b-f3090ddc70cd",
+              "name": "view-clients",
+              "description": "${role_view-clients}",
+              "composite": true,
+              "composites": {
+                "client": {
+                  "realm-management": [
+                    "query-clients"
+                  ]
+                }
+              },
+              "clientRole": true,
+              "containerId": "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+              "attributes": {}
+            },
+            {
+              "id": "bc134dee-52ed-4a92-b62b-16a85f1dbfef",
+              "name": "view-realm",
+              "description": "${role_view-realm}",
+              "composite": false,
+              "clientRole": true,
+              "containerId": "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+              "attributes": {}
+            },
+            {
+              "id": "b75ba6a6-776a-4298-b5ab-e47b2b408e04",
+              "name": "manage-events",
+              "description": "${role_manage-events}",
+              "composite": false,
+              "clientRole": true,
+              "containerId": "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+              "attributes": {}
+            },
+            {
+              "id": "41b7023d-0655-48e7-a31c-75ecccf2a3b6",
+              "name": "query-users",
+              "description": "${role_query-users}",
+              "composite": false,
+              "clientRole": true,
+              "containerId": "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+              "attributes": {}
+            },
+            {
+              "id": "8a4b016a-cd38-4271-b720-61bc6d967fa5",
+              "name": "manage-users",
+              "description": "${role_manage-users}",
+              "composite": false,
+              "clientRole": true,
+              "containerId": "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+              "attributes": {}
+            },
+            {
+              "id": "9c4d75ea-79d4-45dd-80bd-61dea84fd76a",
+              "name": "create-client",
+              "description": "${role_create-client}",
+              "composite": false,
+              "clientRole": true,
+              "containerId": "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+              "attributes": {}
+            },
+            {
+              "id": "e741b0ab-9b92-4ebe-9857-1de46b319c22",
+              "name": "view-events",
+              "description": "${role_view-events}",
+              "composite": false,
+              "clientRole": true,
+              "containerId": "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+              "attributes": {}
+            },
+            {
+              "id": "88e94a65-6f07-47f9-b4a5-36b5b72035e5",
+              "name": "manage-authorization",
+              "description": "${role_manage-authorization}",
+              "composite": false,
+              "clientRole": true,
+              "containerId": "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+              "attributes": {}
+            },
+            {
+              "id": "f0821013-ddd9-4c28-b33d-6838e44f3226",
+              "name": "view-authorization",
+              "description": "${role_view-authorization}",
+              "composite": false,
+              "clientRole": true,
+              "containerId": "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+              "attributes": {}
+            },
+            {
+              "id": "ffb70418-70dd-4d19-9844-2c6c12457ad1",
+              "name": "query-realms",
+              "description": "${role_query-realms}",
+              "composite": false,
+              "clientRole": true,
+              "containerId": "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+              "attributes": {}
+            }
+          ],
+          "fulfillment-controller": [],
+          "security-admin-console": [],
+          "admin-cli": [],
+          "account-console": [],
+          "broker": [
+            {
+              "id": "ff5ec66c-ba91-41e7-b4de-b5ac0457878b",
+              "name": "read-token",
+              "description": "${role_read-token}",
+              "composite": false,
+              "clientRole": true,
+              "containerId": "0e320650-41a8-4561-a026-92042d5f771c",
+              "attributes": {}
+            }
+          ],
+          "account": [
+            {
+              "id": "6f85d323-e6dc-4887-992b-eb44369ce826",
+              "name": "view-profile",
+              "description": "${role_view-profile}",
+              "composite": false,
+              "clientRole": true,
+              "containerId": "23cad6d9-db0b-43b2-9d20-63e90b1b571e",
+              "attributes": {}
+            },
+            {
+              "id": "21936607-e253-41ba-bd6e-dae4cb8c3f93",
+              "name": "manage-account",
+              "description": "${role_manage-account}",
+              "composite": true,
+              "composites": {
+                "client": {
+                  "account": [
+                    "manage-account-links"
+                  ]
+                }
+              },
+              "clientRole": true,
+              "containerId": "23cad6d9-db0b-43b2-9d20-63e90b1b571e",
+              "attributes": {}
+            },
+            {
+              "id": "15ad3c02-23c5-4ae2-929d-ca3f428ff7b9",
+              "name": "manage-consent",
+              "description": "${role_manage-consent}",
+              "composite": true,
+              "composites": {
+                "client": {
+                  "account": [
+                    "view-consent"
+                  ]
+                }
+              },
+              "clientRole": true,
+              "containerId": "23cad6d9-db0b-43b2-9d20-63e90b1b571e",
+              "attributes": {}
+            },
+            {
+              "id": "0432dc1f-787f-4114-b4c7-53df771a3528",
+              "name": "manage-account-links",
+              "description": "${role_manage-account-links}",
+              "composite": false,
+              "clientRole": true,
+              "containerId": "23cad6d9-db0b-43b2-9d20-63e90b1b571e",
+              "attributes": {}
+            },
+            {
+              "id": "855a8b36-b62b-4575-9ea9-8c25b672704b",
+              "name": "view-consent",
+              "description": "${role_view-consent}",
+              "composite": false,
+              "clientRole": true,
+              "containerId": "23cad6d9-db0b-43b2-9d20-63e90b1b571e",
+              "attributes": {}
+            },
+            {
+              "id": "5437fb4f-bd17-47e5-9606-ccbe9c4601a5",
+              "name": "delete-account",
+              "description": "${role_delete-account}",
+              "composite": false,
+              "clientRole": true,
+              "containerId": "23cad6d9-db0b-43b2-9d20-63e90b1b571e",
+              "attributes": {}
+            },
+            {
+              "id": "a7dd623c-4dbe-411c-be95-b4d5ae77beb9",
+              "name": "view-applications",
+              "description": "${role_view-applications}",
+              "composite": false,
+              "clientRole": true,
+              "containerId": "23cad6d9-db0b-43b2-9d20-63e90b1b571e",
+              "attributes": {}
+            },
+            {
+              "id": "89fc823e-9b1d-45b6-8700-bf9c623dc9d6",
+              "name": "view-groups",
+              "description": "${role_view-groups}",
+              "composite": false,
+              "clientRole": true,
+              "containerId": "23cad6d9-db0b-43b2-9d20-63e90b1b571e",
+              "attributes": {}
+            }
+          ]
+        }
+      },
+      "groups": [
+        {
+          "id": "4a0a8896-3d83-4327-b472-61d6880e4643",
+          "name": "admins",
+          "path": "/admins",
+          "subGroups": [],
+          "attributes": {},
+          "realmRoles": [],
+          "clientRoles": {}
+        },
+        {
+          "id": "eb89cecb-39cc-4e20-adb3-8661d9ffd592",
+          "name": "my_group",
+          "path": "/my_group",
+          "subGroups": [],
+          "attributes": {},
+          "realmRoles": [],
+          "clientRoles": {}
+        },
+        {
+          "id": "54cc5f3e-7a2d-47ab-942e-16010f087b98",
+          "name": "your_group",
+          "path": "/your_group",
+          "subGroups": [],
+          "attributes": {},
+          "realmRoles": [],
+          "clientRoles": {}
+        },
+        {
+          "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+          "name": "tenant1",
+          "path": "/tenant1",
+          "subGroups": [],
+          "attributes": {},
+          "realmRoles": [],
+          "clientRoles": {}
+        },
+        {
+          "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+          "name": "tenant2",
+          "path": "/tenant2",
+          "subGroups": [],
+          "attributes": {},
+          "realmRoles": [],
+          "clientRoles": {}
+        }
+      ],
+      "defaultRole": {
+        "id": "69723bdf-7a37-471a-ae8d-d8fda6d0d119",
+        "name": "default-roles-my realm",
+        "description": "${role_default-roles}",
+        "composite": true,
+        "clientRole": false,
+        "containerId": "01e6c34f-6906-4907-9cbd-2dec7a6a0e1d"
+      },
+      "requiredCredentials": [
+        "password"
+      ],
+      "otpPolicyType": "totp",
+      "otpPolicyAlgorithm": "HmacSHA1",
+      "otpPolicyInitialCounter": 0,
+      "otpPolicyDigits": 6,
+      "otpPolicyLookAheadWindow": 1,
+      "otpPolicyPeriod": 30,
+      "otpPolicyCodeReusable": false,
+      "otpSupportedApplications": [
+        "totpAppFreeOTPName",
+        "totpAppGoogleName",
+        "totpAppMicrosoftAuthenticatorName"
+      ],
+      "localizationTexts": {},
+      "webAuthnPolicyRpEntityName": "keycloak",
+      "webAuthnPolicySignatureAlgorithms": [
+        "ES256",
+        "RS256"
+      ],
+      "webAuthnPolicyRpId": "",
+      "webAuthnPolicyAttestationConveyancePreference": "not specified",
+      "webAuthnPolicyAuthenticatorAttachment": "not specified",
+      "webAuthnPolicyRequireResidentKey": "not specified",
+      "webAuthnPolicyUserVerificationRequirement": "not specified",
+      "webAuthnPolicyCreateTimeout": 0,
+      "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
+      "webAuthnPolicyAcceptableAaguids": [],
+      "webAuthnPolicyExtraOrigins": [],
+      "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
+      "webAuthnPolicyPasswordlessSignatureAlgorithms": [
+        "ES256",
+        "RS256"
+      ],
+      "webAuthnPolicyPasswordlessRpId": "",
+      "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
+      "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
+      "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
+      "webAuthnPolicyPasswordlessUserVerificationRequirement": "not specified",
+      "webAuthnPolicyPasswordlessCreateTimeout": 0,
+      "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
+      "webAuthnPolicyPasswordlessAcceptableAaguids": [],
+      "webAuthnPolicyPasswordlessExtraOrigins": [],
+      "users": [
+        {
+          "id": "7aa83fea-6fcd-4167-a8cf-80ed4c3221b7",
+          "username": "admin",
+          "firstName": "Administrator",
+          "lastName": "User",
+          "email": "admin@example.com",
+          "emailVerified": true,
+          "enabled": true,
+          "createdTimestamp": 1757683803195,
+          "totp": false,
+          "credentials": [
+            {
+              "id": "85ac82fc-bbcc-49a0-a709-1ac82d9fb37f",
+              "type": "password",
+              "userLabel": "My password",
+              "createdDate": 1757683819334,
+              "secretData": "{\"value\":\"ETe90wgj32P+Q1rPLulfMazdek0nF+op9EFkdZllsnE=\",\"salt\":\"QhTSTs3ZpWedDP/H7S7UCg==\",\"additionalParameters\":{}}",
+              "credentialData": "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+            }
+          ],
+          "disableableCredentialTypes": [],
+          "requiredActions": [],
+          "realmRoles": [
+            "default-roles-my realm"
+          ],
+          "notBefore": 0,
+          "groups": [
+            "/admins"
+          ]
+        },
+        {
+          "id": "f81e5429-26ff-418e-bf67-c054e449e7b7",
+          "username": "my_user",
+          "firstName": "My",
+          "lastName": "User",
+          "email": "my_user@example.com",
+          "emailVerified": true,
+          "enabled": true,
+          "createdTimestamp": 1757683688569,
+          "totp": false,
+          "credentials": [],
+          "disableableCredentialTypes": [],
+          "requiredActions": [],
+          "realmRoles": [
+            "default-roles-my realm"
+          ],
+          "notBefore": 0,
+          "groups": [
+            "/my_group"
+          ]
+        },
+        {
+          "id": "bd0e8d6c-0095-4937-81a2-7f7c47caae59",
+          "username": "your_user",
+          "firstName": "Your",
+          "lastName": "User",
+          "email": "your_user@example.com",
+          "emailVerified": true,
+          "enabled": true,
+          "createdTimestamp": 1757683762187,
+          "totp": false,
+          "credentials": [],
+          "disableableCredentialTypes": [],
+          "requiredActions": [],
+          "realmRoles": [
+            "default-roles-my realm"
+          ],
+          "notBefore": 0,
+          "groups": [
+            "/your_group"
+          ]
+        },
+        {
+          "id": "c1d2e3f4-a5b6-7890-cdef-123456789012",
+          "username": "tenant1_admin",
+          "firstName": "Tenant1",
+          "lastName": "Admin",
+          "email": "tenant1_admin@example.com",
+          "emailVerified": true,
+          "enabled": true,
+          "createdTimestamp": 1757683900000,
+          "totp": false,
+          "credentials": [],
+          "disableableCredentialTypes": [],
+          "requiredActions": [],
+          "realmRoles": [
+            "default-roles-my realm",
+            "tenant-admin"
+          ],
+          "notBefore": 0,
+          "groups": [
+            "/tenant1"
+          ]
+        },
+        {
+          "id": "d2e3f4a5-b6c7-8901-def0-123456789013",
+          "username": "tenant1_user",
+          "firstName": "Tenant1",
+          "lastName": "User",
+          "email": "tenant1_user@example.com",
+          "emailVerified": true,
+          "enabled": true,
+          "createdTimestamp": 1757683910000,
+          "totp": false,
+          "credentials": [],
+          "disableableCredentialTypes": [],
+          "requiredActions": [],
+          "realmRoles": [
+            "default-roles-my realm"
+          ],
+          "notBefore": 0,
+          "groups": [
+            "/tenant1"
+          ]
+        },
+        {
+          "id": "e3f4a5b6-c7d8-9012-ef01-123456789014",
+          "username": "tenant2_admin",
+          "firstName": "Tenant2",
+          "lastName": "Admin",
+          "email": "tenant2_admin@example.com",
+          "emailVerified": true,
+          "enabled": true,
+          "createdTimestamp": 1757683920000,
+          "totp": false,
+          "credentials": [],
+          "disableableCredentialTypes": [],
+          "requiredActions": [],
+          "realmRoles": [
+            "default-roles-my realm",
+            "tenant-admin"
+          ],
+          "notBefore": 0,
+          "groups": [
+            "/tenant2"
+          ]
+        },
+        {
+          "id": "f4a5b6c7-d8e9-0123-f012-123456789015",
+          "username": "tenant2_user",
+          "firstName": "Tenant2",
+          "lastName": "User",
+          "email": "tenant2_user@example.com",
+          "emailVerified": true,
+          "enabled": true,
+          "createdTimestamp": 1757683930000,
+          "totp": false,
+          "credentials": [],
+          "disableableCredentialTypes": [],
+          "requiredActions": [],
+          "realmRoles": [
+            "default-roles-my realm"
+          ],
+          "notBefore": 0,
+          "groups": [
+            "/tenant2"
+          ]
+        },
+        {
+          "id": "a5b6c7d8-e9f0-1234-0123-123456789016",
+          "username": "twotenant",
+          "firstName": "Two",
+          "lastName": "Tenant",
+          "email": "twotenant@example.com",
+          "emailVerified": true,
+          "enabled": true,
+          "createdTimestamp": 1757683940000,
+          "totp": false,
+          "credentials": [],
+          "disableableCredentialTypes": [],
+          "requiredActions": [],
+          "realmRoles": [
+            "default-roles-my realm"
+          ],
+          "notBefore": 0,
+          "groups": [
+            "/tenant1",
+            "/tenant2"
+          ]
+        }
+      ],
+      "scopeMappings": [
+        {
+          "clientScope": "offline_access",
+          "roles": [
+            "offline_access"
+          ]
+        }
+      ],
+      "clientScopeMappings": {
+        "account": [
+          {
+            "client": "account-console",
+            "roles": [
+              "manage-account",
+              "view-groups"
+            ]
+          }
+        ]
+      },
+      "clients": [
+        {
+          "id": "23cad6d9-db0b-43b2-9d20-63e90b1b571e",
+          "clientId": "account",
+          "name": "${client_account}",
+          "rootUrl": "${authBaseUrl}",
+          "baseUrl": "/realms/My%20realm/account/",
+          "surrogateAuthRequired": false,
+          "enabled": true,
+          "alwaysDisplayInConsole": false,
+          "clientAuthenticatorType": "client-secret",
+          "redirectUris": [
+            "/realms/My%20realm/account/*"
+          ],
+          "webOrigins": [],
+          "notBefore": 0,
+          "bearerOnly": false,
+          "consentRequired": false,
+          "standardFlowEnabled": true,
+          "implicitFlowEnabled": false,
+          "directAccessGrantsEnabled": false,
+          "serviceAccountsEnabled": false,
+          "publicClient": true,
+          "frontchannelLogout": false,
+          "protocol": "openid-connect",
+          "attributes": {
+            "realm_client": "false",
+            "post.logout.redirect.uris": "+"
+          },
+          "authenticationFlowBindingOverrides": {},
+          "fullScopeAllowed": false,
+          "nodeReRegistrationTimeout": 0,
+          "defaultClientScopes": [
+            "web-origins",
+            "acr",
+            "profile",
+            "roles",
+            "basic",
+            "email"
+          ],
+          "optionalClientScopes": [
+            "address",
+            "phone",
+            "organization",
+            "offline_access",
+            "microprofile-jwt"
+          ]
+        },
+        {
+          "id": "b3b07783-b506-4df2-a928-305b2e339502",
+          "clientId": "account-console",
+          "name": "${client_account-console}",
+          "rootUrl": "${authBaseUrl}",
+          "baseUrl": "/realms/My%20realm/account/",
+          "surrogateAuthRequired": false,
+          "enabled": true,
+          "alwaysDisplayInConsole": false,
+          "clientAuthenticatorType": "client-secret",
+          "redirectUris": [
+            "/realms/My%20realm/account/*"
+          ],
+          "webOrigins": [],
+          "notBefore": 0,
+          "bearerOnly": false,
+          "consentRequired": false,
+          "standardFlowEnabled": true,
+          "implicitFlowEnabled": false,
+          "directAccessGrantsEnabled": false,
+          "serviceAccountsEnabled": false,
+          "publicClient": true,
+          "frontchannelLogout": false,
+          "protocol": "openid-connect",
+          "attributes": {
+            "realm_client": "false",
+            "post.logout.redirect.uris": "+",
+            "pkce.code.challenge.method": "S256"
+          },
+          "authenticationFlowBindingOverrides": {},
+          "fullScopeAllowed": false,
+          "nodeReRegistrationTimeout": 0,
+          "protocolMappers": [
+            {
+              "id": "690b8f4d-a61b-4a7b-a801-444323137349",
+              "name": "audience resolve",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-audience-resolve-mapper",
+              "consentRequired": false,
+              "config": {}
+            }
+          ],
+          "defaultClientScopes": [
+            "web-origins",
+            "acr",
+            "profile",
+            "roles",
+            "basic",
+            "email"
+          ],
+          "optionalClientScopes": [
+            "address",
+            "phone",
+            "organization",
+            "offline_access",
+            "microprofile-jwt"
+          ]
+        },
+        {
+          "id": "82884757-645c-45eb-a018-f2a7bdfdd554",
+          "clientId": "admin-cli",
+          "name": "${client_admin-cli}",
+          "surrogateAuthRequired": false,
+          "enabled": true,
+          "alwaysDisplayInConsole": false,
+          "clientAuthenticatorType": "client-secret",
+          "redirectUris": [],
+          "webOrigins": [],
+          "notBefore": 0,
+          "bearerOnly": false,
+          "consentRequired": false,
+          "standardFlowEnabled": false,
+          "implicitFlowEnabled": false,
+          "directAccessGrantsEnabled": true,
+          "serviceAccountsEnabled": false,
+          "publicClient": true,
+          "frontchannelLogout": false,
+          "protocol": "openid-connect",
+          "attributes": {
+            "realm_client": "false",
+            "client.use.lightweight.access.token.enabled": "true",
+            "post.logout.redirect.uris": "+"
+          },
+          "authenticationFlowBindingOverrides": {},
+          "fullScopeAllowed": true,
+          "nodeReRegistrationTimeout": 0,
+          "defaultClientScopes": [
+            "web-origins",
+            "acr",
+            "profile",
+            "roles",
+            "basic",
+            "email"
+          ],
+          "optionalClientScopes": [
+            "address",
+            "phone",
+            "organization",
+            "offline_access",
+            "microprofile-jwt"
+          ]
+        },
+        {
+          "id": "0e320650-41a8-4561-a026-92042d5f771c",
+          "clientId": "broker",
+          "name": "${client_broker}",
+          "surrogateAuthRequired": false,
+          "enabled": true,
+          "alwaysDisplayInConsole": false,
+          "clientAuthenticatorType": "client-secret",
+          "redirectUris": [],
+          "webOrigins": [],
+          "notBefore": 0,
+          "bearerOnly": true,
+          "consentRequired": false,
+          "standardFlowEnabled": true,
+          "implicitFlowEnabled": false,
+          "directAccessGrantsEnabled": false,
+          "serviceAccountsEnabled": false,
+          "publicClient": false,
+          "frontchannelLogout": false,
+          "protocol": "openid-connect",
+          "attributes": {
+            "realm_client": "true",
+            "post.logout.redirect.uris": "+"
+          },
+          "authenticationFlowBindingOverrides": {},
+          "fullScopeAllowed": false,
+          "nodeReRegistrationTimeout": 0,
+          "defaultClientScopes": [
+            "web-origins",
+            "acr",
+            "profile",
+            "roles",
+            "basic",
+            "email"
+          ],
+          "optionalClientScopes": [
+            "address",
+            "phone",
+            "organization",
+            "offline_access",
+            "microprofile-jwt"
+          ]
+        },
+        {
+          "id": "75d02386-879f-4a5f-880f-eb59f4b3f19c",
+          "clientId": "osac-cli",
+          "name": "OSAC CLI",
+          "description": "OSAC command line interface",
+          "rootUrl": "",
+          "adminUrl": "",
+          "baseUrl": "http://localhost",
+          "surrogateAuthRequired": false,
+          "enabled": true,
+          "alwaysDisplayInConsole": false,
+          "clientAuthenticatorType": "client-secret",
+          "redirectUris": [
+            "http://localhost"
+          ],
+          "webOrigins": [
+            "http://localhost"
+          ],
+          "notBefore": 0,
+          "bearerOnly": false,
+          "consentRequired": false,
+          "standardFlowEnabled": true,
+          "implicitFlowEnabled": false,
+          "directAccessGrantsEnabled": true,
+          "serviceAccountsEnabled": false,
+          "publicClient": true,
+          "frontchannelLogout": true,
+          "protocol": "openid-connect",
+          "attributes": {
+            "realm_client": "false",
+            "oidc.ciba.grant.enabled": "false",
+            "backchannel.logout.session.required": "true",
+            "standard.token.exchange.enabled": "false",
+            "post.logout.redirect.uris": "+",
+            "oauth2.device.authorization.grant.enabled": "true",
+            "pkce.code.challenge.method": "S256",
+            "backchannel.logout.revoke.offline.tokens": "false"
+          },
+          "authenticationFlowBindingOverrides": {},
+          "fullScopeAllowed": true,
+          "nodeReRegistrationTimeout": -1,
+          "defaultClientScopes": [
+            "groups",
+            "basic",
+            "username",
+            "roles"
+          ],
+          "optionalClientScopes": []
+        },
+        {
+          "id": "90e7d0e5-cac0-4de7-94cd-bcfe2cb1ae3c",
+          "clientId": "fulfillment-controller",
+          "name": "Fulfillment controller",
+          "description": "Fulfillment controller",
+          "rootUrl": "",
+          "adminUrl": "",
+          "baseUrl": "",
+          "surrogateAuthRequired": false,
+          "enabled": true,
+          "alwaysDisplayInConsole": false,
+          "clientAuthenticatorType": "client-secret",
+          "secret": "t2N7qNiOYZzt6InsHOVsV5AzcZZbA7Sg",
+          "redirectUris": [
+            "/*"
+          ],
+          "webOrigins": [
+            "/*"
+          ],
+          "notBefore": 0,
+          "bearerOnly": false,
+          "consentRequired": false,
+          "standardFlowEnabled": false,
+          "implicitFlowEnabled": false,
+          "directAccessGrantsEnabled": true,
+          "serviceAccountsEnabled": true,
+          "publicClient": false,
+          "frontchannelLogout": true,
+          "protocol": "openid-connect",
+          "attributes": {
+            "realm_client": "false",
+            "oidc.ciba.grant.enabled": "false",
+            "client.secret.creation.time": "1757684016",
+            "backchannel.logout.session.required": "true",
+            "standard.token.exchange.enabled": "false",
+            "post.logout.redirect.uris": "+",
+            "oauth2.device.authorization.grant.enabled": "false",
+            "backchannel.logout.revoke.offline.tokens": "false"
+          },
+          "authenticationFlowBindingOverrides": {},
+          "fullScopeAllowed": true,
+          "nodeReRegistrationTimeout": -1,
+          "defaultClientScopes": [
+            "web-origins",
+            "acr",
+            "profile",
+            "roles",
+            "basic",
+            "email"
+          ],
+          "optionalClientScopes": [
+            "address",
+            "phone",
+            "organization",
+            "offline_access",
+            "microprofile-jwt"
+          ]
+        },
+        {
+          "id": "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+          "clientId": "realm-management",
+          "name": "${client_realm-management}",
+          "surrogateAuthRequired": false,
+          "enabled": true,
+          "alwaysDisplayInConsole": false,
+          "clientAuthenticatorType": "client-secret",
+          "redirectUris": [],
+          "webOrigins": [],
+          "notBefore": 0,
+          "bearerOnly": true,
+          "consentRequired": false,
+          "standardFlowEnabled": true,
+          "implicitFlowEnabled": false,
+          "directAccessGrantsEnabled": false,
+          "serviceAccountsEnabled": false,
+          "publicClient": false,
+          "frontchannelLogout": false,
+          "protocol": "openid-connect",
+          "attributes": {
+            "realm_client": "true",
+            "post.logout.redirect.uris": "+"
+          },
+          "authenticationFlowBindingOverrides": {},
+          "fullScopeAllowed": false,
+          "nodeReRegistrationTimeout": 0,
+          "defaultClientScopes": [
+            "web-origins",
+            "acr",
+            "profile",
+            "roles",
+            "basic",
+            "email"
+          ],
+          "optionalClientScopes": [
+            "address",
+            "phone",
+            "organization",
+            "offline_access",
+            "microprofile-jwt"
+          ]
+        },
+        {
+          "id": "88d75990-993f-4c55-a166-67041a6b3377",
+          "clientId": "security-admin-console",
+          "name": "${client_security-admin-console}",
+          "rootUrl": "${authAdminUrl}",
+          "baseUrl": "/admin/My%20realm/console/",
+          "surrogateAuthRequired": false,
+          "enabled": true,
+          "alwaysDisplayInConsole": false,
+          "clientAuthenticatorType": "client-secret",
+          "redirectUris": [
+            "/admin/My%20realm/console/*"
+          ],
+          "webOrigins": [
+            "+"
+          ],
+          "notBefore": 0,
+          "bearerOnly": false,
+          "consentRequired": false,
+          "standardFlowEnabled": true,
+          "implicitFlowEnabled": false,
+          "directAccessGrantsEnabled": false,
+          "serviceAccountsEnabled": false,
+          "publicClient": true,
+          "frontchannelLogout": false,
+          "protocol": "openid-connect",
+          "attributes": {
+            "realm_client": "false",
+            "client.use.lightweight.access.token.enabled": "true",
+            "post.logout.redirect.uris": "+",
+            "pkce.code.challenge.method": "S256"
+          },
+          "authenticationFlowBindingOverrides": {},
+          "fullScopeAllowed": true,
+          "nodeReRegistrationTimeout": 0,
+          "protocolMappers": [
+            {
+              "id": "a7f78d53-a9a9-4323-92a2-d1744824e1ef",
+              "name": "locale",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usermodel-attribute-mapper",
+              "consentRequired": false,
+              "config": {
+                "introspection.token.claim": "true",
+                "userinfo.token.claim": "true",
+                "user.attribute": "locale",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "locale",
+                "jsonType.label": "String"
+              }
+            }
+          ],
+          "defaultClientScopes": [
+            "web-origins",
+            "acr",
+            "profile",
+            "roles",
+            "basic",
+            "email"
+          ],
+          "optionalClientScopes": [
+            "address",
+            "phone",
+            "organization",
+            "offline_access",
+            "microprofile-jwt"
+          ]
+        }
+      ],
+      "clientScopes": [
+        {
+          "id": "2d4feb76-fd87-46d5-9eca-b7471da62403",
+          "name": "service_account",
+          "description": "Specific scope for a client enabled for service accounts",
+          "protocol": "openid-connect",
+          "attributes": {
+            "include.in.token.scope": "false",
+            "display.on.consent.screen": "false"
+          },
+          "protocolMappers": [
+            {
+              "id": "3b28a355-d2f4-40b5-b89d-4e631d3cccd5",
+              "name": "Client IP Address",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usersessionmodel-note-mapper",
+              "consentRequired": false,
+              "config": {
+                "user.session.note": "clientAddress",
+                "introspection.token.claim": "true",
+                "userinfo.token.claim": "true",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "clientAddress",
+                "jsonType.label": "String"
+              }
+            },
+            {
+              "id": "5993f2c5-3230-4337-844d-e204f5177eaf",
+              "name": "Client ID",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usersessionmodel-note-mapper",
+              "consentRequired": false,
+              "config": {
+                "user.session.note": "client_id",
+                "introspection.token.claim": "true",
+                "userinfo.token.claim": "true",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "client_id",
+                "jsonType.label": "String"
+              }
+            },
+            {
+              "id": "f2a27232-2096-4e88-b5a8-46e9c276b937",
+              "name": "Client Host",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usersessionmodel-note-mapper",
+              "consentRequired": false,
+              "config": {
+                "user.session.note": "clientHost",
+                "introspection.token.claim": "true",
+                "userinfo.token.claim": "true",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "clientHost",
+                "jsonType.label": "String"
+              }
+            }
+          ]
+        },
+        {
+          "id": "031c6268-83a2-4445-90f3-3a773beb1077",
+          "name": "phone",
+          "description": "OpenID Connect built-in scope: phone",
+          "protocol": "openid-connect",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "consent.screen.text": "${phoneScopeConsentText}",
+            "display.on.consent.screen": "true"
+          },
+          "protocolMappers": [
+            {
+              "id": "f3291e1d-b1e9-4ca7-8d2a-7336f9b52e66",
+              "name": "phone number verified",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usermodel-attribute-mapper",
+              "consentRequired": false,
+              "config": {
+                "introspection.token.claim": "true",
+                "userinfo.token.claim": "true",
+                "user.attribute": "phoneNumberVerified",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "phone_number_verified",
+                "jsonType.label": "boolean"
+              }
+            },
+            {
+              "id": "99e7228a-c2a6-47ef-959b-38f759997452",
+              "name": "phone number",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usermodel-attribute-mapper",
+              "consentRequired": false,
+              "config": {
+                "introspection.token.claim": "true",
+                "userinfo.token.claim": "true",
+                "user.attribute": "phoneNumber",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "phone_number",
+                "jsonType.label": "String"
+              }
+            }
+          ]
+        },
+        {
+          "id": "f2837054-fef4-4bb7-aa8f-9d1e102388ea",
+          "name": "username",
+          "description": "User name",
+          "protocol": "openid-connect",
+          "attributes": {
+            "include.in.token.scope": "false",
+            "display.on.consent.screen": "true",
+            "gui.order": "",
+            "consent.screen.text": "User name"
+          },
+          "protocolMappers": [
+            {
+              "id": "08e9ffe6-ad5f-4e60-a1bf-c76f47aa2a21",
+              "name": "username",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usermodel-attribute-mapper",
+              "consentRequired": false,
+              "config": {
+                "aggregate.attrs": "false",
+                "introspection.token.claim": "true",
+                "multivalued": "false",
+                "userinfo.token.claim": "true",
+                "user.attribute": "username",
+                "id.token.claim": "true",
+                "lightweight.claim": "false",
+                "access.token.claim": "true",
+                "claim.name": "username",
+                "jsonType.label": "String"
+              }
+            }
+          ]
+        },
+        {
+          "id": "26c93a2a-6291-4ba0-bbfe-3821617c6713",
+          "name": "role_list",
+          "description": "SAML role list",
+          "protocol": "saml",
+          "attributes": {
+            "consent.screen.text": "${samlRoleListScopeConsentText}",
+            "display.on.consent.screen": "true"
+          },
+          "protocolMappers": [
+            {
+              "id": "d808154b-75f9-4310-93a1-4b385df0045a",
+              "name": "role list",
+              "protocol": "saml",
+              "protocolMapper": "saml-role-list-mapper",
+              "consentRequired": false,
+              "config": {
+                "single": "false",
+                "attribute.nameformat": "Basic",
+                "attribute.name": "Role"
+              }
+            }
+          ]
+        },
+        {
+          "id": "1c7c7b64-1801-4c15-9cbc-b60aaeec89bb",
+          "name": "organization",
+          "description": "Additional claims about the organization a subject belongs to",
+          "protocol": "openid-connect",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "consent.screen.text": "${organizationScopeConsentText}",
+            "display.on.consent.screen": "true"
+          },
+          "protocolMappers": [
+            {
+              "id": "bfbb0aab-8730-4488-b0f9-6be8ceede468",
+              "name": "organization",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-organization-membership-mapper",
+              "consentRequired": false,
+              "config": {
+                "introspection.token.claim": "true",
+                "multivalued": "true",
+                "userinfo.token.claim": "true",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "organization",
+                "jsonType.label": "String"
+              }
+            }
+          ]
+        },
+        {
+          "id": "ced65214-50b1-4c1b-9775-18fcbf5c27a6",
+          "name": "saml_organization",
+          "description": "Organization Membership",
+          "protocol": "saml",
+          "attributes": {
+            "display.on.consent.screen": "false"
+          },
+          "protocolMappers": [
+            {
+              "id": "865cc3fa-7e7c-4921-a059-e4cde1a485f2",
+              "name": "organization",
+              "protocol": "saml",
+              "protocolMapper": "saml-organization-membership-mapper",
+              "consentRequired": false,
+              "config": {}
+            }
+          ]
+        },
+        {
+          "id": "8e0c0caa-cc2c-46a8-b0a1-e6f4bc8d5564",
+          "name": "microprofile-jwt",
+          "description": "Microprofile - JWT built-in scope",
+          "protocol": "openid-connect",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "false"
+          },
+          "protocolMappers": [
+            {
+              "id": "bd8abc7c-6dcd-4d9b-bd3f-d35eb1971302",
+              "name": "upn",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usermodel-attribute-mapper",
+              "consentRequired": false,
+              "config": {
+                "introspection.token.claim": "true",
+                "userinfo.token.claim": "true",
+                "user.attribute": "username",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "upn",
+                "jsonType.label": "String"
+              }
+            },
+            {
+              "id": "06afb588-d617-4795-ba94-48f944db6eef",
+              "name": "groups",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usermodel-realm-role-mapper",
+              "consentRequired": false,
+              "config": {
+                "introspection.token.claim": "true",
+                "multivalued": "true",
+                "userinfo.token.claim": "true",
+                "user.attribute": "foo",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "groups",
+                "jsonType.label": "String"
+              }
+            }
+          ]
+        },
+        {
+          "id": "1b4c4f6d-3fb6-4fe5-8220-e508f5b92cb5",
+          "name": "offline_access",
+          "description": "OpenID Connect built-in scope: offline_access",
+          "protocol": "openid-connect",
+          "attributes": {
+            "consent.screen.text": "${offlineAccessScopeConsentText}",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "id": "3b2c7544-9751-4cc5-999a-02d291bcc336",
+          "name": "acr",
+          "description": "OpenID Connect scope for add acr (authentication context class reference) to the token",
+          "protocol": "openid-connect",
+          "attributes": {
+            "include.in.token.scope": "false",
+            "display.on.consent.screen": "false"
+          },
+          "protocolMappers": [
+            {
+              "id": "7a9ad13d-ff78-4535-9e2c-b68ad155d94f",
+              "name": "acr loa level",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-acr-mapper",
+              "consentRequired": false,
+              "config": {
+                "id.token.claim": "true",
+                "introspection.token.claim": "true",
+                "access.token.claim": "true",
+                "userinfo.token.claim": "true"
+              }
+            }
+          ]
+        },
+        {
+          "id": "d5232a06-84cb-4d4a-9676-33968d98eecc",
+          "name": "roles",
+          "description": "OpenID Connect scope for add user roles to the access token",
+          "protocol": "openid-connect",
+          "attributes": {
+            "include.in.token.scope": "false",
+            "consent.screen.text": "${rolesScopeConsentText}",
+            "display.on.consent.screen": "true"
+          },
+          "protocolMappers": [
+            {
+              "id": "00224eba-ca73-4459-b2dc-f82334ce9b03",
+              "name": "realm roles",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usermodel-realm-role-mapper",
+              "consentRequired": false,
+              "config": {
+                "user.attribute": "foo",
+                "introspection.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "realm_access.roles",
+                "jsonType.label": "String",
+                "multivalued": "true"
+              }
+            },
+            {
+              "id": "5fb5d5c5-26eb-4faa-9bb0-be1401592078",
+              "name": "client roles",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usermodel-client-role-mapper",
+              "consentRequired": false,
+              "config": {
+                "user.attribute": "foo",
+                "introspection.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "resource_access.${client_id}.roles",
+                "jsonType.label": "String",
+                "multivalued": "true"
+              }
+            },
+            {
+              "id": "9e768141-a8df-4415-b26d-f41883612650",
+              "name": "audience resolve",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-audience-resolve-mapper",
+              "consentRequired": false,
+              "config": {
+                "introspection.token.claim": "true",
+                "access.token.claim": "true"
+              }
+            }
+          ]
+        },
+        {
+          "id": "0f46869e-5a98-4ab0-92c7-2cf3f46318c1",
+          "name": "web-origins",
+          "description": "OpenID Connect scope for add allowed web origins to the access token",
+          "protocol": "openid-connect",
+          "attributes": {
+            "include.in.token.scope": "false",
+            "consent.screen.text": "",
+            "display.on.consent.screen": "false"
+          },
+          "protocolMappers": [
+            {
+              "id": "9e455861-2c3c-457b-8a6d-6454e69122d6",
+              "name": "allowed web origins",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-allowed-origins-mapper",
+              "consentRequired": false,
+              "config": {
+                "introspection.token.claim": "true",
+                "access.token.claim": "true"
+              }
+            }
+          ]
+        },
+        {
+          "id": "4a8ef1f3-6531-415f-8972-a52eed55d837",
+          "name": "basic",
+          "description": "OpenID Connect scope for add all basic claims to the token",
+          "protocol": "openid-connect",
+          "attributes": {
+            "include.in.token.scope": "false",
+            "display.on.consent.screen": "false"
+          },
+          "protocolMappers": [
+            {
+              "id": "f64a29f0-28c0-43f1-a9ee-7513ecb22476",
+              "name": "auth_time",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usersessionmodel-note-mapper",
+              "consentRequired": false,
+              "config": {
+                "user.session.note": "AUTH_TIME",
+                "introspection.token.claim": "true",
+                "userinfo.token.claim": "true",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "auth_time",
+                "jsonType.label": "long"
+              }
+            },
+            {
+              "id": "f20a3a6a-6451-4715-b3f1-07c38f5d616f",
+              "name": "sub",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-sub-mapper",
+              "consentRequired": false,
+              "config": {
+                "introspection.token.claim": "true",
+                "access.token.claim": "true"
+              }
+            }
+          ]
+        },
+        {
+          "id": "cd025712-64b4-4221-8b27-e18c1a452ddb",
+          "name": "email",
+          "description": "OpenID Connect built-in scope: email",
+          "protocol": "openid-connect",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "consent.screen.text": "${emailScopeConsentText}",
+            "display.on.consent.screen": "true"
+          },
+          "protocolMappers": [
+            {
+              "id": "6c7fcd01-f651-444f-af02-f78339124c32",
+              "name": "email",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usermodel-attribute-mapper",
+              "consentRequired": false,
+              "config": {
+                "introspection.token.claim": "true",
+                "userinfo.token.claim": "true",
+                "user.attribute": "email",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "email",
+                "jsonType.label": "String"
+              }
+            },
+            {
+              "id": "7e9ef7ff-21a4-4e21-9f69-d6a56a210bc7",
+              "name": "email verified",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usermodel-property-mapper",
+              "consentRequired": false,
+              "config": {
+                "introspection.token.claim": "true",
+                "userinfo.token.claim": "true",
+                "user.attribute": "emailVerified",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "email_verified",
+                "jsonType.label": "boolean"
+              }
+            }
+          ]
+        },
+        {
+          "id": "21cbca22-12c1-4269-ad95-38b6117f8ef2",
+          "name": "profile",
+          "description": "OpenID Connect built-in scope: profile",
+          "protocol": "openid-connect",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "consent.screen.text": "${profileScopeConsentText}",
+            "display.on.consent.screen": "true"
+          },
+          "protocolMappers": [
+            {
+              "id": "05afc1ea-8386-42de-abb3-5221f87f29bd",
+              "name": "locale",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usermodel-attribute-mapper",
+              "consentRequired": false,
+              "config": {
+                "introspection.token.claim": "true",
+                "userinfo.token.claim": "true",
+                "user.attribute": "locale",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "locale",
+                "jsonType.label": "String"
+              }
+            },
+            {
+              "id": "d9e0bd40-7150-45df-ae8d-99d37085c702",
+              "name": "updated at",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usermodel-attribute-mapper",
+              "consentRequired": false,
+              "config": {
+                "introspection.token.claim": "true",
+                "userinfo.token.claim": "true",
+                "user.attribute": "updatedAt",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "updated_at",
+                "jsonType.label": "long"
+              }
+            },
+            {
+              "id": "2d0ede4e-a15d-4fcf-b5e8-6b463cecbe64",
+              "name": "full name",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-full-name-mapper",
+              "consentRequired": false,
+              "config": {
+                "id.token.claim": "true",
+                "introspection.token.claim": "true",
+                "access.token.claim": "true",
+                "userinfo.token.claim": "true"
+              }
+            },
+            {
+              "id": "0ed542d4-bcc8-41be-911f-29d946549b41",
+              "name": "username",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usermodel-attribute-mapper",
+              "consentRequired": false,
+              "config": {
+                "aggregate.attrs": "false",
+                "introspection.token.claim": "true",
+                "multivalued": "false",
+                "userinfo.token.claim": "true",
+                "user.attribute": "username",
+                "id.token.claim": "true",
+                "lightweight.claim": "false",
+                "access.token.claim": "true",
+                "claim.name": "username",
+                "jsonType.label": "String"
+              }
+            },
+            {
+              "id": "9a7b4f77-0dd1-4392-96e6-a8ac2c436d9f",
+              "name": "middle name",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usermodel-attribute-mapper",
+              "consentRequired": false,
+              "config": {
+                "introspection.token.claim": "true",
+                "userinfo.token.claim": "true",
+                "user.attribute": "middleName",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "middle_name",
+                "jsonType.label": "String"
+              }
+            },
+            {
+              "id": "bc285e5b-34e5-4788-939b-a08aef53197b",
+              "name": "picture",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usermodel-attribute-mapper",
+              "consentRequired": false,
+              "config": {
+                "introspection.token.claim": "true",
+                "userinfo.token.claim": "true",
+                "user.attribute": "picture",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "picture",
+                "jsonType.label": "String"
+              }
+            },
+            {
+              "id": "5294a6a5-7652-4335-9065-074c69f28aa5",
+              "name": "profile",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usermodel-attribute-mapper",
+              "consentRequired": false,
+              "config": {
+                "introspection.token.claim": "true",
+                "userinfo.token.claim": "true",
+                "user.attribute": "profile",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "profile",
+                "jsonType.label": "String"
+              }
+            },
+            {
+              "id": "4d7419cd-b239-4c60-a301-9a6605a47b67",
+              "name": "zoneinfo",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usermodel-attribute-mapper",
+              "consentRequired": false,
+              "config": {
+                "introspection.token.claim": "true",
+                "userinfo.token.claim": "true",
+                "user.attribute": "zoneinfo",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "zoneinfo",
+                "jsonType.label": "String"
+              }
+            },
+            {
+              "id": "a69b3a4b-f4e7-4794-a3a5-dd81ff004def",
+              "name": "website",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usermodel-attribute-mapper",
+              "consentRequired": false,
+              "config": {
+                "introspection.token.claim": "true",
+                "userinfo.token.claim": "true",
+                "user.attribute": "website",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "website",
+                "jsonType.label": "String"
+              }
+            },
+            {
+              "id": "b4ff110f-b1a9-4780-a07d-96778c059410",
+              "name": "gender",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usermodel-attribute-mapper",
+              "consentRequired": false,
+              "config": {
+                "introspection.token.claim": "true",
+                "userinfo.token.claim": "true",
+                "user.attribute": "gender",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "gender",
+                "jsonType.label": "String"
+              }
+            },
+            {
+              "id": "39f120f3-f06c-4b69-bf4f-b6caec540830",
+              "name": "family name",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usermodel-attribute-mapper",
+              "consentRequired": false,
+              "config": {
+                "introspection.token.claim": "true",
+                "userinfo.token.claim": "true",
+                "user.attribute": "lastName",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "family_name",
+                "jsonType.label": "String"
+              }
+            },
+            {
+              "id": "886679e1-205d-4836-a2a4-d05d6a693d0d",
+              "name": "birthdate",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usermodel-attribute-mapper",
+              "consentRequired": false,
+              "config": {
+                "introspection.token.claim": "true",
+                "userinfo.token.claim": "true",
+                "user.attribute": "birthdate",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "birthdate",
+                "jsonType.label": "String"
+              }
+            },
+            {
+              "id": "ee282633-004f-44d0-915d-f28879e29cca",
+              "name": "nickname",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usermodel-attribute-mapper",
+              "consentRequired": false,
+              "config": {
+                "introspection.token.claim": "true",
+                "userinfo.token.claim": "true",
+                "user.attribute": "nickname",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "nickname",
+                "jsonType.label": "String"
+              }
+            },
+            {
+              "id": "3c7db46b-84bb-45ec-991d-d4105e56bd9c",
+              "name": "given name",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usermodel-attribute-mapper",
+              "consentRequired": false,
+              "config": {
+                "introspection.token.claim": "true",
+                "userinfo.token.claim": "true",
+                "user.attribute": "firstName",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "given_name",
+                "jsonType.label": "String"
+              }
+            }
+          ]
+        },
+        {
+          "id": "94b64289-42ae-4880-9e6a-e1eac6423a0d",
+          "name": "groups",
+          "description": "List of groups of the user",
+          "protocol": "openid-connect",
+          "attributes": {
+            "include.in.token.scope": "false",
+            "display.on.consent.screen": "true",
+            "gui.order": "",
+            "consent.screen.text": "List of groups"
+          },
+          "protocolMappers": [
+            {
+              "id": "9f1d5d83-5e0d-4718-9dde-1befbbf1a545",
+              "name": "groups",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-group-membership-mapper",
+              "consentRequired": false,
+              "config": {
+                "full.path": "false",
+                "introspection.token.claim": "true",
+                "multivalued": "true",
+                "userinfo.token.claim": "true",
+                "id.token.claim": "true",
+                "lightweight.claim": "false",
+                "access.token.claim": "true",
+                "claim.name": "groups"
+              }
+            }
+          ]
+        },
+        {
+          "id": "c20c7864-23e4-4866-8a2c-889d0a55c568",
+          "name": "address",
+          "description": "OpenID Connect built-in scope: address",
+          "protocol": "openid-connect",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "consent.screen.text": "${addressScopeConsentText}",
+            "display.on.consent.screen": "true"
+          },
+          "protocolMappers": [
+            {
+              "id": "67294e3e-594e-4b55-9fd3-1e42bcaf539c",
+              "name": "address",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-address-mapper",
+              "consentRequired": false,
+              "config": {
+                "user.attribute.formatted": "formatted",
+                "user.attribute.country": "country",
+                "introspection.token.claim": "true",
+                "user.attribute.postal_code": "postal_code",
+                "userinfo.token.claim": "true",
+                "user.attribute.street": "street",
+                "id.token.claim": "true",
+                "user.attribute.region": "region",
+                "access.token.claim": "true",
+                "user.attribute.locality": "locality"
+              }
+            }
+          ]
+        }
+      ],
+      "defaultDefaultClientScopes": [
+        "role_list",
+        "saml_organization",
+        "profile",
+        "email",
+        "roles",
+        "web-origins",
+        "acr",
+        "basic",
+        "groups",
+        "username"
+      ],
+      "defaultOptionalClientScopes": [
+        "offline_access",
+        "address",
+        "phone",
+        "microprofile-jwt",
+        "organization"
+      ],
+      "browserSecurityHeaders": {
+        "contentSecurityPolicyReportOnly": "",
+        "xContentTypeOptions": "nosniff",
+        "referrerPolicy": "no-referrer",
+        "xRobotsTag": "none",
+        "xFrameOptions": "SAMEORIGIN",
+        "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+        "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+      },
+      "smtpServer": {},
+      "eventsEnabled": false,
+      "eventsListeners": [
+        "jboss-logging"
+      ],
+      "enabledEventTypes": [],
+      "adminEventsEnabled": false,
+      "adminEventsDetailsEnabled": false,
+      "identityProviders": [],
+      "identityProviderMappers": [],
+      "components": {
+        "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
+          {
+            "id": "ea92b85a-adc1-4876-a642-064a1828a57a",
+            "name": "Allowed Protocol Mapper Types",
+            "providerId": "allowed-protocol-mappers",
+            "subType": "authenticated",
+            "subComponents": {},
+            "config": {
+              "allowed-protocol-mapper-types": [
+                "saml-user-property-mapper",
+                "oidc-usermodel-property-mapper",
+                "oidc-full-name-mapper",
+                "oidc-usermodel-attribute-mapper",
+                "oidc-sha256-pairwise-sub-mapper",
+                "saml-role-list-mapper",
+                "oidc-address-mapper",
+                "saml-user-attribute-mapper"
+              ]
+            }
+          },
+          {
+            "id": "3f236ec1-309c-48fb-96cd-08c03ae45271",
+            "name": "Allowed Protocol Mapper Types",
+            "providerId": "allowed-protocol-mappers",
+            "subType": "anonymous",
+            "subComponents": {},
+            "config": {
+              "allowed-protocol-mapper-types": [
+                "saml-user-property-mapper",
+                "oidc-address-mapper",
+                "oidc-usermodel-property-mapper",
+                "oidc-usermodel-attribute-mapper",
+                "saml-user-attribute-mapper",
+                "saml-role-list-mapper",
+                "oidc-full-name-mapper",
+                "oidc-sha256-pairwise-sub-mapper"
+              ]
+            }
+          },
+          {
+            "id": "5f50bd47-344d-48f8-b2b3-ee4128dde1cc",
+            "name": "Full Scope Disabled",
+            "providerId": "scope",
+            "subType": "anonymous",
+            "subComponents": {},
+            "config": {}
+          },
+          {
+            "id": "043cceff-34b8-4773-ac85-6ede7790ac35",
+            "name": "Allowed Client Scopes",
+            "providerId": "allowed-client-templates",
+            "subType": "anonymous",
+            "subComponents": {},
+            "config": {
+              "allow-default-scopes": [
+                "true"
+              ]
+            }
+          },
+          {
+            "id": "9426b168-c499-41c8-b83c-b8fb05e3ba71",
+            "name": "Allowed Client Scopes",
+            "providerId": "allowed-client-templates",
+            "subType": "authenticated",
+            "subComponents": {},
+            "config": {
+              "allow-default-scopes": [
+                "true"
+              ]
+            }
+          },
+          {
+            "id": "98212f83-0629-4a54-b8a8-8a209a406094",
+            "name": "Trusted Hosts",
+            "providerId": "trusted-hosts",
+            "subType": "anonymous",
+            "subComponents": {},
+            "config": {
+              "host-sending-registration-request-must-match": [
+                "true"
+              ],
+              "client-uris-must-match": [
+                "true"
+              ]
+            }
+          },
+          {
+            "id": "2bd57be1-f269-4340-bf87-e9b07240097c",
+            "name": "Consent Required",
+            "providerId": "consent-required",
+            "subType": "anonymous",
+            "subComponents": {},
+            "config": {}
+          },
+          {
+            "id": "0d34872b-1a14-442a-8b3c-eea811b9853e",
+            "name": "Max Clients Limit",
+            "providerId": "max-clients",
+            "subType": "anonymous",
+            "subComponents": {},
+            "config": {
+              "max-clients": [
+                "200"
+              ]
+            }
+          }
+        ],
+        "org.keycloak.keys.KeyProvider": [
+          {
+            "id": "bc4fe42f-0ee1-4884-9ba5-df5dfd7f8f40",
+            "name": "hmac-generated-hs512",
+            "providerId": "hmac-generated",
+            "subComponents": {},
+            "config": {
+              "kid": [
+                "513d15f5-06ec-4a5b-b60c-be0150e08772"
+              ],
+              "secret": [
+                "aJUl8piIHK_97LD9LbkCSVQdKundPvfxlCE3HfUOABgo2AO5RNPcPrhtWbatKJdn_8zTlssAvbgOGc3JK1nioGgJC4CEEGST5eB6zW0c5c_QV_Da5YnUNND8x1xx5QA5V_B_gemD3vNM2ETgrF2cAuww8RFxFz5Wj8JLH5RTCJw"
+              ],
+              "priority": [
+                "100"
+              ],
+              "algorithm": [
+                "HS512"
+              ]
+            }
+          },
+          {
+            "id": "b40479fb-88db-4c4c-9c0a-cf6cf0c402b3",
+            "name": "aes-generated",
+            "providerId": "aes-generated",
+            "subComponents": {},
+            "config": {
+              "kid": [
+                "a7dd0fed-b89b-4c8a-8d23-a0f49c41360e"
+              ],
+              "secret": [
+                "1mm6DQuQwmXRWssonexIrQ"
+              ],
+              "priority": [
+                "100"
+              ]
+            }
+          },
+          {
+            "id": "7565d549-7fb3-4165-a55c-b9a48688b379",
+            "name": "rsa-enc-generated",
+            "providerId": "rsa-enc-generated",
+            "subComponents": {},
+            "config": {
+              "privateKey": [
+                "MIIEogIBAAKCAQEA3GbyIS5fpV/NQsruZIrQfDtQl6SBt0k3C+zCn45L/O/Pyn/ikY9EelFnL+9jVsXp1j8CxTgOBNdGRdad0WvwjZOaer1oxM6R7ZvkqHsjctdesz+RYgZRraGVEMgvrnO+JD8jvuiY+91j5F1ieWJIjX28ck990DSNauZxH5A0Ik3imYoZ+PRj5fkkocxzUwrftST17lEfykxsHYEJb9Tpx7LRT6qW2qZgLXWBZSa1oNT6Z1zi5DbrGaiBdRgxE/adSWdAPgy+Eq4ZjjRBUIP90cZB7POGPPE5nWjlHnAQk1tv/o4kELNhPz3FZ/08eG4an6iaPjOUonAdP+F7cwDBtwIDAQABAoH/KNDnwGvhvvitc0hnUfF6ZM0i5X36WTFBgHPYIrRDGHF/WyPfaM+fXtkRfSCGln+cCJEuWuNAzKS0O/TriuiVUlzgeQkPDHqpLpHTGBqegZpg46KQm1x48l1LjzjJPqhH350XmNp6YxMFj627mnlHmUl1kPub/6Fevad7BcYXhHEEPQDyGEtb9uGgyRfeZ7aP+gSICHShMAkwC1K5oNDVN+wSsOHCzgqbEd1hYlx0aAfhY1SfyOf+Cbs6SnTZ5H6kxQb2kR+2/9J5YOWbJjvQVAv9qSpw2MwVf9J/gZrK3jgwoP/jfd2Q/0+yelsPrgBTn/+PhglulyF8yF/5KfPhAoGBAPy6xuSO3fnCq0YLl6HEzrkW8tDZO6mIGloF2Okp9Fbf5eu2WlW1jwTiLHl0T4UFtdmqbBf6HEaFhxz+aw5zGEyWPDhqAtOGxO+BFQyNv6ifNrElVJpBDlQvyvX8/UmZTcTQxWMqwMn54kvKKy1oSSEY1i6YYeWfZDMd/RLIVTdXAoGBAN9BE7QF4Gsx9YArtw2y2uJXUgJyLZ55gkS2ZtsTGEE7l8eI3eQYKvvzky3eHAxO3cNqjwobhSSC9/MxcrBUYqkbDQ5wKcaJgICXg25vsKaYrrtZD4YOPJyl1uRGcmQ1odmmgH9pXI4xpUksoT+3M2v1e0RCIfBZmGFlJsT9iiyhAoGBAO7+Vc2XyRRCYiM4HSluaqsfp3mWpFP6kCjndKtx8E0jKFNSO3Tn35qXo8UrF3PM5Z40CkpWS9zoss/ZTDX641SxkbsrjQapYJy47cXUWhVEkrzMd4fz03ALThx3JLMv1Ro07ySLLosR0k0nntMu1lEFIq4njhROObwZNNRJPES7AoGBAKzDNFccMRVi3MMpkQdVv9Jllj30U18OUoOPzzp6pUtdrU+ol2U6WpEMZXmaJoRTx4LAhB5jO34Mp4mXW1QeiRapq0nf/EP6Ben81aVxYvcYsiaifcPUYo0qPIf8B+uKIUxHb6qpQwl6W5iro8ClqXJCzff9YTwYaTX9S6onNXThAoGAWonGqH4AuHkb+fDGLNfeUKLB8UxK3IznFyEohfp7W7htYAa9HH/11P+pBbn7iVR4qcSBHCZ4qL1dENmmZNrQk5TKRaM0b+mOBRMgEjpYYXCSud07W1IQlu8KRBcqDKO9zEZGJa4LGtCiA48R9KUimWtUW0ld0JNJH+2jC1P8Q3k="
+              ],
+              "keyUse": [
+                "ENC"
+              ],
+              "certificate": [
+                "MIICnzCCAYcCBgGZPhwHiDANBgkqhkiG9w0BAQsFADATMREwDwYDVQQDDAhNeSByZWFsbTAeFw0yNTA5MTIxMzI1NDhaFw0zNTA5MTIxMzI3MjhaMBMxETAPBgNVBAMMCE15IHJlYWxtMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3GbyIS5fpV/NQsruZIrQfDtQl6SBt0k3C+zCn45L/O/Pyn/ikY9EelFnL+9jVsXp1j8CxTgOBNdGRdad0WvwjZOaer1oxM6R7ZvkqHsjctdesz+RYgZRraGVEMgvrnO+JD8jvuiY+91j5F1ieWJIjX28ck990DSNauZxH5A0Ik3imYoZ+PRj5fkkocxzUwrftST17lEfykxsHYEJb9Tpx7LRT6qW2qZgLXWBZSa1oNT6Z1zi5DbrGaiBdRgxE/adSWdAPgy+Eq4ZjjRBUIP90cZB7POGPPE5nWjlHnAQk1tv/o4kELNhPz3FZ/08eG4an6iaPjOUonAdP+F7cwDBtwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBdML7IQdmKK/MDXqI0pc5XD/+gYFzQL+AzHpZQjCngfqBD4SNqK2DWW9/v9gFxwdxVd6O5VQjr9xi7RFgxk7g5GBYc3bm/PZWPmStTDADAQ+zm4N1dwapnvr7r6q7MBkZK1isegRGaxzn7tm2o7GMIQMjb2lsVsApj9oReCYCZlUsaSnJj7l98FBe93Cp0S9bQPPlI3t6MwnZfxMGANyJWb7nX6ghYkN9QnhnHu8UENcuZgCP2WuBOiacHFmBRTzYcybx2JCciOdlx9TzLh+amcD4erJZWwblEF7F4kL/SKe4tThV4eZ4dn740cTS8KPycWpM0+bi7XN22lgD+cM1h"
+              ],
+              "priority": [
+                "100"
+              ],
+              "algorithm": [
+                "RSA-OAEP"
+              ]
+            }
+          },
+          {
+            "id": "ea153e2b-b510-4f1b-a996-3ded2268213b",
+            "name": "rsa-generated",
+            "providerId": "rsa-generated",
+            "subComponents": {},
+            "config": {
+              "privateKey": [
+                "MIIEoQIBAAKCAQEA1ItS1Phk91AWxXW88NiO1vL7juMBmIArT0RuJWb7F/HIHJAokeYoxPEjlqfoNtIR++G7N02RbQGr7SYdbZqiAcO52Yu3VMVilyshjCHn4f4yXnLQUZhLFRiDn9k2ctiCkfCzTMX0y+NYlic2vLM3pn0PxCYfavyMB/szRM13YBI7lXjajvfkyxdC8oLipE+WyMJ4IIbi1r94lR9N1Q/XpYffjtcb+ChO2R7ByO6sL7crq4MmvjpyvqqiPGG+huuMCjYezf2iibiJF1HsfFxqzElPYbzxGGyIOaWmnyNBMUNgi5D6ZO5UVmVZP9mBujAg6DrtFsVT8LB2uPTI3tzNGQIDAQABAoH/F8ZQ+kl94lSUN3/+JeC+Ipc/GdZsY58++hcPKR2k0nx/5wLfSAJl+xrnr+zgHaSIGNdOfbwcaftEw2CKL8cG8yTX1Wz1Bk91TRv5o5Bhvz57J0AjFAH2LjNj/xCBzWsgcz3q2X2XhzKDJWgS2i7ugs9dQZcGlRPi/VblAU5YvFwMF/Z3iFXmfCwSyPHbwvABTI418ne7WqSyVR5V2irTXjxUeEa1J95UqisOk054hg8FqhKBwsqyUQDqvmXjs++QLpqeKZeijVc5zUxFApNm7+SnXbXQs6SDe1qt+uVrE3LSC7A8R0zkXWWn9SvLFMrJq+Hga6XlPxUyNcp2uojBAoGBAOo2AfyALihtsP8c62QO+oRa6FN6IuKvl5NNjrvQ46J98OGeX3Vi0JJmsxniGvtsUkTyc0jeIOs7RyADipN+EqXOzZB3PO4eNCaDS7RyZqcvNbCKsxLXWjAx7wP6i3SN6TEE2VLKnkLJ5WPx3Eqv7ETIEu/FSHmhvHqDu7o2eWShAoGBAOhRTHNK29K/866D6aadljVJ+4p0LOsfSuNWyL9Kc7RPEx+gUJRpD6IJWSrDJrcuuNT3gJfPFDlrpGRyVEWKT7e8DPylQQGMUVHks6uo2QZFyIGBzA+BKfvLQepZVrfo9tAaTShPYGJVfdmWbOohJRM6Myp8b99eemZbX1bxVh15AoGACbA4PtCymBuJgdQZbKct98Gm8KURwlzPIVnI+L34XKVnDH43pqxywkubRwvSX+ooMQ/ycuY1aGWoWIus9NL3RIKcgEhebd8z+w/dVtaQpoPObcIfDD16TpoSMBDyKd0g81UnBES7bTna0lqT6UcDuAiqt95qVBW7rTm7z0UnmmECgYEAqF5rYs9pG4dkSyFtUAS73SkeNYzXFRxbwQGfgguqaY45lN0yKS0vWEcgKX6/61jgOfCacOtyg98AiI/XhYKlHcsbOmtl/oI8WXa/xHQdvY8LrthsFPyOed8oiXhwAd/EKLQ3ITTN7NZ63BxKGTEmVpYCiRMgXSly2gX0xeUofTkCgYASzRe1cnKp8xUj830CTYBcKtmRZcMHCDqxwsuw3l+2ZEdXAG72BkXEDnyt9seRAc8XtP4/ICa/2Decglxyt4+UCTKP6daf0K92yRo4QbzWPOw/7txWkmWZ/NBrASo34vyle3RBqXfMc95CbHDLYEuA6BMO9nFNw71M6aoE0raXxQ=="
+              ],
+              "keyUse": [
+                "SIG"
+              ],
+              "certificate": [
+                "MIICnzCCAYcCBgGZPhwGOjANBgkqhkiG9w0BAQsFADATMREwDwYDVQQDDAhNeSByZWFsbTAeFw0yNTA5MTIxMzI1NDhaFw0zNTA5MTIxMzI3MjhaMBMxETAPBgNVBAMMCE15IHJlYWxtMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1ItS1Phk91AWxXW88NiO1vL7juMBmIArT0RuJWb7F/HIHJAokeYoxPEjlqfoNtIR++G7N02RbQGr7SYdbZqiAcO52Yu3VMVilyshjCHn4f4yXnLQUZhLFRiDn9k2ctiCkfCzTMX0y+NYlic2vLM3pn0PxCYfavyMB/szRM13YBI7lXjajvfkyxdC8oLipE+WyMJ4IIbi1r94lR9N1Q/XpYffjtcb+ChO2R7ByO6sL7crq4MmvjpyvqqiPGG+huuMCjYezf2iibiJF1HsfFxqzElPYbzxGGyIOaWmnyNBMUNgi5D6ZO5UVmVZP9mBujAg6DrtFsVT8LB2uPTI3tzNGQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQAwSlrrdXAn+y9uXgKtIutWJ+m4wW5hCDmQNSS0XkcsAdLUNGp8fjrJKQV6CUiQCh+0tXHu9iybGiQfc5A73VgzNUDtrGplqEPWG3z3rTjfo+gTwvev7izMwU+5/lF2/aMPdYTM7E/RgGW+Phb+wBvTNzc9glhFzQQQLV81HHt907UvTfKonjeMnCUOn/92YR6Y6Kz3WuIVmOjNWwB1TpjWRxiiJ1kRsEgbWt368K3eY1CKkStDAYlpV2Nenzbbgk3hrZq7+JT3ZxMXUqrnScI/SA8/FRt9mld8J4/fnLWe++HiPGDpRKjphFCJLyk31VceMXlvxg+8zUZt4ZIcaoEU"
+              ],
+              "priority": [
+                "100"
+              ]
+            }
+          }
+        ]
+      },
+      "internationalizationEnabled": false,
+      "authenticationFlows": [
+        {
+          "id": "6a92f886-b04d-4b9d-b9eb-dfcaade20688",
+          "alias": "Account verification options",
+          "description": "Method with which to verity the existing account",
+          "providerId": "basic-flow",
+          "topLevel": false,
+          "builtIn": true,
+          "authenticationExecutions": [
+            {
+              "authenticator": "idp-email-verification",
+              "authenticatorFlow": false,
+              "requirement": "ALTERNATIVE",
+              "priority": 10,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            },
+            {
+              "authenticatorFlow": true,
+              "requirement": "ALTERNATIVE",
+              "priority": 20,
+              "autheticatorFlow": true,
+              "flowAlias": "Verify Existing Account by Re-authentication",
+              "userSetupAllowed": false
+            }
+          ]
+        },
+        {
+          "id": "dc925463-8f79-4325-b901-e409847cad23",
+          "alias": "Browser - Conditional 2FA",
+          "description": "Flow to determine if any 2FA is required for the authentication",
+          "providerId": "basic-flow",
+          "topLevel": false,
+          "builtIn": true,
+          "authenticationExecutions": [
+            {
+              "authenticator": "conditional-user-configured",
+              "authenticatorFlow": false,
+              "requirement": "REQUIRED",
+              "priority": 10,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            },
+            {
+              "authenticator": "auth-otp-form",
+              "authenticatorFlow": false,
+              "requirement": "ALTERNATIVE",
+              "priority": 20,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            },
+            {
+              "authenticator": "webauthn-authenticator",
+              "authenticatorFlow": false,
+              "requirement": "DISABLED",
+              "priority": 30,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            },
+            {
+              "authenticator": "auth-recovery-authn-code-form",
+              "authenticatorFlow": false,
+              "requirement": "DISABLED",
+              "priority": 40,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            }
+          ]
+        },
+        {
+          "id": "035628ad-a4d1-4b90-b15d-788015c09f1b",
+          "alias": "Browser - Conditional Organization",
+          "description": "Flow to determine if the organization identity-first login is to be used",
+          "providerId": "basic-flow",
+          "topLevel": false,
+          "builtIn": true,
+          "authenticationExecutions": [
+            {
+              "authenticator": "conditional-user-configured",
+              "authenticatorFlow": false,
+              "requirement": "REQUIRED",
+              "priority": 10,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            },
+            {
+              "authenticator": "organization",
+              "authenticatorFlow": false,
+              "requirement": "ALTERNATIVE",
+              "priority": 20,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            }
+          ]
+        },
+        {
+          "id": "be3c906d-c54a-4964-b7bc-96b8282facb4",
+          "alias": "Direct Grant - Conditional OTP",
+          "description": "Flow to determine if the OTP is required for the authentication",
+          "providerId": "basic-flow",
+          "topLevel": false,
+          "builtIn": true,
+          "authenticationExecutions": [
+            {
+              "authenticator": "conditional-user-configured",
+              "authenticatorFlow": false,
+              "requirement": "REQUIRED",
+              "priority": 10,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            },
+            {
+              "authenticator": "direct-grant-validate-otp",
+              "authenticatorFlow": false,
+              "requirement": "REQUIRED",
+              "priority": 20,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            }
+          ]
+        },
+        {
+          "id": "52c841e3-65d5-4cce-a2f5-046852f6c0b6",
+          "alias": "First Broker Login - Conditional Organization",
+          "description": "Flow to determine if the authenticator that adds organization members is to be used",
+          "providerId": "basic-flow",
+          "topLevel": false,
+          "builtIn": true,
+          "authenticationExecutions": [
+            {
+              "authenticator": "conditional-user-configured",
+              "authenticatorFlow": false,
+              "requirement": "REQUIRED",
+              "priority": 10,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            },
+            {
+              "authenticator": "idp-add-organization-member",
+              "authenticatorFlow": false,
+              "requirement": "REQUIRED",
+              "priority": 20,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            }
+          ]
+        },
+        {
+          "id": "8449f292-7782-4e9a-93bf-ab11a96f4290",
+          "alias": "First broker login - Conditional 2FA",
+          "description": "Flow to determine if any 2FA is required for the authentication",
+          "providerId": "basic-flow",
+          "topLevel": false,
+          "builtIn": true,
+          "authenticationExecutions": [
+            {
+              "authenticator": "conditional-user-configured",
+              "authenticatorFlow": false,
+              "requirement": "REQUIRED",
+              "priority": 10,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            },
+            {
+              "authenticator": "auth-otp-form",
+              "authenticatorFlow": false,
+              "requirement": "ALTERNATIVE",
+              "priority": 20,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            },
+            {
+              "authenticator": "webauthn-authenticator",
+              "authenticatorFlow": false,
+              "requirement": "DISABLED",
+              "priority": 30,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            },
+            {
+              "authenticator": "auth-recovery-authn-code-form",
+              "authenticatorFlow": false,
+              "requirement": "DISABLED",
+              "priority": 40,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            }
+          ]
+        },
+        {
+          "id": "7132a5f2-112c-4971-b8d7-eeaf562994f5",
+          "alias": "Handle Existing Account",
+          "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+          "providerId": "basic-flow",
+          "topLevel": false,
+          "builtIn": true,
+          "authenticationExecutions": [
+            {
+              "authenticator": "idp-confirm-link",
+              "authenticatorFlow": false,
+              "requirement": "REQUIRED",
+              "priority": 10,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            },
+            {
+              "authenticatorFlow": true,
+              "requirement": "REQUIRED",
+              "priority": 20,
+              "autheticatorFlow": true,
+              "flowAlias": "Account verification options",
+              "userSetupAllowed": false
+            }
+          ]
+        },
+        {
+          "id": "84a03f33-a69a-4031-a59d-6f540df66ec2",
+          "alias": "Organization",
+          "providerId": "basic-flow",
+          "topLevel": false,
+          "builtIn": true,
+          "authenticationExecutions": [
+            {
+              "authenticatorFlow": true,
+              "requirement": "CONDITIONAL",
+              "priority": 10,
+              "autheticatorFlow": true,
+              "flowAlias": "Browser - Conditional Organization",
+              "userSetupAllowed": false
+            }
+          ]
+        },
+        {
+          "id": "937e3a93-722c-468b-bd13-dd797c330ff7",
+          "alias": "Reset - Conditional OTP",
+          "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+          "providerId": "basic-flow",
+          "topLevel": false,
+          "builtIn": true,
+          "authenticationExecutions": [
+            {
+              "authenticator": "conditional-user-configured",
+              "authenticatorFlow": false,
+              "requirement": "REQUIRED",
+              "priority": 10,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            },
+            {
+              "authenticator": "reset-otp",
+              "authenticatorFlow": false,
+              "requirement": "REQUIRED",
+              "priority": 20,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            }
+          ]
+        },
+        {
+          "id": "f5e03dc1-6e73-4b3b-84ec-abd522db7bff",
+          "alias": "User creation or linking",
+          "description": "Flow for the existing/non-existing user alternatives",
+          "providerId": "basic-flow",
+          "topLevel": false,
+          "builtIn": true,
+          "authenticationExecutions": [
+            {
+              "authenticatorConfig": "create unique user config",
+              "authenticator": "idp-create-user-if-unique",
+              "authenticatorFlow": false,
+              "requirement": "ALTERNATIVE",
+              "priority": 10,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            },
+            {
+              "authenticatorFlow": true,
+              "requirement": "ALTERNATIVE",
+              "priority": 20,
+              "autheticatorFlow": true,
+              "flowAlias": "Handle Existing Account",
+              "userSetupAllowed": false
+            }
+          ]
+        },
+        {
+          "id": "c54a7183-59ea-4487-a088-c917e6916b68",
+          "alias": "Verify Existing Account by Re-authentication",
+          "description": "Reauthentication of existing account",
+          "providerId": "basic-flow",
+          "topLevel": false,
+          "builtIn": true,
+          "authenticationExecutions": [
+            {
+              "authenticator": "idp-username-password-form",
+              "authenticatorFlow": false,
+              "requirement": "REQUIRED",
+              "priority": 10,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            },
+            {
+              "authenticatorFlow": true,
+              "requirement": "CONDITIONAL",
+              "priority": 20,
+              "autheticatorFlow": true,
+              "flowAlias": "First broker login - Conditional 2FA",
+              "userSetupAllowed": false
+            }
+          ]
+        },
+        {
+          "id": "766e3d62-3553-49c7-be01-f26fddce40e2",
+          "alias": "browser",
+          "description": "Browser based authentication",
+          "providerId": "basic-flow",
+          "topLevel": true,
+          "builtIn": true,
+          "authenticationExecutions": [
+            {
+              "authenticator": "auth-cookie",
+              "authenticatorFlow": false,
+              "requirement": "ALTERNATIVE",
+              "priority": 10,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            },
+            {
+              "authenticator": "auth-spnego",
+              "authenticatorFlow": false,
+              "requirement": "DISABLED",
+              "priority": 20,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            },
+            {
+              "authenticator": "identity-provider-redirector",
+              "authenticatorFlow": false,
+              "requirement": "ALTERNATIVE",
+              "priority": 25,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            },
+            {
+              "authenticatorFlow": true,
+              "requirement": "ALTERNATIVE",
+              "priority": 26,
+              "autheticatorFlow": true,
+              "flowAlias": "Organization",
+              "userSetupAllowed": false
+            },
+            {
+              "authenticatorFlow": true,
+              "requirement": "ALTERNATIVE",
+              "priority": 30,
+              "autheticatorFlow": true,
+              "flowAlias": "forms",
+              "userSetupAllowed": false
+            }
+          ]
+        },
+        {
+          "id": "a9a859e5-e2d9-486e-b4a6-10c5f8e443d5",
+          "alias": "clients",
+          "description": "Base authentication for clients",
+          "providerId": "client-flow",
+          "topLevel": true,
+          "builtIn": true,
+          "authenticationExecutions": [
+            {
+              "authenticator": "client-secret",
+              "authenticatorFlow": false,
+              "requirement": "ALTERNATIVE",
+              "priority": 10,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            },
+            {
+              "authenticator": "client-jwt",
+              "authenticatorFlow": false,
+              "requirement": "ALTERNATIVE",
+              "priority": 20,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            },
+            {
+              "authenticator": "client-secret-jwt",
+              "authenticatorFlow": false,
+              "requirement": "ALTERNATIVE",
+              "priority": 30,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            },
+            {
+              "authenticator": "client-x509",
+              "authenticatorFlow": false,
+              "requirement": "ALTERNATIVE",
+              "priority": 40,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            }
+          ]
+        },
+        {
+          "id": "defe543d-d145-4781-b5f2-ce07b21f9258",
+          "alias": "direct grant",
+          "description": "OpenID Connect Resource Owner Grant",
+          "providerId": "basic-flow",
+          "topLevel": true,
+          "builtIn": true,
+          "authenticationExecutions": [
+            {
+              "authenticator": "direct-grant-validate-username",
+              "authenticatorFlow": false,
+              "requirement": "REQUIRED",
+              "priority": 10,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            },
+            {
+              "authenticator": "direct-grant-validate-password",
+              "authenticatorFlow": false,
+              "requirement": "REQUIRED",
+              "priority": 20,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            },
+            {
+              "authenticatorFlow": true,
+              "requirement": "CONDITIONAL",
+              "priority": 30,
+              "autheticatorFlow": true,
+              "flowAlias": "Direct Grant - Conditional OTP",
+              "userSetupAllowed": false
+            }
+          ]
+        },
+        {
+          "id": "ee72847f-04d5-4eed-bb8b-c576fcc4bd6b",
+          "alias": "docker auth",
+          "description": "Used by Docker clients to authenticate against the IDP",
+          "providerId": "basic-flow",
+          "topLevel": true,
+          "builtIn": true,
+          "authenticationExecutions": [
+            {
+              "authenticator": "docker-http-basic-authenticator",
+              "authenticatorFlow": false,
+              "requirement": "REQUIRED",
+              "priority": 10,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            }
+          ]
+        },
+        {
+          "id": "602e1d5f-ffda-4c40-8adc-b0ae640b4574",
+          "alias": "first broker login",
+          "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+          "providerId": "basic-flow",
+          "topLevel": true,
+          "builtIn": true,
+          "authenticationExecutions": [
+            {
+              "authenticatorConfig": "review profile config",
+              "authenticator": "idp-review-profile",
+              "authenticatorFlow": false,
+              "requirement": "REQUIRED",
+              "priority": 10,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            },
+            {
+              "authenticatorFlow": true,
+              "requirement": "REQUIRED",
+              "priority": 20,
+              "autheticatorFlow": true,
+              "flowAlias": "User creation or linking",
+              "userSetupAllowed": false
+            },
+            {
+              "authenticatorFlow": true,
+              "requirement": "CONDITIONAL",
+              "priority": 50,
+              "autheticatorFlow": true,
+              "flowAlias": "First Broker Login - Conditional Organization",
+              "userSetupAllowed": false
+            }
+          ]
+        },
+        {
+          "id": "014fdbfb-fa59-4e60-95a4-986e932c50e4",
+          "alias": "forms",
+          "description": "Username, password, otp and other auth forms.",
+          "providerId": "basic-flow",
+          "topLevel": false,
+          "builtIn": true,
+          "authenticationExecutions": [
+            {
+              "authenticator": "auth-username-password-form",
+              "authenticatorFlow": false,
+              "requirement": "REQUIRED",
+              "priority": 10,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            },
+            {
+              "authenticatorFlow": true,
+              "requirement": "CONDITIONAL",
+              "priority": 20,
+              "autheticatorFlow": true,
+              "flowAlias": "Browser - Conditional 2FA",
+              "userSetupAllowed": false
+            }
+          ]
+        },
+        {
+          "id": "1f78bafd-0862-4e6b-b7eb-b7e64c51a088",
+          "alias": "registration",
+          "description": "Registration flow",
+          "providerId": "basic-flow",
+          "topLevel": true,
+          "builtIn": true,
+          "authenticationExecutions": [
+            {
+              "authenticator": "registration-page-form",
+              "authenticatorFlow": true,
+              "requirement": "REQUIRED",
+              "priority": 10,
+              "autheticatorFlow": true,
+              "flowAlias": "registration form",
+              "userSetupAllowed": false
+            }
+          ]
+        },
+        {
+          "id": "6f823485-723b-42e0-8c59-80d52377180a",
+          "alias": "registration form",
+          "description": "Registration form",
+          "providerId": "form-flow",
+          "topLevel": false,
+          "builtIn": true,
+          "authenticationExecutions": [
+            {
+              "authenticator": "registration-user-creation",
+              "authenticatorFlow": false,
+              "requirement": "REQUIRED",
+              "priority": 20,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            },
+            {
+              "authenticator": "registration-password-action",
+              "authenticatorFlow": false,
+              "requirement": "REQUIRED",
+              "priority": 50,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            },
+            {
+              "authenticator": "registration-recaptcha-action",
+              "authenticatorFlow": false,
+              "requirement": "DISABLED",
+              "priority": 60,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            },
+            {
+              "authenticator": "registration-terms-and-conditions",
+              "authenticatorFlow": false,
+              "requirement": "DISABLED",
+              "priority": 70,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            }
+          ]
+        },
+        {
+          "id": "12e57c09-0562-4a9e-8bff-a397c9ebf704",
+          "alias": "reset credentials",
+          "description": "Reset credentials for a user if they forgot their password or something",
+          "providerId": "basic-flow",
+          "topLevel": true,
+          "builtIn": true,
+          "authenticationExecutions": [
+            {
+              "authenticator": "reset-credentials-choose-user",
+              "authenticatorFlow": false,
+              "requirement": "REQUIRED",
+              "priority": 10,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            },
+            {
+              "authenticator": "reset-credential-email",
+              "authenticatorFlow": false,
+              "requirement": "REQUIRED",
+              "priority": 20,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            },
+            {
+              "authenticator": "reset-password",
+              "authenticatorFlow": false,
+              "requirement": "REQUIRED",
+              "priority": 30,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            },
+            {
+              "authenticatorFlow": true,
+              "requirement": "CONDITIONAL",
+              "priority": 40,
+              "autheticatorFlow": true,
+              "flowAlias": "Reset - Conditional OTP",
+              "userSetupAllowed": false
+            }
+          ]
+        },
+        {
+          "id": "488caeea-1408-4008-b43b-e6f96f5eef6e",
+          "alias": "saml ecp",
+          "description": "SAML ECP Profile Authentication Flow",
+          "providerId": "basic-flow",
+          "topLevel": true,
+          "builtIn": true,
+          "authenticationExecutions": [
+            {
+              "authenticator": "http-basic-authenticator",
+              "authenticatorFlow": false,
+              "requirement": "REQUIRED",
+              "priority": 10,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            }
+          ]
+        }
+      ],
+      "authenticatorConfig": [
+        {
+          "id": "06643ecc-b0de-4373-8232-ee1ccaddb999",
+          "alias": "create unique user config",
+          "config": {
+            "require.password.update.after.registration": "false"
+          }
+        },
+        {
+          "id": "c77cb09c-5416-4f21-b3c1-4a1928c08777",
+          "alias": "review profile config",
+          "config": {
+            "update.profile.on.first.login": "missing"
+          }
+        }
+      ],
+      "requiredActions": [
+        {
+          "alias": "CONFIGURE_TOTP",
+          "name": "Configure OTP",
+          "providerId": "CONFIGURE_TOTP",
+          "enabled": true,
+          "defaultAction": false,
+          "priority": 10,
+          "config": {}
+        },
+        {
+          "alias": "TERMS_AND_CONDITIONS",
+          "name": "Terms and Conditions",
+          "providerId": "TERMS_AND_CONDITIONS",
+          "enabled": false,
+          "defaultAction": false,
+          "priority": 20,
+          "config": {}
+        },
+        {
+          "alias": "UPDATE_PASSWORD",
+          "name": "Update Password",
+          "providerId": "UPDATE_PASSWORD",
+          "enabled": true,
+          "defaultAction": false,
+          "priority": 30,
+          "config": {}
+        },
+        {
+          "alias": "UPDATE_PROFILE",
+          "name": "Update Profile",
+          "providerId": "UPDATE_PROFILE",
+          "enabled": true,
+          "defaultAction": false,
+          "priority": 40,
+          "config": {}
+        },
+        {
+          "alias": "VERIFY_EMAIL",
+          "name": "Verify Email",
+          "providerId": "VERIFY_EMAIL",
+          "enabled": true,
+          "defaultAction": false,
+          "priority": 50,
+          "config": {}
+        },
+        {
+          "alias": "delete_account",
+          "name": "Delete Account",
+          "providerId": "delete_account",
+          "enabled": false,
+          "defaultAction": false,
+          "priority": 60,
+          "config": {}
+        },
+        {
+          "alias": "webauthn-register",
+          "name": "Webauthn Register",
+          "providerId": "webauthn-register",
+          "enabled": true,
+          "defaultAction": false,
+          "priority": 70,
+          "config": {}
+        },
+        {
+          "alias": "webauthn-register-passwordless",
+          "name": "Webauthn Register Passwordless",
+          "providerId": "webauthn-register-passwordless",
+          "enabled": true,
+          "defaultAction": false,
+          "priority": 80,
+          "config": {}
+        },
+        {
+          "alias": "VERIFY_PROFILE",
+          "name": "Verify Profile",
+          "providerId": "VERIFY_PROFILE",
+          "enabled": true,
+          "defaultAction": false,
+          "priority": 90,
+          "config": {}
+        },
+        {
+          "alias": "delete_credential",
+          "name": "Delete Credential",
+          "providerId": "delete_credential",
+          "enabled": true,
+          "defaultAction": false,
+          "priority": 100,
+          "config": {}
+        },
+        {
+          "alias": "idp_link",
+          "name": "Linking Identity Provider",
+          "providerId": "idp_link",
+          "enabled": true,
+          "defaultAction": false,
+          "priority": 110,
+          "config": {}
+        },
+        {
+          "alias": "CONFIGURE_RECOVERY_AUTHN_CODES",
+          "name": "Recovery Authentication Codes",
+          "providerId": "CONFIGURE_RECOVERY_AUTHN_CODES",
+          "enabled": true,
+          "defaultAction": false,
+          "priority": 120,
+          "config": {}
+        },
+        {
+          "alias": "update_user_locale",
+          "name": "Update User Locale",
+          "providerId": "update_user_locale",
+          "enabled": true,
+          "defaultAction": false,
+          "priority": 1000,
+          "config": {}
+        }
+      ],
+      "browserFlow": "browser",
+      "registrationFlow": "registration",
+      "directGrantFlow": "direct grant",
+      "resetCredentialsFlow": "reset credentials",
+      "clientAuthenticationFlow": "clients",
+      "dockerAuthenticationFlow": "docker auth",
+      "firstBrokerLoginFlow": "first broker login",
+      "attributes": {
+        "cibaBackchannelTokenDeliveryMode": "poll",
+        "cibaExpiresIn": "120",
+        "cibaAuthRequestedUserHint": "login_hint",
+        "oauth2DeviceCodeLifespan": "600",
+        "clientOfflineSessionMaxLifespan": "0",
+        "oauth2DevicePollingInterval": "5",
+        "clientSessionIdleTimeout": "0",
+        "parRequestUriLifespan": "60",
+        "clientSessionMaxLifespan": "0",
+        "clientOfflineSessionIdleTimeout": "0",
+        "cibaInterval": "5",
+        "realmReusableOtpCode": "false"
+      },
+      "keycloakVersion": "26.3.5",
+      "userManagedAccessAllowed": false,
+      "organizationsEnabled": false,
+      "verifiableCredentialsEnabled": false,
+      "adminPermissionsEnabled": false,
+      "clientProfiles": {
+        "profiles": []
+      },
+      "clientPolicies": {
+        "policies": []
+      }
+    }
+kind: ConfigMap
+metadata:
+  name: keycloak-realm
+  namespace: keycloak
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: keycloak-service
+  name: keycloak
+  namespace: keycloak
+spec:
+  ports:
+  - name: https
+    port: 443
+    targetPort: 8001
+  selector:
+    app: keycloak-service
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-database
+  namespace: keycloak
+spec:
+  ports:
+  - name: postgres
+    port: 5432
+    targetPort: postgres
+  selector:
+    app: keycloak-database
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: keycloak-database
+  namespace: keycloak
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keycloak-service
+  namespace: keycloak
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: keycloak-service
+  template:
+    metadata:
+      labels:
+        app: keycloak-service
+    spec:
+      containers:
+      - args:
+        - start
+        - --import-realm
+        env:
+        - name: KEYCLOAK_ADMIN
+          value: admin
+        - name: KEYCLOAK_ADMIN_PASSWORD
+          value: admin
+        - name: KC_HOSTNAME_STRICT
+          value: "true"
+        - name: KC_HOSTNAME_STRICT_HTTPS
+          value: "true"
+        - name: KC_HTTP_ENABLED
+          value: "false"
+        - name: KC_HTTPS_ENABLED
+          value: "true"
+        - name: KC_HTTPS_PORT
+          value: "8001"
+        - name: KC_HTTPS_CERTIFICATE_FILE
+          value: /secrets/tls/tls.crt
+        - name: KC_HTTPS_CERTIFICATE_KEY_FILE
+          value: /secrets/tls/tls.key
+        - name: KC_HOSTNAME
+          value: keycloak.keycloak.svc.cluster.local
+        - name: KC_DB
+          value: postgres
+        - name: KC_DB_URL
+          value: jdbc:postgresql://keycloak-database:5432/keycloak?sslmode=require&sslcert=/secrets/database-client/tls.crt&sslkey=/secrets/database-client/key.der&sslrootcert=/secrets/database-client/ca.crt
+        - name: KC_DB_USERNAME
+          value: keycloak
+        - name: KC_DB_PASSWORD
+          value: ""
+        image: quay.io/keycloak/keycloak:latest
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /realms/master
+            port: 8001
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 30
+        name: keycloak
+        ports:
+        - containerPort: 8001
+          name: https
+        readinessProbe:
+          httpGet:
+            path: /realms/master
+            port: 8001
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        volumeMounts:
+        - mountPath: /opt/keycloak/data/import
+          name: realm
+          readOnly: true
+        - mountPath: /secrets/database-client
+          name: database-client-cert
+          readOnly: true
+        - mountPath: /secrets/tls
+          name: tls-cert
+          readOnly: true
+      initContainers:
+      - command:
+        - /bin/bash
+        - -c
+        - |
+          set -e
+          until pg_isready --host keycloak-database --timeout 1; do
+            sleep 1
+          done
+        image: postgres
+        imagePullPolicy: IfNotPresent
+        name: wait-for-database
+      volumes:
+      - configMap:
+          name: keycloak-realm
+        name: realm
+      - name: database-client-cert
+        secret:
+          secretName: keycloak-database-client-cert
+      - name: tls-cert
+        secret:
+          secretName: keycloak-tls-cert
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: keycloak-database
+  namespace: keycloak
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: keycloak-database
+  serviceName: keycloak-database
+  template:
+    metadata:
+      labels:
+        app: keycloak-database
+    spec:
+      containers:
+      - env:
+        - name: POSTGRESQL_USER
+          value: keycloak
+        - name: POSTGRESQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: POSTGRES_PASSWORD
+              name: keycloak-database-password
+        - name: POSTGRESQL_DATABASE
+          value: keycloak
+        image: quay.io/sclorg/postgresql-15-c9s:latest
+        imagePullPolicy: IfNotPresent
+        name: server
+        ports:
+        - containerPort: 5432
+          name: postgres
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /var/lib/pgsql/data
+          name: data
+        - mountPath: /secrets/cert
+          name: server-cert
+        - mountPath: /opt/app-root/src/postgresql-cfg
+          name: server-config
+        - mountPath: /config/access
+          name: access-config
+      initContainers:
+      - command:
+        - /bin/bash
+        - -c
+        - |
+          if ! oc get secret keycloak-database-password > /dev/null 2>&1; then
+              echo "generating postgresql password"
+              password=$(openssl rand -hex 20)
+              oc create secret generic keycloak-database-password \
+                --from-literal POSTGRES_PASSWORD="$password"
+          fi
+        image: quay.io/openshift/origin-cli:latest
+        name: password-generator
+      serviceAccountName: keycloak-database
+      volumes:
+      - name: server-cert
+        secret:
+          defaultMode: 288
+          secretName: keycloak-database-server-cert
+      - configMap:
+          name: keycloak-db-server-config-6mtfcgkhfc
+        name: server-config
+      - configMap:
+          name: keycloak-db-access-config-b88tb82fkh
+        name: access-config
+      - name: data
+        persistentVolumeClaim:
+          claimName: keycloak-database
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: keycloak-set-passwords
+  namespace: keycloak
+spec:
+  template:
+    spec:
+      containers:
+      - command:
+        - /bin/bash
+        - /scripts/set-passwords.sh
+        image: quay.io/openshift/origin-cli:latest
+        name: set-passwords
+        volumeMounts:
+        - mountPath: /scripts
+          name: scripts
+      restartPolicy: OnFailure
+      volumes:
+      - configMap:
+          defaultMode: 493
+          name: keycloak-password-setup
+        name: scripts
+  ttlSecondsAfterFinished: 300
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: keycloak-database-client
+  namespace: keycloak
+spec:
+  additionalOutputFormats:
+  - type: DER
+  commonName: keycloak
+  issuerRef:
+    kind: ClusterIssuer
+    name: default-ca
+  privateKey:
+    encoding: PKCS8
+    rotationPolicy: Always
+  secretName: keycloak-database-client-cert
+  usages:
+  - client auth
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: keycloak-database-server
+  namespace: keycloak
+spec:
+  dnsNames:
+  - localhost
+  - keycloak-database
+  issuerRef:
+    kind: ClusterIssuer
+    name: default-ca
+  privateKey:
+    rotationPolicy: Always
+  secretName: keycloak-database-server-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: keycloak-tls
+  namespace: keycloak
+spec:
+  dnsNames:
+  - keycloak
+  - keycloak.keycloak.svc.cluster.local
+  issuerRef:
+    kind: ClusterIssuer
+    name: default-ca
+  privateKey:
+    rotationPolicy: Always
+  secretName: keycloak-tls-cert
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: keycloak
+  namespace: keycloak
+spec:
+  port:
+    targetPort: https
+  tls:
+    termination: passthrough
+  to:
+    kind: Service
+    name: keycloak

--- a/plugins/osac/files/trust-manager.yaml
+++ b/plugins/osac/files/trust-manager.yaml
@@ -1,0 +1,906 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+# Trust Manager - Automatically distribute CA certificates to ConfigMaps
+#
+# trust-manager is a component of cert-manager that distributes CA certificates
+# across namespaces. It watches for changes to CA certificates and automatically
+# updates ConfigMaps, ensuring services always have up-to-date trust bundles.
+#
+# Generated from: helm template trust-manager oci://quay.io/jetstack/charts/trust-manager --namespace cert-manager --version v0.20.0
+#
+# Prerequisites:
+# - cert-manager must be installed (see cert-manager.yaml)
+#
+# Installation:
+#   oc apply -f prerequisites/trust-manager.yaml
+#
+# Verify installation:
+#   oc get pods -n cert-manager -l app.kubernetes.io/name=trust-manager
+#   oc get crd bundles.trust.cert-manager.io
+#
+# After installation, you can create Bundle resources to distribute CA certificates.
+#
+# Source: trust-manager/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: true
+metadata:
+  name: trust-manager
+  namespace: cert-manager
+  labels:
+    app.kubernetes.io/name: trust-manager
+    helm.sh/chart: trust-manager-v0.20.0
+    app.kubernetes.io/instance: trust-manager
+    app.kubernetes.io/version: "v0.20.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: trust-manager/templates/crd-trust.cert-manager.io_bundles.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: "bundles.trust.cert-manager.io"
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    app.kubernetes.io/name: trust-manager
+    helm.sh/chart: trust-manager-v0.20.0
+    app.kubernetes.io/instance: trust-manager
+    app.kubernetes.io/version: "v0.20.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  group: trust.cert-manager.io
+  names:
+    kind: Bundle
+    listKind: BundleList
+    plural: bundles
+    singular: bundle
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: Bundle ConfigMap Target Key
+          jsonPath: .spec.target.configMap.key
+          name: ConfigMap Target
+          type: string
+        - description: Bundle Secret Target Key
+          jsonPath: .spec.target.secret.key
+          name: Secret Target
+          type: string
+        - description: Bundle has been synced
+          jsonPath: .status.conditions[?(@.type == "Synced")].status
+          name: Synced
+          type: string
+        - description: Reason Bundle has Synced status
+          jsonPath: .status.conditions[?(@.type == "Synced")].reason
+          name: Reason
+          type: string
+        - description: Timestamp Bundle was created
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Desired state of the Bundle resource.
+              properties:
+                sources:
+                  description: Sources is a set of references to data whose data will sync to the target.
+                  items:
+                    description: |-
+                      BundleSource is the set of sources whose data will be appended and synced to
+                      the BundleTarget in all Namespaces.
+                    properties:
+                      configMap:
+                        description: |-
+                          ConfigMap is a reference (by name) to a ConfigMap's `data` key(s), or to a
+                          list of ConfigMap's `data` key(s) using label selector, in the trust Namespace.
+                        properties:
+                          includeAllKeys:
+                            description: |-
+                              IncludeAllKeys is a flag to include all keys in the object's `data` field to be used. False by default.
+                              This field must not be true when `Key` is set.
+                            type: boolean
+                          key:
+                            description: Key of the entry in the object's `data` field to be used.
+                            minLength: 1
+                            type: string
+                          name:
+                            description: |-
+                              Name is the name of the source object in the trust Namespace.
+                              This field must be left empty when `selector` is set
+                            minLength: 1
+                            type: string
+                          selector:
+                            description: |-
+                              Selector is the label selector to use to fetch a list of objects. Must not be set
+                              when `Name` is set.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      inLine:
+                        description: InLine is a simple string to append as the source data.
+                        type: string
+                      secret:
+                        description: |-
+                          Secret is a reference (by name) to a Secret's `data` key(s), or to a
+                          list of Secret's `data` key(s) using label selector, in the trust Namespace.
+                        properties:
+                          includeAllKeys:
+                            description: |-
+                              IncludeAllKeys is a flag to include all keys in the object's `data` field to be used. False by default.
+                              This field must not be true when `Key` is set.
+                            type: boolean
+                          key:
+                            description: Key of the entry in the object's `data` field to be used.
+                            minLength: 1
+                            type: string
+                          name:
+                            description: |-
+                              Name is the name of the source object in the trust Namespace.
+                              This field must be left empty when `selector` is set
+                            minLength: 1
+                            type: string
+                          selector:
+                            description: |-
+                              Selector is the label selector to use to fetch a list of objects. Must not be set
+                              when `Name` is set.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      useDefaultCAs:
+                        description: |-
+                          UseDefaultCAs, when true, requests the default CA bundle to be used as a source.
+                          Default CAs are available if trust-manager was installed via Helm
+                          or was otherwise set up to include a package-injecting init container by using the
+                          "--default-package-location" flag when starting the trust-manager controller.
+                          If default CAs were not configured at start-up, any request to use the default
+                          CAs will fail.
+                          The version of the default CA package which is used for a Bundle is stored in the
+                          defaultCAPackageVersion field of the Bundle's status field.
+                        type: boolean
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  maxItems: 100
+                  minItems: 1
+                  type: array
+                  x-kubernetes-list-type: atomic
+                target:
+                  description: Target is the target location in all namespaces to sync source data to.
+                  properties:
+                    additionalFormats:
+                      description: AdditionalFormats specifies any additional formats to write to the target
+                      properties:
+                        jks:
+                          description: |-
+                            JKS requests a JKS-formatted binary trust bundle to be written to the target.
+                            The bundle has "changeit" as the default password.
+                            For more information refer to this link https://cert-manager.io/docs/faq/#keystore-passwords
+                            Deprecated: Writing JKS is subject for removal. Please migrate to PKCS12.
+                            PKCS#12 trust stores created by trust-manager are compatible with Java.
+                          properties:
+                            key:
+                              description: Key is the key of the entry in the object's `data` field to be used.
+                              minLength: 1
+                              type: string
+                            password:
+                              default: changeit
+                              description: Password for JKS trust store
+                              maxLength: 128
+                              minLength: 1
+                              type: string
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        pkcs12:
+                          description: |-
+                            PKCS12 requests a PKCS12-formatted binary trust bundle to be written to the target.
+
+                            The bundle is by default created without a password.
+                            For more information refer to this link https://cert-manager.io/docs/faq/#keystore-passwords
+                          properties:
+                            key:
+                              description: Key is the key of the entry in the object's `data` field to be used.
+                              minLength: 1
+                              type: string
+                            password:
+                              default: ""
+                              description: Password for PKCS12 trust store
+                              maxLength: 128
+                              type: string
+                            profile:
+                              description: |-
+                                Profile specifies the certificate encryption algorithms and the HMAC algorithm
+                                used to create the PKCS12 trust store.
+
+                                If provided, allowed values are:
+                                `LegacyRC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
+                                `LegacyDES`: Less secure algorithm. Use this option for maximal compatibility.
+                                `Modern2023`: Secure algorithm. Use this option in case you have to always use secure algorithms (e.g. because of company policy).
+
+                                Default value is `LegacyRC2` for backward compatibility.
+                              enum:
+                                - LegacyRC2
+                                - LegacyDES
+                                - Modern2023
+                              type: string
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    configMap:
+                      description: |-
+                        ConfigMap is the target ConfigMap in Namespaces that all Bundle source
+                        data will be synced to.
+                      properties:
+                        key:
+                          description: Key is the key of the entry in the object's `data` field to be used.
+                          minLength: 1
+                          type: string
+                        metadata:
+                          description: Metadata is an optional set of labels and annotations to be copied to the target.
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a key value map to be copied to the target.
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              description: Labels is a key value map to be copied to the target.
+                              type: object
+                          type: object
+                      required:
+                        - key
+                      type: object
+                    namespaceSelector:
+                      description: |-
+                        NamespaceSelector will, if set, only sync the target resource in
+                        Namespaces which match the selector.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    secret:
+                      description: |-
+                        Secret is the target Secret that all Bundle source data will be synced to.
+                        Using Secrets as targets is only supported if enabled at trust-manager startup.
+                        By default, trust-manager has no permissions for writing to secrets and can only read secrets in the trust namespace.
+                      properties:
+                        key:
+                          description: Key is the key of the entry in the object's `data` field to be used.
+                          minLength: 1
+                          type: string
+                        metadata:
+                          description: Metadata is an optional set of labels and annotations to be copied to the target.
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a key value map to be copied to the target.
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              description: Labels is a key value map to be copied to the target.
+                              type: object
+                          type: object
+                      required:
+                        - key
+                      type: object
+                  type: object
+              required:
+                - sources
+              type: object
+            status:
+              description: Status of the Bundle. This is set and managed automatically.
+              properties:
+                conditions:
+                  description: |-
+                    List of status conditions to indicate the status of the Bundle.
+                    Known condition types are `Bundle`.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                defaultCAVersion:
+                  description: |-
+                    DefaultCAPackageVersion, if set and non-empty, indicates the version information
+                    which was retrieved when the set of default CAs was requested in the bundle
+                    source. This should only be set if useDefaultCAs was set to "true" on a source,
+                    and will be the same for the same version of a bundle with identical certificates.
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: trust-manager/templates/clusterrole.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    app.kubernetes.io/name: trust-manager
+    helm.sh/chart: trust-manager-v0.20.0
+    app.kubernetes.io/instance: trust-manager
+    app.kubernetes.io/version: "v0.20.0"
+    app.kubernetes.io/managed-by: Helm
+  name: trust-manager
+rules:
+  - apiGroups:
+      - "trust.cert-manager.io"
+    resources:
+      - "bundles"
+    verbs: ["get", "list", "watch"]
+  # Permissions to update finalizers are required for trust-manager to work correctly
+  # on OpenShift, even though we don't directly use finalizers at the time of writing
+  - apiGroups:
+      - "trust.cert-manager.io"
+    resources:
+      - "bundles/finalizers"
+    verbs: ["update"]
+  - apiGroups:
+      - "trust.cert-manager.io"
+    resources:
+      - "bundles/status"
+    verbs: ["patch"]
+  - apiGroups:
+      - ""
+    resources:
+      - "namespaces"
+    verbs: ["get", "list", "watch"]
+  - apiGroups:
+      - ""
+    resources:
+      - "configmaps"
+    verbs: ["get", "list", "create", "patch", "watch", "delete"]
+  - apiGroups:
+      - ""
+    resources:
+      - "events"
+    verbs: ["create", "patch"]
+---
+# Source: trust-manager/templates/clusterrolebinding.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    app.kubernetes.io/name: trust-manager
+    helm.sh/chart: trust-manager-v0.20.0
+    app.kubernetes.io/instance: trust-manager
+    app.kubernetes.io/version: "v0.20.0"
+    app.kubernetes.io/managed-by: Helm
+  name: trust-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: trust-manager
+subjects:
+  - kind: ServiceAccount
+    name: trust-manager
+    namespace: cert-manager
+---
+# Source: trust-manager/templates/role.yaml
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: trust-manager
+  namespace: cert-manager
+  labels:
+    app.kubernetes.io/name: trust-manager
+    helm.sh/chart: trust-manager-v0.20.0
+    app.kubernetes.io/instance: trust-manager
+    app.kubernetes.io/version: "v0.20.0"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "secrets"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+---
+# Source: trust-manager/templates/role.yaml
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: trust-manager:leaderelection
+  namespace: cert-manager
+  labels:
+    app.kubernetes.io/name: trust-manager
+    helm.sh/chart: trust-manager-v0.20.0
+    app.kubernetes.io/instance: trust-manager
+    app.kubernetes.io/version: "v0.20.0"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - "leases"
+    verbs:
+      - "get"
+      - "create"
+      - "update"
+      - "watch"
+      - "list"
+---
+# Source: trust-manager/templates/rolebinding.yaml
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: trust-manager
+  namespace: cert-manager
+  labels:
+    app.kubernetes.io/name: trust-manager
+    helm.sh/chart: trust-manager-v0.20.0
+    app.kubernetes.io/instance: trust-manager
+    app.kubernetes.io/version: "v0.20.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: trust-manager
+subjects:
+  - kind: ServiceAccount
+    name: trust-manager
+    namespace: cert-manager
+---
+# Source: trust-manager/templates/rolebinding.yaml
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: trust-manager:leaderelection
+  namespace: cert-manager
+  labels:
+    app.kubernetes.io/name: trust-manager
+    helm.sh/chart: trust-manager-v0.20.0
+    app.kubernetes.io/instance: trust-manager
+    app.kubernetes.io/version: "v0.20.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: trust-manager:leaderelection
+subjects:
+  - kind: ServiceAccount
+    name: trust-manager
+    namespace: cert-manager
+---
+# Source: trust-manager/templates/metrics-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: trust-manager-metrics
+  namespace: cert-manager
+  labels:
+    app: trust-manager
+    app.kubernetes.io/name: trust-manager
+    helm.sh/chart: trust-manager-v0.20.0
+    app.kubernetes.io/instance: trust-manager
+    app.kubernetes.io/version: "v0.20.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9402
+      targetPort: 9402
+      protocol: TCP
+      name: metrics
+  selector:
+    app: trust-manager
+---
+# Source: trust-manager/templates/webhook.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: trust-manager
+  namespace: cert-manager
+  labels:
+    app: trust-manager
+    app.kubernetes.io/name: trust-manager
+    helm.sh/chart: trust-manager-v0.20.0
+    app.kubernetes.io/instance: trust-manager
+    app.kubernetes.io/version: "v0.20.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      targetPort: 6443
+      protocol: TCP
+      name: webhook
+  selector:
+    app: trust-manager
+---
+# Source: trust-manager/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: trust-manager
+  namespace: cert-manager
+  labels:
+    app.kubernetes.io/name: trust-manager
+    helm.sh/chart: trust-manager-v0.20.0
+    app.kubernetes.io/instance: trust-manager
+    app.kubernetes.io/version: "v0.20.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: trust-manager
+  template:
+    metadata:
+      labels:
+        app: trust-manager
+        app.kubernetes.io/name: trust-manager
+        helm.sh/chart: trust-manager-v0.20.0
+        app.kubernetes.io/instance: trust-manager
+        app.kubernetes.io/version: "v0.20.0"
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      serviceAccountName: trust-manager
+      automountServiceAccountToken: true
+      initContainers:
+        - name: cert-manager-package-debian
+          image: "quay.io/jetstack/trust-pkg-debian-bookworm:20230311-deb12u1.1"
+          imagePullPolicy: IfNotPresent
+          args:
+            - "/copyandmaybepause"
+            - "/debian-package"
+            - "/packages"
+          volumeMounts:
+            - mountPath: /packages
+              name: packages
+              readOnly: false
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+      containers:
+        - name: trust-manager
+          image: "quay.io/jetstack/trust-manager:v0.20.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 6443
+              name: webhook
+            - containerPort: 9402
+              name: metrics
+          readinessProbe:
+            httpGet:
+              port: 6060
+              path: /readyz
+            initialDelaySeconds: 3
+            periodSeconds: 7
+          args:
+            - "--log-format=text"
+            - "--log-level=1"
+            - "--metrics-port=9402"
+            - "--readiness-probe-port=6060"
+            - "--readiness-probe-path=/readyz"
+            - "--leader-elect=true"
+            - "--leader-election-lease-duration=15s"
+            - "--leader-election-renew-deadline=10s"
+            # trust
+            - "--trust-namespace=cert-manager"
+            # webhook
+            - "--webhook-host=0.0.0.0"
+            - "--webhook-port=6443"
+            - "--webhook-certificate-dir=/tls"
+            - "--default-package-location=/packages/cert-manager-package-debian.json"
+          volumeMounts:
+            - mountPath: /tls
+              name: tls
+              readOnly: true
+            - mountPath: /packages
+              name: packages
+              readOnly: true
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+      nodeSelector:
+        kubernetes.io/os: linux
+      volumes:
+        - name: packages
+          emptyDir:
+            sizeLimit: 50M
+        - name: tls
+          secret:
+            defaultMode: 420
+            secretName: trust-manager-tls
+---
+# Source: trust-manager/templates/certificate.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: trust-manager
+  namespace: cert-manager
+  labels:
+    app.kubernetes.io/name: trust-manager
+    helm.sh/chart: trust-manager-v0.20.0
+    app.kubernetes.io/instance: trust-manager
+    app.kubernetes.io/version: "v0.20.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  commonName: "trust-manager.cert-manager.svc"
+  dnsNames:
+    - "trust-manager.cert-manager.svc"
+  secretName: trust-manager-tls
+  revisionHistoryLimit: 1
+  issuerRef:
+    name: trust-manager
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: trust-manager/templates/certificate.yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: trust-manager
+  namespace: cert-manager
+  labels:
+    app.kubernetes.io/name: trust-manager
+    helm.sh/chart: trust-manager-v0.20.0
+    app.kubernetes.io/instance: trust-manager
+    app.kubernetes.io/version: "v0.20.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selfSigned: {}
+---
+# Source: trust-manager/templates/webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: trust-manager
+  labels:
+    app: trust-manager
+    app.kubernetes.io/name: trust-manager
+    helm.sh/chart: trust-manager-v0.20.0
+    app.kubernetes.io/instance: trust-manager
+    app.kubernetes.io/version: "v0.20.0"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    cert-manager.io/inject-ca-from: "cert-manager/trust-manager"
+webhooks:
+  - name: trust.cert-manager.io
+    rules:
+      - apiGroups:
+          - "trust.cert-manager.io"
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - bundles
+    admissionReviewVersions: ["v1"]
+    timeoutSeconds: 5
+    failurePolicy: Fail
+    sideEffects: None
+    clientConfig:
+      service:
+        name: trust-manager
+        namespace: cert-manager
+        path: /validate-trust-cert-manager-io-v1alpha1-bundle

--- a/plugins/osac/plugin.yaml
+++ b/plugins/osac/plugin.yaml
@@ -1,0 +1,47 @@
+---
+name: osac
+type: addon
+order: 200
+
+operators:
+  - name: authorino-operator
+    channel: stable
+    namespace: openshift-operators
+    source: cs-redhat-operator-index-v4-20
+  - name: ansible-automation-platform-operator
+    version: 2.5.0-0.1777407881
+    channel: stable-2.5-cluster-scoped
+    init_version: 2.5.0-0.1777407881
+    namespace: ansible-aap
+    source: cs-redhat-operator-index-v4-20
+    global: true
+    csvNames:
+      - aap-operator
+
+defaults:
+  osac_installer:
+    repo_path: /tmp/osac-installer
+    version: main
+    overlay: caas-ci
+    namespace: osac-e2e-ci
+  osac_operator:
+    name: osac-operator
+    ns: osac-operator-system
+  osac_aap:
+    name: osac-aap
+    ns: ansible-aap
+    license_file: /tmp/aap-license.zip
+    license_secret: aap-license
+    controller_disabled: false
+    eda_disabled: false
+    hub_disabled: true
+    image_pull_policy: IfNotPresent
+    lightspeed_disabled: true
+    no_log: true
+    redis_mode: standalone
+    route_tls_termination: Edge
+
+# Used when mirror is set to core or plugin (disconnected mode)
+# registries:
+#   - location: "ghcr.io/osac-project"
+#     mirror: "osac-project"

--- a/plugins/osac/tasks/aap-license.yaml
+++ b/plugins/osac/tasks/aap-license.yaml
@@ -1,0 +1,37 @@
+---
+- name: Ensure AAP namespace exists
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: "{{ osac_aap.ns }}"
+
+- name: Check AAP license file
+  ansible.builtin.stat:
+    path: "{{ osac_aap.license_file }}"
+  register: __r_aap_license_stat
+
+- name: Fail if AAP license file not found
+  ansible.builtin.fail:
+    msg: "AAP license file not found at {{ osac_aap.license_file }}"
+  when: not (__r_aap_license_stat.stat.exists | default(false))
+
+- name: Read AAP license file
+  ansible.builtin.slurp:
+    src: "{{ osac_aap.license_file }}"
+  register: __r_aap_license_content
+
+- name: Create AAP license Secret
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: "{{ osac_aap.license_secret }}"
+        namespace: "{{ osac_aap.ns }}"
+      type: Opaque
+      data:
+        manifest.zip: "{{ __r_aap_license_content.content }}"

--- a/plugins/osac/tasks/check-prerequisites.yaml
+++ b/plugins/osac/tasks/check-prerequisites.yaml
@@ -1,0 +1,54 @@
+---
+- name: Check cluster is reachable
+  kubernetes.core.k8s_info:
+    api_version: config.openshift.io/v1
+    kind: ClusterVersion
+    name: version
+  register: __r_cv
+  retries: 3
+  delay: 5
+  until: __r_cv.resources | length > 0
+
+- name: Debug cluster info
+  ansible.builtin.debug:
+    msg:
+      - "Version: {{ __r_cv.resources[0].status.desired.version }}"
+      - "Channel: {{ __r_cv.resources[0].spec.channel | default('none') }}"
+      - "ClusterID: {{ __r_cv.resources[0].spec.clusterID | default('unknown') }}"
+
+- name: Check for StorageClass
+  kubernetes.core.k8s_info:
+    api_version: storage.k8s.io/v1
+    kind: StorageClass
+  register: __r_sc
+
+- name: Fail if no StorageClass exists
+  ansible.builtin.fail:
+    msg: "No StorageClass found in the cluster"
+  when: __r_sc.resources | length == 0
+
+- name: Debug StorageClass
+  ansible.builtin.debug:
+    msg:
+      - "StorageClasses: {{ __r_sc.resources | map(attribute='metadata.name') | list }}"
+
+- name: Check ACM MultiClusterHub
+  kubernetes.core.k8s_info:
+    api_version: operator.open-cluster-management.io/v1
+    kind: MultiClusterHub
+  register: __r_mch
+
+- name: Fail if ACM is not installed
+  ansible.builtin.fail:
+    msg: "ACM MultiClusterHub not found"
+  when: __r_mch.resources | length == 0
+
+- name: Debug ACM
+  ansible.builtin.debug:
+    msg:
+      - "MultiClusterHub: {{ __r_mch.resources[0].metadata.name }}"
+      - "Status: {{ __r_mch.resources[0].status.phase | default('unknown') }}"
+
+# Check operators installed by the plugin, which are required for OSAC
+#  - cert-manager
+#  - authorino

--- a/plugins/osac/tasks/deploy-aap.yaml
+++ b/plugins/osac/tasks/deploy-aap.yaml
@@ -1,0 +1,137 @@
+---
+- name: Verify AAP operator CSV is installed
+  kubernetes.core.k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    namespace: "{{ osac_aap.ns }}"
+    label_selectors:
+      - "operators.coreos.com/ansible-automation-platform-operator.{{ osac_aap.ns }}"
+  register: __r_aap_csv
+  retries: 30
+  delay: 10
+  until:
+    - __r_aap_csv.resources | length > 0
+    - __r_aap_csv.resources[0].status.phase | default('') == 'Succeeded'
+
+- name: Debug AAP operator CSV
+  ansible.builtin.debug:
+    msg:
+      - "CSV: {{ __r_aap_csv.resources[0].metadata.name }}"
+      - "Phase: {{ __r_aap_csv.resources[0].status.phase }}"
+      - "Version: {{ __r_aap_csv.resources[0].spec.version | default('unknown') }}"
+
+- name: Wait for AAP operator deployment
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: automation-controller-operator-controller-manager
+    namespace: "{{ osac_aap.ns }}"
+  register: __r_aap_operator_deploy
+  retries: 30
+  delay: 10
+  until:
+    - __r_aap_operator_deploy.resources | length > 0
+    - __r_aap_operator_deploy.resources[0].status.availableReplicas | default(0) | int > 0
+
+- name: Debug AAP operator deployment
+  ansible.builtin.debug:
+    msg:
+      - "Deployment: {{ __r_aap_operator_deploy.resources[0].metadata.name }}"
+      - "Replicas: {{ __r_aap_operator_deploy.resources[0].status.replicas | default(0) }}"
+      - "Available: {{ __r_aap_operator_deploy.resources[0].status.availableReplicas | default(0) }}"
+
+- name: Deploy AnsibleAutomationPlatform
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('ansible.builtin.template', plugin_dir ~ '/files/aap.yaml.j2') | from_yaml }}"
+  register: __r_deploy_aap
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: __r_deploy_aap is success
+
+- name: Wait for AAP reconciliation and collect diagnostics on failure
+  block:
+    - name: Wait for AnsibleAutomationPlatform reconciliation (Successful=True, Failure=False)
+      kubernetes.core.k8s_info:
+        api_version: aap.ansible.com/v1alpha1
+        kind: AnsibleAutomationPlatform
+        name: "{{ osac_aap.name }}"
+        namespace: "{{ osac_aap.ns }}"
+      register: __r_aap_resource
+      retries: 60
+      delay: 30
+      until:
+        - __r_aap_resource.resources | length > 0
+        - __r_aap_resource.resources[0].status.conditions | default([]) | selectattr('type', 'equalto', 'Successful') | selectattr('status', 'equalto', 'True') | list | length > 0
+        - __r_aap_resource.resources[0].status.conditions | default([]) | selectattr('type', 'equalto', 'Failure') | selectattr('status', 'equalto', 'True') | list | length == 0
+
+  rescue:
+    - name: Debug AAP CR status on failure
+      ansible.builtin.debug:
+        msg:
+          - "AAP CR conditions: {{ __r_aap_resource.resources[0].status.conditions | default([]) }}"
+
+    - name: Get AAP operator logs
+      ansible.builtin.command:
+        cmd: "oc logs -n {{ osac_aap.ns }} deployment/automation-controller-operator-controller-manager --tail=50"
+      register: __r_aap_operator_logs
+      changed_when: false
+      ignore_errors: true
+
+    - name: Debug AAP operator logs
+      ansible.builtin.debug:
+        var: __r_aap_operator_logs.stdout_lines
+      when: __r_aap_operator_logs.stdout_lines is defined
+
+    - name: Get latest AAP reconciliation runner pod
+      ansible.builtin.shell:
+        cmd: "oc get pods -n {{ osac_aap.ns }} -l ansible-operator-cr={{ osac_aap.name }} --sort-by=.metadata.creationTimestamp -o name | tail -1"
+      register: __r_aap_runner_pod
+      changed_when: false
+      ignore_errors: true
+
+    - name: Get AAP runner pod logs
+      ansible.builtin.command:
+        cmd: "oc logs -n {{ osac_aap.ns }} {{ __r_aap_runner_pod.stdout }} --tail=100"
+      register: __r_aap_runner_logs
+      changed_when: false
+      ignore_errors: true
+      when: __r_aap_runner_pod.stdout | default('') | length > 0
+
+    - name: Debug AAP runner pod logs
+      ansible.builtin.debug:
+        var: __r_aap_runner_logs.stdout_lines
+      when: __r_aap_runner_logs.stdout_lines is defined
+
+    - name: Fail with reconciliation error
+      ansible.builtin.fail:
+        msg: "AnsibleAutomationPlatform reconciliation failed. Check operator logs above."
+
+- name: Debug AnsibleAutomationPlatform resource
+  ansible.builtin.debug:
+    msg:
+      - "Name: {{ __r_aap_resource.resources[0].metadata.name }}"
+      - "Status: {{ __r_aap_resource.resources[0].status.conditions | default([]) | map(attribute='type') | zip(__r_aap_resource.resources[0].status.conditions | default([]) | map(attribute='status')) | list }}"
+
+- name: Get AAP deployments
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    namespace: "{{ osac_aap.ns }}"
+  register: __r_aap_deployments
+
+- name: Get AAP StatefulSets
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: StatefulSet
+    namespace: "{{ osac_aap.ns }}"
+  register: __r_aap_statefulsets
+
+- name: Debug AAP deployment summary
+  ansible.builtin.debug:
+    msg:
+      - "AAP namespace: {{ osac_aap.ns }}"
+      - "AAP name: {{ osac_aap.name }}"
+      - "AAP CR status: {{ __r_aap_resource.resources[0].status.conditions | default([]) | map(attribute='type') | zip(__r_aap_resource.resources[0].status.conditions | default([]) | map(attribute='status')) | list }}"
+      - "Deployments ({{ __r_aap_deployments.resources | length }}): {{ __r_aap_deployments.resources | map(attribute='metadata.name') | zip(__r_aap_deployments.resources | map(attribute='status.availableReplicas', default=0)) | list }}"
+      - "StatefulSets ({{ __r_aap_statefulsets.resources | length }}): {{ __r_aap_statefulsets.resources | map(attribute='metadata.name') | zip(__r_aap_statefulsets.resources | map(attribute='status.readyReplicas', default=0)) | list }}"

--- a/plugins/osac/tasks/deploy-ca-issuer.yaml
+++ b/plugins/osac/tasks/deploy-ca-issuer.yaml
@@ -1,0 +1,26 @@
+---
+- name: Apply CA issuer manifests
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ item }}"
+  loop: "{{ lookup('file', plugin_dir ~ '/files/ca-issuer.yaml') | from_yaml_all | list }}"
+  register: __r_ca_issuer
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: __r_ca_issuer is success
+
+- name: Wait for ClusterIssuer to be ready
+  kubernetes.core.k8s_info:
+    api_version: cert-manager.io/v1
+    kind: ClusterIssuer
+    name: default-ca
+  register: __r_cluster_issuer
+  retries: 30
+  delay: 10
+  until:
+    - __r_cluster_issuer.resources | length > 0
+    - __r_cluster_issuer.resources[0].status.conditions | default([]) | selectattr('type', 'equalto', 'Ready') | selectattr('status', 'equalto', 'True') | list | length > 0
+
+- name: Debug CA issuer status
+  ansible.builtin.debug:
+    msg: "ClusterIssuer default-ca is ready"

--- a/plugins/osac/tasks/deploy-cert-manager.yaml
+++ b/plugins/osac/tasks/deploy-cert-manager.yaml
@@ -1,0 +1,36 @@
+---
+- name: Deploy CertManager CR
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: operator.openshift.io/v1alpha1
+      kind: CertManager
+      metadata:
+        name: cluster
+      spec:
+        managementState: Managed
+  register: __r_deploy_certmanager
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: __r_deploy_certmanager is success
+
+- name: Wait for cert-manager deployments
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: "{{ item }}"
+    namespace: cert-manager
+  register: __r_certmanager_deploy
+  retries: 30
+  delay: 10
+  until:
+    - __r_certmanager_deploy.resources | length > 0
+    - __r_certmanager_deploy.resources[0].status.availableReplicas | default(0) | int > 0
+  loop:
+    - cert-manager
+    - cert-manager-webhook
+    - cert-manager-cainjector
+
+- name: Debug cert-manager status
+  ansible.builtin.debug:
+    msg: "cert-manager deployments are ready in cert-manager namespace"

--- a/plugins/osac/tasks/deploy-keycloak.yaml
+++ b/plugins/osac/tasks/deploy-keycloak.yaml
@@ -1,0 +1,40 @@
+---
+- name: Apply Keycloak manifests
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ item }}"
+  loop: "{{ lookup('file', plugin_dir ~ '/files/keycloak.yaml') | from_yaml_all | list }}"
+  register: __r_keycloak
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: __r_keycloak is success
+
+- name: Wait for Keycloak database
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: StatefulSet
+    name: keycloak-database
+    namespace: keycloak
+  register: __r_keycloak_db
+  retries: 30
+  delay: 10
+  until:
+    - __r_keycloak_db.resources | length > 0
+    - __r_keycloak_db.resources[0].status.readyReplicas | default(0) | int > 0
+
+- name: Wait for Keycloak service
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: keycloak-service
+    namespace: keycloak
+  register: __r_keycloak_svc
+  retries: 60
+  delay: 10
+  until:
+    - __r_keycloak_svc.resources | length > 0
+    - __r_keycloak_svc.resources[0].status.availableReplicas | default(0) | int > 0
+
+- name: Debug Keycloak status
+  ansible.builtin.debug:
+    msg: "Keycloak database and service are ready in keycloak namespace"

--- a/plugins/osac/tasks/deploy-osac.yaml
+++ b/plugins/osac/tasks/deploy-osac.yaml
@@ -1,0 +1,153 @@
+---
+- name: Clone osac-installer
+  ansible.builtin.git:
+    repo: https://github.com/osac-project/osac-installer.git
+    dest: "{{ osac_installer.repo_path }}"
+    version: "{{ osac_installer.version }}"
+    force: true
+    recursive: true
+
+- name: Copy pull secret
+  ansible.builtin.copy:
+    src: "{{ pullSecretPath }}"
+    dest: "{{ osac_installer.repo_path }}/overlays/{{ osac_installer.overlay }}/files/quay-pull-secret.json"
+    mode: "0644"
+
+- name: Copy AAP license
+  ansible.builtin.copy:
+    src: "{{ osac_aap.license_file }}"
+    dest: "{{ osac_installer.repo_path }}/overlays/{{ osac_installer.overlay }}/files/license.zip"
+    mode: "0644"
+
+- name: Ensure osac namespace exists
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: osac
+
+- name: Apply kustomize overlay
+  ansible.builtin.command:
+    cmd: "oc apply --server-side --force-conflicts -k overlays/{{ osac_installer.overlay }}"
+    chdir: "{{ osac_installer.repo_path }}"
+  register: __r_apply_overlay
+  retries: 3
+  delay: 10
+  until: __r_apply_overlay is success
+
+- name: Debug applied resources
+  ansible.builtin.debug:
+    var: __r_apply_overlay.stdout_lines
+
+- name: Create fulfillment-controller OAuth credentials
+  ansible.builtin.shell:
+    cmd: |
+      FC_CLIENT_SECRET=$(jq -r '.clients[] | select(.clientId == "fulfillment-controller") | .secret' prerequisites/keycloak/service/files/realm.json)
+      oc create secret generic fulfillment-controller-credentials \
+        --from-literal=client-id=fulfillment-controller \
+        --from-literal=client-secret="${FC_CLIENT_SECRET}" \
+        -n {{ osac_installer.namespace }} \
+        --dry-run=client -o yaml | oc apply -f -
+    chdir: "{{ osac_installer.repo_path }}"
+  changed_when: true
+
+- name: Run AAP configuration
+  ansible.builtin.command:
+    cmd: ./scripts/aap-configuration.sh
+    chdir: "{{ osac_installer.repo_path }}"
+  environment:
+    INSTALLER_NAMESPACE: "{{ osac_installer.namespace }}"
+    INSTALLER_KUSTOMIZE_OVERLAY: "{{ osac_installer.overlay }}"
+  changed_when: true
+
+- name: Wait for AAP bootstrap job (up to 40 min)
+  kubernetes.core.k8s_info:
+    api_version: batch/v1
+    kind: Job
+    name: aap-bootstrap
+    namespace: "{{ osac_installer.namespace }}"
+  register: __r_aap_bootstrap
+  retries: 80
+  delay: 30
+  until:
+    - __r_aap_bootstrap.resources | length > 0
+    - __r_aap_bootstrap.resources[0].status.conditions | default([]) | selectattr('type', 'equalto', 'Complete') | selectattr('status', 'equalto', 'True') | list | length > 0
+
+- name: Wait for Authorino deployment
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: authorino
+    namespace: "{{ osac_installer.namespace }}"
+  register: __r_authorino
+  retries: 30
+  delay: 10
+  until:
+    - __r_authorino.resources | length > 0
+    - __r_authorino.resources[0].status.availableReplicas | default(0) | int > 0
+
+- name: Wait for fulfillment stack
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: "{{ item }}"
+    namespace: "{{ osac_installer.namespace }}"
+  register: __r_fulfillment
+  retries: 30
+  delay: 10
+  until:
+    - __r_fulfillment.resources | length > 0
+    - __r_fulfillment.resources[0].status.availableReplicas | default(0) | int > 0
+  loop:
+    - fulfillment-grpc-server
+    - fulfillment-ingress-proxy
+
+- name: Wait for AAP gateway route
+  kubernetes.core.k8s_info:
+    api_version: route.openshift.io/v1
+    kind: Route
+    name: osac-aap
+    namespace: "{{ osac_installer.namespace }}"
+  register: __r_aap_route
+  retries: 30
+  delay: 10
+  until:
+    - __r_aap_route.resources | length > 0
+    - __r_aap_route.resources[0].spec.host | default('') | length > 0
+
+- name: Debug AAP gateway route
+  ansible.builtin.debug:
+    msg: "AAP gateway route: {{ __r_aap_route.resources[0].spec.host }}"
+
+- name: Prepare AAP
+  ansible.builtin.command:
+    cmd: ./scripts/prepare-aap.sh
+    chdir: "{{ osac_installer.repo_path }}"
+  environment:
+    INSTALLER_NAMESPACE: "{{ osac_installer.namespace }}"
+    INSTALLER_KUSTOMIZE_OVERLAY: "{{ osac_installer.overlay }}"
+  changed_when: true
+
+- name: Prepare fulfillment service
+  ansible.builtin.command:
+    cmd: ./scripts/prepare-fulfillment-service.sh
+    chdir: "{{ osac_installer.repo_path }}"
+  environment:
+    INSTALLER_NAMESPACE: "{{ osac_installer.namespace }}"
+    INSTALLER_KUSTOMIZE_OVERLAY: "{{ osac_installer.overlay }}"
+  changed_when: true
+
+- name: Prepare tenant
+  ansible.builtin.command:
+    cmd: ./scripts/prepare-tenant.sh
+    chdir: "{{ osac_installer.repo_path }}"
+  environment:
+    INSTALLER_NAMESPACE: "{{ osac_installer.namespace }}"
+    INSTALLER_KUSTOMIZE_OVERLAY: "{{ osac_installer.overlay }}"
+  changed_when: true
+
+- name: Debug OSAC deployment complete
+  ansible.builtin.debug:
+    msg: "OSAC deployment complete in {{ osac_installer.namespace }} namespace"

--- a/plugins/osac/tasks/deploy-trust-manager.yaml
+++ b/plugins/osac/tasks/deploy-trust-manager.yaml
@@ -1,0 +1,27 @@
+---
+- name: Apply trust-manager manifests
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ item }}"
+  loop: "{{ lookup('file', plugin_dir ~ '/files/trust-manager.yaml') | from_yaml_all | list }}"
+  register: __r_trust_manager
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: __r_trust_manager is success
+
+- name: Wait for trust-manager deployment
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: trust-manager
+    namespace: cert-manager
+  register: __r_trust_manager_deploy
+  retries: 30
+  delay: 10
+  until:
+    - __r_trust_manager_deploy.resources | length > 0
+    - __r_trust_manager_deploy.resources[0].status.availableReplicas | default(0) | int > 0
+
+- name: Debug trust-manager status
+  ansible.builtin.debug:
+    msg: "trust-manager deployment is ready in cert-manager namespace"

--- a/plugins/osac/tasks/deploy.yaml
+++ b/plugins/osac/tasks/deploy.yaml
@@ -1,0 +1,21 @@
+---
+- name: Check OSAC prerequisites
+  ansible.builtin.include_tasks: "{{ plugin_dir }}/tasks/check-prerequisites.yaml"
+
+- name: Deploy trust-manager
+  ansible.builtin.include_tasks: "{{ plugin_dir }}/tasks/deploy-trust-manager.yaml"
+
+- name: Deploy CA issuer
+  ansible.builtin.include_tasks: "{{ plugin_dir }}/tasks/deploy-ca-issuer.yaml"
+
+- name: Deploy Keycloak
+  ansible.builtin.include_tasks: "{{ plugin_dir }}/tasks/deploy-keycloak.yaml"
+
+- name: Apply AAP license
+  ansible.builtin.include_tasks: "{{ plugin_dir }}/tasks/aap-license.yaml"
+
+- name: Deploy AAP
+  ansible.builtin.include_tasks: "{{ plugin_dir }}/tasks/deploy-aap.yaml"
+
+- name: Deploy OSAC (via osac-installer)
+  ansible.builtin.include_tasks: "{{ plugin_dir }}/tasks/deploy-osac.yaml"

--- a/plugins/osac/tasks/post-validate.yaml
+++ b/plugins/osac/tasks/post-validate.yaml
@@ -1,0 +1,51 @@
+---
+- name: Verify OSAC operator deployment exists
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: "{{ osac_operator.name }}-controller-manager"
+    namespace: "{{ osac_operator.ns }}"
+  register: __osac_deploy
+  retries: 30
+  delay: 10
+  until: __osac_deploy.resources | length > 0
+
+- name: Verify OSAC operator is available
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: "{{ osac_operator.name }}-controller-manager"
+    namespace: "{{ osac_operator.ns }}"
+  register: __osac_ready
+  retries: 30
+  delay: 10
+  until:
+    - __osac_ready.resources | length > 0
+    - __osac_ready.resources[0].status.availableReplicas | default(0) | int > 0
+
+- name: Get OSAC operator pods
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Pod
+    namespace: "{{ osac_operator.ns }}"
+  register: __osac_pods
+
+- name: Show OSAC operator pod status
+  ansible.builtin.debug:
+    msg: "{{ __osac_pods.resources | map(attribute='metadata.name') | zip(__osac_pods.resources | map(attribute='status.phase')) | list }}"
+
+- name: Get OSAC operator deployment conditions
+  ansible.builtin.debug:
+    msg: "{{ __osac_ready.resources[0].status.conditions }}"
+
+- name: Get OSAC namespace events
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Event
+    namespace: "{{ osac_operator.ns }}"
+  register: __osac_events
+
+- name: Show recent OSAC events
+  ansible.builtin.debug:
+    msg: "{{ __osac_events.resources | rejectattr('lastTimestamp', 'none') | sort(attribute='lastTimestamp') | map(attribute='message') | list }}"
+  when: __osac_events.resources | length > 0

--- a/scripts/setup/configure_devscripts.sh
+++ b/scripts/setup/configure_devscripts.sh
@@ -95,6 +95,9 @@ if [ "$STORAGE_PLUGIN" = "odf" ]; then
     MASTER_MEMORY_VAL=$((MASTER_MEMORY_VAL + 16384)) # +16 GB RAM (ODF/rook/noobaa + Quay)
     VM_EXTRADISKS_SIZE_VAL="60G"    # Masters don't need large LVMS disks with ODF
     LANDINGZONE_DISK_VAL=500        # Ceph OSDs store mirrored images on the LZ disk
+elif [ "${ENCLAVE_HEAVY_WORKLOAD:-false}" = "true" ]; then
+    MASTER_VCPU_VAL=16              # 16 vCPUs (up from 12)
+    MASTER_MEMORY_VAL=$((MASTER_MEMORY_VAL + 16384)) # +16 GB RAM for heavy workloads (e.g. AAP/OSAC)
 fi
 
 # Create configuration file


### PR DESCRIPTION
Introduce the OSAC operator as an enclave plugin with a minimal deploy task that pulls the operator manifests from a container image and applies them to the cluster. Includes a post-validation check that waits for the controller-manager deployment to become available.

The E2E workflow deploys a connected cluster and runs the plugin on top, triggered by changes to `plugins/osac/` or manual dispatch.

MGMT-24065