### PR TITLE
enhance vast-csi plugin with infra tenant provisioning

### DIFF
--- a/ansible_collections.sha256
+++ b/ansible_collections.sha256
@@ -3,3 +3,4 @@ fcf9e22e0440a97e8fcb979b31ab82e87c3024765ebda0aac71217d7020d39aa *collections/co
 7e4435d4bb587c4b2e978cf7e31c02fe78063bcef5d8f07935ea0bae52c1a210 *collections/kubernetes-core-6.2.0.tar.gz
 2281e318d303c7eabb41e3b99eeda85b5bbfff1081f8b2f08fc2235b56d6606c *collections/community-general-12.1.0.tar.gz
 5ff232cf69492a991f2a0990dbb23ef25a600b7e9209de6e33377a6ff08a8a29 *collections/ansible-posix-2.1.0.tar.gz
+5062b15a597edf1beaa6a782747298727250bbb993fbf2d0abf954b5bcd56514 *collections/vastdata-vms-1.2.0.tar.gz

--- a/ansible_collections.txt
+++ b/ansible_collections.txt
@@ -11,3 +11,5 @@ collections:
   version: 6.0.0
 - name: ansible.posix
   version: 2.1.0
+- name: vastdata.vms
+  version: 1.2.0

--- a/config/global.example.yaml
+++ b/config/global.example.yaml
@@ -104,11 +104,20 @@ storage_plugin: lvms
 # vastAdminUsername: "admin"
 # vastAdminPassword: "YOUR_VAST_ADMIN_PASSWORD"
 #
+# VIP pool network configuration (required).
+# The plugin creates a VIP pool on the VAST cluster for CSI traffic.
+# vastVipPool:
+#   subnet_cidr: 24
+#   ip_ranges:
+#     - start: "10.0.100.10"
+#       end: "10.0.100.50"
+#
 # Configure storage tiers (default: single NFS tier for Quay).
-# Each tier creates a StorageClass named {infraTenant}-{tierName}.
+# Each tier creates a VAST view and a K8s StorageClass named {infraTenant}-{tierName}.
 # vastDefaults:
 #   infraTenant: infra
 #   storagePath: /osac
+#   viewPolicyId: 1
 #   quayPvcSize: 2000Gi
 #   tiers:
 #     - name: quay

--- a/config/global.example.yaml
+++ b/config/global.example.yaml
@@ -61,9 +61,9 @@ quayBackendRGWConfiguration:
 # ============================================================================
 # Storage Backend
 # ============================================================================
-# Storage plugin for block devices for quay database and assisted installer
-# Selects which storage plugin (plugins/lvms/ or plugins/odf/) to deploy
-# Options: lvms or odf
+# Storage plugin for quay database and assisted installer
+# Selects which storage plugin to deploy
+# Options: lvms, odf, or vast-csi
 # storage_plugin: odf
 storage_plugin: lvms
 

--- a/config/global.example.yaml
+++ b/config/global.example.yaml
@@ -94,6 +94,31 @@ storage_plugin: lvms
 #     "kind": "ConfigMap", "data": ..}]'
 
 # ============================================================================
+# Storage Configuration (VAST CSI)
+# ============================================================================
+# When storage_plugin is vast-csi, configure the VAST management endpoint
+# and admin credentials. The plugin creates an "infra" tenant following the
+# osac-aap naming convention so both systems can reason about resources.
+#
+# vastEndpoint: "https://vms.example.com"
+# vastAdminUsername: "admin"
+# vastAdminPassword: "YOUR_VAST_ADMIN_PASSWORD"
+#
+# Configure storage tiers (default: single NFS tier for Quay).
+# Each tier creates a StorageClass named {infraTenant}-{tierName}.
+# vastDefaults:
+#   infraTenant: infra
+#   storagePath: /osac
+#   quayPvcSize: 2000Gi
+#   tiers:
+#     - name: quay
+#       protocol: nfs
+#     - name: fast
+#       protocol: block
+#     - name: archive
+#       protocol: nfs
+
+# ============================================================================
 # OpenShift Deployment Configuration (optional)
 # All settings below have defaults. Uncomment only to override.
 # ============================================================================

--- a/config/global.example.yaml
+++ b/config/global.example.yaml
@@ -99,6 +99,7 @@ storage_plugin: lvms
 # When storage_plugin is vast-csi, configure the VAST management endpoint
 # and admin credentials. The plugin creates an "infra" tenant following the
 # osac-aap naming convention so both systems can reason about resources.
+# Also set quayBackend: LocalStorage (VAST NFS uses PVC mount for Quay).
 #
 # vastEndpoint: "https://vms.example.com"
 # vastAdminUsername: "admin"

--- a/plugins/vast-csi/plugin.yaml
+++ b/plugins/vast-csi/plugin.yaml
@@ -41,7 +41,7 @@ requires:
       description: "VAST management API password"
       when: "{{ storage_plugin == 'vast-csi' }}"
     - name: vastVipPool
-      description: "VIP pool configuration: {name, subnet_cidr, ip_ranges: [{start, end}]}"
+      description: "VIP pool configuration: {subnet_cidr, ip_ranges: [{start, end}]}"
       when: "{{ storage_plugin == 'vast-csi' }}"
   files:
     - path: "tasks/deploy.yaml"

--- a/plugins/vast-csi/plugin.yaml
+++ b/plugins/vast-csi/plugin.yaml
@@ -1,17 +1,47 @@
 ---
 name: vast-csi
-type: addon
-order: 20
+type: foundation
+order: 10
 mirror: plugin
 
 catalog: certified
 operators:
   - name: vast-csi-operator
     version: 2.6.5
+    init_version: 2.6.5
     channel: stable
     namespace: vast-csi
 
