### PR TITLE
assert master maxPods with no_log

### DIFF
--- a/playbooks/tasks/wait_for_deployment.yaml
+++ b/playbooks/tasks/wait_for_deployment.yaml
@@ -59,6 +59,7 @@
         fail_msg: "No master nodes matched the selector; cannot validate maxPods."
 
     - name: Assert that all master nodes report the correct maxPods
+      no_log: true
       ansible.builtin.assert:
         that:
           - (item.status.capacity.pods | int) == (masterMaxPods | int)


### PR DESCRIPTION
avoid flooding console with node yaml