### PR TITLE
foundation plugin mirror determined behavior

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ mirror-plugin:
 		echo "Error: PLUGIN variable must be set. Usage: make mirror-plugin PLUGIN=<name>"; \
 		exit 1; \
 	fi
-	@$(AP) playbooks/deploy-plugin.yaml $(AP_FLAGS) -e 'plugin_name=$(PLUGIN)' --tags mirror
+	@$(AP) playbooks/deploy-plugin.yaml $(AP_FLAGS) -e 'plugin_name=$(PLUGIN)' -e 'plugin_mirror=true' --tags mirror
 
 # Convenience targets
 bootstrap:

--- a/docs/PLUGIN_ARCHITECTURE.md
+++ b/docs/PLUGIN_ARCHITECTURE.md
@@ -32,7 +32,6 @@ This is the only required file. It contains all plugin data: metadata, operator 
 name: lvms
 type: foundation
 order: 10
-mirror: core
 
 operators:
   - name: lvms-operator
@@ -67,10 +66,9 @@ registries:
 | `name` | Plugin identifier. Must match the directory name. |
 | `type` | `foundation` -- deploys before core operators (storage, networking). `addon` -- deployed separately. |
 | `order` | Deploy order among same-type plugins. Lower = first. LVMS is 10, ODF is 10. |
-| `mirror` | How images are mirrored. `core` = mirrored in the core run. `plugin` = plugin runs its own oc-mirror. `none` = skip. |
 | `catalog` | Operator catalog name (`redhat` or `certified`). Defaults to `redhat`. |
 | `operators` | List of OLM operators to install. Each entry is passed to `configure_operator.yaml`. |
-| `installOperators` | Set to `false` to skip operator installation (mirror-only plugins). Defaults to `true`. |
+| `installOperators` | Set to `false` to skip operator installation. Defaults to `true`. |
 | `defaults` | Variables loaded into Ansible scope before tasks run. Keeps config namespaced per plugin. |
 | `registries` | Registry mirror entries for MCE patching and `registries.conf`. |
 | `additionalImages` | Extra images to include in the plugin's oc-mirror image set. |
@@ -120,7 +118,6 @@ LVMS is a foundation plugin that provides LVM-based block storage on local disks
 name: lvms
 type: foundation
 order: 10
-mirror: core
 
 operators:
   - name: lvms-operator
@@ -205,7 +202,7 @@ The per-plugin validation in `deploy_plugin.yaml` remains as defense-in-depth du
 
 ### Mirroring (disconnected)
 
-Plugins with `mirror: core` have their operators collected by `collect_core_plugin_operators.yaml` and included in the core oc-mirror run. Plugins with `mirror: plugin` run their own oc-mirror invocation during step 5 of their lifecycle.
+Foundation Plugins have their operators collected by `collect_core_plugin_operators.yaml` and included in the core oc-mirror run. Addon plugins run their own oc-mirror invocation during step 6 of their lifecycle.
 
 Operators with `csvMirror: true` have their `csvNames` entries added as separate packages in the image set.
 
@@ -297,7 +294,7 @@ Don't add `requires.vars` entries for variables that come from `plugin.defaults`
 
 ## Validation-Only Plugins
 
-A plugin doesn't have to deploy anything. If a plugin has no `operators`, no `mirror` config, and no `tasks/deploy.yaml`, all deployment steps are skipped -- only validation runs. This is useful for pre-flight checks, config verification, or environment validation that should gate the pipeline.
+A plugin doesn't have to deploy anything. If a plugin has no `operators`, and no `tasks/deploy.yaml`, all deployment steps are skipped -- only validation runs. This is useful for pre-flight checks, config verification, or environment validation that should gate the pipeline.
 
 A validation-only plugin can hook into any of these checkpoints:
 
@@ -350,10 +347,10 @@ No core files need to be modified.
 
 ## Current Plugins
 
-| Plugin | Type | Order | Mirror | What it does |
-|--------|------|-------|--------|-------------|
-| `lvms` | foundation | 10 | core | LVM-based block storage for edge/single-node |
-| `odf` | foundation | 10 | core | OpenShift Data Foundation (external Ceph) |
-| `openshift-ai` | addon | 100 | plugin | OpenShift AI (RHOAI) with service mesh and dependencies |
-| `nvidia-gpu` | addon | 110 | plugin | NVIDIA GPU operator for GPU-accelerated workloads |
-| `example` | addon | 999 | none | Reference implementation (does nothing useful) |
+| Plugin | Type | Order | What it does |
+|--------|------|-------|--------------|
+| `lvms` | foundation | 10 | LVM-based block storage for edge/single-node |
+| `odf` | foundation | 10 | OpenShift Data Foundation (external Ceph) |
+| `openshift-ai` | addon | 100 | OpenShift AI (RHOAI) with service mesh and dependencies |
+| `nvidia-gpu` | addon | 110 | NVIDIA GPU operator for GPU-accelerated workloads |
+| `example` | addon | 999 | Reference implementation (does nothing useful) |

