### PR TITLE
optimize Docker layer caching for CI image builds

### DIFF
--- a/.github/workflows/Dockerfile.ci
+++ b/.github/workflows/Dockerfile.ci
@@ -40,10 +40,13 @@ WORKDIR /workspace
 
 # Copy project metadata and source for dependency installation
 COPY pyproject.toml uv.lock .python-version README.md /workspace/
-COPY reconcile/ /workspace/reconcile/
 
-# Install all dependency groups into the project venv
-RUN uv sync --all-groups --no-editable
+# Install ONLY dependencies, skip the project itself. We don't install
+# the project in the first uv sync so that we can can leverage the cache
+# of the deps resolution layer leading to faster builds.
+RUN uv sync --all-groups --no-install-project
+COPY reconcile/ /workspace/reconcile/
+RUN uv sync --no-editable
 
 # Put venv on PATH so all commands are available
 ENV PATH="/workspace/.venv/bin:$PATH"

--- a/.github/workflows/resolve-ci-image.yml
+++ b/.github/workflows/resolve-ci-image.yml
@@ -41,6 +41,8 @@ jobs:
               - 'pyproject.toml'
               - 'uv.lock'
               - '.python-version'
+              - 'reconcile/**'
+              - 'README.md'
 
       - name: Build CI image
         if: steps.filter.outputs.changed == 'true'


### PR DESCRIPTION
Split uv sync into two layers:
- First layer installs only dependencies (--no-install-project) cached when uv.lock is unchanged
- Second layer installs the project package re-runs only when reconcile/ source changes

Update workflow trigger to rebuild image when reconcile/ or README.md change, since these now affect the final build layer.

This speeds up rebuilds when only application code changes without dependency updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI image build to separate dependency-only installation from project install for faster, more cache-friendly builds.
  * Expanded CI trigger conditions to run image build/test/push when application sources or README change.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/enclave/pull/369?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->