### PR TITLE
chmod oc-mirror once

### DIFF
--- a/playbooks/tasks/download_control_binaries.yaml
+++ b/playbooks/tasks/download_control_binaries.yaml
@@ -62,6 +62,11 @@
     dest: "{{ workingDir }}/bin/"
     remote_src: true
 
+- name: Change oc-mirror permissions
+  ansible.builtin.file:
+    path: "{{ workingDir }}/bin/oc-mirror"
+    mode: "0755"
+
 - name: Download clairctl
   ansible.builtin.get_url:
     url: "{{ control_binaries.clairctl.url }}"

--- a/playbooks/tasks/mirror_cache.yaml
+++ b/playbooks/tasks/mirror_cache.yaml
@@ -29,11 +29,6 @@
     src: ../../templates/imagesetconfiguration.yaml.j2
     dest: "{{ workingDir }}/config/imagesetconfiguration-cache.yaml"
 
-- name: Change oc-mirror permissions
-  ansible.builtin.file:
-    path: "{{ workingDir }}/bin/oc-mirror"
-    mode: "0755"
-
 - name: Ensure oc-mirror log directory exists
   ansible.builtin.file:
     path: "{{ workingDir }}/logs/"

--- a/playbooks/tasks/mirror_registry.yaml
+++ b/playbooks/tasks/mirror_registry.yaml
@@ -41,11 +41,6 @@
     src: ../../templates/imagesetconfiguration.yaml.j2
     dest: "{{ workingDir }}/config/imagesetconfiguration.yaml"
 
-- name: Change oc-mirror permissions
-  ansible.builtin.file:
-    path: "{{ workingDir }}/bin/oc-mirror"
-    mode: "0755"
-
 - name: Ensure oc-mirror log directory exists
   ansible.builtin.file:
     path: "{{ workingDir }}/logs/"


### PR DESCRIPTION
centralize all binary related operations into a single playbook.