-installOperators: false
+defaults:
+  vastDefaults:
+    infraTenant: infra
+    storagePath: /osac
+    validateCerts: true
+    apiTimeout: 30
+    csiProvisioners:
+      nfs: csi.vastdata.com
+      block: block.csi.vastdata.com
+    csiDriverName: vastcsi-driver
+    quayPvcSize: 1000Gi
+    tiers:
+      - name: quay
+        protocol: nfs
+
+requires:
+  vars:
+    - name: vastEndpoint
+      description: "VAST management endpoint URL (e.g. https://vms.example.com)"
+    - name: vastAdminUsername
+      description: "VAST management API username"
+      when: "{{ storage_plugin == 'vast-csi' }}"
+    - name: vastAdminPassword
+      description: "VAST management API password"
+      when: "{{ storage_plugin == 'vast-csi' }}"
+  files:
+    - path: "tasks/deploy.yaml"
+      description: "VAST CSI deployment tasks"
+    - path: "tasks/quay.yaml"
+      description: "VAST Quay storage configuration"
 
 registries:
   - location: "registry.connect.redhat.com/vastdataorg"

--- a/plugins/vast-csi/plugin.yaml
+++ b/plugins/vast-csi/plugin.yaml
@@ -49,6 +49,10 @@ requires:
     - path: "tasks/quay.yaml"
       description: "VAST Quay storage configuration"
 
+clusterSelector:
+  matchLabels:
+    storage.vastdata.com/enabled: "true"
+
 registries:
   - location: "registry.connect.redhat.com/vastdataorg"
     mirror: "vastdataorg"

--- a/plugins/vast-csi/plugin.yaml
+++ b/plugins/vast-csi/plugin.yaml
@@ -18,6 +18,8 @@ defaults:
     storagePath: /osac
     validateCerts: true
     apiTimeout: 30
+    apiVersion: latest
+    viewPolicyId: 1
     csiProvisioners:
       nfs: csi.vastdata.com
       block: block.csi.vastdata.com
@@ -36,6 +38,9 @@ requires:
       when: "{{ storage_plugin == 'vast-csi' }}"
     - name: vastAdminPassword
       description: "VAST management API password"
+      when: "{{ storage_plugin == 'vast-csi' }}"
+    - name: vastVipPool
+      description: "VIP pool configuration: {name, subnet_cidr, ip_ranges: [{start, end}]}"
       when: "{{ storage_plugin == 'vast-csi' }}"
   files:
     - path: "tasks/deploy.yaml"

--- a/plugins/vast-csi/plugin.yaml
+++ b/plugins/vast-csi/plugin.yaml
@@ -1,0 +1,18 @@
+---
+name: vast-csi
+type: addon
+order: 20
+mirror: plugin
+
+catalog: certified
+operators:
+  - name: vast-csi-operator
+    version: 2.6.5
+    channel: stable
+    namespace: vast-csi
+
+installOperators: false
+
+registries:
+  - location: "registry.connect.redhat.com/vastdataorg"
+    mirror: "vastdataorg"

--- a/plugins/vast-csi/plugin.yaml
+++ b/plugins/vast-csi/plugin.yaml
@@ -33,6 +33,7 @@ requires:
   vars:
     - name: vastEndpoint
       description: "VAST management endpoint URL (e.g. https://vms.example.com)"
+      when: "{{ storage_plugin == 'vast-csi' }}"
     - name: vastAdminUsername
       description: "VAST management API username"
       when: "{{ storage_plugin == 'vast-csi' }}"

--- a/plugins/vast-csi/tasks/deploy.yaml
+++ b/plugins/vast-csi/tasks/deploy.yaml
@@ -18,6 +18,12 @@
     vast_tenant: "{{ vastDefaults.infraTenant }}"
     vast_tiers: "{{ vastDefaults.tiers }}"
     vast_protocols: "{{ vastDefaults.tiers | map(attribute='protocol') | unique | list }}"
+    vast_vms_conn:
+      host: "{{ vastEndpoint | regex_replace('^https?://', '') }}"
+      username: "{{ vastAdminUsername }}"
+      password: "{{ vastAdminPassword }}"
+      validate_certs: "{{ vastDefaults.validateCerts }}"
+      api_version: "{{ vastDefaults.apiVersion }}"
 
 # ── VMS: Create infra tenant ─────────────────────────────────────────────
 
@@ -25,10 +31,7 @@
   no_log: true
   vastdata.vms.tenants:
     name: "{{ vast_tenant }}"
-    vms_host: "{{ vastEndpoint | regex_replace('^https?://', '') }}"
-    vms_user: "{{ vastAdminUsername }}"
-    vms_password: "{{ vastAdminPassword }}"
-    vms_validate_certs: "{{ vastDefaults.validateCerts }}"
+    vms: "{{ vast_vms_conn }}"
     state: present
   register: r_tenant
 
@@ -41,11 +44,9 @@
     subnet_cidr: "{{ vastVipPool.subnet_cidr }}"
     ip_ranges: "{{ vastVipPool.ip_ranges }}"
     role: "{{ vastVipPool.role | default('PROTOCOLS') }}"
+    tenant_id: "{{ r_tenant.tenants.id }}"
     enabled: true
-    vms_host: "{{ vastEndpoint | regex_replace('^https?://', '') }}"
-    vms_user: "{{ vastAdminUsername }}"
-    vms_password: "{{ vastAdminPassword }}"
-    vms_validate_certs: "{{ vastDefaults.validateCerts }}"
+    vms: "{{ vast_vms_conn }}"
     state: present
   register: r_vippool
 
@@ -60,10 +61,7 @@
     tenant_id: "{{ r_tenant.tenants.id }}"
     protocols:
       - "{{ item.protocol | upper }}"
-    vms_host: "{{ vastEndpoint | regex_replace('^https?://', '') }}"
-    vms_user: "{{ vastAdminUsername }}"
-    vms_password: "{{ vastAdminPassword }}"
-    vms_validate_certs: "{{ vastDefaults.validateCerts }}"
+    vms: "{{ vast_vms_conn }}"
     state: present
   loop: "{{ vast_tiers }}"
   loop_control:
