### PR TITLE
Add trust-manager plugin for TLS certificate infrastructure

### DIFF
--- a/plugins/trust-manager/plugin.yaml
+++ b/plugins/trust-manager/plugin.yaml
@@ -1,0 +1,16 @@
+---
+name: trust-manager
+type: addon
+order: 100
+
+helm:
+  - release: trust-manager
+    repo: https://charts.jetstack.io
+    chart: trust-manager
+    version: v0.20.0
+    namespace: cert-manager
+    createNamespace: false
+
+defaults:
+  ca_issuer_duration: 87600h   # 10 years
+  ca_issuer_renew_before: 8760h  # 1 year

--- a/plugins/trust-manager/tasks/deploy.yaml
+++ b/plugins/trust-manager/tasks/deploy.yaml
@@ -1,0 +1,65 @@
+---
+- name: Wait for trust-manager Bundle CRD to be established
+  kubernetes.core.k8s_info:
+    api_version: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    name: bundles.trust.cert-manager.io
+  register: __r_bundle_crd
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until:
+    - __r_bundle_crd.resources | length > 0
+    - __r_bundle_crd.resources[0].status.conditions
+      | default([])
+      | selectattr('type', 'equalto', 'Established')
+      | selectattr('status', 'equalto', 'True')
+      | list
+      | length > 0
+
+- name: Wait for trust-manager deployment to be available
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: trust-manager
+    namespace: cert-manager
+  register: __r_trust_manager_deploy
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until:
+    - __r_trust_manager_deploy.resources | length > 0
+    - __r_trust_manager_deploy.resources[0].status.availableReplicas | default(0) | int > 0
+
+- name: Debug trust-manager status
+  ansible.builtin.debug:
+    msg: "trust-manager deployment is ready in cert-manager namespace"
+
+- name: Apply CA issuer manifests
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ item }}"
+  loop: "{{ lookup('template', plugin_dir ~ '/templates/ca-issuer.yaml.j2') | from_yaml_all | list }}"
+  register: __r_ca_issuer
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: __r_ca_issuer is success
+
+- name: Wait for ClusterIssuer to be ready
+  kubernetes.core.k8s_info:
+    api_version: cert-manager.io/v1
+    kind: ClusterIssuer
+    name: default-ca
+  register: __r_cluster_issuer
+  retries: 30
+  delay: "{{ k8s_delay }}"
+  until:
+    - __r_cluster_issuer.resources | length > 0
+    - __r_cluster_issuer.resources[0].status.conditions
+      | default([])
+      | selectattr('type', 'equalto', 'Ready')
+      | selectattr('status', 'equalto', 'True')
+      | list
+      | length > 0
+
+- name: Debug CA issuer status
+  ansible.builtin.debug:
+    msg: "ClusterIssuer default-ca is ready"

--- a/plugins/trust-manager/tasks/pre-validate.yaml
+++ b/plugins/trust-manager/tasks/pre-validate.yaml
@@ -1,0 +1,27 @@
+---
+- name: Check cert-manager CRD exists
+  kubernetes.core.k8s_info:
+    api_version: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    name: certificates.cert-manager.io
+  register: __r_cert_manager_crd
+
+- name: Fail if cert-manager CRD is not installed
+  ansible.builtin.fail:
+    msg: "certificates.cert-manager.io CRD not found. cert-manager must be installed before trust-manager."
+  when: __r_cert_manager_crd.resources | length == 0
+
+- name: Check cert-manager controller is running
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: cert-manager
+    namespace: cert-manager
+  register: __r_cert_manager_deploy
+
+- name: Fail if cert-manager controller is not running
+  ansible.builtin.fail:
+    msg: "cert-manager controller deployment is not available. cert-manager must be running before trust-manager."
+  when: >
+    __r_cert_manager_deploy.resources | length == 0 or
+    __r_cert_manager_deploy.resources[0].status.availableReplicas | default(0) | int == 0

--- a/plugins/trust-manager/templates/ca-issuer.yaml.j2
+++ b/plugins/trust-manager/templates/ca-issuer.yaml.j2
@@ -1,0 +1,39 @@
+# Self-signed issuer for creating the CA certificate
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: cert-manager
+spec:
+  selfSigned: {}
+
+---
+# CA Certificate that will be used by the ClusterIssuer
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: default-ca-cert
+  namespace: cert-manager
+spec:
+  isCA: true
+  commonName: default-ca
+  secretName: default-ca
+  duration: {{ ca_issuer_duration }}
+  renewBefore: {{ ca_issuer_renew_before }}
+  privateKey:
+    algorithm: RSA
+    size: 4096
+  issuerRef:
+    name: selfsigned-issuer
+    kind: Issuer
+
+---
+# ClusterIssuer that uses the CA certificate
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: default-ca
+spec:
+  ca:
+    secretName: default-ca


### PR DESCRIPTION
Deploys trust-manager v0.20.0 via Helm chart from charts.jetstack.io and a self-signed CA ClusterIssuer into the cert-manager namespace, providing reusable TLS certificate infrastructure for plugins that require it.

Pre-validation checks cert-manager CRD and controller are present and running before deployment.

Requires cert-manager to be installed.

OSAC-218

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added trust-manager addon plugin with support for Certificate Authority (CA) issuance and management
  * Enabled automatic deployment workflow including prerequisite validation and CA issuer provisioning
  * Introduced configurable CA issuer timing parameters for certificate renewal intervals

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/enclave/pull/359?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->