### PR TITLE
Add Helm chart deployment support to plugin framework

### DIFF
--- a/docs/PLUGIN_ARCHITECTURE.md
+++ b/docs/PLUGIN_ARCHITECTURE.md
@@ -19,6 +19,9 @@ plugins/lvms/
     post-operators.yaml    <- runs after operators, before deploy (optional)
     post-validate.yaml     <- post-deployment checks (optional)
     pre-install-validate.yaml <- hardware checks before cluster install (optional)
+  charts/                    <- Helm chart directories (optional)
+  templates/                 <- Jinja2 templates for Helm values or other rendering (optional)
+  files/                     <- Jinja2 templates for K8s manifests (optional)
 ```
 
 ### The Descriptor: `plugin.yaml`
@@ -74,6 +77,7 @@ registries:
 | `additionalImages` | Extra images to include in the plugin's oc-mirror image set. |
 | `blockedImages` | Images to exclude from mirroring (by tag, digest, or pattern). |
 | `requires` | Declarative requirements validated at load time, before any deployment work begins. See [Load-Time Validation](#load-time-validation). |
+| `helm` | List of Helm charts to install after operators, before `tasks/deploy.yaml`. Supports local charts and remote repos. Each entry specifies `release`, `namespace`, and optional `repo`, `version`, and values template. |
 
 The plugin descriptor is validated by JSON Schema (`schemas/plugin.yaml`) during `make validate`. The validator (`make validate-plugins`) also checks directory structure.
 
@@ -91,14 +95,15 @@ Here's what runs and in what order:
  5. tasks/pre-validate.yaml       <- "is the cluster ready for me?"
  6. Mirror (plugin-mode only)      <- template imageset, run oc-mirror, apply manifests
  7. Install operators              <- from plugin.yaml operators list (if installOperators != false)
- 8. tasks/post-operators.yaml     <- "set up infrastructure that deploy needs"
- 9. tasks/deploy.yaml             <- "create my CRs"
-10. tasks/post-validate.yaml      <- "did it work?"
+ 8. tasks/post-operators.yaml     <- "set up infrastructure that Helm or deploy needs"
+ 9. Deploy Helm charts             <- from plugin.yaml helm list (values templates rendered here)
+10. tasks/deploy.yaml             <- "create my CRs"
+11. tasks/post-validate.yaml      <- "did it work?"
 ```
 
 Steps 3-4 are the load-time validation gate. If any declared requirement is missing or the early-validate script fails, the plugin fails immediately -- before mirroring, operator installation, or deployment. Note that `early-validate.yaml` runs before the cluster exists, so it cannot use KUBECONFIG. Use it for config format checks, external connectivity validation, or other pre-flight logic.
 
-Step 8 (`post-operators.yaml`) is useful for plugins that need to set up infrastructure after operators are installed but before deploy tasks run. For example, a plugin might use this hook to create a CR instance and extract credentials that `tasks/deploy.yaml` depends on. Facts set in `post-operators.yaml` are available to later steps because all hooks run in the same Ansible play via `include_tasks`.
+Step 8 (`post-operators.yaml`) is useful for plugins that need to set up infrastructure after operators are installed but before Helm charts or deploy tasks run. For example, a plugin might use this hook to create a CR instance and extract credentials that the Helm values template depends on. Facts set in `post-operators.yaml` are available to later steps because all hooks run in the same Ansible play via `include_tasks`.
 
 Separately, during Quay operator setup:
 
@@ -218,7 +223,7 @@ Foundation plugins deploy before core operators (Quay, GitOps). This ordering en
 1. Disable default CatalogSources (disconnected)
 2. Deploy foundation plugins (sorted by order):
    -> load defaults -> validate requirements -> pre-validate -> mirror -> operators
-   -> post-operators -> deploy -> post-validate
+   -> post-operators -> helm -> deploy -> post-validate
 3. Install core operators
    -> Quay includes plugins/{storage_plugin}/tasks/quay.yaml
 4. Deploy addon plugins (sorted by order)
@@ -253,7 +258,7 @@ Every plugin is validated at two levels:
 2. **Shell script** (`scripts/verification/validate_plugins.sh`) -- validates directory structure:
    - `plugin.yaml` exists with required fields
    - Task files are valid Ansible task lists
