### PR TITLE
[WIP] Add e2e-osac CI workflow

### DIFF
--- a/.github/workflows/e2e-deployment.yml
+++ b/.github/workflows/e2e-deployment.yml
@@ -49,6 +49,39 @@ on:
         required: false
         type: boolean
         default: false
+      enabled-plugins:
+        description: 'Comma-separated list of plugins to deploy (default: storage plugin only)'
+        required: false
+        type: string
+        default: ''
+      heavy-workload:
+        description: 'Enable heavy workload mode (more RAM for VMs)'
+        required: false
+        type: boolean
+        default: false
+  workflow_call:
+    inputs:
+      run-connected:
+        type: boolean
+        default: true
+      run-disconnected:
+        type: boolean
+        default: true
+      storage-plugin:
+        type: string
+        default: 'lvms'
+      skip-cleanup:
+        type: boolean
+        default: false
+      send-slack-notification:
+        type: boolean
+        default: false
+      enabled-plugins:
+        type: string
+        default: ''
+      heavy-workload:
+        type: boolean
+        default: false
   pull_request:
     types: [opened, synchronize, reopened]
   merge_group:
@@ -65,6 +98,8 @@ jobs:
     timeout-minutes: 5
     outputs:
       should_run: ${{ steps.decision.outputs.should_run }}
+      run_connected: ${{ steps.decision.outputs.run_connected }}
+      run_disconnected: ${{ steps.decision.outputs.run_disconnected }}
       storage_plugins: ${{ steps.decision.outputs.storage_plugins }}
       storage_plugins_connected: ${{ steps.decision.outputs.storage_plugins_connected }}
 
@@ -111,6 +146,16 @@ jobs:
           # Determine whether to run and which storage plugins to test.
           # storage_plugins is a JSON array consumed by the job matrix.
           # ODF only runs in disconnected mode. Connected always uses lvms.
+          #
+          # run_connected / run_disconnected: honour caller inputs when present,
+          # default to running both modes. Resolved here (not at job level)
+          # because the inputs context is unreliable in workflow_call when the
+          # caller's event_name is inherited.
+          RUN_CONNECTED="${{ inputs.run-connected }}"
+          RUN_DISCONNECTED="${{ inputs.run-disconnected }}"
+          [[ -z "$RUN_CONNECTED" ]] && RUN_CONNECTED=true
+          [[ -z "$RUN_DISCONNECTED" ]] && RUN_DISCONNECTED=true
+
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "should_run=true" >> $GITHUB_OUTPUT
             PLUGIN="${{ inputs.storage-plugin || 'lvms' }}"
@@ -121,6 +166,16 @@ jobs:
               echo "storage_plugins_connected=[\"${PLUGIN}\"]" >> $GITHUB_OUTPUT
             fi
             echo "Manual trigger - E2E will run (${PLUGIN})" | tee -a $GITHUB_STEP_SUMMARY
+          elif [[ "${{ github.event_name }}" == "workflow_call" ]]; then
+            echo "should_run=true" >> $GITHUB_OUTPUT
+            PLUGIN="${{ inputs.storage-plugin || 'lvms' }}"
+            echo "storage_plugins=[\"${PLUGIN}\"]" >> $GITHUB_OUTPUT
+            if [[ "$PLUGIN" == "odf" ]]; then
+              echo "storage_plugins_connected=[\"lvms\"]" >> $GITHUB_OUTPUT
+            else
+              echo "storage_plugins_connected=[\"${PLUGIN}\"]" >> $GITHUB_OUTPUT
+            fi
+            echo "Called as reusable workflow - E2E will run (${PLUGIN})" | tee -a $GITHUB_STEP_SUMMARY
           elif [[ "${{ github.event_name }}" == "schedule" ]]; then
             echo "should_run=true" >> $GITHUB_OUTPUT
             echo "storage_plugins=[\"lvms\"]" >> $GITHUB_OUTPUT
@@ -149,6 +204,9 @@ jobs:
             echo "To run E2E anyway, use manual workflow_dispatch" | tee -a $GITHUB_STEP_SUMMARY
           fi
 
+          echo "run_connected=${RUN_CONNECTED}" >> $GITHUB_OUTPUT
+          echo "run_disconnected=${RUN_DISCONNECTED}" >> $GITHUB_OUTPUT
+
   # ---------------------------------------------------------------------------
   # Connected mode E2E deployment
   # ---------------------------------------------------------------------------
@@ -157,7 +215,7 @@ jobs:
     needs: check-e2e-needed
     if: >-
       needs.check-e2e-needed.outputs.should_run == 'true' &&
-      (github.event_name != 'workflow_dispatch' || inputs.run-connected == true)
+      needs.check-e2e-needed.outputs.run_connected == 'true'
     runs-on: [self-hosted, enclave-large]
     timeout-minutes: 210
 
@@ -177,7 +235,8 @@ jobs:
       ENCLAVE_IRONIC_HTTPS: 'true'
       CLEANUP_AFTER: 'true'
       STORAGE_PLUGIN: ${{ matrix.storage-plugin }}
-      ENABLED_PLUGINS: ${{ matrix.storage-plugin }}
+      ENABLED_PLUGINS: ${{ inputs.enabled-plugins || matrix.storage-plugin }}
+      ENCLAVE_HEAVY_WORKLOAD: ${{ inputs.heavy-workload && 'true' || 'false' }}
       OPENSHIFT_CI: "true"
       ENCLAVE_ENABLE_GPU_PASSTHROUGH: "false"
       LZ_OS_VARIANT: ${{ vars.LZ_OS_VARIANT }}
@@ -412,7 +471,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Cleanup infrastructure
-        if: always() && (github.event_name != 'workflow_dispatch' || inputs.skip-cleanup != true)
+        if: always() && inputs.skip-cleanup != true
         run: |
           echo "## Cleanup Infrastructure" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -439,7 +498,7 @@ jobs:
           fi
 
       - name: Cleanup skipped notice
-        if: always() && github.event_name == 'workflow_dispatch' && inputs.skip-cleanup == true
+        if: always() && inputs.skip-cleanup == true
         run: |
           echo "## Cleanup Skipped" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -561,7 +620,7 @@ jobs:
     needs: check-e2e-needed
     if: >-
       needs.check-e2e-needed.outputs.should_run == 'true' &&
