### PR TITLE
Add HTTP healthchecks to metal3 quadlet containers

### DIFF
--- a/playbooks/templates/quadlets/metal3-bmo.container.j2
+++ b/playbooks/templates/quadlets/metal3-bmo.container.j2
@@ -17,7 +17,13 @@ Environment=IRONIC_ENDPOINT=http://{{ lzBmcIP }}:6385/v1/
 Environment=WATCH_NAMESPACE=infraenv
 Environment=LIVE_ISO_FORCE_PERSISTENT_BOOT_DEVICE=Never
 Environment=METAL3_AUTH_ROOT_DIR=/auth
-Exec=/baremetal-operator --webhook-port=0 --metrics-addr=0 --health-addr=0 --dev --enable-leader-election=false
+Exec=/baremetal-operator --webhook-port=0 --metrics-addr=0 --health-addr=:9440 --dev --enable-leader-election=false
+HealthCmd=curl -sf http://localhost:9440/healthz
+HealthInterval=30s
+HealthTimeout=10s
+HealthRetries=3
+HealthStartPeriod=60s
+HealthOnFailure=kill
 
 [Service]
 Restart=always

--- a/playbooks/templates/quadlets/metal3-httpd.container.j2
+++ b/playbooks/templates/quadlets/metal3-httpd.container.j2
@@ -15,6 +15,12 @@ Environment=LISTEN_ALL_INTERFACES=true
 Environment=USE_IRONIC_INSPECTOR=false
 Environment=PROVISIONING_IP={{ lzBmcIP }}
 Exec=/bin/runhttpd
+HealthCmd=curl -s http://localhost:6180/
+HealthInterval=30s
+HealthTimeout=10s
+HealthRetries=3
+HealthStartPeriod=60s
+HealthOnFailure=kill
 
 [Service]
 Restart=always

--- a/playbooks/templates/quadlets/metal3-ironic-api.container.j2
+++ b/playbooks/templates/quadlets/metal3-ironic-api.container.j2
@@ -27,6 +27,12 @@ Environment=OS_JSON_RPC__PORT=6189
 Environment=WEBSERVER_CACERT_FILE=/certs/ca-bundle.crt
 {% endif %}
 Exec=/bin/runironic
+HealthCmd=curl -sf http://localhost:6385/
+HealthInterval=30s
+HealthTimeout=10s
+HealthRetries=3
+HealthStartPeriod=60s
+HealthOnFailure=kill
 
 [Service]
 Restart=always


### PR DESCRIPTION
Add podman healthchecks with HealthOnFailure=kill to the three metal3 quadlet container templates. Combined with the existing Restart=always in [Service], this creates a self-healing loop: podman kills unhealthy containers and systemd restarts them automatically.

https://redhat.atlassian.net/browse/MGMT-22876

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automated HTTP health checks for the Baremetal Operator, HTTPD, and Ironic API containers. Each service now exposes an HTTP probe (service-specific ports), with configurable interval, timeout, retries, and start-period settings. Failed health checks are configured to terminate the affected container so the system can restart it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->