### PR TITLE
core plugin mirror to custom catalog

### DIFF
--- a/docs/PLUGIN_ARCHITECTURE.md
+++ b/docs/PLUGIN_ARCHITECTURE.md
@@ -209,6 +209,8 @@ Plugins with `mirror: core` have their operators collected by `collect_core_plug
 
 Operators with `csvMirror: true` have their `csvNames` entries added as separate packages in the image set.
 
+Each Plugin is mirrored to a custom catalog to support operations on day 2, and to not overwrite the core operators catalog.
+
 ### Pre-install Validation
 
 Before cluster installation, plugins with `tasks/pre-install-validate.yaml` run hardware checks against discovered hosts.

--- a/operators/quay-operator/quay_disconnected_start.yaml
+++ b/operators/quay-operator/quay_disconnected_start.yaml
@@ -11,10 +11,10 @@
     src: "{{ workingDir }}/config/imagesetconfiguration.yaml"
     dest: "{{ workingDir }}/config/imagesetconfiguration.internal.yaml"
 
-- name: Replace registry.redhat.io with internal quay
+- name: Replace redhat-operator-index with internal mirror
   ansible.builtin.replace:
     path: "{{ workingDir }}/config/imagesetconfiguration.internal.yaml"
-    regexp: 'catalog: {{ rh_operator_catalog }}'
+    regexp: 'catalog: {{ quayHostname }}:8443/redhat/redhat-operator-index'
     replace: "catalog: {{ quayHostname }}:8443/redhat/{{ mirror_rh_operator_catalog }}"
 
 - name: Ensure .config/containers/ exists

--- a/playbooks/02-mirror.yaml
+++ b/playbooks/02-mirror.yaml
@@ -58,6 +58,11 @@
         - mirror-registry
         - mirror-plugins
 
+    - name: Combine core operators with core plugin operators
+      set_fact:
+        catalog_operators: "{{ {'core': operators} | combine(_core_plugin_operators | default({})) }}"
+      tags: mirror-registry
+
     - name: Include tasks for mirror-registry
       ansible.builtin.include_tasks:
         file: tasks/mirror_registry.yaml

--- a/playbooks/tasks/collect_core_plugin_operators.yaml
+++ b/playbooks/tasks/collect_core_plugin_operators.yaml
@@ -23,7 +23,7 @@
   loop_control:
     loop_var: plugin_path
 
-- name: Build combined plugin operators list
+- name: Build combined plugin operators dictionary
   vars:
     _enabled: >-
       {{ r_cp_slurp.results
@@ -39,10 +39,8 @@
     _core_plugin_operators: >-
       {{ _core
          | selectattr('operators', 'defined')
-         | map(attribute='operators')
-         | flatten
-         | list }}
+         | items2dict(key_name='name', value_name='operators') }}
 
 - name: Display plugin operators to mirror
   ansible.builtin.debug:
-    msg: "Plugin operators to include in imageset: {{ _core_plugin_operators | map(attribute='name') | list }}"
+    msg: "Plugin operators to include in imageset: {{ _core_plugin_operators.values() | flatten | map(attribute='name') | list }}"

--- a/playbooks/tasks/configure_ocp_abi.yaml
+++ b/playbooks/tasks/configure_ocp_abi.yaml
@@ -62,16 +62,26 @@
           maxPods: {{ masterMaxPods }}
     mode: '0644'
 
+- name: Find custom manifests from mirror registry
+  when: disconnected | default(true)
+  ansible.builtin.find:
+    paths: "{{ workingDir }}/config/oc-mirror-workspace/working-dir/cluster-resources/"
+    patterns: 
+      - "idms-oc-mirror.yaml"
+      - "itms-oc-mirror.yaml"
+      - "signature-configmap.yaml"
+      - "cs-*.yaml"
+    recurse: no
+  register: custom_manifests
+
 - name: Copy custom manifests from mirror registry to the ABI directory
   when: disconnected | default(true)
   ansible.builtin.copy:
-    src: "{{ workingDir }}/config/oc-mirror-workspace/working-dir/cluster-resources/{{ item }}"
-    dest: "{{ workingDir }}/ocp-cluster/openshift/{{ item }}"
-  loop:
-    - idms-oc-mirror.yaml
-    - itms-oc-mirror.yaml
-    - signature-configmap.yaml
-    - cs-{{ mirror_rh_operator_catalog }}-v4-20.yaml
+    src: "{{ item_path }}"
+    dest: "{{ workingDir }}/ocp-cluster/openshift/{{ item_path | basename }}"
+  loop: "{{ custom_manifests.files | map(attribute='path') | list }}"
+  loop_control:
+    loop_var: item_path
 
 - name: Enable diskEncryption if set
   when: diskEncryption | default(false) == true

--- a/playbooks/tasks/configure_operators.yaml
+++ b/playbooks/tasks/configure_operators.yaml
@@ -4,7 +4,7 @@
 
     - name: Include configure_operator
       vars:
-        default_operator_source: "cs-{{ mirror_rh_operator_catalog }}-core-v4-20"
+        default_operator_source: "cs-{{ mirror_rh_operator_catalog }}-v4-20"
       ansible.builtin.include_tasks: configure_operator.yaml
       loop: "{{ target_operators }}"
       loop_control:

--- a/playbooks/tasks/configure_operators.yaml
+++ b/playbooks/tasks/configure_operators.yaml
@@ -4,7 +4,7 @@
 
     - name: Include configure_operator
       vars:
-        default_operator_source: "cs-{{ mirror_rh_operator_catalog }}-v4-20"
+        default_operator_source: "cs-{{ mirror_rh_operator_catalog }}-core-v4-20"
       ansible.builtin.include_tasks: configure_operator.yaml
       loop: "{{ target_operators }}"
       loop_control:

--- a/playbooks/tasks/deploy_plugin.yaml
+++ b/playbooks/tasks/deploy_plugin.yaml
@@ -158,7 +158,7 @@
 
 - name: Install plugin operators
   vars:
-    default_operator_source: "{{ catalog_mirror }}"
+    default_operator_source: "cs-{{ catalog_mirror }}-v4-20"
   ansible.builtin.include_tasks:
     file: tasks/configure_operator.yaml
     apply:

--- a/playbooks/tasks/mirror_registry.yaml
+++ b/playbooks/tasks/mirror_registry.yaml
@@ -36,10 +36,46 @@
     content: "{{ pullSecretInternal }}"
     dest: "{{ workingDir }}/config/pull-secret.internal.json"
 
+# We iterate over catalog_operators keys, which are the list of plugins + "core".
+# For each item, we copy the Red Hat Index image to an intermediate image in the mirror registry,
+# to be used as the source catalog image in the ImageSetConfiguration of oc-mirror.
+# This is required to make oc-mirror output a Catalog Source file for each item,
+# which we later use during cluster provisioning.
+# This is done to separate mirroring of plugins from the core operators,
+# and to support plugin operations in day 2.
+# The destination mirror registry does not support signatures and TLS,
+# so we work around by using remove-signatures, insecure-policy and dest-tls-verify.
+- name: Copy Red Hat Index Image for core and plugin operators
+  ansible.builtin.shell: |
+    skopeo copy \
+      --all \
+      --remove-signatures \
+      --insecure-policy \
+      --authfile {{ pullSecretPath }} \
+      --dest-tls-verify=false \
+      --retry-times {{ ocMirrorRetryTimes }} \
+      --retry-delay {{ ocMirrorRetryDelay }} \
+      docker://{{ rh_operator_catalog }}:{{ rh_operator_catalog_version }} \
+      docker://{{ quayHostname }}:8443/redhat/redhat-operator-index{{ '-' ~ item }}:{{ rh_operator_catalog_version }}
+  loop: "{{ catalog_operators.keys() | list }}"
+  loop_control:
+    label: "{{ item }}"
+  register: skopeo_result
+  changed_when: "'Copying blob' in skopeo_result.stdout"
+  retries: "{{ 1 if (mirror_dry_run | default(false) | bool) else ocMirrorAnsibleRetries }}"
+  delay: "{{ 0 if (mirror_dry_run | default(false) | bool) else ocMirrorAnsibleDelay }}"
+  until: skopeo_result.rc == 0
+
 - name: Copy imagesetconfiguration.yaml
   ansible.builtin.template:
     src: ../../templates/imagesetconfiguration.yaml.j2
     dest: "{{ workingDir }}/config/imagesetconfiguration.yaml"
+
+- name: Replace registry.redhat.io with redhat-operator-index in mirror-registry
+  ansible.builtin.replace:
+    path: "{{ workingDir }}/config/imagesetconfiguration.yaml"
+    regexp: 'catalog: {{ rh_operator_catalog }}'
+    replace: "catalog: {{ quayHostname }}:8443/redhat/redhat-operator-index"
 
 - name: Ensure oc-mirror log directory exists
   ansible.builtin.file:
@@ -62,6 +98,8 @@
           {{ '--dry-run' if (mirror_dry_run | default(false) | bool) else '' }} \
           --log-level {{ ocMirrorLogLevel }} \
           --authfile {{ pullSecretPath }} \
+          --ignore-release-signature \
+          --src-tls-verify=false \
           --dest-tls-verify=false \
           -c {{ workingDir }}/config/imagesetconfiguration.yaml \
           --workspace file://{{ workingDir }}/config/oc-mirror-workspace \

--- a/playbooks/tasks/mirror_registry.yaml
+++ b/playbooks/tasks/mirror_registry.yaml
@@ -56,7 +56,7 @@
       --retry-times {{ ocMirrorRetryTimes }} \
       --retry-delay {{ ocMirrorRetryDelay }} \
       docker://{{ rh_operator_catalog }}:{{ rh_operator_catalog_version }} \
-      docker://{{ quayHostname }}:8443/redhat/redhat-operator-index{{ '-' ~ item }}:{{ rh_operator_catalog_version }}
+      docker://{{ quayHostname }}:8443/redhat/redhat-operator-index{{ (item == 'core') | ternary('', '-' ~ item) }}:{{ rh_operator_catalog_version }}
   loop: "{{ catalog_operators.keys() | list }}"
   loop_control:
     label: "{{ item }}"

--- a/playbooks/tasks/template_validation/test_imagesetconfiguration.yaml
+++ b/playbooks/tasks/template_validation/test_imagesetconfiguration.yaml
@@ -4,7 +4,8 @@
 
 - name: Render imagesetconfiguration.yaml for each storage backend
   vars:
-    _core_plugin_operators: "{{ item.operators }}"
+    _core_plugin_operators: "{{ {item.name: item.operators} }}"
+    catalog_operators: "{{ {'core': operators} | combine(_core_plugin_operators) }}"
   ansible.builtin.template:
     src: ../../templates/imagesetconfiguration.yaml.j2
     dest: "{{ temp_dir.path }}/imagesetconfiguration-{{ item.name }}.yaml"

--- a/plugins/lvms/plugin.yaml
+++ b/plugins/lvms/plugin.yaml
@@ -10,7 +10,6 @@ operators:
     channel: stable-4.20
     init_version: 4.20.0
     namespace: openshift-storage
-    source: cs-mirror-redhat-operators-v4-20
 
 requires:
   files:

--- a/plugins/odf/plugin.yaml
+++ b/plugins/odf/plugin.yaml
@@ -10,7 +10,6 @@ operators:
     channel: stable-4.20
     init_version: 4.20.7-rhodf
     namespace: openshift-storage
-    source: cs-mirror-redhat-operators-v4-20
     csvMirror: true
     csvNames:
       - odf-operator

--- a/scripts/deployment/install_enclave.sh
+++ b/scripts/deployment/install_enclave.sh
@@ -186,6 +186,14 @@ else
     echo "  Python kubernetes library is already installed"
 fi
 
+# Install skopeo (needed for mirroring)
+if ! command -v skopeo &>/dev/null; then
+    echo "  Installing skopeo..."
+    sudo dnf install -y skopeo
+else
+    echo "  skopeo is already installed"
+fi
+
 # Install required Ansible collections
 echo "  Installing required Ansible collections..."
 cd /home/cloud-user/enclave

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -16,6 +16,7 @@ dnf install -y \
     podman \
     python3-pip \
     rsync \
+    skopeo \
     tar \
     vim
 

--- a/templates/imagesetconfiguration.yaml.j2
+++ b/templates/imagesetconfiguration.yaml.j2
@@ -26,10 +26,11 @@ mirror:
 {% endfor %}
     graph: true
   operators:
-    - catalog: {{ rh_operator_catalog }}:{{ rh_operator_catalog_version }}
-      targetCatalog: redhat/{{ mirror_rh_operator_catalog }}
+{% for c_name, c_operators in catalog_operators.items() %}
+    - catalog: {{ rh_operator_catalog }}-{{ c_name }}:{{ rh_operator_catalog_version }}
+      targetCatalog: redhat/{{ mirror_rh_operator_catalog }}-{{ c_name }}
       packages:
-{% for operator in operators + (_core_plugin_operators | default([])) %}
+{% for operator in c_operators %}
 {% set additional_operator_names = operator.csvNames if (operator.csvMirror | default(false) | bool) else [] %}
 {% for operator_name in [operator.name] + additional_operator_names %}
         - name: {{ operator_name }}
@@ -41,6 +42,7 @@ mirror:
 {% endfor %}
 {% for pkg in operator.extraMirrorPackages | default([]) %}
         - name: {{ pkg }}
+{% endfor %}
 {% endfor %}
 {% endfor %}
 

--- a/templates/imagesetconfiguration.yaml.j2
+++ b/templates/imagesetconfiguration.yaml.j2
@@ -27,8 +27,13 @@ mirror:
     graph: true
   operators:
 {% for c_name, c_operators in catalog_operators.items() %}
+{% if c_name == 'core' %}
+    - catalog: {{ rh_operator_catalog }}:{{ rh_operator_catalog_version }}
+      targetCatalog: redhat/{{ mirror_rh_operator_catalog }}
+{% else %}
     - catalog: {{ rh_operator_catalog }}-{{ c_name }}:{{ rh_operator_catalog_version }}
       targetCatalog: redhat/{{ mirror_rh_operator_catalog }}-{{ c_name }}
+{% endif %}
       packages:
 {% for operator in c_operators %}
 {% set additional_operator_names = operator.csvNames if (operator.csvMirror | default(false) | bool) else [] %}


### PR DESCRIPTION
part of https://redhat.atlassian.net/browse/OSAC-875

follow up on #261 and #309

the goal of the PR is to mirror core plugins to a custom per-plugin catalog, and thus making this method consistent for all plugins. this PR may also serve as a stepping stone towards enabling day2 installations of core plugins.

the problem is that core plugins are currently mirrored into the default catalog. in day2 when we install only the plugin, we don't have the full context of the default catalog and it will be overridden.

in this PR we are changing the imagesetconfiguration template to create a catalog per core plugin. this enables us to install a core plugin on day0 with a custom catalog, which will be consistent with a day2 installation.

to change the imagesetconfiguration template we are updating the `_core_plugin_operators` from a list to a dict (with the plugin name as the key), allowing us to iterate over plugins and create custom catalogs.

we update the list of custom manifests passed to openshift-install to find all custom catalog sources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized operator catalog output to emit per-plugin operator catalogs rather than a single combined list.
* **Chores**
  * Switched to runtime discovery of mirror manifest files instead of a fixed file list.
  * Updated operator catalog source naming to use plugin-specific mirrored catalogs and versioned source strings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/enclave/pull/318)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->