### PR TITLE
Fix ModuleNotFoundError: No module named 'click' on operator install

### DIFF
--- a/playbooks/05-operators.yaml
+++ b/playbooks/05-operators.yaml
@@ -25,6 +25,13 @@
           tags: always
       tags: always
 
+    - name: Ensure Python requirements for reconcile CLI and collections (ansible_pip_requirements.txt)
+      ansible.builtin.include_tasks:
+        file: tasks/ensure_reconcile_python_requirements.yaml
+        apply:
+          tags: always
+      tags: always
+
     - name: Display operator installation mode
       ansible.builtin.debug:
         msg: "Installing operators in {{ 'disconnected' if (disconnected | default(true)) else 'connected' }} mode"

--- a/playbooks/tasks/ensure_reconcile_python_requirements.yaml
+++ b/playbooks/tasks/ensure_reconcile_python_requirements.yaml
@@ -1,0 +1,28 @@
+---
+# Idempotent pip install of Enclave repo ansible_pip_requirements.txt on the play host
+# (localhost = Landing Zone). Needed for reconcile/cli.py (click) and kubernetes.core, etc.
+# Complements bootstrap.sh --step setup / setup_ansible.sh when those were not run.
+
+- name: Resolve path to ansible_pip_requirements.txt (Enclave repo root)
+  ansible.builtin.set_fact:
+    _enclave_pip_requirements_path: "{{ playbook_dir | dirname }}/ansible_pip_requirements.txt"
+
+- name: Stat ansible_pip_requirements.txt
+  ansible.builtin.stat:
+    path: "{{ _enclave_pip_requirements_path }}"
+  register: r_enclave_pip_requirements
+
+- name: Install Python requirements from ansible_pip_requirements.txt
+  ansible.builtin.pip:
+    requirements: "{{ _enclave_pip_requirements_path }}"
+    executable: pip3
+    extra_args: "--disable-pip-version-check"
+  become: true
+  when: r_enclave_pip_requirements.stat.exists
+
+- name: Warn when ansible_pip_requirements.txt is missing
+  ansible.builtin.debug:
+    msg: >-
+      ansible_pip_requirements.txt not found at {{ _enclave_pip_requirements_path }}.
+      reconcile/cli.py and some Ansible modules may fail; run setup_ansible.sh on the LZ or fix checkout path.
+  when: not r_enclave_pip_requirements.stat.exists


### PR DESCRIPTION
When locally invoking 'make -f Makefile.ci ci-flow-disconnected': Operator playbook fails in 'Approve Install Plan (multicluster-engine)' since reconcile/cli.py ran on the Landing Zone without ansible_pip_requirements installed.

    Traceback (most recent call last):
      File "/home/cloud-user/enclave/playbooks/../reconcile/cli.py", line 1, in <module>
        import click
    ModuleNotFoundError: No module named 'click'

Thus, install ansible_pip_requirements.txt at the start of playbooks/05-operators.yaml so reconcile CLI and collection dependencies are present before configure_operator.