### PR TITLE
add name metadata to plugin image set configuration

### DIFF
--- a/templates/plugin-imageset.yaml.j2
+++ b/templates/plugin-imageset.yaml.j2
@@ -1,6 +1,8 @@
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1
+metadata:
+  name: {{ catalog_mirror }}
 mirror:
   operators:
     - catalog: {{ catalog_image }}:{{ catalog_version }}


### PR DESCRIPTION
this is intended to be used to distinct plugin mirroring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced resource configuration by introducing proper identification metadata for improved resource management and organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->