@@ -162,3 +160,10 @@
   retries: "{{ k8s_retries }}"
   delay: "{{ k8s_delay }}"
   until: r_snapshotclass is success or r_snapshotclass is skipped
+
+# ── Credential cleanup ────────────────────────────────────────────────────
+
+- name: Clear VMS connection facts
+  no_log: true
+  ansible.builtin.set_fact:
+    vast_vms_conn: null

--- a/plugins/vast-csi/tasks/deploy.yaml
+++ b/plugins/vast-csi/tasks/deploy.yaml
@@ -1,12 +1,19 @@
 ---
-# Provisions the infra tenant's K8s resources: CSI credentials Secret,
-# per-tier StorageClasses, and optional VolumeSnapshotClasses.
+# Provisions the infra tenant on the VAST management plane (VMS API), then
+# creates matching K8s resources (Secrets, StorageClasses, VolumeSnapshotClasses).
+#
+# Calls the VMS REST API directly via ansible.builtin.uri to avoid depending
+# on the vastdata.vms Ansible collection. osac-aap uses the same API through
+# the vendored collection modules for tenant lifecycle operations.
 #
 # Follows the osac-aap naming convention so both systems can reason about
 # each other's resources:
-#   Tenant:           {tenant}
-#   StorageClass:     {tenant}-{tier}
-#   CSI Secret:       vast-csi-{tenant}
+#   Tenant:              {tenant}
+#   VIP pool:            vippool-{tenant}
+#   View:                view-{tenant}-{tier}
+#   View path:           {storagePath}/{tenant}/{tier}
+#   StorageClass:        {tenant}-{tier}
+#   CSI Secret:          vast-csi-{tenant}
 #   VolumeSnapshotClass: vast-snapshot-{tenant}-{tier}
 
 - name: Set infra tenant variables
@@ -14,6 +21,135 @@
     vast_tenant: "{{ vastDefaults.infraTenant }}"
     vast_tiers: "{{ vastDefaults.tiers }}"
     vast_protocols: "{{ vastDefaults.tiers | map(attribute='protocol') | unique | list }}"
+    vast_api_base: "{{ vastEndpoint }}/api/{{ vastDefaults.apiVersion }}"
+    vast_api_headers:
+      Content-Type: application/json
+    vast_api_auth:
+      url_username: "{{ vastAdminUsername }}"
+      url_password: "{{ vastAdminPassword }}"
+      force_basic_auth: true
+
+# ── VMS: Create infra tenant ─────────────────────────────────────────────
+
+- name: Check if infra tenant already exists
+  ansible.builtin.uri:
+    url: "{{ vast_api_base }}/tenants/?name={{ vast_tenant }}"
+    method: GET
+    headers: "{{ vast_api_headers }}"
+    url_username: "{{ vastAdminUsername }}"
+    url_password: "{{ vastAdminPassword }}"
+    force_basic_auth: true
+    validate_certs: "{{ vastDefaults.validateCerts }}"
+    timeout: "{{ vastDefaults.apiTimeout }}"
+    status_code: [200]
+  register: r_tenant_lookup
+  no_log: true
+
+- name: Create infra tenant on VAST
+  ansible.builtin.uri:
+    url: "{{ vast_api_base }}/tenants/"
+    method: POST
+    headers: "{{ vast_api_headers }}"
+    url_username: "{{ vastAdminUsername }}"
+    url_password: "{{ vastAdminPassword }}"
+    force_basic_auth: true
+    validate_certs: "{{ vastDefaults.validateCerts }}"
+    timeout: "{{ vastDefaults.apiTimeout }}"
+    body_format: json
+    body:
+      name: "{{ vast_tenant }}"
+    status_code: [200, 201]
+  register: r_tenant_create
+  when: r_tenant_lookup.json | length == 0
+  no_log: true
+
+- name: Set tenant ID
+  ansible.builtin.set_fact:
+    vast_tenant_id: "{{ (r_tenant_lookup.json | length > 0) | ternary(r_tenant_lookup.json[0].id, r_tenant_create.json.id) }}"
+
+# ── VMS: Create VIP pool ─────────────────────────────────────────────────
+
+- name: Check if VIP pool already exists
+  ansible.builtin.uri:
+    url: "{{ vast_api_base }}/vippools/?name=vippool-{{ vast_tenant }}"
+    method: GET
+    headers: "{{ vast_api_headers }}"
+    url_username: "{{ vastAdminUsername }}"
+    url_password: "{{ vastAdminPassword }}"
+    force_basic_auth: true
+    validate_certs: "{{ vastDefaults.validateCerts }}"
+    timeout: "{{ vastDefaults.apiTimeout }}"
+    status_code: [200]
+  register: r_vippool_lookup
+  no_log: true
+
+- name: Create VIP pool for infra tenant
+  ansible.builtin.uri:
+    url: "{{ vast_api_base }}/vippools/"
+    method: POST
+    headers: "{{ vast_api_headers }}"
+    url_username: "{{ vastAdminUsername }}"
+    url_password: "{{ vastAdminPassword }}"
+    force_basic_auth: true
+    validate_certs: "{{ vastDefaults.validateCerts }}"
+    timeout: "{{ vastDefaults.apiTimeout }}"
+    body_format: json
+    body:
+      name: "vippool-{{ vast_tenant }}"
+      subnet_cidr: "{{ vastVipPool.subnet_cidr }}"
+      ip_ranges: "{{ vastVipPool.ip_ranges }}"
+      role: "{{ vastVipPool.role | default('PROTOCOLS') }}"
+      enabled: true
+    status_code: [200, 201]
+  register: r_vippool_create
+  when: r_vippool_lookup.json | length == 0
+  no_log: true
+
+# ── VMS: Create views per tier ────────────────────────────────────────────
+
+- name: Check which views already exist
+  ansible.builtin.uri:
+    url: "{{ vast_api_base }}/views/?path={{ vastDefaults.storagePath }}/{{ vast_tenant }}/{{ item.name }}"
+    method: GET
+    headers: "{{ vast_api_headers }}"
+    url_username: "{{ vastAdminUsername }}"
+    url_password: "{{ vastAdminPassword }}"
+    force_basic_auth: true
+    validate_certs: "{{ vastDefaults.validateCerts }}"
+    timeout: "{{ vastDefaults.apiTimeout }}"
+    status_code: [200]
+  loop: "{{ vast_tiers }}"
+  loop_control:
+    label: "view-{{ vast_tenant }}-{{ item.name }}"
+  register: r_view_lookups
+  no_log: true
+
+- name: Create view for each new tier
+  ansible.builtin.uri:
+    url: "{{ vast_api_base }}/views/"
+    method: POST
+    headers: "{{ vast_api_headers }}"
+    url_username: "{{ vastAdminUsername }}"
+    url_password: "{{ vastAdminPassword }}"
+    force_basic_auth: true
+    validate_certs: "{{ vastDefaults.validateCerts }}"
+    timeout: "{{ vastDefaults.apiTimeout }}"
+    body_format: json
+    body:
+      path: "{{ vastDefaults.storagePath }}/{{ item.item.name }}"
+      name: "view-{{ vast_tenant }}-{{ item.item.name }}"
+      policy_id: "{{ vastDefaults.viewPolicyId }}"
+      tenant_id: "{{ vast_tenant_id }}"
+      protocols:
+        - "{{ item.item.protocol | upper }}"
+    status_code: [200, 201]
+  loop: "{{ r_view_lookups.results }}"
+  loop_control:
+    label: "view-{{ vast_tenant }}-{{ item.item.name }}"
+  when: item.json | length == 0
+  no_log: true
+
+# ── K8s: Create CSI credentials Secret ───────────────────────────────────
 
 - name: Create CSI credentials Secret for infra tenant
   no_log: true
