### PR TITLE
MGMT-23874: fix plugin IDMS/ITMS overwrite during mirror deploy

### DIFF
--- a/operators/quay-operator/quay_disconnected_mirrors.yaml
+++ b/operators/quay-operator/quay_disconnected_mirrors.yaml
@@ -1,28 +1,44 @@
 ---
 # Quay disconnected: apply IDMS/ITMS from oc-mirror and trust Quay registry CA for image pulls.
 # Included from quay_disconnected.yaml.
-# Copy to idms-oc-mirror-internal.yaml / itms-oc-mirror-internal.yaml, rename the resource inside,
-# then apply so they coexist with the landing-zone IDMS/ITMS (idms-oc-mirror, itms-oc-mirror).
-# The cluster then has both: landing-zone mirrors (primary) and internal Quay mirrors (fallback).
+# Copy to a target manifest name based on mode:
+# - default: idms-<slice>-internal (core); plugin mode: quay_mirror_suffix is plugin-<plugin>-internal
+#   → idms-<slice>-plugin-<plugin>-internal (oc-mirror may emit multiple slices per file; keep \2 in the name).
+# LZ plugin manifests use idms-<slice>-plugin-<plugin> (mirror_plugin.yaml).
+
+- name: Set target mirror suffix and base directory
+  ansible.builtin.set_fact:
+    quay_mirror_suffix: >-
+      {{
+        ('plugin-' ~ plugin_name ~ '-internal')
+        if (quay_plugin_mirror | default(false) | bool)
+        else 'internal'
+      }}
+    quay_cluster_resources_dir: "{{ workingDir }}/config/oc-mirror-workspace-quay/working-dir/cluster-resources"
+
+- name: Set target mirror manifest paths
+  ansible.builtin.set_fact:
+    quay_idms_internal_manifest: "{{ quay_cluster_resources_dir }}/idms-oc-mirror-{{ quay_mirror_suffix }}.yaml"
+    quay_itms_internal_manifest: "{{ quay_cluster_resources_dir }}/itms-oc-mirror-{{ quay_mirror_suffix }}.yaml"
 
 - name: Stat IDMS source from oc-mirror workspace
   ansible.builtin.stat:
     path: "{{ workingDir }}/config/oc-mirror-workspace-quay/working-dir/cluster-resources/idms-oc-mirror.yaml"
   register: quay_idms_src_stat
 
-- name: Copy IDMS to idms-oc-mirror-internal.yaml
+- name: Copy IDMS to target mirror manifest
   ansible.builtin.copy:
     src: "{{ workingDir }}/config/oc-mirror-workspace-quay/working-dir/cluster-resources/idms-oc-mirror.yaml"
-    dest: "{{ workingDir }}/config/oc-mirror-workspace-quay/working-dir/cluster-resources/idms-oc-mirror-internal.yaml"
+    dest: "{{ quay_idms_internal_manifest }}"
     remote_src: true
   when: quay_idms_src_stat.stat.exists
 
-# oc-mirror v2 uses names like idms-release-0, idms-operator-0 (not idms-oc-mirror); rename all with '-internal' suffix.
-- name: Rename ImageDigestMirrorSet resources in IDMS manifest to avoid conflict with landing-zone
+# oc-mirror v2 uses names like idms-release-0, idms-operator-0 (not idms-oc-mirror); multiple docs per file are normal.
+- name: Rename ImageDigestMirrorSet resources in IDMS manifest (suffix per mode)
   ansible.builtin.replace:
-    path: "{{ workingDir }}/config/oc-mirror-workspace-quay/working-dir/cluster-resources/idms-oc-mirror-internal.yaml"
+    path: "{{ quay_idms_internal_manifest }}"
     regexp: '^(\s*name:\s*)idms-([^\s]+)\s*$'
-    replace: '\1idms-\2-internal'
+    replace: '\1idms-\2-{{ quay_mirror_suffix }}'
   when: quay_idms_src_stat.stat.exists
 
 - name: Stat ITMS source from oc-mirror workspace
@@ -30,19 +46,29 @@
     path: "{{ workingDir }}/config/oc-mirror-workspace-quay/working-dir/cluster-resources/itms-oc-mirror.yaml"
   register: quay_itms_src_stat
 
