### PR TITLE
limit bootstrap setup to rhel 10

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -184,8 +184,8 @@ step_setup() {
     echo 'Runtime Host:' | tee -a ${log}
     cat /etc/redhat-release | tee -a ${log}
     echo ' - '
-    if ! [[ $(</etc/os-release) =~ CPE_NAME=\"cpe:/o:(redhat:enterprise_linux|centos:centos):10(\.?.*)?\" ]]; then
-        echo "RHEL 10 / CentOS Stream 10 Check Failed"
+    if ! [[ $(</etc/os-release) =~ CPE_NAME=\"cpe:/o:redhat:enterprise_linux:10(\.?.*)?\" ]]; then
+        echo "RHEL 10 Check Failed"
         exit 1
     fi
 


### PR DESCRIPTION
follow up on #274

reverts centos support added in #254

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * RHEL 10 system identification validation is now stricter, requiring systems to report the correct Red Hat Enterprise Linux 10 CPE string in OS identification to pass bootstrap checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->