### PR TITLE
bump multicluster-engine 2.10.1 -> 2.10.2

### DIFF
--- a/defaults/operators.yaml
+++ b/defaults/operators.yaml
@@ -8,7 +8,7 @@ operators:
     namespace: quay-enterprise
 
   - name: multicluster-engine
-    version: 2.10.1
+    version: 2.10.2
     channel: stable-2.10
     init_version: 2.10.0
     namespace: multicluster-engine


### PR DESCRIPTION
in an environment where 2.10.2 is available and we are pinning to 2.10.1, MultiClusterHub will not be ready since there is a pending upgrade for multicluster-engine-sub.

this PR bumps multicluster-engine, but we should probably come up with a better story for connected. or discard connected?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated multicluster-engine operator to version 2.10.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->