-      (github.event_name != 'workflow_dispatch' || inputs.run-disconnected == true)
+      needs.check-e2e-needed.outputs.run_disconnected == 'true'
     runs-on: ${{ matrix.storage-plugin == 'odf' && fromJSON('["self-hosted", "enclave-large", "odf"]') || fromJSON('["self-hosted", "enclave-large"]') }}
     timeout-minutes: ${{ github.event_name == 'schedule' && 600 || 360 }}
 
@@ -580,7 +639,8 @@ jobs:
       ENCLAVE_DEPLOYMENT_MODE: disconnected
       CLEANUP_AFTER: 'true'
       STORAGE_PLUGIN: ${{ matrix.storage-plugin }}
-      ENABLED_PLUGINS: ${{ matrix.storage-plugin }}
+      ENABLED_PLUGINS: ${{ inputs.enabled-plugins || matrix.storage-plugin }}
+      ENCLAVE_HEAVY_WORKLOAD: ${{ inputs.heavy-workload && 'true' || 'false' }}
       OPENSHIFT_CI: "true"
       ENCLAVE_ENABLE_GPU_PASSTHROUGH: "false"
       LZ_OS_VARIANT: ${{ vars.LZ_OS_VARIANT }}
@@ -831,7 +891,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Cleanup infrastructure
-        if: always() && (github.event_name != 'workflow_dispatch' || inputs.skip-cleanup != true)
+        if: always() && inputs.skip-cleanup != true
         run: |
           echo "## Cleanup Infrastructure" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -858,7 +918,7 @@ jobs:
           fi
 
       - name: Cleanup skipped notice
-        if: always() && github.event_name == 'workflow_dispatch' && inputs.skip-cleanup == true
+        if: always() && inputs.skip-cleanup == true
         run: |
           echo "## Cleanup Skipped" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/e2e-osac.yml
+++ b/.github/workflows/e2e-osac.yml
@@ -38,7 +38,7 @@ jobs:
     with:
       run-connected: true
       run-disconnected: false
-      enabled-plugins: 'lvms,trust-manager,rhbk,authorino,cnv,aap,osac'
+      enabled-plugins: 'lvms,trust-manager,rhbk,authorino,cnv,aap'
       heavy-workload: true
       skip-cleanup: ${{ inputs.skip-cleanup || false }}
       send-slack-notification: ${{ inputs.send-slack-notification || false }}

--- a/.github/workflows/e2e-osac.yml
+++ b/.github/workflows/e2e-osac.yml
@@ -1,0 +1,44 @@
+name: E2E OSAC
+
+on:
+  workflow_dispatch:
+    inputs:
+      skip-cleanup:
+        description: 'Skip cleanup after deployment (leave infrastructure running)'
+        required: false
+        type: boolean
+        default: false
+      send-slack-notification:
+        description: 'Send Slack notification on completion'
+        required: false
+        type: boolean
+        default: false
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'plugins/trust-manager/**'
+      - 'plugins/keycloak/**'
+      - 'plugins/authorino/**'
+      - 'plugins/cnv/**'
+      - 'plugins/aap/**'
+      - '.github/workflows/e2e-osac.yml'
+
+permissions:
+  contents: read
+  checks: write
+
+concurrency:
+  group: e2e-osac-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  e2e-osac:
+    uses: ./.github/workflows/e2e-deployment.yml
+    with:
+      run-connected: true
+      run-disconnected: false
+      enabled-plugins: 'lvms,trust-manager,keycloak,authorino,cnv,aap'
+      heavy-workload: true
+      skip-cleanup: ${{ inputs.skip-cleanup || false }}
+      send-slack-notification: ${{ inputs.send-slack-notification || false }}
+    secrets: inherit

--- a/.github/workflows/e2e-osac.yml
+++ b/.github/workflows/e2e-osac.yml
@@ -17,7 +17,7 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - 'plugins/trust-manager/**'
-      - 'plugins/keycloak/**'
+      - 'plugins/rhbk/**'
       - 'plugins/authorino/**'
       - 'plugins/cnv/**'
       - 'plugins/aap/**'
@@ -37,7 +37,7 @@ jobs:
     with:
       run-connected: true
       run-disconnected: false
-      enabled-plugins: 'lvms,trust-manager,keycloak,authorino,cnv,aap'
+      enabled-plugins: 'lvms,trust-manager,rhbk,authorino,cnv,aap'
       heavy-workload: true
       skip-cleanup: ${{ inputs.skip-cleanup || false }}
       send-slack-notification: ${{ inputs.send-slack-notification || false }}

--- a/.github/workflows/e2e-osac.yml
+++ b/.github/workflows/e2e-osac.yml
@@ -21,6 +21,7 @@ on:
       - 'plugins/authorino/**'
       - 'plugins/cnv/**'
       - 'plugins/aap/**'
+      - 'plugins/osac/**'
       - '.github/workflows/e2e-osac.yml'
 
 permissions:
@@ -37,7 +38,7 @@ jobs:
     with:
       run-connected: true
       run-disconnected: false
-      enabled-plugins: 'lvms,trust-manager,rhbk,authorino,cnv,aap'
+      enabled-plugins: 'lvms,trust-manager,rhbk,authorino,cnv,aap,osac'
       heavy-workload: true
       skip-cleanup: ${{ inputs.skip-cleanup || false }}
       send-slack-notification: ${{ inputs.send-slack-notification || false }}

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ __pycache__/
 .ruff_cache/
 .coverage
 
+# Synced OSAC sub-charts (fetched by scripts/setup/sync_osac_chart.sh)
+plugins/osac/charts/osac/charts/
+
 # IDE folders
 .vscode/
 .idea/

--- a/plugins/osac/charts/osac/Chart.yaml
+++ b/plugins/osac/charts/osac/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: osac
+description: Open Sovereign AI Cloud - Enclave umbrella chart
+type: application
+version: 0.0.1
+appVersion: "0.0.1"
+dependencies:
+  - name: osac-operator-crds
+    version: "0.0.0"
+    repository: "file://charts/operator-crds"
+    alias: operatorCrds
+  - name: osac-operator
+    version: "0.0.0"
+    repository: "file://charts/operator"
+    alias: operator
+  - name: fulfillment-service
+    version: "0.0.0"
+    repository: "file://charts/service"
+    alias: service
+  - name: osac-aap
+    version: "0.0.0"
+    repository: "file://charts/aap"
+    alias: aap