-- name: Copy ITMS to itms-oc-mirror-internal.yaml
+- name: Copy ITMS to target mirror manifest
   ansible.builtin.copy:
     src: "{{ workingDir }}/config/oc-mirror-workspace-quay/working-dir/cluster-resources/itms-oc-mirror.yaml"
-    dest: "{{ workingDir }}/config/oc-mirror-workspace-quay/working-dir/cluster-resources/itms-oc-mirror-internal.yaml"
+    dest: "{{ quay_itms_internal_manifest }}"
     remote_src: true
   when: quay_itms_src_stat.stat.exists
 
-# oc-mirror v2 uses names like itms-release-0, itms-operator-0; rename all with -internal suffix.
-- name: Rename ImageTagMirrorSet resources in ITMS manifest to avoid conflict with landing-zone
+# oc-mirror v2 uses names like itms-release-0, itms-operator-0; multiple docs per file are normal.
+- name: Rename ImageTagMirrorSet resources in ITMS manifest (suffix per mode)
   ansible.builtin.replace:
-    path: "{{ workingDir }}/config/oc-mirror-workspace-quay/working-dir/cluster-resources/itms-oc-mirror-internal.yaml"
+    path: "{{ quay_itms_internal_manifest }}"
     regexp: '^(\s*name:\s*)itms-([^\s]+)\s*$'
-    replace: '\1itms-\2-internal'
+    replace: '\1itms-\2-{{ quay_mirror_suffix }}'
+  when: quay_itms_src_stat.stat.exists
+
+- name: Set IDMS apply manifest path
+  ansible.builtin.set_fact:
+    quay_idms_apply_manifest: "{{ quay_idms_internal_manifest }}"
+  when: quay_idms_src_stat.stat.exists
+
+- name: Set ITMS apply manifest path
+  ansible.builtin.set_fact:
+    quay_itms_apply_manifest: "{{ quay_itms_internal_manifest }}"
   when: quay_itms_src_stat.stat.exists
 
 - name: Apply Quay IDMS to cluster (fallback mirrors to internal Quay)
@@ -51,7 +77,7 @@
       - "{{ workingDir }}/bin/oc"
       - apply
       - -f
-      - "{{ workingDir }}/config/oc-mirror-workspace-quay/working-dir/cluster-resources/idms-oc-mirror-internal.yaml"
+      - "{{ quay_idms_apply_manifest }}"
   environment:
     KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
   when: quay_idms_src_stat.stat.exists
@@ -62,7 +88,7 @@
       - "{{ workingDir }}/bin/oc"
       - apply
       - -f
-      - "{{ workingDir }}/config/oc-mirror-workspace-quay/working-dir/cluster-resources/itms-oc-mirror-internal.yaml"
+      - "{{ quay_itms_apply_manifest }}"
   environment:
     KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
   when: quay_itms_src_stat.stat.exists

--- a/playbooks/tasks/deploy_plugin.yaml
+++ b/playbooks/tasks/deploy_plugin.yaml
@@ -117,6 +117,8 @@
 - name: Mirror plugin
   ansible.builtin.include_tasks:
     file: mirror_plugin.yaml
+  vars:
+    quay_plugin_mirror: true
   when:
     - plugin.mirror | default('none') == 'plugin'
     - plugin.operators | default([]) | length > 0 or plugin.additionalImages | default([]) | length > 0

--- a/playbooks/tasks/mirror_plugin.yaml
+++ b/playbooks/tasks/mirror_plugin.yaml
@@ -85,12 +85,71 @@
           Full log: {{ _oc_mirror_plugin_log }}
 
 - name: Apply updated mirror manifests to cluster