@@ -37,6 +173,8 @@
   retries: "{{ k8s_retries }}"
   delay: "{{ k8s_delay }}"
   until: r_csi_secret is success
+
+# ── K8s: Create StorageClasses ────────────────────────────────────────────
 
 - name: Create StorageClass for each tier
   kubernetes.core.k8s:
@@ -68,6 +206,8 @@
   retries: "{{ k8s_retries }}"
   delay: "{{ k8s_delay }}"
   until: r_storageclass is success
+
+# ── K8s: Create VolumeSnapshotClasses ─────────────────────────────────────
 
 - name: Check if VolumeSnapshot CRD is available
   kubernetes.core.k8s_info:
@@ -102,3 +242,11 @@
   retries: "{{ k8s_retries }}"
   delay: "{{ k8s_delay }}"
   until: r_snapshotclass is success or r_snapshotclass is skipped
+
+# ── Credential cleanup ────────────────────────────────────────────────────
+
+- name: Clear credential facts
+  no_log: true
+  ansible.builtin.set_fact:
+    vast_api_auth: null
+    vast_api_headers: null

--- a/plugins/vast-csi/tasks/deploy.yaml
+++ b/plugins/vast-csi/tasks/deploy.yaml
@@ -14,10 +14,12 @@
 #   VolumeSnapshotClass: vast-snapshot-{tenant}-{tier}
 
 - name: Set infra tenant variables
+  no_log: true
   ansible.builtin.set_fact:
     vast_tenant: "{{ vastDefaults.infraTenant }}"
     vast_tiers: "{{ vastDefaults.tiers }}"
     vast_protocols: "{{ vastDefaults.tiers | map(attribute='protocol') | unique | list }}"
+    vast_host: "{{ vastEndpoint | regex_replace('^https?://', '') }}"
     vast_vms_conn:
       host: "{{ vastEndpoint | regex_replace('^https?://', '') }}"
       username: "{{ vastAdminUsername }}"
@@ -84,7 +86,7 @@
           osac.openshift.io/tenant: "{{ vast_tenant }}"
       type: Opaque
       stringData:
-        endpoint: "{{ vastEndpoint }}"
+        endpoint: "{{ vast_host }}"
         username: "{{ vastAdminUsername }}"
         password: "{{ vastAdminPassword }}"
   register: r_csi_secret