--- a/operators/quay-operator/quay_disconnected_mirrors.yaml
+++ b/operators/quay-operator/quay_disconnected_mirrors.yaml
@@ -11,7 +11,7 @@
     quay_mirror_suffix: >-
       {{
         ('plugin-' ~ plugin_name ~ '-internal')
-        if (quay_plugin_mirror | default(false) | bool)
+        if (plugin_mirror | default(false) | bool)
         else 'internal'
       }}
     quay_cluster_resources_dir: "{{ workingDir }}/config/oc-mirror-workspace-quay/working-dir/cluster-resources"

--- a/playbooks/deploy-plugin.yaml
+++ b/playbooks/deploy-plugin.yaml
@@ -33,4 +33,6 @@
     - name: Deploy plugin
       ansible.builtin.include_tasks:
         file: tasks/deploy_plugin.yaml
+      vars:
+        plugin_mirror: true
       tags: always

--- a/playbooks/tasks/collect_core_plugin_operators.yaml
+++ b/playbooks/tasks/collect_core_plugin_operators.yaml
@@ -1,9 +1,6 @@
 ---
-# Collect operator definitions from all enabled plugins
-# so they can be included in the main imageset for a single oc-mirror run.
-#
-# This avoids running separate oc-mirror invocations per plugin, which
-# would overwrite the catalog index and lose operators from earlier runs.
+# Collect operator definitions from all enabled foundation plugins
+# so they can be included in the core imageset for a single oc-mirror run.
 #
 # Sets fact: _core_plugin_operators (list of operator dicts)
 
@@ -25,19 +22,17 @@
 
 - name: Build combined plugin operators dictionary
   vars:
-    _enabled: >-
+    _foundation: >-
       {{ r_cp_slurp.results
          | map(attribute='content')
          | map('b64decode')
          | map('from_yaml')
+         | selectattr('type', 'equalto', 'foundation')
          | selectattr('name', 'in', enabled_plugins)
          | list }}
-    _core: >-
-      {{ (_enabled | rejectattr('mirror', 'defined') | list)
-         + (_enabled | selectattr('mirror', 'defined') | selectattr('mirror', 'equalto', 'core') | list) }}
   ansible.builtin.set_fact:
     _core_plugin_operators: >-
