### PR TITLE
readd kubevirt-hyperconverged to mirroring

### DIFF
--- a/defaults/operators.yaml
+++ b/defaults/operators.yaml
@@ -124,3 +124,5 @@ operators:
     global: true
     csvNames:
       - metallb-operator
+    extraMirrorPackages:
+      - kubevirt-hyperconverged


### PR DESCRIPTION
removed in #317, restoring it in this PR as it is very likely used and should not have been removed.

first added here: https://github.com/rh-ecosystem-edge/gori-lab/commit/bf9e2ed7de1ace6f204fd5d45883b931242ca316#diff-7dc010656150750b7f2abdc8fa75b19fdffa11c25ec0075e7ac20c2a478de9d8R15