### PR TITLE
ACM MultiClusterHub disable update ClusterImageSets

### DIFF
--- a/operators/advanced-cluster-management/configure_mch.yaml
+++ b/operators/advanced-cluster-management/configure_mch.yaml
@@ -30,7 +30,8 @@
         namespace: open-cluster-management
         annotations:
           installer.open-cluster-management.io/mce-subscription-spec: "{{ mce_subscription_spec | to_json }}"
-      spec: {}
+      spec:
+        disableUpdateClusterImageSets: true
   retries: 60
   delay: 10
   register: r_mch


### PR DESCRIPTION
ref: https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.15/html/install/installing#advanced-config-hub

we manage our own ClusterImageSets: https://github.com/rh-ecosystem-edge/enclave/blob/953808a2915e4ef5dd29f3d30bd4f2b29f582a6a/operators/advanced-cluster-management/acm_cis.yaml

disable to avoid updates and possibly initial population.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
  - Disabled automatic updates to cluster image sets in the MultiClusterHub configuration.
  - Existing subscription annotation and readiness behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->