### PR TITLE
add deploy-plugin to e2e-disconnected

### DIFF
--- a/.github/workflows/e2e-deployment.yml
+++ b/.github/workflows/e2e-deployment.yml
@@ -746,6 +746,13 @@ jobs:
           make -f Makefile.ci deploy-cluster-discovery
           echo "Discovery complete" >> $GITHUB_STEP_SUMMARY
 
+      - name: Deploy - Addon Plugin (example)
+        id: deploy_addon_plugin
+        run: |
+          echo "## Deploy: Addon Plugin" >> $GITHUB_STEP_SUMMARY
+          make -f Makefile.ci deploy-plugin PLUGIN=example
+          echo "Deploy Addon Plugin complete" >> $GITHUB_STEP_SUMMARY
+
       - name: Verify cluster deployment
         if: success()
         id: verify_cluster


### PR DESCRIPTION
this PR adds a deployment of an addon plugin to e2e-disconnected. we use the example plugin, to which we can add more content to increase our test coverage.