### PR TITLE
add default operator source to configure operator and rename default catalog

### DIFF
--- a/defaults/operators.yaml
+++ b/defaults/operators.yaml
@@ -6,28 +6,24 @@ operators:
     channel: stable-3.15
     init_version: 3.15.0
     namespace: quay-enterprise
-    source: cs-redhat-operator-index-v4-20
 
   - name: multicluster-engine
     version: 2.10.1
     channel: stable-2.10
     init_version: 2.10.0
     namespace: multicluster-engine
-    source: cs-redhat-operator-index-v4-20
 
   - name: advanced-cluster-management
     version: 2.15.1
     channel: release-2.15
     init_version: 2.15.0
     namespace: open-cluster-management
-    source: cs-redhat-operator-index-v4-20
 
   - name: cincinnati-operator
     version: 5.0.3
     channel: v1
     init_version: 5.0.3
     namespace: openshift-update-service
-    source: cs-redhat-operator-index-v4-20
     csvNames:
       - update-service-operator
 
@@ -36,7 +32,6 @@ operators:
     channel: gitops-1.19
     init_version: 1.19.2
     namespace: openshift-gitops-operator
-    source: cs-redhat-operator-index-v4-20
     global: true
 
   - name: openshift-pipelines-operator-rh
@@ -44,7 +39,6 @@ operators:
     channel: pipelines-1.20
     init_version: 1.20.3
     namespace: openshift-pipelines
-    source: cs-redhat-operator-index-v4-20
     global: true
 
   - name: netobserv-operator
@@ -52,7 +46,6 @@ operators:
     channel: stable
     init_version: 1.11.0
     namespace: openshift-netobserv-operator
-    source: cs-redhat-operator-index-v4-20
     global: true
     csvNames:
       - network-observability-operator
@@ -62,14 +55,12 @@ operators:
     channel: stable-6.4
     init_version: 6.4.2
     namespace: openshift-logging
-    source: cs-redhat-operator-index-v4-20
 
   - name: loki-operator
     version: 6.4.2
     channel: stable-6.4
     init_version: 6.4.2
     namespace: openshift-operators-redhat
-    source: cs-redhat-operator-index-v4-20
     global: true
 
   - name: redhat-oadp-operator
@@ -77,7 +68,6 @@ operators:
     channel: stable
     init_version: 1.5.5
     namespace: openshift-oadp
-    source: cs-redhat-operator-index-v4-20
     csvNames:
       - oadp-operator
 
@@ -86,7 +76,6 @@ operators:
     channel: stable-v1
     init_version: 1.18.1
     namespace: cert-manager-operator
-    source: cs-redhat-operator-index-v4-20
     csvNames:
       - cert-manager-operator
 
@@ -95,7 +84,6 @@ operators:
     channel: stable
     init_version: 1.3.1
     namespace: openshift-cluster-observability-operator
-    source: cs-redhat-operator-index-v4-20
     global: true
 
   - name: openshift-external-secrets-operator
@@ -103,7 +91,6 @@ operators:
     channel: stable-v1.0
     init_version: 1.0.0
     namespace: external-secrets-operator
-    source: cs-redhat-operator-index-v4-20
     global: true
     csvNames:
       - external-secrets-operator
@@ -113,14 +100,12 @@ operators:
     channel: stable
     init_version: 1.8.2
     namespace: openshift-compliance
-    source: cs-redhat-operator-index-v4-20
 
   - name: metallb-operator
     version: 4.20.0-202602261925
     channel: stable
     init_version: 4.20.0-202602261925
     namespace: metallb-system
-    source: cs-redhat-operator-index-v4-20
     global: true
     csvNames:
       - metallb-operator

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -357,43 +357,36 @@ operators:
   - name: quay-operator
     channel: stable-3.15
     namespace: quay-enterprise
-    source: cs-redhat-operator-index-v4-20
 
   # Advanced Cluster Management
   - name: advanced-cluster-management
     channel: release-2.15
     namespace: open-cluster-management
