### PR TITLE
default operator.init_version to operator.version

### DIFF
--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -1180,7 +1180,7 @@ operators:
 | `name` | Operator package name as it appears in the catalog | Yes |
 | `version` | Operator version | Yes |
 | `channel` | Update channel for the operator | Yes |
-| `init_version` | Initial operator version | Yes |
+| `init_version` | Initial operator version (default: `version`) | No |
 | `namespace` | Target namespace for installation. OperatorGroup is auto-created if not `openshift-operators` | No |
 | `source` | Catalog source name (from oc-mirror). Must match a source created by oc-mirror | No |
 | `global` | Set to `true` to configure operator to watch the entire cluster | No |

--- a/schemas/operators.yaml
+++ b/schemas/operators.yaml
@@ -48,7 +48,6 @@ definitions:
     - name
     - version
     - channel
-    - init_version
 
 additionalProperties: false
 properties:

--- a/schemas/plugin.yaml
+++ b/schemas/plugin.yaml
@@ -49,7 +49,6 @@ definitions:
       - name
       - version
       - channel
-      - init_version
 
   registry:
     type: object

--- a/templates/imagesetconfiguration.yaml.j2
+++ b/templates/imagesetconfiguration.yaml.j2
@@ -36,7 +36,7 @@ mirror:
           defaultChannel: {{ operator.channel }}
           channels:
             - name: {{ operator.channel }}
-              minVersion: {{ operator.init_version }}
+              minVersion: {{ operator.init_version | default(operator.version) }}
               maxVersion: {{ operator.version }}
 {% endfor %}
 {% for pkg in operator.extraMirrorPackages | default([]) %}

--- a/templates/plugin-imageset.yaml.j2
+++ b/templates/plugin-imageset.yaml.j2
@@ -13,7 +13,7 @@ mirror:
           defaultChannel: {{ operator.channel }}
           channels:
             - name: {{ operator.channel }}
-              minVersion: {{ operator.init_version }}
+              minVersion: {{ operator.init_version | default(operator.version) }}
               maxVersion: {{ operator.version }}
 {% endfor %}
 {% for pkg in operator.extraMirrorPackages | default([]) %}


### PR DESCRIPTION
to simplify initial configuration of components and plugins.