### PR TITLE
Cancel previous CI workflow runs when a PR is updated

### DIFF
--- a/.github/workflows/build-push-tarball.yml
+++ b/.github/workflows/build-push-tarball.yml
@@ -13,6 +13,11 @@ on:
   merge_group:
     types: [checks_requested]
 
+# Cancel previous runs when a PR is updated
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/disconnected-dry-run.yml
+++ b/.github/workflows/disconnected-dry-run.yml
@@ -9,6 +9,11 @@ name: Disconnected Dry-Run
 # 2. Automatic: On every PR
 # 3. Scheduled: Daily at 11:00 PM EST (04:00 UTC)
 
+# Cancel previous runs when a PR is updated
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 on:
   schedule:
     # Run daily at 11:00 PM EST (04:00 UTC)
@@ -33,11 +38,6 @@ on:
 
 permissions:
   contents: read
-
-# Allow parallel execution with unique cluster names per run
-concurrency:
-  group: disconnected-dry-run-${{ github.run_id }}
-  cancel-in-progress: false
 
 jobs:
   disconnected-dry-run:

--- a/.github/workflows/e2e-deployment.yml
+++ b/.github/workflows/e2e-deployment.yml
@@ -9,6 +9,11 @@ name: E2E Deployment
 # Both jobs run on every PR and nightly schedule. Manual dispatch allows
 # selecting which modes to run, skipping cleanup, and sending Slack notifications.
 
+# Cancel previous runs when a PR is updated
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 on:
   schedule:
     # Run daily at 10:00 PM EST (03:00 UTC)

--- a/.github/workflows/infra-verify.yml
+++ b/.github/workflows/infra-verify.yml
@@ -7,11 +7,10 @@ on:
   merge_group:
     types: [checks_requested]
 
-# Allow parallel execution with unique cluster names per run
-# Each job gets isolated VMs, networks, and resources
+# Cancel previous runs when a PR is updated
 concurrency:
-  group: enclave-ci-${{ github.run_id }}
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   infra-verify:


### PR DESCRIPTION
Add workflow-level concurrency groups to `e2e-deployment`, `infra-verify`, `disconnected-dry-run`, and `build-push-tarball` workflows. Uses PR number for grouping so only same-PR runs cancel each other.
Non-PR triggers (schedule, dispatch) fall back to `run_id` so do not cancel each other.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflow concurrency handling to prevent redundant pipeline executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->