### PR TITLE
Revert "add name metadata to plugin image set configuration"

### DIFF
--- a/templates/plugin-imageset.yaml.j2
+++ b/templates/plugin-imageset.yaml.j2
@@ -1,8 +1,6 @@
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1
-metadata:
-  name: {{ catalog_mirror }}
 mirror:
   operators:
     - catalog: {{ catalog_image }}:{{ catalog_version }}


### PR DESCRIPTION
Reverts rh-ecosystem-edge/enclave#306

seems ImageSetConfiguration does not support `metadata`.