--- a/plugins/vast-csi/tasks/deploy.yaml
+++ b/plugins/vast-csi/tasks/deploy.yaml
@@ -1,0 +1,104 @@
+---
+# Provisions the infra tenant's K8s resources: CSI credentials Secret,
+# per-tier StorageClasses, and optional VolumeSnapshotClasses.
+#
+# Follows the osac-aap naming convention so both systems can reason about
+# each other's resources:
+#   Tenant:           {tenant}
+#   StorageClass:     {tenant}-{tier}
+#   CSI Secret:       vast-csi-{tenant}
+#   VolumeSnapshotClass: vast-snapshot-{tenant}-{tier}
+
+- name: Set infra tenant variables
+  ansible.builtin.set_fact:
+    vast_tenant: "{{ vastDefaults.infraTenant }}"
+    vast_tiers: "{{ vastDefaults.tiers }}"
+    vast_protocols: "{{ vastDefaults.tiers | map(attribute='protocol') | unique | list }}"
+
+- name: Create CSI credentials Secret for infra tenant
+  no_log: true
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: "vast-csi-{{ vast_tenant }}"
+        namespace: vast-csi
+        labels:
+          app.kubernetes.io/managed-by: enclave
+          osac.openshift.io/tenant: "{{ vast_tenant }}"
+      type: Opaque
+      stringData:
+        endpoint: "{{ vastEndpoint }}"
+        username: "{{ vastAdminUsername }}"
+        password: "{{ vastAdminPassword }}"
+  register: r_csi_secret
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_csi_secret is success
+
+- name: Create StorageClass for each tier
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: storage.k8s.io/v1
+      kind: StorageClass
+      metadata:
+        name: "{{ vast_tenant }}-{{ item.name }}"
+        labels:
+          app.kubernetes.io/managed-by: enclave
+          osac.openshift.io/tenant: "{{ vast_tenant }}"
+          osac.openshift.io/tier: "{{ item.name }}"
+        annotations:
+          storageclass.kubernetes.io/is-default-class: "{{ (item.default | default(false)) | ternary('true', 'false') }}"
+      provisioner: "{{ vastDefaults.csiProvisioners[item.protocol] }}"
+      parameters:
+        vipPool: "vippool-{{ vast_tenant }}"
+        storagePath: "{{ vastDefaults.storagePath }}/{{ vast_tenant }}/{{ item.name }}"
+        secretName: "vast-csi-{{ vast_tenant }}"
+        secretNamespace: vast-csi
+      reclaimPolicy: Delete
+      allowVolumeExpansion: true
+      volumeBindingMode: "{{ (item.protocol == 'block') | ternary('WaitForFirstConsumer', 'Immediate') }}"
+  loop: "{{ vast_tiers }}"
+  loop_control:
+    label: "{{ vast_tenant }}-{{ item.name }}"
+  register: r_storageclass
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_storageclass is success
+
+- name: Check if VolumeSnapshot CRD is available
+  kubernetes.core.k8s_info:
+    api_version: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    name: volumesnapshotclasses.snapshot.storage.k8s.io
+  register: r_snapshot_crd
+
+- name: Create VolumeSnapshotClass for each tier
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: snapshot.storage.k8s.io/v1
+      kind: VolumeSnapshotClass
+      metadata:
+        name: "vast-snapshot-{{ vast_tenant }}-{{ item.name }}"
+        labels:
+          app.kubernetes.io/managed-by: enclave
+          osac.openshift.io/tenant: "{{ vast_tenant }}"
+          osac.openshift.io/tier: "{{ item.name }}"
+      driver: "{{ vastDefaults.csiProvisioners[item.protocol] }}"
+      deletionPolicy: Delete
+      parameters:
+        secretName: "vast-csi-{{ vast_tenant }}"
+        secretNamespace: vast-csi
+  loop: "{{ vast_tiers }}"
+  loop_control:
+    label: "vast-snapshot-{{ vast_tenant }}-{{ item.name }}"
+  when:
+    - r_snapshot_crd.resources | default([]) | length > 0
+  register: r_snapshotclass
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_snapshotclass is success or r_snapshotclass is skipped

--- a/plugins/vast-csi/tasks/deploy.yaml
+++ b/plugins/vast-csi/tasks/deploy.yaml
@@ -1,10 +1,7 @@
 ---
-# Provisions the infra tenant on the VAST management plane (VMS API), then
-# creates matching K8s resources (Secrets, StorageClasses, VolumeSnapshotClasses).
-#
-# Calls the VMS REST API directly via ansible.builtin.uri to avoid depending
-# on the vastdata.vms Ansible collection. osac-aap uses the same API through
-# the vendored collection modules for tenant lifecycle operations.
+# Provisions the infra tenant on the VAST management plane via the vastdata.vms
+# collection, then creates matching K8s resources (Secrets, StorageClasses,
+# VolumeSnapshotClasses).
 #
 # Follows the osac-aap naming convention so both systems can reason about
 # each other's resources:
@@ -21,133 +18,56 @@
     vast_tenant: "{{ vastDefaults.infraTenant }}"
     vast_tiers: "{{ vastDefaults.tiers }}"
     vast_protocols: "{{ vastDefaults.tiers | map(attribute='protocol') | unique | list }}"
-    vast_api_base: "{{ vastEndpoint }}/api/{{ vastDefaults.apiVersion }}"
-    vast_api_headers:
-      Content-Type: application/json
-    vast_api_auth:
-      url_username: "{{ vastAdminUsername }}"
-      url_password: "{{ vastAdminPassword }}"
-      force_basic_auth: true
 
 # ── VMS: Create infra tenant ─────────────────────────────────────────────
 
-- name: Check if infra tenant already exists
-  ansible.builtin.uri:
-    url: "{{ vast_api_base }}/tenants/?name={{ vast_tenant }}"
-    method: GET
-    headers: "{{ vast_api_headers }}"
-    url_username: "{{ vastAdminUsername }}"
-    url_password: "{{ vastAdminPassword }}"
-    force_basic_auth: true
-    validate_certs: "{{ vastDefaults.validateCerts }}"
-    timeout: "{{ vastDefaults.apiTimeout }}"
-    status_code: [200]
-  register: r_tenant_lookup
-  no_log: true
-
 - name: Create infra tenant on VAST
-  ansible.builtin.uri:
-    url: "{{ vast_api_base }}/tenants/"
-    method: POST
-    headers: "{{ vast_api_headers }}"
-    url_username: "{{ vastAdminUsername }}"
-    url_password: "{{ vastAdminPassword }}"
-    force_basic_auth: true
-    validate_certs: "{{ vastDefaults.validateCerts }}"
-    timeout: "{{ vastDefaults.apiTimeout }}"
-    body_format: json
-    body:
-      name: "{{ vast_tenant }}"
-    status_code: [200, 201]
-  register: r_tenant_create
-  when: r_tenant_lookup.json | length == 0
   no_log: true
-
-- name: Set tenant ID
-  ansible.builtin.set_fact:
-    vast_tenant_id: "{{ (r_tenant_lookup.json | length > 0) | ternary(r_tenant_lookup.json[0].id, r_tenant_create.json.id) }}"
+  vastdata.vms.tenants:
+    name: "{{ vast_tenant }}"
+    vms_host: "{{ vastEndpoint | regex_replace('^https?://', '') }}"
+    vms_user: "{{ vastAdminUsername }}"
+    vms_password: "{{ vastAdminPassword }}"
+    vms_validate_certs: "{{ vastDefaults.validateCerts }}"
+    state: present
+  register: r_tenant
 
 # ── VMS: Create VIP pool ─────────────────────────────────────────────────
 