--- a/plugins/osac/charts/osac/README.md
+++ b/plugins/osac/charts/osac/README.md
@@ -1,0 +1,53 @@
+# OSAC Umbrella Helm Chart
+
+This directory contains the umbrella chart for the Open Sovereign AI Cloud (OSAC)
+deployment via Enclave.
+
+## Sub-chart Dependencies
+
+The `Chart.yaml` declares four sub-chart dependencies that must be populated
+before deployment:
+
+| Alias | Sub-chart directory | Source repository |
+|-------|-------------------|-------------------|
+| `operatorCrds` | `charts/operator-crds/` | `osac-project/osac-operator` |
+| `operator` | `charts/operator/` | `osac-project/osac-operator` |
+| `service` | `charts/service/` | `osac-project/fulfillment-service` |
+| `aap` | `charts/aap/` | `osac-project/osac-aap` |
+
+## Populating Sub-charts
+
+### Option A: From osac-installer
+
+1. Clone `osac-project/osac-installer`
+2. Run `helm dependency build` in the osac-installer chart directory
+3. Copy the resulting `charts/` contents into this directory
+
+### Option B: From individual repos
+
+1. Clone each component repository listed above
+2. Copy each component's `charts/` directory into the corresponding path under
+   `charts/osac/charts/`
+3. Each sub-chart directory must contain its own `Chart.yaml`
+
+## Verification
+
+After populating, verify the chart structure:
+
+```
+charts/osac/
+  Chart.yaml          # This file
+  charts/
+    operator-crds/
+      Chart.yaml
+      templates/
+    operator/
+      Chart.yaml
+      templates/
+    service/
+      Chart.yaml
+      templates/
+    aap/
+      Chart.yaml
+      templates/
+```

--- a/plugins/osac/charts/osac/README.md
+++ b/plugins/osac/charts/osac/README.md
@@ -17,13 +17,18 @@ before deployment:
 
 ## Populating Sub-charts
 
-### Option A: From osac-installer
+### Option A: Sync script (recommended)
 
-1. Clone `osac-project/osac-installer`
-2. Run `helm dependency build` in the osac-installer chart directory
-3. Copy the resulting `charts/` contents into this directory
+```bash
+scripts/setup/sync_osac_chart.sh           # sync from main
+scripts/setup/sync_osac_chart.sh --ref v1.0 # sync from a specific tag
+```
 
-### Option B: From individual repos
+The script clones `osac-project/osac-installer` with submodules, copies each
+sub-chart into the correct path, and runs `helm dependency build`. A `.synced-ref`
+file records the commit for traceability.
+
+### Option B: Manual from individual repos
 
 1. Clone each component repository listed above
 2. Copy each component's `charts/` directory into the corresponding path under

--- a/plugins/osac/files/aap-osac-clusterrole.yaml.j2
+++ b/plugins/osac/files/aap-osac-clusterrole.yaml.j2
@@ -1,0 +1,21 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: osac-operator
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces", "secrets", "configmaps", "serviceaccounts"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["roles", "rolebindings", "clusterroles", "clusterrolebindings"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: ["route.openshift.io"]
+    resources: ["routes"]
+    verbs: ["get", "list", "watch"]

--- a/plugins/osac/files/aap-osac-rolebinding.yaml.j2
+++ b/plugins/osac/files/aap-osac-rolebinding.yaml.j2
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: osac-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: osac-operator
+subjects:
+  - kind: ServiceAccount
+    name: osac-operator
+    namespace: "{{ osacDefaults.aapNamespace }}"

--- a/plugins/osac/files/aap-osac-sa.yaml.j2
+++ b/plugins/osac/files/aap-osac-sa.yaml.j2
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: osac-operator
+  namespace: "{{ osacDefaults.aapNamespace }}"

--- a/plugins/osac/files/aap.yaml.j2
+++ b/plugins/osac/files/aap.yaml.j2
@@ -1,0 +1,19 @@
+---
+apiVersion: aap.ansible.com/v1alpha1
+kind: AnsibleAutomationPlatform
+metadata:
+  name: "{{ osacDefaults.aapName }}"
+  namespace: "{{ osacDefaults.aapNamespace }}"
+spec:
+  controller:
+    disabled: false
+  eda:
+    disabled: false
+  hub:
+    disabled: true
+  lightspeed:
+    disabled: true
+  redis_mode: standalone
+  route_tls_termination_mechanism: Edge
+  image_pull_policy: IfNotPresent
+  no_log: true

--- a/plugins/osac/files/osac-config.yaml.j2
+++ b/plugins/osac/files/osac-config.yaml.j2
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: osac-config
+  namespace: "{{ osacDefaults.osacNamespace }}"
+type: Opaque
+stringData:
+  OSAC_AAP_URL: "{{ osac_aap_url }}"
+  OSAC_AAP_TOKEN: "{{ osac_aap_token }}"

--- a/plugins/osac/files/osac-rolebinding.yaml.j2
+++ b/plugins/osac/files/osac-rolebinding.yaml.j2
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: osac-operator
+  namespace: "{{ osacDefaults.osacNamespace }}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: osac-operator
+subjects:
+  - kind: ServiceAccount
+    name: osac-operator
+    namespace: "{{ osacDefaults.aapNamespace }}"

