### PR TITLE
Fix Ansible 2.19 deprecation in background_task_wait until condition

### DIFF
--- a/playbooks/tasks/background_task_wait.yaml
+++ b/playbooks/tasks/background_task_wait.yaml
@@ -66,7 +66,7 @@
   ansible.builtin.async_status:
     jid: "{{ vars[_async_job_id_var] }}"
   register: _async_task_result
-  until: _async_task_result.finished
+  until: _async_task_result.finished | default(false) | bool
   retries: "{{ _max_retries | int }}"
   delay: "{{ _retry_delay | int }}"
 


### PR DESCRIPTION
Ansible warns when waiting on async tasks (e.g. quay oc-mirror):

  [DEPRECATION WARNING]: Conditional result at location
  .../background_task_wait.yaml 69:10 was of type 'int'. Conditional results
  should only be True or False. The result was interpreted as False/True.
  This feature will be removed in version 2.19.

async_status sets `finished` to 0 or 1 while the job runs or completes. The `until: _async_task_result.finished` expression passed that integer through, which Ansible 2.19+ rejects for conditionals.

Coerce to a boolean with `| default(false) | bool` so retries behave the same without deprecation noise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced async task completion detection to more reliably handle edge cases where status information may be incomplete or missing, improving the stability of task waiting operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/enclave/pull/362?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->