### PR TITLE
support plugin operators deploy to fleet via acm policies

### DIFF
--- a/docs/PLUGIN_ARCHITECTURE.md
+++ b/docs/PLUGIN_ARCHITECTURE.md
@@ -68,7 +68,8 @@ registries:
 | `order` | Deploy order among same-type plugins. Lower = first. LVMS is 10, ODF is 10. |
 | `catalog` | Operator catalog name (`redhat` or `certified`). Defaults to `redhat`. |
 | `operators` | List of OLM operators to install. Each entry is passed to `configure_operator.yaml`. |
-| `installOperators` | Set to `false` to skip operator installation. Defaults to `true`. |
+| `installOperators` | Set to `false` to skip operator installation (mirror-only plugins). Defaults to `true`. |
+| `clusterSelector` | Label-matching expressions to identify and select specific managed clusters for deploying the plugin (using ACM policies). |
 | `defaults` | Variables loaded into Ansible scope before tasks run. Keeps config namespaced per plugin. |
 | `registries` | Registry mirror entries for MCE patching and `registries.conf`. |
 | `additionalImages` | Extra images to include in the plugin's oc-mirror image set. |

--- a/files/plugin-fleet-configuration/00-namespace.yaml
+++ b/files/plugin-fleet-configuration/00-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-acm-policies

--- a/files/plugin-fleet-configuration/09-policy-catalogsource.yaml.j2
+++ b/files/plugin-fleet-configuration/09-policy-catalogsource.yaml.j2
@@ -1,0 +1,46 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+  name: {{ plugin.name }}-catalogsource
+  namespace: openshift-acm-policies
+spec:
+  disabled: false
+  remediationAction: enforce
+  policy-templates:
+  - objectDefinition:
+      apiVersion: policy.open-cluster-management.io/v1
+      kind: ConfigurationPolicy
+      metadata:
+        name: {{ plugin.name }}-catalogsource
+      spec:
+        evaluationInterval:
+          compliant: 5m
+          noncompliant: 45s
+        object-templates:
+        # Create custom CatalogSource for the plugin
+        - complianceType: mustonlyhave
+          metadataComplianceType: musthave
+          objectDefinition:
+            apiVersion: operators.coreos.com/v1alpha1
+            kind: CatalogSource
+            metadata:
+              name: {{ catalog_mirror }}
+              namespace: openshift-marketplace
+            spec:
+              image: registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/redhat/{{ catalog_mirror }}:{{ catalog_version }}
+              sourceType: grpc
+        - complianceType: musthave
+          metadataComplianceType: musthave
+          objectDefinition:
+            apiVersion: operators.coreos.com/v1alpha1
+            kind: CatalogSource
+            metadata:
+              name: {{ catalog_mirror }}
+              namespace: openshift-marketplace
+            status:
+              connectionState:
+                lastObservedState: READY

--- a/files/plugin-fleet-configuration/10-policy-operators.yaml.j2
+++ b/files/plugin-fleet-configuration/10-policy-operators.yaml.j2
@@ -1,0 +1,63 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+  name: {{ plugin.name }}-operators
+  namespace: openshift-acm-policies
+spec:
+  dependencies:
+  - apiVersion: policy.open-cluster-management.io/v1
+    compliance: Compliant
+    kind: Policy
+    name: {{ plugin.name }}-catalogsource
+    namespace: openshift-acm-policies
+  disabled: false
+  remediationAction: enforce
+  policy-templates:
+  - objectDefinition:
+      apiVersion: policy.open-cluster-management.io/v1
+      kind: ConfigurationPolicy
+      metadata:
+        name: {{ plugin.name }}-operators
+      spec:
+        evaluationInterval:
+          compliant: 2h
+          noncompliant: 45s
+        object-templates:
+{% for operator in plugin.operators | default([]) %}
+        - complianceType: mustonlyhave
+          metadataComplianceType: musthave
+          objectDefinition:
+            apiVersion: v1
+            kind: Namespace
+            metadata:
+                name: {{ operator.namespace }}
+        - complianceType: mustonlyhave
+          metadataComplianceType: musthave
+          objectDefinition:
+            apiVersion: operators.coreos.com/v1
+            kind: OperatorGroup
+            metadata:
+              name: {{ operator.name }}
+              namespace: {{ operator.namespace }}
+            spec:
+              targetNamespaces:
+              - {{ operator.namespace }}
+        - complianceType: mustonlyhave
+          metadataComplianceType: musthave
+          objectDefinition:
+            apiVersion: operators.coreos.com/v1alpha1
+            kind: Subscription
+            metadata:
+              name: {{ operator.name }}
+              namespace: {{ operator.namespace }}
+            spec:
+              channel: {{ operator.channel }}
+              installPlanApproval: Automatic
+              name: {{ operator.name }}
+              source: {{ operator.source | default(catalog_mirror) }}
+              sourceNamespace: openshift-marketplace
+{% endfor %}

