### PR TITLE
Use 32 GB master memory for connected and disconnected dev-scripts

### DIFF
--- a/scripts/setup/configure_devscripts.sh
+++ b/scripts/setup/configure_devscripts.sh
@@ -75,13 +75,12 @@ ENCLAVE_NUM_MASTERS="${ENCLAVE_NUM_MASTERS:-3}"
 ENCLAVE_NUM_LANDINGZONE="${ENCLAVE_NUM_LANDINGZONE:-1}"
 
 # VM extra disk size: 1200G for disconnected (mirroring), 60G for connected
+MASTER_MEMORY_VAL=32768    # 32 GB
 DEPLOYMENT_MODE="${ENCLAVE_DEPLOYMENT_MODE:-disconnected}"
 if [ "$DEPLOYMENT_MODE" = "connected" ]; then
     VM_EXTRADISKS_SIZE_VAL="60G"
-    MASTER_MEMORY_VAL=24576    # 24 GB for connected
 else
     VM_EXTRADISKS_SIZE_VAL="1200G"
-    MASTER_MEMORY_VAL=32768    # 32 GB for disconnected
 fi
 
 # ODF requires additional resources for Ceph/Rook operators, noobaa, and CSI daemons.


### PR DESCRIPTION
Raise MASTER_MEMORY_VAL from 24 GB (connected) to 32 GB for both deployment modes. Connected clusters were too tight on control-plane memory for Quay Enterprise on compact masters.

Without enough allocatable memory, registry-quay-database stays Pending:
```
  Warning  FailedScheduling  default-scheduler
  0/3 nodes are available: 1 Insufficient memory, 2 node(s) didn't match
  PersistentVolume's node affinity.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment memory configuration to ensure consistent resource allocation across all deployment modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/enclave/pull/372?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->