-- name: Check if VIP pool already exists
-  ansible.builtin.uri:
-    url: "{{ vast_api_base }}/vippools/?name=vippool-{{ vast_tenant }}"
-    method: GET
-    headers: "{{ vast_api_headers }}"
-    url_username: "{{ vastAdminUsername }}"
-    url_password: "{{ vastAdminPassword }}"
-    force_basic_auth: true
-    validate_certs: "{{ vastDefaults.validateCerts }}"
-    timeout: "{{ vastDefaults.apiTimeout }}"
-    status_code: [200]
-  register: r_vippool_lookup
-  no_log: true
-
 - name: Create VIP pool for infra tenant
-  ansible.builtin.uri:
-    url: "{{ vast_api_base }}/vippools/"
-    method: POST
-    headers: "{{ vast_api_headers }}"
-    url_username: "{{ vastAdminUsername }}"
-    url_password: "{{ vastAdminPassword }}"
-    force_basic_auth: true
-    validate_certs: "{{ vastDefaults.validateCerts }}"
-    timeout: "{{ vastDefaults.apiTimeout }}"
-    body_format: json
-    body:
-      name: "vippool-{{ vast_tenant }}"
-      subnet_cidr: "{{ vastVipPool.subnet_cidr }}"
-      ip_ranges: "{{ vastVipPool.ip_ranges }}"
-      role: "{{ vastVipPool.role | default('PROTOCOLS') }}"
-      enabled: true
-    status_code: [200, 201]
-  register: r_vippool_create
-  when: r_vippool_lookup.json | length == 0
   no_log: true
+  vastdata.vms.vippools:
+    name: "vippool-{{ vast_tenant }}"
+    subnet_cidr: "{{ vastVipPool.subnet_cidr }}"
+    ip_ranges: "{{ vastVipPool.ip_ranges }}"
+    role: "{{ vastVipPool.role | default('PROTOCOLS') }}"
+    enabled: true
+    vms_host: "{{ vastEndpoint | regex_replace('^https?://', '') }}"
+    vms_user: "{{ vastAdminUsername }}"
+    vms_password: "{{ vastAdminPassword }}"
+    vms_validate_certs: "{{ vastDefaults.validateCerts }}"
+    state: present
+  register: r_vippool
 
 # ── VMS: Create views per tier ────────────────────────────────────────────
 
-- name: Check which views already exist
-  ansible.builtin.uri:
-    url: "{{ vast_api_base }}/views/?path={{ vastDefaults.storagePath }}/{{ vast_tenant }}/{{ item.name }}"
-    method: GET
-    headers: "{{ vast_api_headers }}"
-    url_username: "{{ vastAdminUsername }}"
-    url_password: "{{ vastAdminPassword }}"
-    force_basic_auth: true
-    validate_certs: "{{ vastDefaults.validateCerts }}"
-    timeout: "{{ vastDefaults.apiTimeout }}"
-    status_code: [200]
+- name: Create view for each tier
+  no_log: true
+  vastdata.vms.views:
+    name: "view-{{ vast_tenant }}-{{ item.name }}"
+    path: "{{ vastDefaults.storagePath }}/{{ vast_tenant }}/{{ item.name }}"
+    policy_id: "{{ vastDefaults.viewPolicyId }}"
+    tenant_id: "{{ r_tenant.resource.id }}"
+    protocols:
+      - "{{ item.protocol | upper }}"
+    vms_host: "{{ vastEndpoint | regex_replace('^https?://', '') }}"
+    vms_user: "{{ vastAdminUsername }}"
+    vms_password: "{{ vastAdminPassword }}"
+    vms_validate_certs: "{{ vastDefaults.validateCerts }}"
+    state: present
   loop: "{{ vast_tiers }}"
   loop_control:
     label: "view-{{ vast_tenant }}-{{ item.name }}"
-  register: r_view_lookups
-  no_log: true
-
-- name: Create view for each new tier
-  ansible.builtin.uri:
-    url: "{{ vast_api_base }}/views/"
-    method: POST
-    headers: "{{ vast_api_headers }}"
-    url_username: "{{ vastAdminUsername }}"
-    url_password: "{{ vastAdminPassword }}"
-    force_basic_auth: true
-    validate_certs: "{{ vastDefaults.validateCerts }}"
-    timeout: "{{ vastDefaults.apiTimeout }}"
-    body_format: json
-    body:
-      path: "{{ vastDefaults.storagePath }}/{{ item.item.name }}"
-      name: "view-{{ vast_tenant }}-{{ item.item.name }}"
-      policy_id: "{{ vastDefaults.viewPolicyId }}"
-      tenant_id: "{{ vast_tenant_id }}"
-      protocols:
-        - "{{ item.item.protocol | upper }}"
-    status_code: [200, 201]
-  loop: "{{ r_view_lookups.results }}"
-  loop_control:
-    label: "view-{{ vast_tenant }}-{{ item.item.name }}"
-  when: item.json | length == 0
-  no_log: true
 
 # ── K8s: Create CSI credentials Secret ───────────────────────────────────
 
@@ -242,11 +162,3 @@
   retries: "{{ k8s_retries }}"
   delay: "{{ k8s_delay }}"
   until: r_snapshotclass is success or r_snapshotclass is skipped
-
-# ── Credential cleanup ────────────────────────────────────────────────────
-
-- name: Clear credential facts
-  no_log: true
-  ansible.builtin.set_fact:
-    vast_api_auth: null
-    vast_api_headers: null

--- a/plugins/vast-csi/tasks/deploy.yaml
+++ b/plugins/vast-csi/tasks/deploy.yaml
@@ -57,7 +57,7 @@
     name: "view-{{ vast_tenant }}-{{ item.name }}"
     path: "{{ vastDefaults.storagePath }}/{{ vast_tenant }}/{{ item.name }}"
     policy_id: "{{ vastDefaults.viewPolicyId }}"
-    tenant_id: "{{ r_tenant.resource.id }}"
+    tenant_id: "{{ r_tenant.tenants.id }}"
     protocols:
       - "{{ item.protocol | upper }}"
     vms_host: "{{ vastEndpoint | regex_replace('^https?://', '') }}"