-   - No unexpected files outside `plugin.yaml`, `tasks/`, and `files/`
+   - No unexpected files outside `plugin.yaml`, `tasks/`, `files/`, `charts/`, and `templates/`
 
 ## Load-Time Validation
 
@@ -334,11 +339,12 @@ requires:
 4. Add `registries` if disconnected mirroring is needed
 5. Add `requires` to declare variables or files that must exist at load time
 6. Add `tasks/early-validate.yaml` for custom pre-flight checks that don't need cluster access (optional)
-7. Add `tasks/post-operators.yaml` for setup needed after operators but before deploy (optional)
-8. Add `tasks/deploy.yaml` with your post-operator setup logic
-9. Add `tasks/quay.yaml` if your plugin provides storage for Quay
-10. Run `make validate-plugins` to verify
-11. Add your plugin name to `enabled_plugins` in `config/global.yaml`
+7. Add `tasks/post-operators.yaml` for setup needed after operators but before Helm or deploy (optional)
+8. Add `helm` list if you need Helm chart deployments, with chart sources under `charts/` or from a remote `repo`
+9. Add `tasks/deploy.yaml` with your post-operator (or post-Helm) setup logic
+10. Add `tasks/quay.yaml` if your plugin provides storage for Quay
+11. Run `make validate-plugins` to verify
+12. Add your plugin name to `enabled_plugins` in `config/global.yaml`
 
 No core files need to be modified.
 

--- a/playbooks/tasks/deploy_plugin.yaml
+++ b/playbooks/tasks/deploy_plugin.yaml
@@ -163,6 +163,22 @@
   when: lookup('ansible.builtin.fileglob', plugin_dir ~ '/tasks/post-operators.yaml') | length > 0
   tags: post-operators
 
+- name: Deploy Helm charts
+  ansible.builtin.include_tasks:
+    file: tasks/helm_deploy.yaml
+    apply:
+      tags: helm
+      environment:
+        KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  loop: "{{ plugin.helm }}"
+  loop_control:
+    loop_var: helm_chart
+    label: "{{ helm_chart.release }}"
+  when:
+    - plugin.helm is defined
+    - plugin.helm | length > 0
+  tags: helm
+
 - name: Run deploy
   ansible.builtin.include_tasks:
     file: "{{ plugin_dir }}/tasks/deploy.yaml"

