### PR TITLE
Remove ci connected mode

### DIFF
--- a/.github/workflows/e2e-deployment-rc.yml
+++ b/.github/workflows/e2e-deployment-rc.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Trigger E2E (ODF)
         run: |
+          # we keep the run-connected/run-disconnected flags here
+          # since this runs in 0-rc where they still exist
           gh workflow run e2e-deployment.yml --ref 0-rc \
             -f run-connected=false \
             -f run-disconnected=true \

--- a/.github/workflows/e2e-deployment.yml
+++ b/.github/workflows/e2e-deployment.yml
@@ -1,9 +1,7 @@
 name: E2E Deployment
 
-# Unified end-to-end deployment testing for connected and disconnected modes.
+# Unified end-to-end deployment testing for disconnected mode.
 #
-# Runs two parallel jobs:
-#   - e2e-connected:    Fast deployment pulling from upstream registries
 #   - e2e-disconnected: Full air-gapped deployment with local mirror registry
 #
 # Both jobs run on every PR and nightly schedule. Manual dispatch allows
@@ -20,16 +18,6 @@ on:
     - cron: '0 3 * * *'
   workflow_dispatch:
     inputs:
-      run-connected:
-        description: 'Run connected mode E2E test'
-        required: false
-        type: boolean
-        default: true
-      run-disconnected:
-        description: 'Run disconnected mode E2E test'
-        required: false
-        type: boolean
-        default: true
       storage-plugin:
         description: 'Storage plugin to deploy (lvms or odf)'
         required: true
@@ -65,7 +53,6 @@ jobs:
     outputs:
       should_run: ${{ steps.decision.outputs.should_run }}
       storage_plugins: ${{ steps.decision.outputs.storage_plugins }}
-      storage_plugins_connected: ${{ steps.decision.outputs.storage_plugins_connected }}
 
     steps:
       - name: Checkout code
@@ -112,25 +99,17 @@ jobs:
             echo "should_run=true" >> $GITHUB_OUTPUT
             PLUGIN="${{ inputs.storage-plugin || 'lvms' }}"
             echo "storage_plugins=[\"${PLUGIN}\"]" >> $GITHUB_OUTPUT
-            if [[ "$PLUGIN" == "odf" ]]; then
-              echo "storage_plugins_connected=[\"lvms\"]" >> $GITHUB_OUTPUT
-            else
-              echo "storage_plugins_connected=[\"${PLUGIN}\"]" >> $GITHUB_OUTPUT
-            fi
             echo "Manual trigger - E2E will run (${PLUGIN})" | tee -a $GITHUB_STEP_SUMMARY
           elif [[ "${{ github.event_name }}" == "schedule" ]]; then
             echo "should_run=true" >> $GITHUB_OUTPUT
             echo "storage_plugins=[\"lvms\"]" >> $GITHUB_OUTPUT
-            echo "storage_plugins_connected=[\"lvms\"]" >> $GITHUB_OUTPUT
             echo "Scheduled trigger - E2E will run" | tee -a $GITHUB_STEP_SUMMARY
           elif [[ "${{ github.event_name }}" == "merge_group" ]]; then
             echo "should_run=true" >> $GITHUB_OUTPUT
             echo "storage_plugins=[\"lvms\"]" >> $GITHUB_OUTPUT
-            echo "storage_plugins_connected=[\"lvms\"]" >> $GITHUB_OUTPUT
             echo "Merge queue - E2E will run" | tee -a $GITHUB_STEP_SUMMARY
           elif [[ "${{ steps.filter.outputs.e2e }}" == "true" ]]; then
             echo "should_run=true" >> $GITHUB_OUTPUT
-            echo "storage_plugins_connected=[\"lvms\"]" >> $GITHUB_OUTPUT
             if [[ "${{ steps.filter.outputs.odf }}" == "true" ]]; then
               echo "storage_plugins=[\"odf\"]" >> $GITHUB_OUTPUT
               echo "E2E-relevant files changed (including ODF) - ODF disconnected will run" | tee -a $GITHUB_STEP_SUMMARY
@@ -141,422 +120,9 @@ jobs:
           else
             echo "should_run=false" >> $GITHUB_OUTPUT
             echo "storage_plugins=[\"lvms\"]" >> $GITHUB_OUTPUT
