### PR TITLE
Auto-deploy addon plugins during deploy-cluster

### DIFF
--- a/playbooks/05-operators.yaml
+++ b/playbooks/05-operators.yaml
@@ -8,6 +8,9 @@
 #   Storage plugins (LVMS/ODF) run here, BEFORE core operators,
 #   so that Quay can rely on the storage backend being present.
 # - Install general operators from defaults/operators.yaml
+# - Auto-discover and deploy addon plugins (type: addon)
+#   Addon plugins (nvidia-gpu, openshift-ai, etc.) run AFTER core
+#   operators and Quay mirroring are complete.
 #
 # Usage:
 #   ansible-playbook playbooks/05-operators.yaml -e workingDir=/home/cloud-user [-e disconnected=false]
@@ -78,3 +81,14 @@
         apply:
           tags: operators
       tags: operators
+
+    - name: Auto-discover and deploy addon plugins
+      ansible.builtin.include_tasks:
+        file: tasks/deploy_addon_plugins.yaml
+        apply:
+          tags:
+            - addon-plugins
+            - operators
+      tags:
+        - addon-plugins
+        - operators

--- a/playbooks/tasks/collect_core_plugin_operators.yaml
+++ b/playbooks/tasks/collect_core_plugin_operators.yaml
@@ -1,5 +1,5 @@
 ---
-# Collect operator definitions from all enabled foundation plugins
+# Collect operator definitions from all enabled plugins (foundation + addon)
 # so they can be included in the core imageset for a single oc-mirror run.
 #
 # Sets fact: _core_plugin_operators (list of operator dicts)
@@ -22,17 +22,16 @@
 
 - name: Build combined plugin operators dictionary
   vars:
-    _foundation: >-
+    _enabled: >-
       {{ r_cp_slurp.results
          | map(attribute='content')
          | map('b64decode')
          | map('from_yaml')
-         | selectattr('type', 'equalto', 'foundation')
          | selectattr('name', 'in', enabled_plugins)
          | list }}
   ansible.builtin.set_fact:
     _core_plugin_operators: >-
-      {{ _foundation
+      {{ _enabled
          | selectattr('operators', 'defined')
          | items2dict(key_name='name', value_name='operators') }}
 

--- a/playbooks/tasks/collect_plugin_registries.yaml
+++ b/playbooks/tasks/collect_plugin_registries.yaml
@@ -1,5 +1,5 @@
 ---
-# Collect registry mirror entries from all enabled foundation plugins
+# Collect registry mirror entries from all enabled plugins (foundation + addon)
 # so they can be included in the core registries.conf for oc-mirror.
 #
 # Sets fact: _core_plugin_registries (list of dicts with 'location' and 'mirror')
@@ -22,17 +22,16 @@
 
 - name: Build combined plugin registries list
   vars:
-    _foundation: >-
+    _enabled: >-
       {{ r_pr_slurp.results
          | map(attribute='content')
          | map('b64decode')
          | map('from_yaml')
-         | selectattr('type', 'equalto', 'foundation')
          | selectattr('name', 'in', enabled_plugins)
          | list }}
   ansible.builtin.set_fact:
     _core_plugin_registries: >-
-      {{ _foundation
+      {{ _enabled
          | selectattr('registries', 'defined')
          | map(attribute='registries')
          | flatten

--- a/playbooks/tasks/deploy_addon_plugins.yaml
+++ b/playbooks/tasks/deploy_addon_plugins.yaml
@@ -1,0 +1,55 @@
+---
+# Auto-discover and deploy all addon plugins (type: addon)
+# sorted by order field.
+#
+# Only plugins listed in enabled_plugins are deployed.
+#
+# Called from 05-operators.yaml after core operators and Quay mirroring.
+
+- name: Find all plugin descriptors
+  ansible.builtin.find:
+    paths: "{{ playbook_dir }}/../plugins"
+    patterns: "plugin.yaml"
+    recurse: true
+    depth: 2
+  register: r_addon_find
+
+- name: Read plugin descriptors
+  ansible.builtin.slurp:
+    src: "{{ plugin_path }}"
+  loop: "{{ r_addon_find.files | map(attribute='path') | list }}"
+  register: r_addon_slurp
+  loop_control:
+    loop_var: plugin_path
+
+- name: Parse addon plugin descriptors
+  ansible.builtin.set_fact:
+    _addon_all_parsed: >-
+      {{ r_addon_slurp.results
+         | map(attribute='content')
+         | map('b64decode')
+         | map('from_yaml')
+         | selectattr('type', 'equalto', 'addon')
+         | selectattr('name', 'in', enabled_plugins)
+         | selectattr('order', 'defined')
+         | sort(attribute='order')
+         | list }}
+
+- name: Build addon plugin deploy list
+  ansible.builtin.set_fact:
+    _addon_deploy_list: >-
+      {{ _addon_all_parsed | map(attribute='name') | list }}
+
+- name: Display addon plugins to deploy
+  ansible.builtin.debug:
+    msg: "Addon plugins to deploy (sorted by order): {{ _addon_deploy_list }}"
+
+- name: Deploy addon plugin
+  ansible.builtin.include_tasks:
+    file: tasks/deploy_plugin.yaml
+  vars:
+    plugin_name: "{{ _addon_plugin_name }}"
+  loop: "{{ _addon_deploy_list }}"
+  loop_control:
+    loop_var: _addon_plugin_name
+  when: _addon_deploy_list | length > 0


### PR DESCRIPTION
## Summary
- Remove `type: foundation` filter from `collect_core_plugin_operators.yaml` and `collect_plugin_registries.yaml` so all enabled plugins (foundation + addon) are mirrored in a single oc-mirror pass
- Add `deploy_addon_plugins.yaml` to auto-deploy addon plugins (e.g. nvidia-gpu, openshift-ai) after core operators and Quay mirroring complete
- Add addon deployment step to `05-operators.yaml` at the end of Phase 5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic discovery and deployment of addon plugins in Phase 5, occurring after core operators and Quay mirroring completion.
  * Registry mirroring configuration now includes all enabled plugins (foundation and addon).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/enclave/pull/357)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->