-  ansible.builtin.shell: |
-    {{ workingDir }}/bin/oc apply \
-      -f {{ workingDir }}/config/oc-mirror-workspace/working-dir/cluster-resources/ \
-      --server-side --force-conflicts
-  environment:
-    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  block:
+    - name: Set landing-zone cluster resources directory
+      ansible.builtin.set_fact:
+        lz_cluster_resources_dir: "{{ workingDir }}/config/oc-mirror-workspace/working-dir/cluster-resources"
+
+    - name: Stat landing-zone IDMS source
+      ansible.builtin.stat:
+        path: "{{ lz_cluster_resources_dir }}/idms-oc-mirror.yaml"
+      register: lz_idms_src_stat
+
+    - name: Stat landing-zone ITMS source
+      ansible.builtin.stat:
+        path: "{{ lz_cluster_resources_dir }}/itms-oc-mirror.yaml"
+      register: lz_itms_src_stat
+
+    # Dedicated IDMS/ITMS per plugin; oc-mirror overwrites generic idms-oc-mirror.yaml — remove after copy.
+    # oc-mirror v2 may emit multiple resources per file; names must stay unique (idms-<slice>-plugin-<name>).
+    # Quay apply uses idms-<slice>-plugin-<name>-internal (quay_disconnected_mirrors.yaml).
+    - name: Copy LZ IDMS to plugin-specific manifest
+      ansible.builtin.copy:
+        src: "{{ lz_cluster_resources_dir }}/idms-oc-mirror.yaml"
+        dest: "{{ lz_cluster_resources_dir }}/idms-oc-mirror-plugin-{{ plugin_name }}.yaml"
+        remote_src: true
+      when: lz_idms_src_stat.stat.exists
+
+    - name: Rename ImageDigestMirrorSet names in plugin LZ IDMS manifest
+      ansible.builtin.replace:
+        path: "{{ lz_cluster_resources_dir }}/idms-oc-mirror-plugin-{{ plugin_name }}.yaml"
+        regexp: '^(\s*name:\s*)idms-([^\s]+)\s*$'
+        replace: '\1idms-\2-plugin-{{ plugin_name }}'
+      when: lz_idms_src_stat.stat.exists
+
+    - name: Remove generic LZ IDMS after plugin-specific copy
+      ansible.builtin.file:
+        path: "{{ lz_cluster_resources_dir }}/idms-oc-mirror.yaml"
+        state: absent
+      when: lz_idms_src_stat.stat.exists
+
+    - name: Copy LZ ITMS to plugin-specific manifest
+      ansible.builtin.copy:
+        src: "{{ lz_cluster_resources_dir }}/itms-oc-mirror.yaml"
+        dest: "{{ lz_cluster_resources_dir }}/itms-oc-mirror-plugin-{{ plugin_name }}.yaml"
+        remote_src: true
+      when: lz_itms_src_stat.stat.exists
+
+    - name: Rename ImageTagMirrorSet names in plugin LZ ITMS manifest
+      ansible.builtin.replace:
+        path: "{{ lz_cluster_resources_dir }}/itms-oc-mirror-plugin-{{ plugin_name }}.yaml"
+        regexp: '^(\s*name:\s*)itms-([^\s]+)\s*$'
+        replace: '\1itms-\2-plugin-{{ plugin_name }}'
+      when: lz_itms_src_stat.stat.exists
+
+    - name: Remove generic LZ ITMS after plugin-specific copy
+      ansible.builtin.file:
+        path: "{{ lz_cluster_resources_dir }}/itms-oc-mirror.yaml"
+        state: absent
+      when: lz_itms_src_stat.stat.exists
+
+    - name: Apply updated mirror manifests to cluster
+      ansible.builtin.shell: |
+        {{ workingDir }}/bin/oc apply \
+          -f {{ lz_cluster_resources_dir }}/ \
+          --server-side --force-conflicts
+      environment:
+        KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
   when:
     - plugin.installOperators | default(true)
     - r_plugin_mirror is defined
@@ -233,6 +292,8 @@
     apply:
       environment:
         KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  vars:
+    quay_plugin_mirror: true
   when:
     - plugin.installOperators | default(true)
     - r_plugin_mirror_quay is defined


### PR DESCRIPTION
Each plugin mirror run used oc-mirror output whose ImageDigestMirrorSet and ImageTagMirrorSet objects reused generic names, so applying Quay disconnected mirrors could overwrite or collide with other plugins or the core flow.

Landing-zone manifests are copied and renamed to stable per-plugin names (idms-plugin-[name], itms-plugin-[name]).
Quay Enterprise follow-on mirrors use matching internal names (idms-plugin-[name]-internal, itms-plugin-[name]-internal).

Example of resulting resources:
$ oc get idms
NAME
idms-operator-0-plugin-lso
idms-operator-0-plugin-lso-internal
idms-operator-0-plugin-mtv
idms-operator-0-plugin-mtv-internal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugin mirror support now generates plugin-specific mirror manifests and unique resource names so each plugin’s mirrors are isolated and applied safely.

* **Chores**
  * Refactored mirror manifest workflow to use mode-dependent naming and dynamic manifest selection, improving flexibility when deploying mirror resources in plugin mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->