### PR TITLE
Add disconnected condition to MCE operator tasks

### DIFF
--- a/operators/multicluster-engine/tasks.yaml
+++ b/operators/multicluster-engine/tasks.yaml
@@ -282,7 +282,8 @@
   delay: "{{ k8s_delay }}"
   until: r_configmap_disconnected is success
 
-- name: Create assisted-service-user-config ConfigMap
+- name: Create assisted-service-user-config ConfigMap for disconnected
+  when: disconnected | default(true)
   kubernetes.core.k8s:
     state: present
     definition:
@@ -300,6 +301,7 @@
   until: r_configmap_assisted_service is success
 
 - name: Create AgentServiceConfig for disconnected environment
+  when: disconnected | default(true)
   vars:
     _osimages: |
       {% for v in openshift_versions %}


### PR DESCRIPTION
These tasks reference disconnected-only resources (local Quay mirror, mirrored RHCOS ISOs). Guard them with the same condition used by the existing custom-registries ConfigMap task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed task execution in disconnected environments to run only when appropriate conditions are met.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/enclave/pull/374?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->