-            echo "storage_plugins_connected=[\"lvms\"]" >> $GITHUB_OUTPUT
             echo "Only documentation/config files changed - E2E will be skipped" | tee -a $GITHUB_STEP_SUMMARY
             echo "To run E2E anyway, use manual workflow_dispatch" | tee -a $GITHUB_STEP_SUMMARY
           fi
-
-  # ---------------------------------------------------------------------------
-  # Connected mode E2E deployment
-  # ---------------------------------------------------------------------------
-  e2e-connected:
-    name: E2E Connected (${{ matrix.storage-plugin }})
-    needs: check-e2e-needed
-    if: >-
-      needs.check-e2e-needed.outputs.should_run == 'true' &&
-      (github.event_name != 'workflow_dispatch' || inputs.run-connected == true)
-    runs-on: [self-hosted, enclave-large]
-    timeout-minutes: 210
-
-    strategy:
-      fail-fast: false
-      matrix:
-        storage-plugin: ${{ fromJSON(needs.check-e2e-needed.outputs.storage_plugins_connected) }}
-
-    concurrency:
-      group: enclave-ci-connected-${{ matrix.storage-plugin }}-${{ github.run_id }}
-      cancel-in-progress: false
-
-    env:
-      DEV_SCRIPTS_PATH: ${{ vars.DEV_SCRIPTS_PATH }}
-      BASE_WORKING_DIR: ${{ vars.BASE_WORKING_DIR }}
-      PULL_SECRET: ${{ secrets.PULL_SECRET }}
-      ENCLAVE_DEPLOYMENT_MODE: connected
-      ENCLAVE_IRONIC_HTTPS: 'true'
-      CLEANUP_AFTER: 'true'
-      STORAGE_PLUGIN: ${{ matrix.storage-plugin }}
-      ENABLED_PLUGINS: ${{ matrix.storage-plugin }}
-      OPENSHIFT_CI: "true"
-      ENCLAVE_ENABLE_GPU_PASSTHROUGH: "false"
-      LZ_OS_VARIANT: ${{ vars.LZ_OS_VARIANT }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Generate unique cluster name
-        uses: ./.github/actions/setup-cluster-name
-        with:
-          naming-strategy: hash
-          prefix: ${{ github.event_name == 'schedule' && 'nc' || 'eci' }}
-          run-id: ${{ github.run_id }}
-
-      - name: Setup cluster-specific working directory
-        run: |
-          make -f Makefile.ci setup-working-dir
-          echo "WORKING_DIR=$(cat /tmp/working_dir)" >> $GITHUB_ENV
-
-      - name: Workflow information
-        run: |
-          echo "## E2E Deployment - Connected Mode" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Started at**: $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_STEP_SUMMARY
-          echo "**Cluster name**: $ENCLAVE_CLUSTER_NAME" >> $GITHUB_STEP_SUMMARY
-          echo "**Trigger**: ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-      - name: Pre-flight checks
-        uses: ./.github/actions/preflight-checks
-        with:
-          title: E2E Deployment - Connected Mode
-          check-pull-secret: 'true'
-          check-system-resources: 'true'
-          check-libvirt: 'true'
-
-      - name: Allocate unique subnet for cluster
-        uses: ./.github/actions/allocate-subnet
-
-      - name: Create infrastructure
-        env:
-          WORKING_DIR: ${{ env.WORKING_DIR }}
-        run: |
-          echo "## Creating Infrastructure" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Creating VMs, networks, and BMC emulation..." >> $GITHUB_STEP_SUMMARY
-          echo "Using subnet: ${ENCLAVE_SUBNET_ID:-not-set}" >> $GITHUB_STEP_SUMMARY
-          echo "BMC Network: ${ENCLAVE_BMC_NETWORK:-not-set}" >> $GITHUB_STEP_SUMMARY
-          echo "Cluster Network: ${ENCLAVE_CLUSTER_NETWORK:-not-set}" >> $GITHUB_STEP_SUMMARY
-          echo "Working Directory: ${WORKING_DIR:-not-set}" >> $GITHUB_STEP_SUMMARY
-
-          make -f Makefile.ci environment
-          echo "Infrastructure created" >> $GITHUB_STEP_SUMMARY
-
-      - name: Provision Landing Zone
-        env:
-          LZ_CLOUD_IMAGE_URL: ${{ vars.LZ_CLOUD_IMAGE_URL }}
-          LZ_CLOUD_IMAGE_NAME: ${{ vars.LZ_CLOUD_IMAGE_NAME }}
-          LZ_RHSM_ORG: ${{ secrets.LZ_RHSM_ORG }}
-          LZ_RHSM_ACTIVATION_KEY: ${{ secrets.LZ_RHSM_ACTIVATION_KEY }}
-        run: |
-          echo "## Provisioning Landing Zone" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Installing ${LZ_OS_VARIANT:-centos-stream10} on Landing Zone VM..." >> $GITHUB_STEP_SUMMARY
-          make -f Makefile.ci provision-landing-zone
-          echo "Landing Zone provisioned" >> $GITHUB_STEP_SUMMARY
-
-      - name: Install Enclave Lab
-        run: |
-          echo "## Installing Enclave Lab" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Installing dev-scripts and required packages on Landing Zone..." >> $GITHUB_STEP_SUMMARY
-          make -f Makefile.ci install-enclave
-          echo "Enclave Lab installed" >> $GITHUB_STEP_SUMMARY
-
-      - name: Generate Ironic ISO server TLS certificate
-        id: generate_ironic_cert
-        if: env.ENCLAVE_IRONIC_HTTPS == 'true'
-        run: ./scripts/deployment/generate_ironic_cert.sh
-
-      - name: Setup Ceph on Landing Zone
-        if: env.STORAGE_PLUGIN == 'odf'
-        id: setup_ceph
-        run: |
-          echo "## Ceph Setup on Landing Zone" >> $GITHUB_STEP_SUMMARY
-          make -f Makefile.ci setup-ceph
-          echo "Ceph cluster deployed on Landing Zone" >> $GITHUB_STEP_SUMMARY
-
-      - name: Bootstrap - Setup environment
-        id: bootstrap_setup
-        run: |
-          echo "## Bootstrap: Setup" >> $GITHUB_STEP_SUMMARY
-          make -f Makefile.ci deploy-cluster-setup
-          echo "Setup complete" >> $GITHUB_STEP_SUMMARY
-
-      - name: Bootstrap - Validate configuration
-        id: bootstrap_validate
-        run: |
-          echo "## Bootstrap: Validate" >> $GITHUB_STEP_SUMMARY
-          make -f Makefile.ci deploy-cluster-validate
-          echo "Validation complete" >> $GITHUB_STEP_SUMMARY
-
-      - name: Bootstrap - Download content
-        id: bootstrap_download_content
-        run: |
-          echo "## Bootstrap: Download Content" >> $GITHUB_STEP_SUMMARY
-          make -f Makefile.ci deploy-cluster-prepare
-          echo "Download complete" >> $GITHUB_STEP_SUMMARY
-
-      - name: Bootstrap - Build local cache
-        id: bootstrap_build_cache
-        run: |
-          echo "## Bootstrap: Build Cache" >> $GITHUB_STEP_SUMMARY
-          make -f Makefile.ci deploy-cluster-mirror
-          echo "Cache build complete" >> $GITHUB_STEP_SUMMARY
-
-      - name: Bootstrap - Acquire hardware
-        id: bootstrap_acquire_hardware
-        run: |
-          echo "## Bootstrap: Acquire Hardware" >> $GITHUB_STEP_SUMMARY
-          make -f Makefile.ci deploy-cluster-acquire-hardware
-          echo "Hardware acquired" >> $GITHUB_STEP_SUMMARY
-
-      - name: Bootstrap - Deploy cluster
-        id: bootstrap_deploy
-        run: |
-          echo "## Bootstrap: Deploy Cluster" >> $GITHUB_STEP_SUMMARY
-          make -f Makefile.ci deploy-cluster-install
-          echo "Cluster deployed" >> $GITHUB_STEP_SUMMARY
-
-      - name: Bootstrap - Post-install
-        id: bootstrap_post_install
-        run: |
-          echo "## Bootstrap: Post-Install" >> $GITHUB_STEP_SUMMARY
-          make -f Makefile.ci deploy-cluster-post-install
-          echo "Post-install complete" >> $GITHUB_STEP_SUMMARY
-
-      - name: Bootstrap - Operators
-        id: bootstrap_operators
-        run: |
-          echo "## Bootstrap: Operators" >> $GITHUB_STEP_SUMMARY
-          make -f Makefile.ci deploy-cluster-operators
-          echo "Operators installed" >> $GITHUB_STEP_SUMMARY
-
-      - name: Bootstrap - Day-2
-        id: bootstrap_day2
-        run: |
-          echo "## Bootstrap: Day-2" >> $GITHUB_STEP_SUMMARY
-          make -f Makefile.ci deploy-cluster-day2
-          echo "Day-2 complete" >> $GITHUB_STEP_SUMMARY
-
-      - name: Bootstrap - Discovery
-        id: bootstrap_discovery
-        run: |
-          echo "## Bootstrap: Discovery" >> $GITHUB_STEP_SUMMARY
-          make -f Makefile.ci deploy-cluster-discovery
-          echo "Discovery complete" >> $GITHUB_STEP_SUMMARY
-
-      - name: Verify cluster deployment
-        if: success()
-        id: verify_cluster
-        run: make -f Makefile.ci verify-cluster
-
-      - name: Collect artifacts
-        if: always()
-        uses: ./.github/actions/collect-artifacts
-        with:
-          artifact-type: deployment
-          output-directory: artifacts
-
-      - name: Collect full diagnostics on failure
-        if: failure()
-        run: |
-          echo "## Collecting Full Diagnostics (failure)" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          if ! ./scripts/verification/collect_ci_artifacts.sh full artifacts 2>&1 | tee artifact-collection-full.log; then
-            echo "Full artifact collection failed; continuing with must-gather" >> $GITHUB_STEP_SUMMARY
-          fi
-
-          LZ_IP=$(./scripts/utils/get_landing_zone_ip.sh)
-          if [ -n "$LZ_IP" ]; then
-            SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10"
-
-            if ssh $SSH_OPTS cloud-user@$LZ_IP "test -f /home/cloud-user/enclave/scripts/diagnostics/gather.sh" 2>/dev/null; then
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo "### Running must-gather..." >> $GITHUB_STEP_SUMMARY
-
-              mkdir -p artifacts/must-gather
-              GATHER_OUT=$(ssh $SSH_OPTS cloud-user@$LZ_IP \
-                "cd /home/cloud-user/enclave/scripts/diagnostics && \
-                 export KUBECONFIG=/home/cloud-user/ocp-cluster/auth/kubeconfig && \
-                 GITHUB_RUN_ID='${{ github.run_id }}' ./gather.sh --must-gather=full ../../config/global.yaml 2>&1" || true)
-              echo "$GATHER_OUT" >> artifacts/must-gather/gather-output.txt
-
-              scp $SSH_OPTS "cloud-user@${LZ_IP}:/home/cloud-user/enclave/scripts/diagnostics/lz-logs-*.tar.gz" artifacts/must-gather/ 2>/dev/null || true
-              scp $SSH_OPTS "cloud-user@${LZ_IP}:/home/cloud-user/enclave/scripts/diagnostics/cluster-logs-*.tar.gz" artifacts/must-gather/ 2>/dev/null || true
-
-              if ls artifacts/must-gather/*-logs-*.tar.gz 1>/dev/null 2>&1; then
-                echo "Collected must-gather archives" >> $GITHUB_STEP_SUMMARY
-              else
-                echo "Must-gather failed (see must-gather/gather-output.txt)" >> $GITHUB_STEP_SUMMARY
-              fi
-            fi
-          fi
-
-      - name: Upload artifacts
-        if: always()
-        id: upload_artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: e2e-connected-${{ env.ENCLAVE_CLUSTER_NAME }}-${{ github.run_id }}
-          path: artifacts/
-          retention-days: 7
-          if-no-files-found: warn
-
-      - name: Get artifact download URL
-        if: always()
-        id: artifact_url
-        run: |
-          ARTIFACT_ID=""
-          for attempt in 1 2 3 4 5; do
-            sleep $((attempt * 2))
-            ARTIFACT_ID=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts \
-              --jq '[.artifacts[] | select(.name == "e2e-connected-${{ env.ENCLAVE_CLUSTER_NAME }}-${{ github.run_id }}")] | sort_by(.created_at) | last // empty | .id')
-            if [ -n "$ARTIFACT_ID" ]; then
-              break
-            fi
-          done
-
-          if [ -n "$ARTIFACT_ID" ]; then
-            ARTIFACT_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${ARTIFACT_ID}"
-            echo "ARTIFACT_URL=${ARTIFACT_URL}" >> $GITHUB_OUTPUT
-          else
-            echo "ARTIFACT_URL=" >> $GITHUB_OUTPUT
-          fi
-        env:
-          GH_TOKEN: ${{ github.token }}
-
-      - name: Cleanup infrastructure
-        if: always() && (github.event_name != 'workflow_dispatch' || inputs.skip-cleanup != true)
-        run: |
-          echo "## Cleanup Infrastructure" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Removing infrastructure for cluster: $ENCLAVE_CLUSTER_NAME" >> $GITHUB_STEP_SUMMARY
-
-          mkdir -p cleanup-logs
-
-          set +e
-          make -f Makefile.ci clean 2>&1 | tee cleanup-logs/cleanup.log
-          CLEANUP_EXIT_CODE=$?
-          set -e
-
-          if grep -q "WARNING:" cleanup-logs/cleanup.log; then
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "Cleanup completed with warnings:" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            grep "WARNING:" cleanup-logs/cleanup.log >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-          elif [ $CLEANUP_EXIT_CODE -eq 0 ]; then
-            echo "Infrastructure cleaned up successfully" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "Cleanup completed with errors (exit code: $CLEANUP_EXIT_CODE)" >> $GITHUB_STEP_SUMMARY
-            echo "Check cleanup-logs/cleanup.log for details" >> $GITHUB_STEP_SUMMARY
-          fi
-
-      - name: Cleanup skipped notice
-        if: always() && github.event_name == 'workflow_dispatch' && inputs.skip-cleanup == true
-        run: |
-          echo "## Cleanup Skipped" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Infrastructure cleanup was skipped as requested." >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**IMPORTANT**: Remember to manually clean up the infrastructure:" >> $GITHUB_STEP_SUMMARY
-          echo '```bash' >> $GITHUB_STEP_SUMMARY
-          echo "make clean" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Cluster name**: $ENCLAVE_CLUSTER_NAME" >> $GITHUB_STEP_SUMMARY
-
-      - name: Collect post-cleanup state
-        if: always()
-        run: |
-          mkdir -p cleanup-state/libvirt cleanup-state/system
-
-          sudo virsh pool-list --all --details > cleanup-state/libvirt/storage-pools.txt 2>&1 || true
-          sudo virsh net-list --all > cleanup-state/libvirt/networks.txt 2>&1 || true
-          sudo virsh list --all > cleanup-state/libvirt/vms.txt 2>&1 || true
-          df -h > cleanup-state/system/disk-usage.txt 2>&1 || true
-
-      - name: Upload post-cleanup artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: post-cleanup-connected-${{ github.run_id }}
-          path: |
-            cleanup-logs/
-            cleanup-state/
-          retention-days: 7
-
-      - name: Summary
-        if: always()
-        run: |
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "---" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "## Deployment Summary" >> $GITHUB_STEP_SUMMARY
-          echo "- **Mode**: Connected" >> $GITHUB_STEP_SUMMARY
-          echo "- **Storage Plugin**: $STORAGE_PLUGIN" >> $GITHUB_STEP_SUMMARY
-          echo "- **Cluster**: $ENCLAVE_CLUSTER_NAME" >> $GITHUB_STEP_SUMMARY
-          echo "- **Branch**: ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Commit**: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Triggered by**: @${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Completed at**: $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_STEP_SUMMARY
-          echo "- **Status**: ${{ job.status }}" >> $GITHUB_STEP_SUMMARY
-
-      - name: Determine failed step
-        if: failure()
-        id: failed_step
-        env:
-          STEPS_JSON: ${{ toJSON(steps) }}
-        run: |
-          declare -A step_names=(
-            ["generate_ironic_cert"]="Generate Ironic ISO server TLS certificate"
-            ["setup_ceph"]="Setup Ceph on Landing Zone"
-            ["bootstrap_setup"]="Bootstrap: Setup environment"
-            ["bootstrap_validate"]="Bootstrap: Validate configuration"
-            ["bootstrap_download_content"]="Bootstrap: Download content"
-            ["bootstrap_build_cache"]="Bootstrap: Build local cache"
-            ["bootstrap_acquire_hardware"]="Bootstrap: Acquire hardware"
-            ["bootstrap_deploy"]="Bootstrap: Deploy cluster"
-            ["bootstrap_post_install"]="Bootstrap: Post-install"
-            ["bootstrap_operators"]="Bootstrap: Operators"
-            ["bootstrap_day2"]="Bootstrap: Day-2"
-            ["bootstrap_discovery"]="Bootstrap: Discovery"
-            ["verify_cluster"]="Verify cluster deployment"
-          )
-
-          step_order=(
-            generate_ironic_cert
-            setup_ceph
-            bootstrap_setup
-            bootstrap_validate
-            bootstrap_download_content
-            bootstrap_build_cache
-            bootstrap_acquire_hardware
-            bootstrap_deploy
-            bootstrap_post_install
-            bootstrap_operators
-            bootstrap_day2
-            bootstrap_discovery
-            verify_cluster
-          )
-
-          FAILED_STEP=""
-          for step_id in "${step_order[@]}"; do
-            outcome=$(printf '%s' "$STEPS_JSON" | jq -r --arg id "$step_id" '.[$id].outcome // "skipped"')
-            if [ "$outcome" == "failure" ]; then
-              FAILED_STEP="${step_names[$step_id]}"
-              break
-            fi
-          done
-
-          if [ -n "$FAILED_STEP" ]; then
-            echo "FAILED_STEP=$FAILED_STEP" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Notify Slack
-        if: always() && (github.event_name == 'schedule' || inputs.send-slack-notification == true)
-        uses: ./.github/actions/notify-slack
-        with:
-          status: ${{ job.status }}
-          workflow-name: E2E Deployment - Connected
-          cluster-name: ${{ env.ENCLAVE_CLUSTER_NAME }}
-          slack-webhook-urls: ${{ secrets.SLACK_WEBHOOK_URLS }}
-          workflow-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          branch-name: ${{ github.ref_name }}
-          commit-sha: ${{ github.sha }}
-          failed-step: ${{ steps.failed_step.outputs.FAILED_STEP }}
-          artifact-url: ${{ steps.artifact_url.outputs.ARTIFACT_URL }}
 
   # ---------------------------------------------------------------------------
   # Disconnected mode E2E deployment
@@ -565,8 +131,7 @@ jobs:
     name: E2E Disconnected (${{ matrix.storage-plugin }})
     needs: check-e2e-needed
     if: >-
-      needs.check-e2e-needed.outputs.should_run == 'true' &&
-      (github.event_name != 'workflow_dispatch' || inputs.run-disconnected == true)
+      needs.check-e2e-needed.outputs.should_run == 'true'
     runs-on: ${{ matrix.storage-plugin == 'odf' && fromJSON('["self-hosted", "enclave-large", "odf"]') || fromJSON('["self-hosted", "enclave-large"]') }}
     timeout-minutes: ${{ github.event_name == 'schedule' && 600 || 360 }}
 

--- a/.github/workflows/e2e-odf-schedule.yml
+++ b/.github/workflows/e2e-odf-schedule.yml
@@ -23,8 +23,6 @@ jobs:
         run: |
           gh workflow run e2e-deployment.yml \
             --ref "${{ github.ref }}" \
-            -f run-connected=false \
-            -f run-disconnected=true \
             -f storage-plugin=odf \
             -f send-slack-notification=true \
             -R "${{ github.repository }}"

--- a/.github/workflows/slash-command.yml
+++ b/.github/workflows/slash-command.yml
@@ -99,14 +99,13 @@ jobs:
           | `/test validation` | Lint and validate (shell, YAML, Ansible, Makefile) | pr-validation |
           | `/test tarball` | Build and push tarball | pr-validation |
           | `/test infra` | Infrastructure verification | enclave-small |
-          | `/test e2e-connected` | Dispatch E2E (connected only) | enclave-large |
           | `/test e2e-disconnected` | Dispatch E2E (disconnected only) | enclave-large |
           | `/test e2e-disconnected-odf` | Dispatch E2E disconnected with ODF storage | enclave-large |
           | `/test cleanup` | Run cleanup workflow | enclave-small |
-          | `/test all` | Run validation + tarball + infra + e2e (both modes) | multiple |
+          | `/test all` | Run validation + tarball + infra + e2e (disconnected) | multiple |
           | `/test ?` or `/test help` | Show this help message | — |
           | `/retest` | Re-run all failed checks on this PR | — |
-          | `/cancel <name>` | Cancel a running check (e.g. `/cancel e2e-connected`) | — |
+          | `/cancel <name>` | Cancel a running check (e.g. `/cancel e2e-disconnected`) | — |
           | `/cancel` | Cancel all running checks on this PR | — |
           EOF
           )"
@@ -204,22 +203,12 @@ jobs:
             infra)
               rerun_pr_workflow infra-verify.yml; track_result "Infra Verify" $?
               ;;
-            e2e-connected)
-              dispatch_workflow e2e-deployment.yml \
-                -f run-connected=true \
-                -f run-disconnected=false
-              track_result "E2E Connected" $?
-              ;;
             e2e-disconnected)
-              dispatch_workflow e2e-deployment.yml \
-                -f run-connected=false \
-                -f run-disconnected=true
+              dispatch_workflow e2e-deployment.yml
               track_result "E2E Disconnected" $?
               ;;
             e2e-disconnected-odf)
               dispatch_workflow e2e-deployment.yml \
-                -f run-connected=false \
-                -f run-disconnected=true \
                 -f storage-plugin=odf
               track_result "E2E Disconnected ODF" $?
               ;;
@@ -230,9 +219,7 @@ jobs:
               rerun_pr_workflow pr-validation.yml; track_result "PR Validation" $?
               rerun_pr_workflow build-push-tarball.yml; track_result "Build Tarball" $?
               rerun_pr_workflow infra-verify.yml; track_result "Infra Verify" $?
-              dispatch_workflow e2e-deployment.yml \
-                -f run-connected=true \
-                -f run-disconnected=true
+              dispatch_workflow e2e-deployment.yml
               track_result "E2E" $?
               ;;
             *)
@@ -330,7 +317,6 @@ jobs:
               validation)           echo "pr-validation.yml" ;;
               tarball)              echo "build-push-tarball.yml" ;;
               infra)                echo "infra-verify.yml" ;;
-              e2e-connected)        echo "e2e-deployment.yml" ;;
               e2e-disconnected)     echo "e2e-deployment.yml" ;;
               e2e-disconnected-odf) echo "e2e-deployment.yml" ;;
               cleanup)              echo "cleanup.yml" ;;

--- a/docs/CI_WORKFLOWS.md
+++ b/docs/CI_WORKFLOWS.md
@@ -173,8 +173,6 @@ Both connected and disconnected jobs run automatically on every PR with E2E-rele
 2. Select "E2E Deployment"
 3. Click "Run workflow"
 4. Configure options:
-   - **run-connected**: Run connected mode (default: true)
-   - **run-disconnected**: Run disconnected mode (default: true)
    - **storage-plugin**: lvms or odf (default: lvms)
    - **skip-cleanup**: Leave infrastructure running (default: false)
    - **send-slack-notification**: Send Slack notification (default: false)


### PR DESCRIPTION
We initially added connected deployment for testing purposes. Back then, the disconnected job took 8/6 hours to run so we had to get some option to test something in our CI. Now if we don't have a use case for connected mode we can remove it.

xref: https://redhat-internal.slack.com/archives/C09G9BS83T9/p1778134946053789

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined E2E test deployment workflows by consolidating testing mode configurations and removing redundant execution parameters.

* **Documentation**
  * Updated CI workflow documentation to reflect changes to test deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->