### PR TITLE
add deploy foundation plugin to e2e-disconnected (odf)

### DIFF
--- a/.github/workflows/e2e-deployment.yml
+++ b/.github/workflows/e2e-deployment.yml
@@ -746,6 +746,13 @@ jobs:
           make -f Makefile.ci deploy-cluster-discovery
           echo "Discovery complete" >> $GITHUB_STEP_SUMMARY
 
+      - name: Deploy - Foundation Plugin (odf)
+        id: deploy_foundation_plugin
+        run: |
+          echo "## Deploy: Foundation Plugin" >> $GITHUB_STEP_SUMMARY
+          make -f Makefile.ci deploy-plugin PLUGIN=odf
+          echo "Deploy Foundation Plugin complete" >> $GITHUB_STEP_SUMMARY
+
       - name: Deploy - Addon Plugin (example)
         id: deploy_addon_plugin
         run: |


### PR DESCRIPTION
part of https://redhat.atlassian.net/browse/OSAC-875

follow up on #348 and #318

test odf installation on day 2 as part of e2e as requested in https://github.com/rh-ecosystem-edge/enclave/pull/318#issuecomment-4346563789