### PR TITLE
remove kubevirt-hyperconverged from mirroring

### DIFF
--- a/templates/imagesetconfiguration.yaml.j2
+++ b/templates/imagesetconfiguration.yaml.j2
@@ -28,7 +28,6 @@ mirror:
   operators:
     - catalog: {{ rh_operator_catalog }}:{{ rh_operator_catalog_version }}
       packages:
-        - name: kubevirt-hyperconverged
 {% for operator in operators + (_core_plugin_operators | default([])) %}
 {% set additional_operator_names = operator.csvNames if (operator.csvMirror | default(false) | bool) else [] %}
 {% for operator_name in [operator.name] + additional_operator_names %}


### PR DESCRIPTION
should come from #291

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored operator configuration to streamline how operators are included in mirror settings through standardized templating instead of explicit declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->