### PR TITLE
add vast-csi plugin

### DIFF
--- a/plugins/vast-csi/plugin.yaml
+++ b/plugins/vast-csi/plugin.yaml
@@ -1,0 +1,18 @@
+---
+name: vast-csi
+type: addon
+order: 20
+mirror: plugin
+
+catalog: certified
+operators:
+  - name: vast-csi-operator
+    version: 2.6.5
+    channel: stable
+    namespace: vast-csi
+
+installOperators: false
+
+registries:
+  - location: "registry.connect.redhat.com/vastdataorg"
+    mirror: "vastdataorg"


### PR DESCRIPTION
this PR adds vast-csi as a plugin: https://catalog.redhat.com/en/software/container-stacks/detail/5f74e44ee13f2c4bdca41b30

in this plugin definition we specify the required operator to install (`operators`), the required catalog to use (`catalog`), installation not on management cluster (`installOperators`), and the registries for mirroring configuration.

more on plugins: https://github.com/rh-ecosystem-edge/enclave/blob/main/docs/PLUGIN_ARCHITECTURE.md

an addition to this PR may be ACM policies to install the operator on spoke clusters, which is being implemented in #340.