### PR TITLE
bump openshift version to 4.20.21

### DIFF
--- a/config/global.example.yaml
+++ b/config/global.example.yaml
@@ -135,6 +135,9 @@ storage_plugin: lvms
 # Disconnected mode (default: true, set to false for connected deployments)
 # disconnected: false
 
+# Fresh install mode (default: true, set to false to mirror multiple OpenShift versions)
+# fresh: false
+
 # Configure High Density Pod Limits for ABI (default: 500)
 # masterMaxPods: 250
 

--- a/defaults/control_binaries.yaml
+++ b/defaults/control_binaries.yaml
@@ -1,8 +1,8 @@
 ---
 control_binaries:
   openshift_client:
-    url: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.20.8/openshift-client-linux.tar.gz"
-    checksum: "sha256:baa84c69b15dbfd3f3c2b920b2eceb674cd6be30ef3aa3484d6fb88ca0a98445"
+    url: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.20.21/openshift-client-linux.tar.gz"
+    checksum: "sha256:bc49d2bcc26812668ceed77e703aca247a48b81440da022bd14870600a33e6e8"
   helm:
     url: "https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/helm/3.17.1/helm-linux-amd64"
     checksum: "sha256:ef6c04f6a748d0f1d624a94a56dc0db83f8d70a65e3dbb19e94107126efcc5fd"

--- a/defaults/deployment.yaml
+++ b/defaults/deployment.yaml
@@ -2,6 +2,9 @@
 # Default deployment mode. Override in config/global.yaml to deploy in connected mode.
 disconnected: true
 
+# Fresh install mode. Override in config/global.yaml to mirror multiple OpenShift versions.
+fresh: true
+
 # Configure High Density Pod Limits for ABI. Override in config/global.yaml.
 masterMaxPods: 500
 

--- a/defaults/platforms.yaml
+++ b/defaults/platforms.yaml
@@ -1,5 +1,5 @@
 ---
-mgmt_openshift_version: 4.20.8
+mgmt_openshift_version: 4.20.21
 
 openshift_versions:
-- version: 4.20.8
+- version: 4.20.21

--- a/defaults/platforms.yaml
+++ b/defaults/platforms.yaml
@@ -2,4 +2,5 @@
 mgmt_openshift_version: 4.20.21
 
 openshift_versions:
+- version: 4.20.8
 - version: 4.20.21

--- a/playbooks/common/load-vars.yaml
+++ b/playbooks/common/load-vars.yaml
@@ -29,3 +29,8 @@
 - name: Ensure storage plugin is in enabled_plugins
   ansible.builtin.set_fact:
     enabled_plugins: "{{ enabled_plugins | union([storage_plugin]) }}"
+
+- name: Override OpenShift versions on fresh install
+  ansible.builtin.set_fact:
+    openshift_versions: "{{ [{'version': mgmt_openshift_version}] }}"
+  when: fresh | default(true) | bool

--- a/schemas/definitions.yaml
+++ b/schemas/definitions.yaml
@@ -25,6 +25,11 @@ definitions:
     description: >-
       Whether the deployment is disconnected (air-gapped). Default: true.
       Set to false for connected deployments.
+  fresh:
+    type: boolean
+    description: >-
+      Whether this is a fresh install. default: true.
+      Set to false to mirror multiple OpenShift versions.
   masterMaxPods:
     type: integer
     minimum: 1

--- a/schemas/deployment.yaml
+++ b/schemas/deployment.yaml
@@ -7,6 +7,8 @@ additionalProperties: false
 properties:
   disconnected:
     "$ref": "#/definitions/disconnected"
+  fresh:
+    "$ref": "#/definitions/fresh"
   masterMaxPods:
     "$ref": "#/definitions/masterMaxPods"
   diskEncryption:
@@ -35,6 +37,7 @@ properties:
 
 required:
   - disconnected
+  - fresh
   - masterMaxPods
   - diskEncryption
   - ocMirrorLogLevel

--- a/sync.sh
+++ b/sync.sh
@@ -69,26 +69,26 @@ done
 step_done
 
 echo "Validating Config .. " | tee -a ${log}
-    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/validation/validate-schema.yaml -e@$global_vars -e@$certs_vars --tags schema-validation
+    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/validation/validate-schema.yaml -e fresh=false -e@$global_vars -e@$certs_vars --tags schema-validation
     bash ./validations.sh --global-vars $global_vars --certs-vars $certs_vars 2>&1 | tee -a ${log}
 step_done
 
 echo "Building local cache .. " | tee -a ${log}
-    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/02-mirror.yaml -e@$global_vars -e@$certs_vars --tags mirror-registry
+    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/02-mirror.yaml -e fresh=false -e@$global_vars -e@$certs_vars --tags mirror-registry
 step_done
 
 echo "Quay disconnected .." | tee -a ${log}
-    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/06-day2.yaml -e@$global_vars -e@$certs_vars --tags quay-disconnected
+    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/06-day2.yaml -e fresh=false -e@$global_vars -e@$certs_vars --tags quay-disconnected
 step_done
 
 echo "Clair disconnected .." | tee -a ${log}
-    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/06-day2.yaml -e@$global_vars -e@$certs_vars --tags clair-disconnected
+    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/06-day2.yaml -e fresh=false -e@$global_vars -e@$certs_vars --tags clair-disconnected
 step_done
 
 echo "ACM ClusterImageSets .." | tee -a ${log}
-    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/06-day2.yaml -e@$global_vars -e@$certs_vars --tags acm-cis
+    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/06-day2.yaml -e fresh=false -e@$global_vars -e@$certs_vars --tags acm-cis
 step_done
 
 echo "OpenShift Pipelines .." | tee -a ${log}
-    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/06-day2.yaml -e@$global_vars -e@$certs_vars --tags openshift-pipelines
+    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/06-day2.yaml -e fresh=false -e@$global_vars -e@$certs_vars --tags openshift-pipelines
 step_done


### PR DESCRIPTION
this PR bumps the management cluster openshift version from 4.20.8 to 4.20.21.
we are also adding a `fresh` variable to avoid mirroring all versions for a fresh install. all versions should be mirrored only in existing installs where the previous version is the current one (to enable upgrades).

removing a version essentially means it's no longer supported (TBD).

[upgrade path](https://access.redhat.com/labs/ocpupgradegraph/update_path/?channel=stable-4.20&arch=x86_64&is_show_hot_fix=false&current_ocp_version=4.20.8&target_ocp_version=4.20.21) exists between 4.20.8 -> 4.20.21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated OpenShift client and management version to 4.20.21.

* **New Features**
  * Added "fresh install mode" configuration option (enabled by default) to support both fresh deployments and multi-version mirroring scenarios.

* **Chores**
  * Improved deployment script formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/enclave/pull/365?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->