--- a/files/plugin-fleet-configuration/20-placementrule.yaml.j2
+++ b/files/plugin-fleet-configuration/20-placementrule.yaml.j2
@@ -1,0 +1,7 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: {{ plugin.name }}-fleet-configuration
+  namespace: openshift-acm-policies
+spec:
+  clusterSelector: {{ plugin.clusterSelector }}

--- a/files/plugin-fleet-configuration/30-placementbinding.yaml.j2
+++ b/files/plugin-fleet-configuration/30-placementbinding.yaml.j2
@@ -6,7 +6,7 @@ metadata:
 placementRef:
   apiGroup: apps.open-cluster-management.io
   kind: PlacementRule
-  name: {{ plugin.name }}-configuration
+  name: {{ plugin.name }}-fleet-configuration
 subjects:
 - apiGroup: policy.open-cluster-management.io
   kind: Policy

--- a/files/plugin-fleet-configuration/30-placementbinding.yaml.j2
+++ b/files/plugin-fleet-configuration/30-placementbinding.yaml.j2
@@ -1,0 +1,16 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: {{ plugin.name }}-fleet-configuration
+  namespace: openshift-acm-policies
+placementRef:
+  apiGroup: apps.open-cluster-management.io
+  kind: PlacementRule
+  name: {{ plugin.name }}-configuration
+subjects:
+- apiGroup: policy.open-cluster-management.io
+  kind: Policy
+  name: {{ plugin.name }}-catalogsource
+- apiGroup: policy.open-cluster-management.io
+  kind: Policy
+  name: {{ plugin.name }}-operators

--- a/playbooks/tasks/configure_operators_fleet.yaml
+++ b/playbooks/tasks/configure_operators_fleet.yaml
@@ -3,7 +3,7 @@
     KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
   kubernetes.core.k8s:
     state: present
-    definition: "{{ lookup('ansible.builtin.file', '/files/00-namespace.yaml') | from_yaml }}"
+    definition: "{{ lookup('ansible.builtin.file', 'files/plugin-fleet-configuration/00-namespace.yaml') | from_yaml }}"
   register: r_acm_policy_ns
   retries: "{{ k8s_retries }}"
   delay: "{{ k8s_delay }}"

--- a/playbooks/tasks/configure_operators_fleet.yaml
+++ b/playbooks/tasks/configure_operators_fleet.yaml
@@ -1,0 +1,58 @@
+- name: Create Namespace for ACM Policies
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('ansible.builtin.file', '/files/00-namespace.yaml') | from_yaml }}"
+  register: r_acm_policy_ns
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_acm_policy_ns is success
+
+- name: Create ACM Policy for Plugin CatalogSource
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  kubernetes.core.k8s:
+    state: present
+    namespace: openshift-acm-policies
+    definition: "{{ lookup('ansible.builtin.template', 'files/plugin-fleet-configuration/09-policy-catalogsource.yaml.j2') | from_yaml }}"
+  register: r_acm_policy_cs
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_acm_policy_cs is success
+
+- name: Create ACM Policy for Plugin Operators
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  kubernetes.core.k8s:
+    state: present
+    namespace: openshift-acm-policies
+    definition: "{{ lookup('ansible.builtin.template', 'files/plugin-fleet-configuration/10-policy-operators.yaml.j2') | from_yaml }}"
+  register: r_acm_policy_operators
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_acm_policy_operators is success
+
+- name: Create ACM PlacementRule for Plugin
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  kubernetes.core.k8s:
+    state: present
+    namespace: openshift-acm-policies
+    definition: "{{ lookup('ansible.builtin.template', 'files/plugin-fleet-configuration/20-placementrule.yaml.j2') | from_yaml }}"
+  register: r_acm_placementrule
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_acm_placementrule is success
+
+- name: Create ACM PlacementBinding for Plugin
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  kubernetes.core.k8s:
+    state: present
+    namespace: openshift-acm-policies
+    definition: "{{ lookup('ansible.builtin.template', 'files/plugin-fleet-configuration/30-placementbinding.yaml.j2') | from_yaml }}"
+  register: r_acm_placementbinding
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_acm_placementbinding is success

