### PR TITLE
only mirror plugin when operators is not an empty list

### DIFF
--- a/playbooks/tasks/deploy_plugin.yaml
+++ b/playbooks/tasks/deploy_plugin.yaml
@@ -119,6 +119,7 @@
     file: mirror_plugin.yaml
   when:
     - plugin.mirror | default('none') == 'plugin'
+    - plugin.operators | default([]) | length > 0
     - disconnected | default(true) | bool
   tags: mirror
 

--- a/playbooks/tasks/deploy_plugin.yaml
+++ b/playbooks/tasks/deploy_plugin.yaml
@@ -119,7 +119,7 @@
     file: mirror_plugin.yaml
   when:
     - plugin.mirror | default('none') == 'plugin'
-    - plugin.operators | default([]) | length > 0
+    - plugin.operators | default([]) | length > 0 or plugin.additionalImages | default([]) | length > 0
     - disconnected | default(true) | bool
   tags: mirror
 
@@ -135,7 +135,6 @@
   when:
     - plugin.registries is defined
     - plugin.mirror | default('none') in ['core', 'plugin']
-    - plugin.operators | default([]) | length > 0
     - disconnected | default(true) | bool
   tags: mirror
 

--- a/playbooks/tasks/deploy_plugin.yaml
+++ b/playbooks/tasks/deploy_plugin.yaml
@@ -135,6 +135,7 @@
   when:
     - plugin.registries is defined
     - plugin.mirror | default('none') in ['core', 'plugin']
+    - plugin.operators | default([]) | length > 0
     - disconnected | default(true) | bool
   tags: mirror
 
@@ -149,7 +150,7 @@
   loop_control:
     loop_var: operator
   when:
-    - plugin.operators is defined
+    - plugin.operators | default([]) | length > 0
     - plugin.installOperators | default(true)
   tags: operators
 

--- a/playbooks/tasks/mirror_plugin.yaml
+++ b/playbooks/tasks/mirror_plugin.yaml
@@ -4,9 +4,11 @@
     that:
       - plugin is defined
       - plugin.mirror | default('none') == 'plugin'
-      - plugin.operators | default([]) | length > 0
+      - plugin.operators | default([]) | length > 0 or plugin.additionalImages | default([]) | length > 0
       - disconnected | default(true) | bool
-    fail_msg: "Validation Error: Ensure 'plugin' is defined, 'plugin.mirror' is set to 'plugin', 'plugin.operators' is not empty, and 'disconnected' is true."
+    fail_msg: >-
+      Validation Error: Ensure 'plugin' is defined, 'plugin.mirror' is set to 'plugin',
+      'plugin.operators' or 'plugin.additionalImages' are not empty, and 'disconnected' is true.
 
 - name: Set catalog image and mirror defaults
   set_fact:

--- a/playbooks/tasks/mirror_plugin.yaml
+++ b/playbooks/tasks/mirror_plugin.yaml
@@ -4,16 +4,15 @@
     that:
       - plugin is defined
       - plugin.mirror | default('none') == 'plugin'
+      - plugin.operators | default([]) | length > 0
       - disconnected | default(true) | bool
-    fail_msg: "Validation Error: Ensure 'plugin' is defined, 'plugin.mirror' is set to 'plugin', and 'disconnected' is true."
+    fail_msg: "Validation Error: Ensure 'plugin' is defined, 'plugin.mirror' is set to 'plugin', 'plugin.operators' is not empty, and 'disconnected' is true."
 
 - name: Set catalog image and mirror defaults
   set_fact:
     catalog_image: "{{ rh_operator_catalog }}"
     catalog_mirror: "{{ mirror_rh_operator_catalog }}-{{ plugin.name }}"
     catalog_version: "{{ rh_operator_catalog_version }}"
-  when:
-    - plugin.operators is defined
 
 - name: Override variables for certified catalog
   set_fact:
@@ -21,15 +20,12 @@
     catalog_mirror: "{{ mirror_certified_rh_operator_catalog }}-{{ plugin.name }}"
     catalog_version: "{{ certified_operator_catalog_version }}"
   when:
-    - plugin.operators is defined
     - plugin.catalog | default("") == "certified"
 
 - name: Template plugin imageset configuration
   ansible.builtin.template:
     src: "{{ playbook_dir }}/../templates/plugin-imageset.yaml.j2"
     dest: "{{ workingDir }}/plugin-{{ plugin_name }}-imageset.yaml"
-  when:
-    - plugin.operators is defined
 
 - name: Ensure oc-mirror log directory exists
   ansible.builtin.file:


### PR DESCRIPTION
otherwise what would be mirrored?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enhanced plugin mirroring logic to execute when plugins include operator or additional images, improving configuration flexibility
* Strengthened operator installation validation by requiring list elements rather than just variable presence
* Improved catalog configuration handling to support additional images scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->