--- a/plugins/vast-csi/tasks/post-operators.yaml
+++ b/plugins/vast-csi/tasks/post-operators.yaml
@@ -1,0 +1,49 @@
+---
+# After the VAST CSI operator is installed via OLM, wait for the VastCSIDriver CRD
+# and create CSI driver instances for each protocol in use.
+
+- name: Collect protocols from configured tiers
+  ansible.builtin.set_fact:
+    vast_protocols: "{{ vastDefaults.tiers | map(attribute='protocol') | unique | list }}"
+
+- name: Wait for VastCSIDriver CRD to be registered
+  kubernetes.core.k8s_info:
+    api_version: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    name: vastcsidrivers.csi.vastdata.com
+  register: r_vast_crd
+  retries: 30
+  delay: 10
+  until:
+    - r_vast_crd.resources is defined
+    - r_vast_crd.resources | length > 0
+
+- name: Create VastCSIDriver CR for each protocol
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: csi.vastdata.com/v1
+      kind: VastCSIDriver
+      metadata:
+        name: "{{ (item == vast_protocols[0]) | ternary(vastDefaults.csiDriverName, vastDefaults.csiDriverName ~ '-' ~ item) }}"
+        namespace: vast-csi
+      spec:
+        driverType: "{{ item }}"
+  loop: "{{ vast_protocols }}"
+  register: r_vast_driver
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_vast_driver is success
+
+- name: Wait for CSI drivers to register
+  kubernetes.core.k8s_info:
+    api_version: storage.k8s.io/v1
+    kind: CSIDriver
+    name: "{{ vastDefaults.csiProvisioners[item] }}"
+  loop: "{{ vast_protocols }}"
+  register: r_csi_registered
+  retries: 30
+  delay: 10
+  until:
+    - r_csi_registered.resources is defined
+    - r_csi_registered.resources | length > 0

--- a/plugins/vast-csi/tasks/post-validate.yaml
+++ b/plugins/vast-csi/tasks/post-validate.yaml
@@ -1,0 +1,47 @@
+---
+# Post-deployment validation: verify CSI drivers and StorageClasses are functional.
+
+- name: Set validation variables
+  ansible.builtin.set_fact:
+    vast_tenant: "{{ vastDefaults.infraTenant }}"
+    vast_expected_protocols: "{{ vastDefaults.tiers | map(attribute='protocol') | unique | list }}"
+
+- name: Verify CSI drivers are registered
+  kubernetes.core.k8s_info:
+    api_version: storage.k8s.io/v1
+    kind: CSIDriver
+    name: "{{ vastDefaults.csiProvisioners[item] }}"
+  loop: "{{ vast_expected_protocols }}"
+  register: r_csi_verify
+  failed_when:
+    - r_csi_verify.resources | length == 0
+
+- name: Verify StorageClasses exist for each tier
+  kubernetes.core.k8s_info:
+    api_version: storage.k8s.io/v1
+    kind: StorageClass
+    name: "{{ vast_tenant }}-{{ item.name }}"
+  loop: "{{ vastDefaults.tiers }}"
+  loop_control:
+    label: "{{ vast_tenant }}-{{ item.name }}"
+  register: r_sc_verify
+  failed_when:
+    - r_sc_verify.resources | length == 0
+
+- name: Verify CSI credentials Secret exists
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    name: "vast-csi-{{ vast_tenant }}"
+    namespace: vast-csi
+  register: r_secret_verify
+  failed_when:
+    - r_secret_verify.resources | length == 0
+
+- name: Report VAST plugin deployment status
+  ansible.builtin.debug:
+    msg: >-
+      VAST CSI plugin deployed successfully.
+      Infra tenant: {{ vast_tenant }}
+      Protocols: {{ vast_expected_protocols | join(', ') }}
+      StorageClasses: {{ vastDefaults.tiers | map(attribute='name') | map('regex_replace', '^(.*)$', vast_tenant ~ '-\1') | list | join(', ') }}

--- a/plugins/vast-csi/tasks/pre-validate.yaml
+++ b/plugins/vast-csi/tasks/pre-validate.yaml
@@ -1,0 +1,68 @@
+---
+# Pre-deployment validation: verify VAST endpoint connectivity and credential format.
+
+- name: Validate VAST endpoint is a valid URL
+  ansible.builtin.assert:
+    that:
+      - vastEndpoint is regex('^https?://')
+    fail_msg: >-
+      vastEndpoint must be a URL starting with http:// or https://.
+      Got: {{ vastEndpoint }}
+
+- name: Validate VAST tier configuration
+  ansible.builtin.assert:
+    that:
+      - vastDefaults.tiers | length > 0
+      - vastDefaults.tiers | length <= 20
+    fail_msg: "vastDefaults.tiers must have 1-20 entries"
+
+- name: Validate tier protocols
+  ansible.builtin.assert:
+    that:
+      - item.protocol in ['nfs', 'block']
+    fail_msg: >-
+      Tier '{{ item.name }}' has invalid protocol '{{ item.protocol }}'.
+      Must be 'nfs' or 'block'.
+  loop: "{{ vastDefaults.tiers }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+- name: Validate tier names are unique
+  ansible.builtin.assert:
+    that:
+      - vastDefaults.tiers | map(attribute='name') | list | unique | length == vastDefaults.tiers | length
+    fail_msg: "Tier names must be unique"
+
+- name: Validate tier names are DNS-safe
+  ansible.builtin.assert:
+    that:
+      - item.name is regex('^[a-z0-9]([a-z0-9-]*[a-z0-9])?$')
+    fail_msg: >-
+      Tier name '{{ item.name }}' must be a valid DNS label
+      (lowercase alphanumeric, hyphens allowed in the middle).
+  loop: "{{ vastDefaults.tiers }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+- name: Check VAST endpoint connectivity
+  ansible.builtin.uri:
+    url: "{{ vastEndpoint }}/api/clusters/"
+    method: GET
+    validate_certs: "{{ vastDefaults.validateCerts }}"
+    timeout: "{{ vastDefaults.apiTimeout }}"
+    status_code:
+      - 200
+      - 401
+      - 403
+  register: r_vast_connectivity
+  failed_when: false
+
+- name: Warn if VAST endpoint is unreachable
+  ansible.builtin.debug:
+    msg: >-
+      WARNING: VAST endpoint {{ vastEndpoint }} is not reachable
+      (status={{ r_vast_connectivity.status | default('connection_error') }}).
+      This may be expected in disconnected environments where VMS is on a separate network.
+      CSI driver will still be installed, but StorageClasses may not be functional
+      until VMS connectivity is established.
+  when: r_vast_connectivity.status is not defined or r_vast_connectivity.status == -1