--- a/plugins/osac/plugin.yaml
+++ b/plugins/osac/plugin.yaml
@@ -1,0 +1,84 @@
+---
+name: osac
+type: addon
+order: 200
+
+operators:
+  - name: ansible-automation-platform-operator
+    version: "2.5.0"
+    channel: stable-2.5-cluster-scoped
+    init_version: "2.5.0"
+    namespace: ansible-aap
+    global: true
+  - name: openshift-cert-manager-operator
+    version: "1.15.0"
+    channel: stable-v1
+    init_version: "1.15.0"
+    namespace: cert-manager-operator
+
+helm:
+  - release: osac
+    namespace: osac
+    chart: charts/osac
+    valuesTemplate: templates/values.yaml.j2
+    createNamespace: true
+    timeout: "45m"
+    wait: false
+    extractImages: true
+
+additionalImages:
+  # OSAC core (ghcr.io)
+  - ghcr.io/osac-project/osac-operator:latest
+  - ghcr.io/osac-project/fulfillment-service:latest
+  - ghcr.io/osac-project/osac-aap:latest
+  # Fulfillment service sidecar
+  - docker.io/envoyproxy/envoy:v1.33.0
+  # AAP bootstrap CLI
+  - quay.io/openshift/origin-cli:4.20.0
+  # Keycloak (identity provider)
+  - quay.io/keycloak/keycloak:26.3
+  # PostgreSQL (database)
+  - quay.io/sclorg/postgresql-15-c9s:latest
+  # Prometheus (monitoring)
+  - quay.io/prometheus/prometheus:v3.8.1
+  # Validation hook (kubectl)
+  - docker.io/bitnami/kubectl:latest
+
+registries:
+  - location: "ghcr.io/osac-project"
+    mirror: "osac-project"
+  - location: "docker.io/envoyproxy"
+    mirror: "envoyproxy"
+  - location: "docker.io/bitnami"
+    mirror: "bitnami"
+  - location: "quay.io/keycloak"
+    mirror: "keycloak"
+  - location: "quay.io/sclorg"
+    mirror: "sclorg"
+  - location: "quay.io/prometheus"
+    mirror: "prometheus"
+
+defaults:
+  osacDefaults:
+    aapName: "osac-aap"
+    aapNamespace: "ansible-aap"
+    aapTokenDescription: "OSAC Operator Token"
+    aapTokenOverwrite: false
+    aapApiUser: "admin"
+    aapApiValidateCerts: false
+    osacNamespace: "osac"
+    images:
+      operator: "ghcr.io/osac-project/osac-operator"
+      operatorTag: "latest"
+      fulfillmentService: "ghcr.io/osac-project/fulfillment-service:latest"
+      envoy: "docker.io/envoyproxy/envoy:v1.33.0"
+      aapBootstrap: "ghcr.io/osac-project/osac-aap:latest"
+      cli: "quay.io/openshift/origin-cli:4.20.0"
+
+requires:
+  vars:
+    - name: aap_license_file
+      description: "Path to AAP license file (zip) on the Landing Zone"
+  files:
+    - path: "charts/osac/Chart.yaml"
+      description: "OSAC umbrella Helm chart must be bundled"

--- a/plugins/osac/tasks/deploy.yaml
+++ b/plugins/osac/tasks/deploy.yaml
@@ -1,0 +1,21 @@
+---
+# Post-Helm deployment tasks for OSAC plugin.
+# Runs after the OSAC Helm chart is installed.
+#
+# Responsibilities:
+#   1. Create OSAC operator config secret (AAP URL/token)
+#   2. Create OSAC RoleBinding in osac namespace
+
+- name: Create OSAC config secret
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('ansible.builtin.template', plugin_dir ~ '/files/osac-config.yaml.j2') | from_yaml }}"
+
+- name: Create OSAC RoleBinding
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('ansible.builtin.template', plugin_dir ~ '/files/osac-rolebinding.yaml.j2') | from_yaml }}"
+
+- name: Log OSAC deploy completion
+  ansible.builtin.debug:
+    msg: "OSAC post-Helm configuration applied (config secret and RBAC)"

--- a/plugins/osac/tasks/post-operators.yaml
+++ b/plugins/osac/tasks/post-operators.yaml
@@ -1,0 +1,178 @@
+---
+# Post-operators hook for OSAC plugin.
+# Runs after AAP and cert-manager operators are installed, before Helm chart deploy.
+#
+# Responsibilities:
+#   1. Create AAP namespace and RBAC resources
+#   2. Deploy AnsibleAutomationPlatform CR
+#   3. Wait for AAP controller to become ready
+#   4. Extract AAP admin credentials
+#   5. Create AAP Personal Access Token via API
+#   6. Upload license and kubeconfig secrets
+#   7. Create config-as-code secrets for bootstrap
+#   8. Set osac_aap_url and osac_aap_token facts for Helm values template
+#
+# Facts exported:
+#   osac_aap_url   — AAP controller route URL (used in templates/values.yaml.j2)
+#   osac_aap_token — AAP personal access token (used in templates/values.yaml.j2)
+
+# --- Namespace and RBAC ---
+
+- name: Ensure AAP namespace exists
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: "{{ osacDefaults.aapNamespace }}"
+
+- name: Ensure OSAC namespace exists
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: "{{ osacDefaults.osacNamespace }}"
+
+- name: Create OSAC ServiceAccount in AAP namespace
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('ansible.builtin.template', plugin_dir ~ '/files/aap-osac-sa.yaml.j2') | from_yaml }}"
+
+- name: Create OSAC ClusterRole
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('ansible.builtin.template', plugin_dir ~ '/files/aap-osac-clusterrole.yaml.j2') | from_yaml }}"
+
+- name: Create OSAC ClusterRoleBinding
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('ansible.builtin.template', plugin_dir ~ '/files/aap-osac-rolebinding.yaml.j2') | from_yaml }}"
+
+# --- AAP Instance ---
+
+- name: Create AnsibleAutomationPlatform CR
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('ansible.builtin.template', plugin_dir ~ '/files/aap.yaml.j2') | from_yaml }}"
+
+- name: Wait for AAP controller route
+  kubernetes.core.k8s_info:
+    api_version: route.openshift.io/v1
+    kind: Route
+    namespace: "{{ osacDefaults.aapNamespace }}"
+    label_selectors:
+      - "app.kubernetes.io/component=automationcontroller"
+  register: r_aap_route
+  until: r_aap_route.resources | length > 0
+  retries: 60
+  delay: 30
+
+- name: Set AAP URL fact
+  ansible.builtin.set_fact:
+    osac_aap_url: "https://{{ r_aap_route.resources[0].spec.host }}"
+
+# --- AAP Credentials ---
+
+- name: Wait for AAP admin secret
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    namespace: "{{ osacDefaults.aapNamespace }}"
+    name: "{{ osacDefaults.aapName }}-admin-password"
+  register: r_aap_admin_secret
+  until: r_aap_admin_secret.resources | length > 0
+  retries: 30
+  delay: 10
+
+- name: Extract AAP admin password
+  ansible.builtin.set_fact:
+    _aap_admin_password: "{{ r_aap_admin_secret.resources[0].data.password | b64decode }}"
+
+# --- AAP Token ---
+
+- name: Create AAP personal access token
+  ansible.builtin.uri:
+    url: "{{ osac_aap_url }}/api/v2/tokens/"
+    method: POST
+    user: "{{ osacDefaults.aapApiUser }}"
+    password: "{{ _aap_admin_password }}"
+    force_basic_auth: true
+    validate_certs: "{{ osacDefaults.aapApiValidateCerts }}"
+    body_format: json
+    body:
+      description: "{{ osacDefaults.aapTokenDescription }}"
+    status_code: 201
+  register: r_aap_token
+  until: r_aap_token.status == 201
+  retries: 10
+  delay: 15
+
+- name: Set AAP token fact
+  ansible.builtin.set_fact:
+    osac_aap_token: "{{ r_aap_token.json.token }}"
+
+# --- License and Kubeconfig Secrets ---
+
+- name: Create AAP license secret
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: "{{ osacDefaults.aapName }}-license"
+        namespace: "{{ osacDefaults.aapNamespace }}"
+      type: Opaque
+      data:
+        license.zip: "{{ lookup('ansible.builtin.file', aap_license_file) | b64encode }}"
+
+- name: Create kubeconfig secret for AAP
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: "{{ osacDefaults.aapName }}-kubeconfig"
+        namespace: "{{ osacDefaults.aapNamespace }}"
+      type: Opaque
+      data:
+        kubeconfig: "{{ lookup('ansible.builtin.file', workingDir ~ '/ocp-cluster/auth/kubeconfig') | b64encode }}"
+
+# --- Config-as-Code Secrets for Bootstrap ---
+
+- name: Create config-as-code-ig secret for bootstrap
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: config-as-code-ig
+        namespace: "{{ osacDefaults.osacNamespace }}"
+      type: Opaque
+      stringData:
+        controller_hostname: "{{ osac_aap_url }}"
+        controller_username: "{{ osacDefaults.aapApiUser }}"
+        controller_password: "{{ _aap_admin_password }}"
+        controller_validate_certs: "{{ osacDefaults.aapApiValidateCerts | string | lower }}"
+
+- name: Create config-as-code-manifest-ig secret for bootstrap
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: config-as-code-manifest-ig
+        namespace: "{{ osacDefaults.osacNamespace }}"
+      type: Opaque
+      data:
+        manifest.zip: "{{ lookup('ansible.builtin.file', aap_license_file) | b64encode }}"
+
+- name: Log OSAC post-operators completion
+  ansible.builtin.debug:
+    msg: "OSAC post-operators complete. AAP URL={{ osac_aap_url }}, token set."

