### PR TITLE
disable e2e-connected by default

### DIFF
--- a/.github/workflows/e2e-deployment.yml
+++ b/.github/workflows/e2e-deployment.yml
@@ -24,7 +24,7 @@ on:
         description: 'Run connected mode E2E test'
         required: false
         type: boolean
-        default: true
+        default: false
       run-disconnected:
         description: 'Run disconnected mode E2E test'
         required: false


### PR DESCRIPTION
slack: https://redhat-internal.slack.com/archives/C09G9BS83T9/p1778134946053789

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted default behavior for manual end-to-end testing workflow to optimize testing execution patterns during deployment cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->