### PR TITLE
wait for async task until bool fix

### DIFF
--- a/playbooks/tasks/background_task_wait.yaml
+++ b/playbooks/tasks/background_task_wait.yaml
@@ -66,7 +66,7 @@
   ansible.builtin.async_status:
     jid: "{{ vars[_async_job_id_var] }}"
   register: _async_task_result
-  until: _async_task_result.finished
+  until: _async_task_result.finished | bool
   retries: "{{ _max_retries | int }}"
   delay: "{{ _retry_delay | int }}"
 


### PR DESCRIPTION
```
TASK [Wait for quay async task to complete] ************************************
[DEPRECATION WARNING]: Conditional result at location /home/cloud-
user/enclave/playbooks/tasks/background_task_wait.yaml 69:10 was of type 'int'.
 Conditional results should only be True or False. The result was interpreted 
as False. This feature will be removed in version 2.19. Deprecation warnings 
can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced async task completion detection to ensure more reliable polling during background task operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/enclave/pull/347)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->