--- a/plugins/osac/tasks/post-validate.yaml
+++ b/plugins/osac/tasks/post-validate.yaml
@@ -1,0 +1,76 @@
+---
+# Post-deployment validation for OSAC plugin.
+# Verifies that AAP and OSAC components are running.
+
+- name: Check AAP controller deployments
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    namespace: "{{ osacDefaults.aapNamespace }}"
+    label_selectors:
+      - "app.kubernetes.io/component=automationcontroller"
+  register: r_aap_deployments
+
+- name: Assert AAP controller is running
+  ansible.builtin.assert:
+    that:
+      - r_aap_deployments.resources | length > 0
+      - r_aap_deployments.resources | map(attribute='status.readyReplicas') | select('defined') | list | length > 0
+    fail_msg: "AAP controller deployment not found or not ready in {{ osacDefaults.aapNamespace }}"
+
+- name: Check AAP EDA controller deployments
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    namespace: "{{ osacDefaults.aapNamespace }}"
+    label_selectors:
+      - "app.kubernetes.io/component=eda"
+  register: r_eda_deployments
+
+- name: Assert AAP EDA controller is running
+  ansible.builtin.assert:
+    that:
+      - r_eda_deployments.resources | length > 0
+    fail_msg: "AAP EDA controller deployment not found in {{ osacDefaults.aapNamespace }}"
+
+- name: Check OSAC namespace exists
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Namespace
+    name: "{{ osacDefaults.osacNamespace }}"
+  register: r_osac_namespace
+
+- name: Assert OSAC namespace exists
+  ansible.builtin.assert:
+    that: r_osac_namespace.resources | length > 0
+    fail_msg: "OSAC namespace '{{ osacDefaults.osacNamespace }}' not found"
+
+- name: Check OSAC Helm release status
+  ansible.builtin.command:
+    cmd: "{{ workingDir }}/bin/helm status osac --namespace {{ osacDefaults.osacNamespace }}"
+  register: r_osac_helm_status
+  changed_when: false
+
+- name: Assert OSAC Helm release is deployed
+  ansible.builtin.assert:
+    that: "'deployed' in r_osac_helm_status.stdout"
+    fail_msg: "OSAC Helm release is not in 'deployed' state"
+
+- name: Check OSAC operator deployment
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    namespace: "{{ osacDefaults.osacNamespace }}"
+    label_selectors:
+      - "app.kubernetes.io/name=osac-operator"
+  register: r_osac_operator
+
+- name: Assert OSAC operator is deployed
+  ansible.builtin.assert:
+    that:
+      - r_osac_operator.resources | length > 0
+    fail_msg: "OSAC operator deployment not found in {{ osacDefaults.osacNamespace }}"
+
+- name: Log OSAC validation success
+  ansible.builtin.debug:
+    msg: "OSAC post-validate passed: AAP controller running, EDA running, OSAC namespace exists, Helm release deployed, OSAC operator deployed"

--- a/plugins/osac/tasks/pre-validate.yaml
+++ b/plugins/osac/tasks/pre-validate.yaml
@@ -1,0 +1,32 @@
+---
+# Pre-deployment validation for OSAC plugin.
+# Runs before mirroring/operators — checks cluster prerequisites.
+
+- name: Verify at least one StorageClass exists
+  kubernetes.core.k8s_info:
+    api_version: storage.k8s.io/v1
+    kind: StorageClass
+  register: r_storageclasses
+
+- name: Assert StorageClass is available
+  ansible.builtin.assert:
+    that: r_storageclasses.resources | length > 0
+    fail_msg: >-
+      No StorageClass found on the cluster. OSAC requires storage for AAP
+      (PostgreSQL PVCs). Install a storage plugin (e.g. lvms, odf) first.
+
+- name: Log available StorageClasses
+  ansible.builtin.debug:
+    msg: "Available StorageClasses: {{ r_storageclasses.resources | map(attribute='metadata.name') | list | join(', ') }}"
+
+- name: Verify AAP license file exists
+  ansible.builtin.stat:
+    path: "{{ aap_license_file }}"
+  register: r_aap_license
+
+- name: Assert AAP license file is present
+  ansible.builtin.assert:
+    that: r_aap_license.stat.exists
+    fail_msg: >-
+      AAP license file not found at '{{ aap_license_file }}'.
+      Set aap_license_file to the path of the AAP license zip on the Landing Zone.