--- a/plugins/vast-csi/tasks/quay.yaml
+++ b/plugins/vast-csi/tasks/quay.yaml
@@ -63,6 +63,8 @@
   until: r_quay_vast is succeeded
 
 - name: Quay VAST NFS storage (PVC and deployment patch)
+  when:
+    - quayBackend == 'LocalStorage'
   block:
   - name: Wait for Quay app deployment to exist (VAST)
     kubernetes.core.k8s_info:

--- a/plugins/vast-csi/tasks/quay.yaml
+++ b/plugins/vast-csi/tasks/quay.yaml
@@ -1,0 +1,123 @@
+---
+# VAST-specific tasks for Quay: QuayRegistry CR and NFS PVC mount for registry storage.
+# Included from operators/quay-operator/tasks.yaml via dynamic plugin include.
+#
+# Uses the infra tenant's quay-tier StorageClass following the osac-aap naming
+# convention: {tenant}-{tier} → infra-quay
+
+- name: Set Quay storage variables
+  ansible.builtin.set_fact:
+    vast_quay_storageclass: "{{ vastDefaults.infraTenant }}-quay"
+    vast_quay_pvc_size: "{{ vastDefaults.quayPvcSize }}"
+
+- name: Ensure QuayRegistry is present (VAST Backend)
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: quay.redhat.com/v1
+      kind: QuayRegistry
+      metadata:
+        name: registry
+        namespace: quay-enterprise
+      spec:
+        configBundleSecret: quay-config
+        components:
+        - kind: horizontalpodautoscaler
+          managed: "{{ quayBackend != 'LocalStorage' }}"
+        - kind: objectstorage
+          managed: false
+        - kind: quay
+          managed: true
+          overrides:
+            replicas: null
+            resources:
+              limits:
+                cpu: "4"
+                memory: 12Gi
+              requests:
+                cpu: "{{ '2' if (disconnected | default(true)) else '1' }}"
+                memory: "{{ '6Gi' if (disconnected | default(true)) else '4Gi' }}"
+        - kind: postgres
+          managed: true
+          overrides:
+            resources:
+              limits:
+                cpu: 500m
+                memory: 2Gi
+              requests:
+                cpu: 500m
+                memory: 2Gi
+        - kind: clairpostgres
+          managed: true
+          overrides:
+            resources:
+              limits:
+                cpu: 500m
+                memory: 2Gi
+              requests:
+                cpu: 500m
+                memory: 2Gi
+  retries: 60
+  delay: 10
+  register: r_quay_vast
+  until: r_quay_vast is succeeded
+
+- name: Quay VAST NFS storage (PVC and deployment patch)
+  block:
+  - name: Wait for Quay app deployment to exist (VAST)
+    kubernetes.core.k8s_info:
+      api_version: apps/v1
+      kind: Deployment
+      namespace: quay-enterprise
+      name: registry-quay-app
+    register: quay_app_deployment
+    retries: 30
+    delay: 10
+    until: quay_app_deployment.resources | length > 0
+
+  - name: Check if Quay app deployment already has registry-storage volume (VAST)
+    ansible.builtin.set_fact:
+      quay_registry_storage_already_patched: >-
+        {{ quay_app_deployment.resources[0].spec.template.spec.volumes
+           | selectattr('name', 'equalto', 'registry-storage') | list | length > 0 }}
+
+  - name: Create VAST NFS PVC for Quay Storage
+    kubernetes.core.k8s:
+      state: present
+      definition:
+        apiVersion: v1
+        kind: PersistentVolumeClaim
+        metadata:
+          name: quay-storage-pvc
+          namespace: quay-enterprise
+          labels:
+            app.kubernetes.io/managed-by: enclave
+            osac.openshift.io/tenant: "{{ vastDefaults.infraTenant }}"
+        spec:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: "{{ vast_quay_pvc_size }}"
+          storageClassName: "{{ vast_quay_storageclass }}"
+
+  - name: Patch Quay app deployment to mount registry storage PVC (VAST)
+    environment:
+      KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+    ansible.builtin.shell: |
+      {{ workingDir }}/bin/oc patch deployment registry-quay-app -n quay-enterprise --type=json -p='{{ quay_vast_patch | to_json }}'
+    vars:
+      quay_vast_patch:
+        - op: add
+          path: /spec/template/spec/volumes/-
+          value:
+            name: registry-storage
+            persistentVolumeClaim:
+              claimName: quay-storage-pvc
+        - op: add
+          path: /spec/template/spec/containers/0/volumeMounts/-
+          value:
+            name: registry-storage
+            mountPath: /datastorage/registry
+    when: not (quay_registry_storage_already_patched | default(false))
+    register: quay_patch_result


### PR DESCRIPTION
## Summary
- Promotes vast-csi from mirror-only addon to a full foundation storage plugin with operator installation, CSI driver lifecycle, per-tier StorageClass provisioning, and Quay NFS integration
- Introduces the infra tenant pattern: platform services (Quay, monitoring) get their own isolated VAST tenant with quotas, following osac-aap naming conventions so both systems can reason about each other's resources
- Adds clusterSelector for spoke cluster fleet deployment via ACM (depends on #340)