### PR TITLE
Enable Slack notification for scheduled ODF E2E runs

### DIFF
--- a/.github/workflows/e2e-odf-schedule.yml
+++ b/.github/workflows/e2e-odf-schedule.yml
@@ -26,5 +26,6 @@ jobs:
             -f run-connected=false \
             -f run-disconnected=true \
             -f storage-plugin=odf \
+            -f send-slack-notification=true \
             -R "${{ github.repository }}"
           echo "Dispatched E2E Disconnected with ODF storage plugin" | tee -a $GITHUB_STEP_SUMMARY


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced workflow notifications for scheduled end-to-end testing to provide better visibility into deployment status and results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->