--- a/plugins/osac/templates/values.yaml.j2
+++ b/plugins/osac/templates/values.yaml.j2
@@ -1,0 +1,71 @@
+# Rendered by Enclave from Ansible variables.
+# Values populated after AAP infrastructure setup in post-operators.yaml.
+
+# Operator
+operator:
+  image:
+    repository: "{{ osacDefaults.images.operator }}"
+    tag: "{{ osacDefaults.images.operatorTag }}"
+  aap:
+    url: "{{ osac_aap_url }}"
+    token: "{{ osac_aap_token }}"
+    insecureSkipVerify: {{ osacDefaults.aapApiValidateCerts | ternary('false','true') }}
+  fulfillment:
+    serverAddress: "fulfillment-api:8000"
+    tokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  configSecret:
+    name: "osac-config"
+    optional: true
+
+# Fulfillment service
+service:
+  variant: openshift
+  images:
+    service: "{{ osacDefaults.images.fulfillmentService }}"
+    envoy: "{{ osacDefaults.images.envoy }}"
+  certs:
+    issuerRef:
+      kind: ClusterIssuer
+      name: default-ca
+    caBundle:
+      configMap: ca-bundle
+  auth:
+    issuerUrl: "https://keycloak.keycloak.svc.cluster.local/realms/osac"
+    controllerCredentials:
+      - secret:
+          name: fulfillment-controller-credentials
+          items:
+            - key: client-id
+              param: client-id
+            - key: client-secret
+              param: client-secret
+  database:
+    connection:
+      - secret:
+          name: fulfillment-db
+          items:
+            - key: url
+              param: url
+
+# AAP — Enclave manages the instance in post-operators.yaml
+aap:
+  aap:
+    instance:
+      enabled: false
+      name: "{{ osacDefaults.aapName }}"
+  bootstrap:
+    enabled: true
+    image: "{{ osacDefaults.images.aapBootstrap }}"
+    cliImage: "{{ osacDefaults.images.cli }}"
+    backoffLimit: 15
+  configAsCode:
+    manifestSecret: "config-as-code-manifest-ig"
+    secret: "config-as-code-ig"
+
+# Disable chart's built-in validation (Enclave handles in pre-validate.yaml)
+validation:
+  enabled: false
+
+# DB migration not yet available
+dbMigrate:
+  enabled: false

--- a/scripts/deployment/install_enclave.sh
+++ b/scripts/deployment/install_enclave.sh
@@ -274,7 +274,7 @@ if [[ ",${ENABLED_PLUGINS:-}," == *",aap,"* ]]; then
         scp $SSH_OPTS "$AAP_LICENSE_SOURCE" "${LZ_SSH}:${AAP_LICENSE_LZ_PATH}"
         success "AAP license copied to ${AAP_LICENSE_LZ_PATH}"
     else
-        warn "Step 6b: AAP plugin enabled but license file not found at ${AAP_LICENSE_SOURCE}"
+        warning "Step 6b: AAP plugin enabled but license file not found at ${AAP_LICENSE_SOURCE}"
     fi
 fi
 

--- a/scripts/deployment/install_enclave.sh
+++ b/scripts/deployment/install_enclave.sh
@@ -265,6 +265,19 @@ else
     exit 1
 fi
 
+# Step 6b: Copy AAP license file (when aap plugin is enabled)
+if [[ ",${ENABLED_PLUGINS:-}," == *",aap,"* ]]; then
+    AAP_LICENSE_SOURCE="${AAP_LICENSE_FILE:-${DEV_SCRIPTS_PATH}/aap-license.zip}"
+    if [ -f "$AAP_LICENSE_SOURCE" ]; then
+        info "Step 6b: Copying AAP license file..."
+        AAP_LICENSE_LZ_PATH="${LZ_ROOT_DIR}/config/aap-license.zip"
+        scp $SSH_OPTS "$AAP_LICENSE_SOURCE" "${LZ_SSH}:${AAP_LICENSE_LZ_PATH}"
+        success "AAP license copied to ${AAP_LICENSE_LZ_PATH}"
+    else
+        warn "Step 6b: AAP plugin enabled but license file not found at ${AAP_LICENSE_SOURCE}"
+    fi
+fi
+
 # Step 7: Generate SSH key if needed
 info "Step 7: Checking SSH key on Landing Zone..."
 ssh $SSH_OPTS "$LZ_SSH" bash <<'EOSSH'

--- a/scripts/deployment/install_enclave.sh
+++ b/scripts/deployment/install_enclave.sh
@@ -270,7 +270,7 @@ if [[ ",${ENABLED_PLUGINS:-}," == *",aap,"* ]]; then
     AAP_LICENSE_SOURCE="${AAP_LICENSE_FILE:-${DEV_SCRIPTS_PATH}/aap-license.zip}"
     if [ -f "$AAP_LICENSE_SOURCE" ]; then
         info "Step 6b: Copying AAP license file..."
-        AAP_LICENSE_LZ_PATH="${LZ_ROOT_DIR}/config/aap-license.zip"
+        AAP_LICENSE_LZ_PATH="${LZ_ENCLAVE_DIR}/config/aap-license.zip"
         scp $SSH_OPTS "$AAP_LICENSE_SOURCE" "${LZ_SSH}:${AAP_LICENSE_LZ_PATH}"
         success "AAP license copied to ${AAP_LICENSE_LZ_PATH}"
     else

--- a/scripts/deployment/install_enclave.sh
+++ b/scripts/deployment/install_enclave.sh
@@ -267,7 +267,7 @@ fi
 
 # Step 6b: Copy AAP license file (when aap plugin is enabled)
 if [[ ",${ENABLED_PLUGINS:-}," == *",aap,"* ]]; then
-    AAP_LICENSE_SOURCE="${AAP_LICENSE_FILE:-${DEV_SCRIPTS_PATH}/aap-license.zip}"
+    AAP_LICENSE_SOURCE="${AAP_LICENSE_FILE:-/opt/aap-license.zip}"
     if [ -f "$AAP_LICENSE_SOURCE" ]; then
         info "Step 6b: Copying AAP license file..."
         AAP_LICENSE_LZ_PATH="${LZ_ENCLAVE_DIR}/config/aap-license.zip"