--- a/playbooks/tasks/deploy_plugin.yaml
+++ b/playbooks/tasks/deploy_plugin.yaml
@@ -171,6 +171,19 @@
     - plugin.installOperators | default(true)
   tags: operators
 
+- name: Install plugin operators to fleet
+  ansible.builtin.include_tasks:
+    file: tasks/configure_operators_fleet.yaml
+    apply:
+      tags: operators
+      environment:
+        KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  when:
+    - plugin.operators | default([]) | length > 0
+    - plugin.clusterSelector is defined
+    - plugin.clusterSelector
+  tags: operators
+
 - name: Run post-operators
   ansible.builtin.include_tasks:
     file: "{{ plugin_dir }}/tasks/post-operators.yaml"

--- a/schemas/plugin.yaml
+++ b/schemas/plugin.yaml
@@ -50,6 +50,46 @@ definitions:
       - version
       - channel
 
+  selector:
+    description: Defines a set of label matching selectors for ACM.
+    type: object
+    additionalProperties: false
+    properties:
+      matchLabels:
+        type: object
+        description: >-
+          A map of {key,value} pairs. A single {key,value} in the matchLabels map 
+          is equivalent to an element of matchExpressions with operator 'In'.
+        additionalProperties:
+          type: string
+      matchExpressions:
+        type: array
+        description: A list of label selector requirements. The requirements are ANDed.
+        items:
+          type: object
+          required:
+            - key
+            - operator
+          properties:
+            key:
+              type: string
+              description: The label key that the selector applies to.
+            operator:
+              type: string
+              description: Represents a key's relationship to a set of values.
+              enum:
+                - In
+                - NotIn
+                - Exists
+                - DoesNotExist
+            values:
+              type: array
+              description: >-
+                An array of string values. Required if operator is 'In' or 'NotIn'.
+                Must be empty if operator is 'Exists' or 'DoesNotExist'.
+              items:
+                type: string
+
   registry:
     type: object
     additionalProperties: false
@@ -173,6 +213,8 @@ properties:
   installOperators:
     type: boolean
     decsription: Install operators.
+  clusterSelector:
+    $ref: "#/definitions/selector"
   helm:
     type: array
     description: Helm charts to install, in order. Runs after OLM operators, before tasks/deploy.yaml.

--- a/schemas/plugin.yaml
+++ b/schemas/plugin.yaml
@@ -70,6 +70,7 @@ definitions:
           required:
             - key
             - operator
+          additionalProperties: false
           properties:
             key:
               type: string
@@ -89,6 +90,24 @@ definitions:
                 Must be empty if operator is 'Exists' or 'DoesNotExist'.
               items:
                 type: string
+          allOf:
+            - if:
+                properties:
+                  operator:
+                    enum: [In, NotIn]
+              then:
+                required: [values]
+                properties:
+                  values:
+                    minItems: 1
+            - if:
+                properties:
+                  operator:
+                    enum: [Exists, DoesNotExist]
+              then:
+                properties:
+                  values:
+                    maxItems: 0
 
   registry:
     type: object

--- a/scripts/verification/validate_plugins.sh
+++ b/scripts/verification/validate_plugins.sh
@@ -83,7 +83,7 @@ filepath = sys.argv[1]
 required_fields = ['name', 'type']
 valid_fields = ['name', 'type', 'order', 'catalog', 'operators', 'defaults',
                 'installOperators', 'registries', 'additionalImages', 'blockedImages',
-                'requires', 'helm']
+                'requires', 'helm', 'clusterSelector']
 
 try:
     with open(filepath) as f:


### PR DESCRIPTION
part of https://redhat.atlassian.net/browse/OSAC-538

this PR adds support to deploy operators to spoke clusters in the fleet using ACM policies. the feature is exposed using a `clusterSelector` field in a plugin file to be used for the policy placement rule (to select managed clusters).

this PR adds support for a custom CatalogSource and operators installation using Namespace, OperatorGroup and Subscription.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `clusterSelector` field to enable targeting specific managed clusters for plugin deployment.
  * Introduced fleet-wide operator deployment via Advanced Cluster Management policies and placement rules.

* **Documentation**
  * Updated plugin architecture documentation to describe the `clusterSelector` field.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/enclave/pull/340)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->