### PR TITLE
use explicit loop_var for plugin slurp task

### DIFF
--- a/playbooks/tasks/collect_core_plugin_operators.yaml
+++ b/playbooks/tasks/collect_core_plugin_operators.yaml
@@ -17,9 +17,11 @@
 
 - name: Read plugin descriptors
   ansible.builtin.slurp:
-    src: "{{ item }}"
+    src: "{{ plugin_path }}"
   loop: "{{ r_cp_find.files | map(attribute='path') | list }}"
   register: r_cp_slurp
+  loop_control:
+    loop_var: plugin_path
 
 - name: Build combined plugin operators list
   vars:

--- a/playbooks/tasks/collect_plugin_registries.yaml
+++ b/playbooks/tasks/collect_plugin_registries.yaml
@@ -14,9 +14,11 @@
 
 - name: Read plugin descriptors
   ansible.builtin.slurp:
-    src: "{{ item }}"
+    src: "{{ plugin_path }}"
   loop: "{{ r_pr_find.files | map(attribute='path') | list }}"
   register: r_pr_slurp
+  loop_control:
+    loop_var: plugin_path
 
 - name: Build combined plugin registries list
   vars:

--- a/playbooks/tasks/deploy_foundation_plugins.yaml
+++ b/playbooks/tasks/deploy_foundation_plugins.yaml
@@ -16,9 +16,11 @@
 
 - name: Read plugin descriptors
   ansible.builtin.slurp:
-    src: "{{ item }}"
+    src: "{{ plugin_path }}"
   loop: "{{ r_foundation_find.files | map(attribute='path') | list }}"
   register: r_foundation_slurp
+  loop_control:
+    loop_var: plugin_path
 
 - name: Parse foundation plugin descriptors
   ansible.builtin.set_fact:

--- a/playbooks/tasks/pre_install_validate_plugins.yaml
+++ b/playbooks/tasks/pre_install_validate_plugins.yaml
@@ -102,9 +102,11 @@
 
 - name: Read plugin descriptors for filtering
   ansible.builtin.slurp:
-    src: "{{ item }}/plugin.yaml"
+    src: "{{ plugin_dir_path }}/plugin.yaml"
   loop: "{{ r_pre_install_plugins.files | map(attribute='path') | map('dirname') | map('dirname') | unique | list | sort }}"
   register: r_pre_install_slurp
+  loop_control:
+    loop_var: plugin_dir_path
   when: r_pre_install_plugins.files | length > 0
 
 - name: Build enabled plugin name list

--- a/playbooks/tasks/validate_enabled_plugins.yaml
+++ b/playbooks/tasks/validate_enabled_plugins.yaml
@@ -18,9 +18,11 @@
 
 - name: Read plugin descriptors
   ansible.builtin.slurp:
-    src: "{{ item }}"
+    src: "{{ plugin_path }}"
   loop: "{{ _vp_find.files | map(attribute='path') | list }}"
   register: _vp_slurp
+  loop_control:
+    loop_var: plugin_path
 
 - name: Filter to enabled plugins with requirements
   ansible.builtin.set_fact:


### PR DESCRIPTION
```
Warning: : TASK: Read plugin descriptors: The loop variable 'item' is already
in use. You should set the `loop_var` value in the `loop_control` option for
the task to something else to avoid variable collisions and unexpected behavior. 
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code clarity in plugin management automation tasks across multiple playbooks through variable naming refinements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->