--- a/scripts/deployment/install_enclave.sh
+++ b/scripts/deployment/install_enclave.sh
@@ -129,6 +129,12 @@ scp $SSH_OPTS "${WORKING_DIR}/config/global.yaml" "${LZ_SSH}:${LZ_ENCLAVE_DIR}/c
 scp $SSH_OPTS "${WORKING_DIR}/config/certificates.yaml" "${LZ_SSH}:${LZ_ENCLAVE_DIR}/config/certificates.yaml"
 scp $SSH_OPTS "${WORKING_DIR}/config/cloud_infra.yaml" "${LZ_SSH}:${LZ_ENCLAVE_DIR}/config/cloud_infra.yaml"
 
+# Copy plugin config files if they exist
+if [ -d "${WORKING_DIR}/config/plugins" ]; then
+    ssh $SSH_OPTS "$LZ_SSH" "mkdir -p ${LZ_ENCLAVE_DIR}/config/plugins"
+    scp $SSH_OPTS "${WORKING_DIR}"/config/plugins/*.yaml "${LZ_SSH}:${LZ_ENCLAVE_DIR}/config/plugins/" 2>/dev/null || true
+fi
+
 success "Configuration generated and copied to Landing Zone"
 
 # Step 5.5: Configure DNS resolution for cluster endpoints via libvirt dnsmasq

--- a/scripts/infrastructure/generate_enclave_vars.sh
+++ b/scripts/infrastructure/generate_enclave_vars.sh
@@ -307,12 +307,16 @@ if [ -n "${ENABLED_PLUGINS:-}" ]; then
     } >> "$GLOBAL_VARS_OUTPUT"
     info "Enabled plugins: $ENABLED_PLUGINS"
 
-    # Append AAP license file path when aap plugin is enabled
+    # Write AAP license file path to plugin config when aap plugin is enabled
     if [[ ",${ENABLED_PLUGINS}," == *",aap,"* ]]; then
         AAP_LICENSE_SOURCE="${AAP_LICENSE_FILE:-/opt/aap-license.zip}"
         if [ -f "$AAP_LICENSE_SOURCE" ]; then
             AAP_LICENSE_LZ_PATH="{{ workingDir }}/enclave/config/aap-license.zip"
-            echo "aapLicenseFile: \"${AAP_LICENSE_LZ_PATH}\"" >> "$GLOBAL_VARS_OUTPUT"
+            mkdir -p "${WORKING_DIR}/config/plugins"
+            cat > "${WORKING_DIR}/config/plugins/aap.yaml" <<AAPEOF
+---
+aapLicenseFile: "${AAP_LICENSE_LZ_PATH}"
+AAPEOF
             info "AAP license file configured: ${AAP_LICENSE_LZ_PATH}"
         else
             warning "AAP plugin enabled but license file not found at ${AAP_LICENSE_SOURCE}"

--- a/scripts/infrastructure/generate_enclave_vars.sh
+++ b/scripts/infrastructure/generate_enclave_vars.sh
@@ -315,7 +315,7 @@ if [ -n "${ENABLED_PLUGINS:-}" ]; then
             echo "aapLicenseFile: \"${AAP_LICENSE_LZ_PATH}\"" >> "$GLOBAL_VARS_OUTPUT"
             info "AAP license file configured: ${AAP_LICENSE_LZ_PATH}"
         else
-            warn "AAP plugin enabled but license file not found at ${AAP_LICENSE_SOURCE}"
+            warning "AAP plugin enabled but license file not found at ${AAP_LICENSE_SOURCE}"
         fi
     fi
 fi

--- a/scripts/infrastructure/generate_enclave_vars.sh
+++ b/scripts/infrastructure/generate_enclave_vars.sh
@@ -311,8 +311,8 @@ if [ -n "${ENABLED_PLUGINS:-}" ]; then
     if [[ ",${ENABLED_PLUGINS}," == *",aap,"* ]]; then
         AAP_LICENSE_SOURCE="${AAP_LICENSE_FILE:-${DEV_SCRIPTS_PATH}/aap-license.zip}"
         if [ -f "$AAP_LICENSE_SOURCE" ]; then
-            AAP_LICENSE_LZ_PATH="{{ workingDir }}/config/aap-license.zip"
-            echo "aap_license_file: \"${AAP_LICENSE_LZ_PATH}\"" >> "$GLOBAL_VARS_OUTPUT"
+            AAP_LICENSE_LZ_PATH="{{ workingDir }}/enclave/config/aap-license.zip"
+            echo "aapLicenseFile: \"${AAP_LICENSE_LZ_PATH}\"" >> "$GLOBAL_VARS_OUTPUT"
             info "AAP license file configured: ${AAP_LICENSE_LZ_PATH}"
         else
             warn "AAP plugin enabled but license file not found at ${AAP_LICENSE_SOURCE}"

--- a/scripts/infrastructure/generate_enclave_vars.sh
+++ b/scripts/infrastructure/generate_enclave_vars.sh
@@ -309,7 +309,7 @@ if [ -n "${ENABLED_PLUGINS:-}" ]; then
 
     # Append AAP license file path when aap plugin is enabled
     if [[ ",${ENABLED_PLUGINS}," == *",aap,"* ]]; then
-        AAP_LICENSE_SOURCE="${AAP_LICENSE_FILE:-${DEV_SCRIPTS_PATH}/aap-license.zip}"
+        AAP_LICENSE_SOURCE="${AAP_LICENSE_FILE:-/opt/aap-license.zip}"
         if [ -f "$AAP_LICENSE_SOURCE" ]; then
             AAP_LICENSE_LZ_PATH="{{ workingDir }}/enclave/config/aap-license.zip"
             echo "aapLicenseFile: \"${AAP_LICENSE_LZ_PATH}\"" >> "$GLOBAL_VARS_OUTPUT"

--- a/scripts/infrastructure/generate_enclave_vars.sh
+++ b/scripts/infrastructure/generate_enclave_vars.sh
@@ -294,6 +294,32 @@ cat > "$CLOUD_INFRA_VARS_OUTPUT" <<EOF
 discovery_hosts: []
 EOF
 
+# Append enabled plugins list to global vars (comma-separated env var to YAML list)
+if [ -n "${ENABLED_PLUGINS:-}" ]; then
+    {
+        echo ""
+        echo "# Plugins to deploy (from ENABLED_PLUGINS env var)"
+        echo "enabled_plugins:"
+        IFS=',' read -ra _plugins <<< "$ENABLED_PLUGINS"
+        for _plugin in "${_plugins[@]}"; do
+            echo "  - ${_plugin// /}"
+        done
+    } >> "$GLOBAL_VARS_OUTPUT"
+    info "Enabled plugins: $ENABLED_PLUGINS"
+
+    # Append AAP license file path when aap plugin is enabled
+    if [[ ",${ENABLED_PLUGINS}," == *",aap,"* ]]; then
+        AAP_LICENSE_SOURCE="${AAP_LICENSE_FILE:-${DEV_SCRIPTS_PATH}/aap-license.zip}"
+        if [ -f "$AAP_LICENSE_SOURCE" ]; then
+            AAP_LICENSE_LZ_PATH="{{ workingDir }}/config/aap-license.zip"
+            echo "aap_license_file: \"${AAP_LICENSE_LZ_PATH}\"" >> "$GLOBAL_VARS_OUTPUT"
+            info "AAP license file configured: ${AAP_LICENSE_LZ_PATH}"
+        else
+            warn "AAP plugin enabled but license file not found at ${AAP_LICENSE_SOURCE}"
+        fi
+    fi
+fi
+
 # Override storage plugin and quay backend when STORAGE_PLUGIN=odf
 if [ "${STORAGE_PLUGIN:-lvms}" = "odf" ]; then
     sed -i 's/^storage_plugin: lvms$/storage_plugin: odf/' "$GLOBAL_VARS_OUTPUT"

--- a/scripts/setup/sync_osac_chart.sh
+++ b/scripts/setup/sync_osac_chart.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Sync OSAC Helm sub-charts from the osac-installer repository.
+#
+# Clones osac-project/osac-installer (with submodules), copies each sub-chart
+# into plugins/osac/charts/osac/charts/, and runs helm dependency build.
+#
+# Usage:
+#   scripts/setup/sync_osac_chart.sh [--ref REF]
+#
+# Options:
+#   --ref REF   Git ref (branch, tag, or commit) to check out. Default: main
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+ENCLAVE_DIR="$(cd -- "${SCRIPT_DIR}/../.." &>/dev/null && pwd)"
+
+source "${ENCLAVE_DIR}/scripts/lib/output.sh"
+
+INSTALLER_REPO="https://github.com/osac-project/osac-installer.git"
+PLUGIN_CHART_DIR="${ENCLAVE_DIR}/plugins/osac/charts/osac"
+REF="main"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --ref)
+            REF="$2"
+            shift 2
+            ;;
+        *)
+            error "Unknown option: $1"
+            echo "Usage: $0 [--ref REF]" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Sub-chart mapping: <destination dir> <submodule path>/<chart path>
+declare -A CHART_MAP=(
+    ["operator-crds"]="base/osac-operator/charts/operator-crds"
+    ["operator"]="base/osac-operator/charts/operator"
+    ["service"]="base/osac-fulfillment-service/charts/service"
+    ["aap"]="base/osac-aap/charts/aap"
+)
+
+# Validate plugin chart directory
+if [[ ! -f "${PLUGIN_CHART_DIR}/Chart.yaml" ]]; then
+    error "OSAC umbrella Chart.yaml not found at ${PLUGIN_CHART_DIR}/Chart.yaml"
+    exit 1
+fi
+
+# Clone installer repo into a temp directory
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+info "Cloning osac-installer (ref: ${REF}) with submodules..."
+git clone --depth 1 --branch "${REF}" --recurse-submodules --shallow-submodules \
+    "${INSTALLER_REPO}" "${TMPDIR}/osac-installer"
+
+# Copy each sub-chart
+DEST_CHARTS="${PLUGIN_CHART_DIR}/charts"
+mkdir -p "${DEST_CHARTS}"
+
+for chart_name in "${!CHART_MAP[@]}"; do
+    src="${TMPDIR}/osac-installer/${CHART_MAP[$chart_name]}"
+    dest="${DEST_CHARTS}/${chart_name}"
+
+    if [[ ! -d "${src}" ]]; then
+        error "Sub-chart not found: ${src}"
+        exit 1
+    fi
+
+    rm -rf "${dest}"
+    cp -r "${src}" "${dest}"
+    info "Copied ${chart_name} from ${CHART_MAP[$chart_name]}"
+done
+
+# Record the synced ref for traceability
+COMMIT=$(git -C "${TMPDIR}/osac-installer" rev-parse HEAD)
+echo "${REF} (${COMMIT})" > "${PLUGIN_CHART_DIR}/charts/.synced-ref"
+info "Synced from commit: ${COMMIT}"
+
+# Run helm dependency build if helm is available
+if command -v helm &>/dev/null; then
+    info "Running helm dependency build..."
+    helm dependency build "${PLUGIN_CHART_DIR}"
+    success "Helm dependency build completed"
+elif [[ -x "${ENCLAVE_DIR}/bin/helm" ]]; then
+    info "Running helm dependency build..."
+    "${ENCLAVE_DIR}/bin/helm" dependency build "${PLUGIN_CHART_DIR}"
+    success "Helm dependency build completed"
+else
+    warning "helm not found — skipping dependency build. Run 'helm dependency build ${PLUGIN_CHART_DIR}' manually."
+fi
+
+success "OSAC chart sync complete. Sub-charts at: ${DEST_CHARTS}/"


### PR DESCRIPTION
## Summary
- Make e2e-deployment.yml callable via workflow_call with enabled-plugins and heavy-workload inputs
- Add e2e-osac.yml as a thin caller that passes the OSAC plugin list (lvms, trust-manager, rhbk, authorino, cnv, aap)
- Write AAP license file path to config/plugins/aap.yaml instead of global.yaml to pass schema validation
- Copy plugin config files to Landing Zone during install

## Test plan
- [ ] e2e-osac workflow triggers correctly on OSAC-related file changes
- [ ] Schema validation passes (aapLicenseFile in plugin config, not global.yaml)
- [ ] Plugin config files are copied to Landing Zone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OSAC plugin with Helm chart and automated deployment configuration
  * Enhanced E2E deployment workflow with `enabled-plugins` and `heavy-workload` inputs for flexible test customization
  * Added support for plugin-specific configuration and AAP license management

* **Documentation**
  * Added OSAC umbrella chart setup and dependency documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->