-      {{ _core
+      {{ _foundation
          | selectattr('operators', 'defined')
          | items2dict(key_name='name', value_name='operators') }}
 

--- a/playbooks/tasks/collect_plugin_registries.yaml
+++ b/playbooks/tasks/collect_plugin_registries.yaml
@@ -1,6 +1,6 @@
 ---
-# Collect registry mirror entries from all enabled plugins
-# so they can be included in registries.conf for oc-mirror.
+# Collect registry mirror entries from all enabled foundation plugins
+# so they can be included in the core registries.conf for oc-mirror.
 #
 # Sets fact: _core_plugin_registries (list of dicts with 'location' and 'mirror')
 
@@ -22,19 +22,17 @@
 
 - name: Build combined plugin registries list
   vars:
-    _enabled: >-
+    _foundation: >-
       {{ r_pr_slurp.results
          | map(attribute='content')
          | map('b64decode')
          | map('from_yaml')
+         | selectattr('type', 'equalto', 'foundation')
          | selectattr('name', 'in', enabled_plugins)
          | list }}
-    _core: >-
-      {{ (_enabled | rejectattr('mirror', 'defined') | list)
-         + (_enabled | selectattr('mirror', 'defined') | selectattr('mirror', 'equalto', 'core') | list) }}
   ansible.builtin.set_fact:
     _core_plugin_registries: >-
-      {{ _core
+      {{ _foundation
          | selectattr('registries', 'defined')
          | map(attribute='registries')
          | flatten

--- a/playbooks/tasks/deploy_plugin.yaml
+++ b/playbooks/tasks/deploy_plugin.yaml
@@ -42,7 +42,7 @@
 
 - name: Display plugin info
   ansible.builtin.debug:
-    msg: "Deploying plugin '{{ plugin.name }}' (type={{ plugin.type }}, order={{ plugin.order | default('unset') }}, mirror={{ plugin.mirror | default('none') }})"
+    msg: "Deploying plugin '{{ plugin.name }}' (type={{ plugin.type }}, order={{ plugin.order | default('unset') }}, mirror={{ plugin_mirror | default(false) | bool }})"
   tags: always
 
 # Dynamically set each key in plugin.defaults as an Ansible fact.
@@ -133,10 +133,8 @@
 - name: Mirror plugin
   ansible.builtin.include_tasks:
     file: mirror_plugin.yaml
-  vars:
-    quay_plugin_mirror: true
   when:
-    - plugin.mirror | default('none') == 'plugin'
+    - plugin_mirror | default(false) | bool
     - plugin.operators | default([]) | length > 0 or plugin.additionalImages | default([]) | length > 0
     - disconnected | default(true) | bool
   tags: mirror
@@ -152,7 +150,7 @@
     plugin_registries_entries: "{{ plugin.registries }}"
   when:
     - plugin.registries is defined
-    - plugin.mirror | default('none') in ['core', 'plugin']
+    - plugin_mirror | default(false) | bool
     - disconnected | default(true) | bool
   tags: mirror
 

--- a/playbooks/tasks/mirror_plugin.yaml
+++ b/playbooks/tasks/mirror_plugin.yaml
@@ -7,7 +7,7 @@
       - plugin.operators | default([]) | length > 0 or plugin.additionalImages | default([]) | length > 0
       - disconnected | default(true) | bool
     fail_msg: >-
-      Validation Error: Ensure 'plugin' is defined, 'plugin_mirror' is set to false or not set,
+      Validation Error: Ensure 'plugin' is defined, 'plugin_mirror' is set to true,
       'plugin.operators' or 'plugin.additionalImages' are not empty, and 'disconnected' is true.
 
 - name: Template plugin imageset configuration

--- a/playbooks/tasks/mirror_plugin.yaml
+++ b/playbooks/tasks/mirror_plugin.yaml
@@ -3,11 +3,11 @@
   ansible.builtin.assert:
     that:
       - plugin is defined
-      - plugin.mirror | default('none') == 'plugin'
+      - plugin_mirror | default(false) | bool
       - plugin.operators | default([]) | length > 0 or plugin.additionalImages | default([]) | length > 0
       - disconnected | default(true) | bool
     fail_msg: >-
-      Validation Error: Ensure 'plugin' is defined, 'plugin.mirror' is set to 'plugin',
+      Validation Error: Ensure 'plugin' is defined, 'plugin_mirror' is set to false or not set,
       'plugin.operators' or 'plugin.additionalImages' are not empty, and 'disconnected' is true.
 
 - name: Template plugin imageset configuration
@@ -278,8 +278,6 @@
     apply:
       environment:
         KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
-  vars:
-    quay_plugin_mirror: true
   when:
     - plugin.installOperators | default(true)
     - r_plugin_mirror_quay is defined

--- a/plugins/lvms/plugin.yaml
+++ b/plugins/lvms/plugin.yaml
@@ -2,7 +2,6 @@
 name: lvms
 type: foundation
 order: 10
-mirror: core
 
 operators:
   - name: lvms-operator

--- a/plugins/nvidia-gpu/plugin.yaml
+++ b/plugins/nvidia-gpu/plugin.yaml
@@ -2,7 +2,6 @@
 name: nvidia-gpu
 type: addon
 order: 110
-mirror: plugin
 
 catalog: certified
 operators:

--- a/plugins/odf/plugin.yaml
+++ b/plugins/odf/plugin.yaml
@@ -2,7 +2,6 @@
 name: odf
 type: foundation
 order: 10
-mirror: core
 
 operators:
   - name: odf-operator

--- a/plugins/openshift-ai/plugin.yaml
+++ b/plugins/openshift-ai/plugin.yaml
@@ -2,7 +2,6 @@
 name: openshift-ai
 type: addon
 order: 100
-mirror: plugin
 
 operators:
   - name: nfd

--- a/schemas/plugin.yaml
+++ b/schemas/plugin.yaml
@@ -159,15 +159,6 @@ properties:
   order:
     type: integer
     description: Deploy order among same-type plugins. Lower values deploy first.
-  mirror:
-    type: string
-    enum:
-      - core
-      - plugin
-      - none
-    description: >-
-      How images are mirrored. core = included in the main oc-mirror run.
-      plugin = plugin runs its own oc-mirror during deploy. none = no mirroring.
   catalog:
     type: string
     description: The Operator catalog name to include in the image set.

--- a/scripts/verification/validate_plugins.sh
+++ b/scripts/verification/validate_plugins.sh
@@ -81,7 +81,7 @@ import yaml, sys
 
 filepath = sys.argv[1]
 required_fields = ['name', 'type']
-valid_fields = ['name', 'type', 'order', 'mirror', 'catalog', 'operators', 'defaults',
+valid_fields = ['name', 'type', 'order', 'catalog', 'operators', 'defaults',
                 'installOperators', 'registries', 'additionalImages', 'blockedImages',
                 'requires', 'helm']
 


### PR DESCRIPTION
part of https://redhat.atlassian.net/browse/OSAC-875

follow up on https://github.com/rh-ecosystem-edge/enclave/pull/318#issuecomment-4350980155, #298 and https://github.com/rh-ecosystem-edge/enclave/pull/288#issuecomment-4305001170

this PR replaces usage of the plugin `mirror` attribute with a determined behavior depending on the flow.

1. bootstrap - collect enabled foundation plugins into the **core** oc-mirror run and avoid mirroring when deploying the plugin.
2. deploy-plugin - enable mirroring when deploying a plugin regardless of type.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated plugin descriptor documentation to clarify available configuration fields and mirroring behavior for disconnected deployments.

* **Refactor**
  * Plugin mirroring is now controlled via deployment parameters instead of descriptor configuration fields.
  * Simplified plugin mirror detection logic for improved consistency across deployments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/enclave/pull/348)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->