--- a/playbooks/tasks/helm_deploy.yaml
+++ b/playbooks/tasks/helm_deploy.yaml
@@ -1,0 +1,111 @@
+---
+# Reusable tasks for deploying a single Helm chart.
+#
+# Required loop_var: helm_chart (from deploy_plugin.yaml loop)
+# Required vars: plugin_dir, plugin_name, workingDir
+#
+# Supports two modes:
+#   Remote chart: set helm_chart.repo (Helm repo URL) and helm_chart.chart (chart name).
+#   Local chart:  set helm_chart.chart (path relative to plugin dir) or omit for default.
+
+# --- Remote repo setup ---
+
+- name: "Helm | Add repo for {{ helm_chart.release }}"
+  ansible.builtin.command:
+    cmd: >-
+      {{ workingDir }}/bin/helm repo add
+      {{ helm_chart.release }}-repo
+      {{ helm_chart.repo }}
+  when: helm_chart.repo is defined
+  changed_when: true
+
+- name: "Helm | Update repo cache"
+  ansible.builtin.command:
+    cmd: "{{ workingDir }}/bin/helm repo update"
+  when: helm_chart.repo is defined
+  changed_when: true
+
+# --- Chart reference ---
+
+- name: "Helm | Set chart reference for {{ helm_chart.release }}"
+  ansible.builtin.set_fact:
+    _helm_chart_ref: >-
+      {{ helm_chart.release ~ '-repo/' ~ helm_chart.chart
+         if helm_chart.repo is defined
+         else plugin_dir ~ '/' ~ (helm_chart.chart | default('charts/' ~ helm_chart.release)) }}
+
+- name: "Helm | Verify local chart exists"
+  ansible.builtin.stat:
+    path: "{{ _helm_chart_ref }}"
+  register: _r_chart_stat
+  when: helm_chart.repo is not defined
+
+- name: "Helm | Assert local chart exists"
+  ansible.builtin.assert:
+    that: _r_chart_stat.stat.exists
+    fail_msg: "Helm chart not found: {{ _helm_chart_ref }}"
+  when: helm_chart.repo is not defined
+
+# --- Values ---
+
+- name: "Helm | Render values template"
+  ansible.builtin.template:
+    src: "{{ plugin_dir }}/{{ helm_chart.valuesTemplate }}"
+    dest: "{{ workingDir }}/helm-values-{{ plugin_name }}-{{ helm_chart.release }}.yaml"
+  when: helm_chart.valuesTemplate is defined
+
+- name: "Helm | Copy static values file"
+  ansible.builtin.copy:
+    src: "{{ plugin_dir }}/{{ helm_chart.valuesFile }}"
+    dest: "{{ workingDir }}/helm-values-{{ plugin_name }}-{{ helm_chart.release }}.yaml"
+  when:
+    - helm_chart.valuesFile is defined
+    - helm_chart.valuesTemplate is not defined
+
+- name: "Helm | Build values arg"
+  ansible.builtin.set_fact:
+    _helm_values_arg: >-
+      {{ '-f ' ~ workingDir ~ '/helm-values-' ~ plugin_name ~ '-' ~ helm_chart.release ~ '.yaml'
+         if (helm_chart.valuesTemplate is defined or helm_chart.valuesFile is defined)
+         else '' }}
+
+# --- Install ---
+
+- name: "Helm | Ensure log directory exists"
+  ansible.builtin.file:
+    path: "{{ workingDir }}/logs/"
+    state: directory
+
+- name: "Helm | Set log path"
+  ansible.builtin.set_fact:
+    _helm_log: "{{ workingDir }}/logs/helm-{{ plugin_name }}-{{ helm_chart.release }}.{{ lookup('pipe', 'date +%s') }}.log"
+
+- name: "Helm | Install {{ helm_chart.release }}"
+  ansible.builtin.shell: |
+    set -o pipefail
+    {{ workingDir }}/bin/helm upgrade --install \
+      {{ helm_chart.release }} \
+      {{ _helm_chart_ref }} \
+      --namespace {{ helm_chart.namespace }} \
+      {{ '--create-namespace' if (helm_chart.createNamespace | default(true) | bool) else '' }} \
+      {{ '--wait' if (helm_chart.wait | default(true) | bool) else '' }} \
+      --timeout {{ helm_chart.timeout | default('15m') }} \
+      {{ '--version ' ~ helm_chart.version if helm_chart.version is defined else '' }} \
+      {{ _helm_values_arg }} \
+      2>&1 | tee {{ _helm_log }}
+  args:
+    executable: /bin/bash
+  register: r_helm_install
+  retries: 2
+  delay: 30
+  until: r_helm_install is success
+
+- name: "Helm | Verify release status"
+  ansible.builtin.command:
+    cmd: "{{ workingDir }}/bin/helm status {{ helm_chart.release }} --namespace {{ helm_chart.namespace }}"
+  register: r_helm_status
+  changed_when: false
+
+- name: "Helm | Show status"
+  ansible.builtin.debug:
+    msg: "{{ r_helm_status.stdout_lines | default([]) }}"

--- a/schemas/plugin.yaml
+++ b/schemas/plugin.yaml
@@ -97,6 +97,54 @@ definitions:
     required:
       - path
 
+  helm_chart:
+    type: object
+    additionalProperties: false
+    not:
+      required: [valuesTemplate, valuesFile]
+    if:
+      required: [repo]
+    then:
+      required: [chart]
+    properties:
+      chart:
+        type: string
+        description: >-
+          Chart name (when repo is set) or path relative to the plugin
+          directory (local chart). Default for local: charts/<release>.
+      repo:
+        type: string
+        description: >-
+          Helm repository URL. When set, the chart is fetched from this
+          remote repo instead of the local plugin directory.
+      version:
+        type: string
+        description: Chart version constraint (e.g. '1.2.3' or '^1.0').
+      release:
+        type: string
+        description: Helm release name.
+      namespace:
+        type: string
+        description: Kubernetes namespace for the release.
+      valuesTemplate:
+        type: string
+        description: Path to Jinja2 values template relative to plugin directory.
+      valuesFile:
+        type: string
+        description: Path to static values file relative to plugin directory.
+      createNamespace:
+        type: boolean
+        description: "Pass --create-namespace. Default: true."
+      timeout:
+        type: string
+        description: "Helm timeout (e.g. '15m'). Default: '15m'."
+      wait:
+        type: boolean
+        description: "Pass --wait. Default: true."
+    required:
+      - release
+      - namespace
+
 additionalProperties: false
 properties:
   name:
@@ -135,6 +183,11 @@ properties:
   installOperators:
     type: boolean
     decsription: Install operators.
+  helm:
+    type: array
+    description: Helm charts to install, in order. Runs after OLM operators, before tasks/deploy.yaml.
+    items:
+      $ref: "#/definitions/helm_chart"
   defaults:
     type: object
     description: Default variables loaded into Ansible scope before plugin tasks run.

--- a/scripts/verification/validate_plugins.sh
+++ b/scripts/verification/validate_plugins.sh
@@ -83,7 +83,7 @@ filepath = sys.argv[1]
 required_fields = ['name', 'type']
 valid_fields = ['name', 'type', 'order', 'mirror', 'catalog', 'operators', 'defaults',
                 'installOperators', 'registries', 'additionalImages', 'blockedImages',
-                'requires']
+                'requires', 'helm']
 
 try:
     with open(filepath) as f:
@@ -125,8 +125,10 @@ if unexpected:
     # 3. Check for unexpected files/directories (only plugin.yaml and tasks/ allowed)
     for entry in "${plugin_dir}"*; do
         entry_name=$(basename "$entry")
-        if [ "$entry_name" != "plugin.yaml" ] && [ "$entry_name" != "tasks" ] && [ "$entry_name" != "files" ]; then
-            error "  Unexpected file or directory: $entry_name (only plugin.yaml, tasks/ and files/ are allowed)"
+        if [ "$entry_name" != "plugin.yaml" ] && [ "$entry_name" != "tasks" ] && \
+           [ "$entry_name" != "files" ] && [ "$entry_name" != "charts" ] && \
+           [ "$entry_name" != "templates" ]; then
+            error "  Unexpected file or directory: $entry_name (only plugin.yaml, tasks/, files/, charts/ and templates/ are allowed)"
             FAILED=1
             plugin_failed=1
         fi


### PR DESCRIPTION
## Summary

- Add Helm chart deployment phase to plugin lifecycle — plugins can declare `helm[]` in `plugin.yaml` to install Helm charts after operators, before `tasks/deploy.yaml`
- **Remote charts**: set `repo` (Helm repo URL) + `chart` (chart name) + optional `version` — fetched via `helm repo add`
- **Local charts**: set `chart` (path relative to plugin dir) or omit for default `charts/<release>`
- Jinja2 values templates or static values files (schema rejects both set together)
- Configurable namespace, timeout, wait, createNamespace, and retry logic with logging
- Schema updated with `helm_chart` definition including `repo`, `version`, `chart` fields
- Validation script updated to allow `helm` field, `charts/` and `templates/` directories
- Documentation updated with Helm in lifecycle, field table, and plugin checklist

**Updated plugin lifecycle:**
```
 1. Load plugin.yaml + defaults + validate requirements
 2. tasks/pre-validate.yaml
 3. Mirror (disconnected)
 4. Patch MCE registries
 5. Install OLM operators
 6. Deploy Helm charts            ← NEW
 7. tasks/deploy.yaml
 8. tasks/post-validate.yaml
```

Backward compatible — plugins without `helm[]` skip the step.

## Test plan

- [x] `scripts/verification/validate_plugins.sh` passes for all plugins
- [x] All `plugin.yaml` files validate against `schemas/plugin.yaml`
- [x] Schema rejects ambiguous `valuesTemplate` + `valuesFile` combinations
- [ ] `make deploy-plugin PLUGIN=lvms` still works (no helm = skip)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Helm chart deployment support to the plugin lifecycle, executing between post-operators and deploy phases.
  * Plugins can now declare Helm charts in their configuration with support for local and remote chart repositories.
  * Plugin structure now accepts `charts/` and `templates/` directories.

* **Documentation**
  * Updated plugin architecture documentation to reflect new Helm deployment capabilities and execution order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->