-    source: cs-redhat-operator-index-v4-20
 
   # OpenShift GitOps (ArgoCD)
   - name: openshift-gitops-operator
     channel: gitops-1.19
     namespace: openshift-gitops-operator
-    source: cs-redhat-operator-index-v4-20
 
   # OpenShift Pipelines (Tekton)
   - name: openshift-pipelines-operator-rh
     channel: pipelines-1.20
     namespace: openshift-pipelines
-    source: cs-redhat-operator-index-v4-20
 
   # Network Observability
   - name: netobserv-operator
     channel: stable
     namespace: openshift-netobserv-operator
-    source: cs-redhat-operator-index-v4-20
 
   # Backup and Restore
   - name: redhat-oadp-operator
     channel: stable
     namespace: openshift-oadp
-    source: cs-redhat-operator-index-v4-20
 
   # Certificate Manager
   - name: openshift-cert-manager-operator
     channel: stable-v1
     namespace: cert-manager-operator
-    source: cs-redhat-operator-index-v4-20
   # ... and more (see defaults/operators.yaml for full list)
 ```
 

--- a/docs/PLUGIN_ARCHITECTURE.md
+++ b/docs/PLUGIN_ARCHITECTURE.md
@@ -37,7 +37,6 @@ operators:
     channel: stable-4.20
     init_version: 4.20.0
     namespace: openshift-storage
-    source: cs-redhat-operator-index-v4-20
 
 requires:
   files:
@@ -124,7 +123,6 @@ operators:
     channel: stable-4.20
     init_version: 4.20.0
     namespace: openshift-storage
-    source: cs-redhat-operator-index-v4-20
 
 requires:
   files:

--- a/files/catalogsource-configuration/10-policy.yaml.j2
+++ b/files/catalogsource-configuration/10-policy.yaml.j2
@@ -41,5 +41,5 @@ spec:
               name: {{ mirror_rh_operator_catalog }}
               namespace: openshift-marketplace
             spec:
-              image: registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/redhat/redhat-operator-index:v{{ short_version_dot }}
+              image: registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/redhat/{{ mirror_rh_operator_catalog }}:v{{ short_version_dot }}
               sourceType: grpc

--- a/operators/quay-operator/quay_disconnected.yaml
+++ b/operators/quay-operator/quay_disconnected.yaml
@@ -14,8 +14,8 @@
 - name: Replace registry.redhat.io with internal quay
   ansible.builtin.replace:
     path: "{{ workingDir }}/config/imagesetconfiguration.internal.yaml"
-    regexp: 'catalog: registry.redhat.io'
-    replace: "catalog: {{ quayHostname }}:8443"
+    regexp: 'catalog: {{ rh_operator_catalog }}'
+    replace: "catalog: {{ quayHostname }}:8443/redhat/{{ mirror_rh_operator_catalog }}"
 
 - name: Ensure .config/containers/ exists
   ansible.builtin.file:

--- a/playbooks/tasks/configure_ocp_abi.yaml
+++ b/playbooks/tasks/configure_ocp_abi.yaml
@@ -71,7 +71,7 @@
     - idms-oc-mirror.yaml
     - itms-oc-mirror.yaml
     - signature-configmap.yaml
-    - cs-redhat-operator-index-v4-20.yaml
+    - cs-{{ mirror_rh_operator_catalog }}-v4-20.yaml
 
 - name: Enable diskEncryption if set
   when: diskEncryption | default(false) == true

--- a/playbooks/tasks/configure_operator.yaml
+++ b/playbooks/tasks/configure_operator.yaml
@@ -91,7 +91,7 @@
         installPlanApproval: Automatic
         channel: "{{ operator.channel }}"
         name: "{{ operator.name }}"
-        source: "{{ operator.source if (disconnected | default(true)) else 'redhat-operators' }}"
+        source: "{{ operator.source | default(default_operator_source) if (disconnected | default(true)) else 'redhat-operators' }}"
         sourceNamespace: openshift-marketplace
   register: r_sub_exists
   retries: "{{ k8s_retries }}"
@@ -114,7 +114,7 @@
         installPlanApproval: Manual
         channel: "{{ operator.channel }}"
         name: "{{ operator.name }}"
-        source: "{{ operator.source if (disconnected | default(true)) else 'redhat-operators' }}"
+        source: "{{ operator.source | default(default_operator_source) if (disconnected | default(true)) else 'redhat-operators' }}"
         sourceNamespace: openshift-marketplace
         startingCSV: "{{ operator.csvNames | default([]) | first | default(operator.name) }}.v{{ operator.version | replace('+', '-') }}"
   register: r_sub_exists

--- a/playbooks/tasks/configure_operators.yaml
+++ b/playbooks/tasks/configure_operators.yaml
@@ -4,7 +4,7 @@
 
     - name: Include configure_operator
       vars:
-        default_operator_source: "cs-redhat-operator-index-v4-20"
+        default_operator_source: "cs-{{ mirror_rh_operator_catalog }}-v4-20"
       ansible.builtin.include_tasks: configure_operator.yaml
       loop: "{{ operators }}"
       loop_control:

--- a/playbooks/tasks/configure_operators.yaml
+++ b/playbooks/tasks/configure_operators.yaml
@@ -3,6 +3,8 @@
   block:
 
     - name: Include configure_operator
+      vars:
+        default_operator_source: "cs-redhat-operator-index-v4-20"
       ansible.builtin.include_tasks: configure_operator.yaml
       loop: "{{ operators }}"
       loop_control:

--- a/playbooks/tasks/deploy_plugin.yaml
+++ b/playbooks/tasks/deploy_plugin.yaml
@@ -119,6 +119,7 @@
     catalog_image: "{{ rh_operator_catalog }}"
     catalog_mirror: "{{ mirror_rh_operator_catalog }}-{{ plugin.name }}"
     catalog_version: "{{ rh_operator_catalog_version }}"
+  tags: always
 
 - name: Override variables for certified catalog
   set_fact:
@@ -127,6 +128,7 @@
     catalog_version: "{{ certified_operator_catalog_version }}"
   when:
     - plugin.catalog | default("") == "certified"
+  tags: always
 
 - name: Mirror plugin
   ansible.builtin.include_tasks:

--- a/playbooks/tasks/deploy_plugin.yaml
+++ b/playbooks/tasks/deploy_plugin.yaml
@@ -114,6 +114,20 @@
   when: lookup('ansible.builtin.fileglob', plugin_dir ~ '/tasks/pre-validate.yaml') | length > 0
   tags: pre-validate
 
+- name: Set catalog image and mirror defaults
+  set_fact:
+    catalog_image: "{{ rh_operator_catalog }}"
+    catalog_mirror: "{{ mirror_rh_operator_catalog }}-{{ plugin.name }}"
+    catalog_version: "{{ rh_operator_catalog_version }}"
+
+- name: Override variables for certified catalog
+  set_fact:
+    catalog_image: "{{ certified_operator_catalog }}"
+    catalog_mirror: "{{ mirror_certified_rh_operator_catalog }}-{{ plugin.name }}"
+    catalog_version: "{{ certified_operator_catalog_version }}"
+  when:
+    - plugin.catalog | default("") == "certified"
+
 - name: Mirror plugin
   ansible.builtin.include_tasks:
     file: mirror_plugin.yaml

--- a/playbooks/tasks/deploy_plugin.yaml
+++ b/playbooks/tasks/deploy_plugin.yaml
@@ -153,6 +153,8 @@
   tags: mirror
 
 - name: Install plugin operators
+  vars:
+    default_operator_source: "{{ catalog_mirror }}"
   ansible.builtin.include_tasks:
     file: tasks/configure_operator.yaml
     apply:

--- a/playbooks/tasks/mirror_plugin.yaml
+++ b/playbooks/tasks/mirror_plugin.yaml
@@ -10,20 +10,6 @@
       Validation Error: Ensure 'plugin' is defined, 'plugin.mirror' is set to 'plugin',
       'plugin.operators' or 'plugin.additionalImages' are not empty, and 'disconnected' is true.
 
-- name: Set catalog image and mirror defaults
-  set_fact:
-    catalog_image: "{{ rh_operator_catalog }}"
-    catalog_mirror: "{{ mirror_rh_operator_catalog }}-{{ plugin.name }}"
-    catalog_version: "{{ rh_operator_catalog_version }}"
-
-- name: Override variables for certified catalog
-  set_fact:
-    catalog_image: "{{ certified_operator_catalog }}"
-    catalog_mirror: "{{ mirror_certified_rh_operator_catalog }}-{{ plugin.name }}"
-    catalog_version: "{{ certified_operator_catalog_version }}"
-  when:
-    - plugin.catalog | default("") == "certified"
-
 - name: Template plugin imageset configuration
   ansible.builtin.template:
     src: "{{ playbook_dir }}/../templates/plugin-imageset.yaml.j2"

--- a/plugins/lvms/plugin.yaml
+++ b/plugins/lvms/plugin.yaml
@@ -10,7 +10,7 @@ operators:
     channel: stable-4.20
     init_version: 4.20.0
     namespace: openshift-storage
-    source: cs-redhat-operator-index-v4-20
+    source: cs-mirror-redhat-operators-v4-20
 
 requires:
   files:

--- a/plugins/odf/plugin.yaml
+++ b/plugins/odf/plugin.yaml
@@ -10,7 +10,7 @@ operators:
     channel: stable-4.20
     init_version: 4.20.7-rhodf
     namespace: openshift-storage
-    source: cs-redhat-operator-index-v4-20
+    source: cs-mirror-redhat-operators-v4-20
     csvMirror: true
     csvNames:
       - odf-operator

--- a/plugins/odf/plugin.yaml
+++ b/plugins/odf/plugin.yaml
@@ -10,7 +10,7 @@ operators:
     channel: stable-4.20
     init_version: 4.20.7-rhodf
     namespace: openshift-storage
-    source: cs-mirror-redhat-operators-v4-20
+    source: cs-redhat-operator-index-v4-20
     csvMirror: true
     csvNames:
       - odf-operator

--- a/templates/imagesetconfiguration.yaml.j2
+++ b/templates/imagesetconfiguration.yaml.j2
@@ -27,6 +27,7 @@ mirror:
     graph: true
   operators:
     - catalog: {{ rh_operator_catalog }}:{{ rh_operator_catalog_version }}
+      targetCatalog: redhat/{{ mirror_rh_operator_catalog }}
       packages:
 {% for operator in operators + (_core_plugin_operators | default([])) %}
 {% set additional_operator_names = operator.csvNames if (operator.csvMirror | default(false) | bool) else [] %}


### PR DESCRIPTION
part of https://redhat.atlassian.net/browse/OSAC-875

we use `cs-redhat-operator-index-v4-20` which is the default catalog name when not defining a target catalog in ImageSetConfiguration. this PR uses the variable `mirror_rh_operator_catalog` as the name and target catalog for the core mirroring.

we're introducing a default operator source that is determined by the execution flow with a `default_operator_source` variable, and we keep `operator.source` as a way to override default values.

for plugins we set the default to be the per-plugin catalog and keeping overrides while we establish a unified approach for mirroring plugins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  - Simplified operator configuration examples in the deployment guide and plugin architecture docs.

* **Configuration**
  - Switched default operator catalog source to use the mirrored operator index and added support for directing mirrored operators to a target catalog path.
  - Improved operator source selection for disconnected installs to allow configurable defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->