### PR TITLE
Ensure global variables are checked via bootstrap.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ validate-config:
 	@bash ./validations.sh --global-vars $(GLOBAL_VARS) --certs-vars $(CERTS_VARS)
 
 validate-schema:
-	@$(AP) playbooks/validate-schema.yaml -e@$(GLOBAL_VARS) -e@$(CERTS_VARS) --tags schema-validation
+	@$(AP) playbooks/validate-schema.yaml -e@$(GLOBAL_VARS) -e@$(CERTS_VARS) --tags validate-config
 
 # Deploy targets
 deploy-cluster:

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -197,7 +197,9 @@ step_setup() {
 
 step_validate() {
     echo "Validating Config .. "  | tee -a ${log}
-    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/validation/validate-schema.yaml -e@$global_vars -e@$certs_vars $EXTRA_VARS --tags schema-validation
+    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/validation/validate-schema.yaml $EXTRA_VARS \
+        -e@$global_vars -e@$certs_vars -e@$cloud_infra_vars \
+        --tags validate-config
     bash ./validations.sh --global-vars $global_vars --certs-vars $certs_vars 2>&1 | tee -a ${log}
     step_done
 }

--- a/defaults/deployment.yaml
+++ b/defaults/deployment.yaml
@@ -17,10 +17,6 @@ ocMirrorLogLevel: info
 # Default storage plugin. Override in config/global.yaml to use odf.
 storage_plugin: lvms
 
-# Backward-compatible alias for storage_plugin, used by templates and quay tasks.
-# Will be removed when those are migrated to use storage_plugin directly.
-blockStorageBackend: "{{ storage_plugin }}"
-
 # Plugins to deploy during the pipeline. Override in config/global.yaml to add or remove plugins.
 # By default only the selected storage plugin is enabled.
 enabled_plugins:

--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -314,7 +314,7 @@ agent_hosts:
 | `name` | Hostname for the node | `mgmt-ctl01` |
 | `macAddress` | MAC address of the primary network interface | `0c:c4:7a:62:fe:ec` |
 | `ipAddress` | Static IP address for the node (must be in `machineNetwork`) | `192.168.2.24` |
-| `redfish` | BMC IP address for Redfish API access | `100.64.1.24` |
+| `redfish` | BMC IP address (or `ip:port`) for Redfish API access | `100.64.1.24` or `100.64.1.1:8008` |
 | `rootDisk` | Physical disk path for root filesystem (use `/dev/disk/by-path/` paths) | `/dev/disk/by-path/pci-0000:0011.4-ata-1.0` |
 | `redfishUser` | Override Username for Redfish API authentication on BMCs | `admin-override` |
 | `redfishPassword` | Override Password for Redfish API authentication on BMCs | `YourSecurePassword-override` |
@@ -751,6 +751,22 @@ quayBackendRGWConfiguration:
 - `is_secure`, `port`, and `storage_path` have defaults in `defaults/quay_operator.yaml` and only need to be set here when overriding those defaults
 - `minimum_chunk_size_mb` and `maximum_chunk_size_mb` default to `100` and `500` respectively; override in `quayBackendRGWConfiguration` if needed
 - `server_side_assembly` is always enabled as it is included in the defaults alongside `maximum_chunk_size_mb`
+
+#### `quayBackendLocalStorageConfiguration`
+
+**Description**: Optional overrides for the LocalStorage backend configuration merged with the default `storage_path: /datastorage/registry`. Only relevant when `quayBackend` is `LocalStorage`.
+
+**Type**: Dictionary
+
+**Default**: `{}` (uses `quayBackendDefaults` as-is)
+
+**Example**:
+```yaml
+quayBackendLocalStorageConfiguration:
+  storage_path: /custom/registry/path
+```
+
+**Note**: If omitted, Quay uses `storage_path: /datastorage/registry` from `defaults/quay_operator.yaml`.
 
 ### Pull Secrets
 

--- a/playbooks/common/load-vars.yaml
+++ b/playbooks/common/load-vars.yaml
@@ -1,16 +1,18 @@
 ---
 
+- name: Set user config file paths
+  ansible.builtin.set_fact:
+    user_config_files:
+      - "{{ vars_file | default('../../config/global.yaml', true) }}"
+      - "{{ certs_vars_file | default('../../config/certificates.yaml', true) }}"
+      - "{{ cloud_infra_vars_file | default('../../config/cloud_infra.yaml', true) }}"
+
 - name: Include deployment defaults
   ansible.builtin.include_vars: ../../defaults/deployment.yaml
 
-- name: Include global deployment vars
-  ansible.builtin.include_vars: "{{ vars_file | default('../../config/global.yaml') }}"
-
-- name: Include certificate vars
-  ansible.builtin.include_vars: ../../config/certificates.yaml
-
-- name: Include cloud infra vars
-  ansible.builtin.include_vars: ../../config/cloud_infra.yaml
+- name: Include user config vars
+  ansible.builtin.include_vars: "{{ item }}"
+  loop: "{{ user_config_files }}"
 
 - name: Include common configuration
   ansible.builtin.include_vars: "../../defaults/{{ config_file }}"

--- a/playbooks/validation/tasks/variables_fixtures_validation.yaml
+++ b/playbooks/validation/tasks/variables_fixtures_validation.yaml
@@ -1,0 +1,47 @@
+- name: Load shared schema definitions
+  ansible.builtin.set_fact:
+    schema_definitions: "{{ lookup('ansible.builtin.file', '../../schemas/definitions.yaml') | from_yaml }}"
+
+- name: Load variables schema
+  ansible.builtin.set_fact:
+    variables_schema: "{{ lookup('ansible.builtin.file', '../../schemas/variables.yaml') | from_yaml | combine(schema_definitions, recursive=True) | to_json }}"
+
+- name: Find valid fixtures
+  ansible.builtin.find:
+    paths: "{{ playbook_dir }}/../../test-fixtures/schemas/valid"
+    patterns: "*.yaml"
+  register: valid_fixtures
+
+- name: Validate valid fixtures
+  ansible.utils.validate:
+    data: "{{ lookup('ansible.builtin.file', item.path) | from_yaml | to_json }}"
+    criteria: "{{ variables_schema }}"
+    engine: ansible.utils.jsonschema
+  loop: "{{ valid_fixtures.files }}"
+  loop_control:
+    label: "{{ item.path | basename }}"
+
+- name: Find invalid fixtures
+  ansible.builtin.find:
+    paths: "{{ playbook_dir }}/../../test-fixtures/schemas/invalid"
+    patterns: "*.yaml"
+  register: invalid_fixtures
+
+- name: Validate invalid fixtures (expect failure)
+  ansible.utils.validate:
+    data: "{{ lookup('ansible.builtin.file', item.path) | from_yaml | to_json }}"
+    criteria: "{{ variables_schema }}"
+    engine: ansible.utils.jsonschema
+  loop: "{{ invalid_fixtures.files }}"
+  loop_control:
+    label: "{{ item.path | basename }}"
+  register: invalid_results
+  ignore_errors: true
+
+- name: Assert invalid fixtures failed validation
+  ansible.builtin.assert:
+    that: item.failed
+    fail_msg: "Invalid fixture {{ item.item.path | basename }} unexpectedly passed schema validation"
+  loop: "{{ invalid_results.results }}"
+  loop_control:
+    label: "{{ item.item.path | basename }}"

--- a/playbooks/validation/tasks/variables_schema_validation.yaml
+++ b/playbooks/validation/tasks/variables_schema_validation.yaml
@@ -6,42 +6,23 @@
   ansible.builtin.set_fact:
     variables_schema: "{{ lookup('ansible.builtin.file', '../../schemas/variables.yaml') | from_yaml | combine(schema_definitions, recursive=True) | to_json }}"
 
-- name: Find valid fixtures
-  ansible.builtin.find:
-    paths: "{{ playbook_dir }}/../../test-fixtures/schemas/valid"
-    patterns: "*.yaml"
-  register: valid_fixtures
+- name: Include load-vars to resolve user config file paths
+  ansible.builtin.include_tasks:
+    file: ../../common/load-vars.yaml
 
-- name: Validate valid fixtures
+- name: Merge user config files for schema validation
+  ansible.builtin.set_fact:
+    merged_config: >-
+      {{ merged_config | default({})
+         | combine(lookup('ansible.builtin.file', item) | from_yaml) }}
+  loop: "{{ user_config_files }}"
+  when: user_config_files is defined
+  no_log: true
+
+- name: Validate merged config against variables schema
   ansible.utils.validate:
-    data: "{{ lookup('ansible.builtin.file', item.path) | from_yaml | to_json }}"
+    data: "{{ merged_config | to_json }}"
     criteria: "{{ variables_schema }}"
     engine: ansible.utils.jsonschema
-  loop: "{{ valid_fixtures.files }}"
-  loop_control:
-    label: "{{ item.path | basename }}"
-
-- name: Find invalid fixtures
-  ansible.builtin.find:
-    paths: "{{ playbook_dir }}/../../test-fixtures/schemas/invalid"
-    patterns: "*.yaml"
-  register: invalid_fixtures
-
-- name: Validate invalid fixtures (expect failure)
-  ansible.utils.validate:
-    data: "{{ lookup('ansible.builtin.file', item.path) | from_yaml | to_json }}"
-    criteria: "{{ variables_schema }}"
-    engine: ansible.utils.jsonschema
-  loop: "{{ invalid_fixtures.files }}"
-  loop_control:
-    label: "{{ item.path | basename }}"
-  register: invalid_results
-  ignore_errors: true
-
-- name: Assert invalid fixtures failed validation
-  ansible.builtin.assert:
-    that: item.failed
-    fail_msg: "Invalid fixture {{ item.item.path | basename }} unexpectedly passed schema validation"
-  loop: "{{ invalid_results.results }}"
-  loop_control:
-    label: "{{ item.item.path | basename }}"
+  when: merged_config is defined
+  no_log: true

--- a/playbooks/validation/validate-schema.yaml
+++ b/playbooks/validation/validate-schema.yaml
@@ -13,12 +13,19 @@
       ansible.builtin.include_tasks:
         file: tasks/defaults_schema_validation.yaml
         apply:
-          tags: schema-validation
-      tags: schema-validation
+          tags: test-fixtures
+      tags: test-fixtures
+
+    - name: Include variables fixtures validation tasks
+      ansible.builtin.include_tasks:
+        file: tasks/variables_fixtures_validation.yaml
+        apply:
+          tags: test-fixtures
+      tags: test-fixtures
 
     - name: Include variables schema validation tasks
       ansible.builtin.include_tasks:
         file: tasks/variables_schema_validation.yaml
         apply:
-          tags: schema-validation
-      tags: schema-validation
+          tags: validate-config
+      tags: validate-config

--- a/schemas/definitions.yaml
+++ b/schemas/definitions.yaml
@@ -4,6 +4,10 @@ definitions:
     type: string
     pattern: "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
     description: IPv4 address
+  ipv4AddressWithOptionalPort:
+    type: string
+    pattern: "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(:(([1-9][0-9]{0,3})|([1-5][0-9]{4})|(6[0-4][0-9]{3})|(65[0-4][0-9]{2})|(655[0-2][0-9])|(6553[0-5])))?$"
+    description: IPv4 address with optional port (e.g. 192.168.1.1 or 192.168.1.1:8008)
   cidr:
     type: string
     pattern: "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/(3[0-2]|[12]?[0-9])$"
@@ -12,6 +16,10 @@ definitions:
     type: string
     pattern: "^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$"
     description: MAC address in colon-separated hex notation
+  httpUrl:
+    type: string
+    pattern: "^https?://[^/]"
+    description: HTTP or HTTPS URL with a non-empty hostname
   nonEmptyString:
     type: string
     minLength: 1
@@ -87,7 +95,7 @@ definitions:
         type: object
         description: Network configuration
       redfish:
-        "$ref": "#/definitions/ipv4Address"
+        "$ref": "#/definitions/ipv4AddressWithOptionalPort"
       redfishPassword:
         "$ref": "#/definitions/nonEmptyString"
       redfishUser:

--- a/schemas/deployment.yaml
+++ b/schemas/deployment.yaml
@@ -21,7 +21,7 @@ properties:
       Path to the pull secret JSON file. Default: {{ workingDir }}/config/pull-secret.json.
   storage_plugin:
     type: string
-    enum: [lvms, odf]
+    enum: [lvms, odf, vast-csi]
     description: >-
       Which storage plugin to deploy. Default: lvms.
   enabled_plugins:
@@ -30,11 +30,6 @@ properties:
       type: string
     description: >-
       List of plugins to deploy during the pipeline. Default: [storage_plugin].
-  blockStorageBackend:
-    type: string
-    description: >-
-      Backward-compatible alias for storage_plugin. Will be removed after migration.
-
 required:
   - disconnected
   - fresh

--- a/schemas/quay_operator.yaml
+++ b/schemas/quay_operator.yaml
@@ -61,9 +61,8 @@ properties:
         description: Organization name for OAuth application
         pattern: "^[a-z0-9]+(?:[._-][a-z0-9]+)*$"
       redirect_uri:
-        type: string
+        "$ref": "#/definitions/httpUrl"
         description: Redirect URI for OAuth application
-        pattern: "^https?://.+"
       scopes:
         type: string
         description: Space-separated list of OAuth scopes

--- a/schemas/variables.yaml
+++ b/schemas/variables.yaml
@@ -16,10 +16,27 @@ properties:
     "$ref": "#/definitions/ipv4Address"
   baseDomain:
     "$ref": "#/definitions/nonEmptyString"
-  blockStorageBackend:
+  storage_plugin:
     type: string
-    enum: [lvms, odf]
-    description: Block storage backend for Quay database and assisted installer
+    enum: [lvms, odf, vast-csi]
+    description: Storage plugin to deploy for Quay database and assisted installer
+  enabled_plugins:
+    type: array
+    description: List of plugins to deploy during the pipeline
+    items:
+      "$ref": "#/definitions/nonEmptyString"
+  pullSecretPath:
+    "$ref": "#/definitions/nonEmptyString"
+    description: Path to the pull secret JSON file
+  dc_cache_address:
+    "$ref": "#/definitions/nonEmptyString"
+    description: Address of the disconnected cache registry
+  dc_cache_user:
+    "$ref": "#/definitions/nonEmptyString"
+    description: Username for the disconnected cache registry
+  dc_cache_password:
+    "$ref": "#/definitions/nonEmptyString"
+    description: Password for the disconnected cache registry
   clusterName:
     "$ref": "#/definitions/nonEmptyString"
   defaultDNS:
@@ -78,6 +95,9 @@ properties:
     type: string
     enum: [RadosGWStorage, LocalStorage]
     description: Quay storage backend type
+  quayBackendLocalStorageConfiguration:
+    type: object
+    description: Custom LocalStorage backend configuration merged with quayBackendDefaults
   quayBackendRGWConfiguration:
     type: object
     description: RadosGW/S3 backend configuration for Quay
@@ -137,6 +157,87 @@ properties:
   sslIngressCertificateKey:
     type: string
     description: PEM-encoded private key for ingress wildcard certificate
+  vastAdminPassword:
+    "$ref": "#/definitions/nonEmptyString"
+  vastAdminUsername:
+    "$ref": "#/definitions/nonEmptyString"
+  vastDefaults:
+    type: object
+    description: VAST CSI default configuration
+    additionalProperties: false
+    properties:
+      infraTenant:
+        "$ref": "#/definitions/nonEmptyString"
+      storagePath:
+        "$ref": "#/definitions/nonEmptyString"
+      validateCerts:
+        type: boolean
+      apiTimeout:
+        type: integer
+        minimum: 1
+      apiVersion:
+        "$ref": "#/definitions/nonEmptyString"
+      csiProvisioners:
+        type: object
+        additionalProperties: false
+        properties:
+          nfs:
+            "$ref": "#/definitions/nonEmptyString"
+          block:
+            "$ref": "#/definitions/nonEmptyString"
+      csiDriverName:
+        "$ref": "#/definitions/nonEmptyString"
+      quayPvcSize:
+        "$ref": "#/definitions/nonEmptyString"
+      tiers:
+        type: array
+        minItems: 1
+        maxItems: 20
+        items:
+          type: object
+          additionalProperties: false
+          properties:
+            name:
+              type: string
+              pattern: "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$"
+              maxLength: 63
+            protocol:
+              type: string
+              enum: [nfs, block]
+            default:
+              type: boolean
+          required:
+            - name
+            - protocol
+  vastEndpoint:
+    "$ref": "#/definitions/httpUrl"
+    description: VAST management endpoint URL
+  vastVipPool:
+    type: object
+    description: VAST VIP pool configuration
+    additionalProperties: false
+    properties:
+      subnet_cidr:
+        type: integer
+        minimum: 1
+        maximum: 32
+      ip_ranges:
+        type: array
+        items:
+          type: object
+          properties:
+            start:
+              "$ref": "#/definitions/ipv4Address"
+            end:
+              "$ref": "#/definitions/ipv4Address"
+          required:
+            - start
+            - end
+      role:
+        type: string
+    required:
+      - subnet_cidr
+      - ip_ranges
   workingDir:
     "$ref": "#/definitions/nonEmptyString"
 
@@ -144,7 +245,6 @@ required:
   - agent_hosts
   - apiVIP
   - baseDomain
-  - blockStorageBackend
   - clusterName
   - defaultDNS
   - defaultGateway
@@ -170,11 +270,25 @@ allOf:
         - quayBackendRGWConfiguration
   - if:
       properties:
-        blockStorageBackend:
+        storage_plugin:
           const: odf
+      required:
+        - storage_plugin
     then:
       required:
         - odfExternalConfig
+  - if:
+      properties:
+        storage_plugin:
+          const: vast-csi
+      required:
+        - storage_plugin
+    then:
+      required:
+        - vastEndpoint
+        - vastAdminUsername
+        - vastAdminPassword
+        - vastVipPool
   - if:
       properties:
         sslAPICertificateFullChain:

--- a/scripts/verification/collect_ci_artifacts.sh
+++ b/scripts/verification/collect_ci_artifacts.sh
@@ -578,6 +578,45 @@ collect_lz_config_files() {
     scp $ssh_opts cloud-user@"$lz_ip":/home/cloud-user/.openshift_install.log "${OUTPUT_DIR}/landing-zone/openshift_install_agent.log" 2>/dev/null || true
 }
 
+collect_lz_enclave_config() {
+    local lz_ip="$1"
+    local ssh_opts="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -q"
+    local config_dir="${OUTPUT_DIR}/landing-zone/config"
+
+    mkdir -p "$config_dir"
+    info "Collecting enclave configuration files from Landing Zone..."
+
+    # Redact any key matching /password|secret|key|cert/i at all nesting levels before collecting.
+    # String values that are valid JSON are parsed and redacted recursively (e.g. odfExternalConfig).
+    local redact_py='
+import yaml, sys, re, json
+PATTERN = re.compile(r"password|secret|key|cert", re.IGNORECASE)
+def redact(obj):
+    if isinstance(obj, dict):
+        return {k: "REDACTED" if PATTERN.search(k) else redact(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [redact(i) for i in obj]
+    if isinstance(obj, str):
+        try:
+            return json.dumps(redact(json.loads(obj)))
+        except (json.JSONDecodeError, ValueError):
+            pass
+    return obj
+data = yaml.safe_load(open(sys.argv[1]))
+print(yaml.dump(redact(data), default_flow_style=False))
+'
+
+    for cfg in global.yaml certificates.yaml cloud_infra.yaml; do
+        local remote_path="/home/cloud-user/enclave/config/${cfg}"
+        local out
+        out=$(ssh $ssh_opts cloud-user@"$lz_ip" \
+            "[ -f ${remote_path} ] && python3 -c '${redact_py}' ${remote_path}" 2>/dev/null) \
+            && [ -n "$out" ] \
+            && echo "$out" > "${config_dir}/${cfg}" \
+            || warn "Could not collect ${cfg}"
+    done
+}
+
 collect_lz_services() {
     local lz_ip="$1"
     local ssh_opts="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -q"
@@ -787,6 +826,7 @@ collect_deployment() {
     collect_lz_deployment_logs "$lz_ip"
     collect_lz_oc_mirror_logs "$lz_ip"
     collect_lz_config_files "$lz_ip"
+    collect_lz_enclave_config "$lz_ip"
     collect_lz_services "$lz_ip"
     collect_lz_registry "$lz_ip"
 

--- a/scripts/verification/validate.sh
+++ b/scripts/verification/validate.sh
@@ -64,7 +64,7 @@ validate_yaml() {
 validate_json_schema() {
     print_header "Validating JSON schema"
 
-    if ansible-playbook playbooks/validation/validate-schema.yaml -e@config/global.example.yaml; then
+    if ansible-playbook playbooks/validation/validate-schema.yaml --tags test-fixtures; then
         print_success "JSON schema validation passed"
         return 0
     else
@@ -135,8 +135,8 @@ validate_tags() {
         "playbooks/05-operators.yaml:operators:Configure remaining operators"
         "playbooks/06-day2.yaml:clair-disconnected:Configure Clair in disconnected environments"
         "playbooks/06-day2.yaml:acm-policy-catalogsources:Mirrored catalogsource configuration ACM policy"
-        "playbooks/validation/validate-schema.yaml:schema-validation:Include defaults schema validation tasks"
-        "playbooks/validation/validate-schema.yaml:schema-validation:Include variables schema validation tasks"
+        "playbooks/validation/validate-schema.yaml:test-fixtures:Include defaults schema validation tasks"
+        "playbooks/validation/validate-schema.yaml:validate-config:Include variables schema validation tasks"
         "playbooks/validation/validate-mirror.yaml:mirror-validation:Include mirror validation tasks"
     )
 

--- a/sync.sh
+++ b/sync.sh
@@ -69,7 +69,7 @@ done
 step_done
 
 echo "Validating Config .. " | tee -a ${log}
-    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/validation/validate-schema.yaml -e fresh=false -e@$global_vars -e@$certs_vars --tags schema-validation
+    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/validation/validate-schema.yaml -e fresh=false -e@$global_vars -e@$certs_vars --tags validate-config
     bash ./validations.sh --global-vars $global_vars --certs-vars $certs_vars 2>&1 | tee -a ${log}
 step_done
 

--- a/test-fixtures/schemas/invalid/invalid-additional-property.yaml
+++ b/test-fixtures/schemas/invalid/invalid-additional-property.yaml
@@ -16,7 +16,7 @@ lzBmcIP: 100.64.1.10
 quayUser: admin
 quayPassword: password
 quayBackend: LocalStorage
-blockStorageBackend: lvms
+storage_plugin: lvms
 pullSecret: {"auths":{}}
 sshPubPath: /home/enclave/.ssh/id_rsa.pub
 agent_hosts:

--- a/test-fixtures/schemas/invalid/invalid-discovery-host-missing-field.yaml
+++ b/test-fixtures/schemas/invalid/invalid-discovery-host-missing-field.yaml
@@ -15,7 +15,7 @@ lzBmcIP: 100.64.1.10
 quayUser: admin
 quayPassword: password
 quayBackend: LocalStorage
-blockStorageBackend: lvms
+storage_plugin: lvms
 pullSecret: {"auths":{}}
 sshPubPath: /home/enclave/.ssh/id_rsa.pub
 discovery_hosts:

--- a/test-fixtures/schemas/invalid/invalid-empty-string.yaml
+++ b/test-fixtures/schemas/invalid/invalid-empty-string.yaml
@@ -15,7 +15,7 @@ lzBmcIP: 100.64.1.10
 quayUser: admin
 quayPassword: password
 quayBackend: LocalStorage
-blockStorageBackend: lvms
+storage_plugin: lvms
 pullSecret: {"auths":{}}
 sshPubPath: /home/enclave/.ssh/id_rsa.pub
 agent_hosts:

--- a/test-fixtures/schemas/invalid/invalid-enum.yaml
+++ b/test-fixtures/schemas/invalid/invalid-enum.yaml
@@ -1,6 +1,6 @@
 ---
 # Invalid fixture: unknown storage_plugin value
-# Expected failure: storage_plugin must be one of [lvms, odf].
+# Expected failure: storage_plugin must be one of [lvms, odf, vast-csi].
 workingDir: /home/enclave
 baseDomain: enclave-test.nodns.in
 clusterName: mgmt

--- a/test-fixtures/schemas/invalid/invalid-enum.yaml
+++ b/test-fixtures/schemas/invalid/invalid-enum.yaml
@@ -1,6 +1,6 @@
 ---
-# Invalid fixture: unknown blockStorageBackend value
-# Expected failure: blockStorageBackend must be one of [lvms, odf].
+# Invalid fixture: unknown storage_plugin value
+# Expected failure: storage_plugin must be one of [lvms, odf].
 workingDir: /home/enclave
 baseDomain: enclave-test.nodns.in
 clusterName: mgmt
@@ -15,7 +15,7 @@ lzBmcIP: 100.64.1.10
 quayUser: admin
 quayPassword: password
 quayBackend: LocalStorage
-blockStorageBackend: nfs
+storage_plugin: nfs
 pullSecret: {"auths":{}}
 sshPubPath: /home/enclave/.ssh/id_rsa.pub
 agent_hosts:

--- a/test-fixtures/schemas/invalid/invalid-port.yaml
+++ b/test-fixtures/schemas/invalid/invalid-port.yaml
@@ -21,7 +21,7 @@ quayBackendRGWConfiguration:
   bucket_name: quay-storage
   hostname: radosgw.enclave-test.nodns.in
   port: 0
-blockStorageBackend: lvms
+storage_plugin: lvms
 pullSecret: {"auths":{}}
 sshPubPath: /home/enclave/.ssh/id_rsa.pub
 agent_hosts:

--- a/test-fixtures/schemas/invalid/invalid-rgw-unknown-key.yaml
+++ b/test-fixtures/schemas/invalid/invalid-rgw-unknown-key.yaml
@@ -15,7 +15,7 @@ lzBmcIP: 100.64.1.10
 quayUser: admin
 quayPassword: password
 quayBackend: RadosGWStorage
-blockStorageBackend: lvms
+storage_plugin: lvms
 pullSecret: {"auths":{}}
 sshPubPath: /home/enclave/.ssh/id_rsa.pub
 quayBackendRGWConfiguration:

--- a/test-fixtures/schemas/invalid/invalid-storage-path.yaml
+++ b/test-fixtures/schemas/invalid/invalid-storage-path.yaml
@@ -22,7 +22,7 @@ quayBackendRGWConfiguration:
   bucket_name: quay-storage
   hostname: radosgw.enclave-test.nodns.in
   storage_path: no-leading-slash
-blockStorageBackend: lvms
+storage_plugin: lvms
 pullSecret: {"auths":{}}
 sshPubPath: /home/enclave/.ssh/id_rsa.pub
 agent_hosts:

--- a/test-fixtures/schemas/invalid/ironic-https-empty-key.yaml
+++ b/test-fixtures/schemas/invalid/ironic-https-empty-key.yaml
@@ -16,7 +16,7 @@ lzBmcIP: 100.64.1.10
 quayUser: admin
 quayPassword: password
 quayBackend: LocalStorage
-blockStorageBackend: lvms
+storage_plugin: lvms
 pullSecret: {"auths":{}}
 sshPubPath: /home/enclave/.ssh/id_rsa.pub
 ironicHTTPSCertificate: |

--- a/test-fixtures/schemas/invalid/ironic-https-missing-key.yaml
+++ b/test-fixtures/schemas/invalid/ironic-https-missing-key.yaml
@@ -16,7 +16,7 @@ lzBmcIP: 100.64.1.10
 quayUser: admin
 quayPassword: password
 quayBackend: LocalStorage
-blockStorageBackend: lvms
+storage_plugin: lvms
 pullSecret: {"auths":{}}
 sshPubPath: /home/enclave/.ssh/id_rsa.pub
 ironicHTTPSCertificate: |

--- a/test-fixtures/schemas/invalid/odf-without-external-config.yaml
+++ b/test-fixtures/schemas/invalid/odf-without-external-config.yaml
@@ -1,7 +1,7 @@
 ---
 # Invalid fixture: odf block storage without odfExternalConfig
 # Expected failure: variables schema requires odfExternalConfig
-# when blockStorageBackend is odf.
+# when storage_plugin is odf.
 workingDir: /home/enclave
 baseDomain: enclave-test.nodns.in
 clusterName: mgmt
@@ -16,7 +16,7 @@ lzBmcIP: 100.64.1.10
 quayUser: admin
 quayPassword: password
 quayBackend: LocalStorage
-blockStorageBackend: odf
+storage_plugin: odf
 pullSecret: {"auths":{}}
 sshPubPath: /home/enclave/.ssh/id_rsa.pub
 agent_hosts:

--- a/test-fixtures/schemas/invalid/radosgw-without-rgw-config.yaml
+++ b/test-fixtures/schemas/invalid/radosgw-without-rgw-config.yaml
@@ -16,7 +16,7 @@ lzBmcIP: 100.64.1.10
 quayUser: admin
 quayPassword: password
 quayBackend: RadosGWStorage
-blockStorageBackend: lvms
+storage_plugin: lvms
 pullSecret: {"auths":{}}
 sshPubPath: /home/enclave/.ssh/id_rsa.pub
 agent_hosts:

--- a/test-fixtures/schemas/invalid/redfish-invalid-port.yaml
+++ b/test-fixtures/schemas/invalid/redfish-invalid-port.yaml
@@ -1,11 +1,11 @@
 ---
-# Invalid fixture: malformed IP address in apiVIP
-# Expected failure: apiVIP does not match the IPv4 pattern in definitions.yaml.
+# Fixture: redfish BMC address with out-of-range port (99999 > 65535)
+# Validates that ipv4AddressWithOptionalPort rejects ports outside 1-65535.
 workingDir: /home/enclave
 baseDomain: enclave-test.nodns.in
 clusterName: mgmt
 machineNetwork: 192.168.2.0/24
-apiVIP: not-an-ip
+apiVIP: 192.168.2.201
 ingressVIP: 192.168.2.202
 defaultDNS: 9.30.31.32
 defaultGateway: 192.168.2.10
@@ -22,22 +22,7 @@ agent_hosts:
   - name: mgmt-ctl01
     macAddress: 0c:c4:7a:62:fe:ec
     ipAddress: 192.168.2.24
-    redfish: 192.168.1.101
+    redfish: 100.64.1.1:99999
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
     redfishPassword: password
-  - name: mgmt-ctl02
-    macAddress: 0c:c4:7a:62:fe:ed
-    ipAddress: 192.168.2.25
-    redfish: 192.168.1.102
-    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
-    redfishUser: admin
-    redfishPassword: password
-  - name: mgmt-ctl03
-    macAddress: 0c:c4:7a:62:fe:ee
-    ipAddress: 192.168.2.26
-    redfish: 192.168.1.103
-    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
-    redfishUser: admin
-    redfishPassword: password
-

--- a/test-fixtures/schemas/invalid/ssl-empty-key.yaml
+++ b/test-fixtures/schemas/invalid/ssl-empty-key.yaml
@@ -16,7 +16,7 @@ lzBmcIP: 100.64.1.10
 quayUser: admin
 quayPassword: password
 quayBackend: LocalStorage
-blockStorageBackend: lvms
+storage_plugin: lvms
 pullSecret: {"auths":{}}
 sshPubPath: /home/enclave/.ssh/id_rsa.pub
 sslAPICertificateFullChain: |

--- a/test-fixtures/schemas/invalid/ssl-missing-key.yaml
+++ b/test-fixtures/schemas/invalid/ssl-missing-key.yaml
@@ -17,7 +17,7 @@ lzBmcIP: 100.64.1.10
 quayUser: admin
 quayPassword: password
 quayBackend: LocalStorage
-blockStorageBackend: lvms
+storage_plugin: lvms
 pullSecret: {"auths":{}}
 sshPubPath: /home/enclave/.ssh/id_rsa.pub
 sslAPICertificateFullChain: |

--- a/test-fixtures/schemas/invalid/vast-csi-without-endpoint.yaml
+++ b/test-fixtures/schemas/invalid/vast-csi-without-endpoint.yaml
@@ -1,7 +1,7 @@
 ---
-# Fixture: LocalStorage backend + lvms block storage
-# Validates that quayBackendRGWConfiguration is NOT required for LocalStorage
-# and that odfExternalConfig is NOT required for lvms.
+# Invalid fixture: vast-csi block storage without required VAST properties
+# Expected failure: variables schema requires vastEndpoint, vastAdminUsername,
+# vastAdminPassword, and vastVipPool when storage_plugin is vast-csi.
 workingDir: /home/enclave
 baseDomain: enclave-test.nodns.in
 clusterName: mgmt
@@ -16,7 +16,7 @@ lzBmcIP: 100.64.1.10
 quayUser: admin
 quayPassword: password
 quayBackend: LocalStorage
-storage_plugin: lvms
+storage_plugin: vast-csi
 pullSecret: {"auths":{}}
 sshPubPath: /home/enclave/.ssh/id_rsa.pub
 agent_hosts:
@@ -41,4 +41,3 @@ agent_hosts:
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
     redfishPassword: password
-

--- a/test-fixtures/schemas/valid/local-lvms-redfish-with-port.yaml
+++ b/test-fixtures/schemas/valid/local-lvms-redfish-with-port.yaml
@@ -1,7 +1,6 @@
 ---
-# Fixture: LocalStorage backend + lvms block storage
-# Validates that quayBackendRGWConfiguration is NOT required for LocalStorage
-# and that odfExternalConfig is NOT required for lvms.
+# Fixture: redfish BMC address with explicit port
+# Validates that redfish accepts ip:port format (e.g. sushy-tools emulator).
 workingDir: /home/enclave
 baseDomain: enclave-test.nodns.in
 clusterName: mgmt
@@ -23,22 +22,21 @@ agent_hosts:
   - name: mgmt-ctl01
     macAddress: 0c:c4:7a:62:fe:ec
     ipAddress: 192.168.2.24
-    redfish: 192.168.1.101
+    redfish: 100.64.1.1:8008
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
     redfishPassword: password
   - name: mgmt-ctl02
     macAddress: 0c:c4:7a:62:fe:ed
     ipAddress: 192.168.2.25
-    redfish: 192.168.1.102
+    redfish: 100.64.1.1:8008
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
     redfishPassword: password
   - name: mgmt-ctl03
     macAddress: 0c:c4:7a:62:fe:ee
     ipAddress: 192.168.2.26
-    redfish: 192.168.1.103
+    redfish: 100.64.1.1:8008
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
     redfishPassword: password
-

--- a/test-fixtures/schemas/valid/local-lvms-with-discovery.yaml
+++ b/test-fixtures/schemas/valid/local-lvms-with-discovery.yaml
@@ -15,7 +15,7 @@ lzBmcIP: 100.64.1.10
 quayUser: admin
 quayPassword: password
 quayBackend: LocalStorage
-blockStorageBackend: lvms
+storage_plugin: lvms
 pullSecret: {"auths":{}}
 sshPubPath: /home/enclave/.ssh/id_rsa.pub
 discovery_hosts:

--- a/test-fixtures/schemas/valid/local-lvms-with-ironic-https.yaml
+++ b/test-fixtures/schemas/valid/local-lvms-with-ironic-https.yaml
@@ -16,7 +16,7 @@ lzBmcIP: 100.64.1.10
 quayUser: admin
 quayPassword: password
 quayBackend: LocalStorage
-blockStorageBackend: lvms
+storage_plugin: lvms
 pullSecret: {"auths":{}}
 sshPubPath: /home/enclave/.ssh/id_rsa.pub
 ironicHTTPSCertificate: |

--- a/test-fixtures/schemas/valid/local-lvms-with-ssl.yaml
+++ b/test-fixtures/schemas/valid/local-lvms-with-ssl.yaml
@@ -16,7 +16,7 @@ lzBmcIP: 100.64.1.10
 quayUser: admin
 quayPassword: password
 quayBackend: LocalStorage
-blockStorageBackend: lvms
+storage_plugin: lvms
 pullSecret: {"auths":{}}
 sshPubPath: /home/enclave/.ssh/id_rsa.pub
 sslAPICertificateFullChain: |

--- a/test-fixtures/schemas/valid/local-odf.yaml
+++ b/test-fixtures/schemas/valid/local-odf.yaml
@@ -16,7 +16,7 @@ lzBmcIP: 100.64.1.10
 quayUser: admin
 quayPassword: password
 quayBackend: LocalStorage
-blockStorageBackend: odf
+storage_plugin: odf
 odfExternalConfig: >-
   [{"name": "external-cluster-user-command", "kind": "ConfigMap",
   "data": {"userKey": "AQBf0000000000000000000000==", "userID": "ocs-client"}}]

--- a/test-fixtures/schemas/valid/local-vast-csi.yaml
+++ b/test-fixtures/schemas/valid/local-vast-csi.yaml
@@ -1,7 +1,7 @@
 ---
-# Fixture: LocalStorage backend + lvms block storage
-# Validates that quayBackendRGWConfiguration is NOT required for LocalStorage
-# and that odfExternalConfig is NOT required for lvms.
+# Fixture: LocalStorage backend + vast-csi block storage
+# Validates that LocalStorage + vast-csi is accepted with all required
+# VAST properties (vastEndpoint, vastAdminUsername, vastAdminPassword, vastVipPool).
 workingDir: /home/enclave
 baseDomain: enclave-test.nodns.in
 clusterName: mgmt
@@ -16,7 +16,15 @@ lzBmcIP: 100.64.1.10
 quayUser: admin
 quayPassword: password
 quayBackend: LocalStorage
-storage_plugin: lvms
+storage_plugin: vast-csi
+vastEndpoint: https://vms.example.com
+vastAdminUsername: admin
+vastAdminPassword: password
+vastVipPool:
+  subnet_cidr: 24
+  ip_ranges:
+    - start: 10.0.100.10
+      end: 10.0.100.50
 pullSecret: {"auths":{}}
 sshPubPath: /home/enclave/.ssh/id_rsa.pub
 agent_hosts:
@@ -41,4 +49,3 @@ agent_hosts:
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
     redfishPassword: password
-

--- a/test-fixtures/schemas/valid/radosgw-lvms-all-optionals.yaml
+++ b/test-fixtures/schemas/valid/radosgw-lvms-all-optionals.yaml
@@ -35,7 +35,7 @@ quayBackendRGWConfiguration:
   maximum_chunk_size_mb: 250
   server_side_assembly: false
   storage_path: /custom/registry
-blockStorageBackend: lvms
+storage_plugin: lvms
 lvmsConfig:
   deviceSelector:
     optionalPaths:

--- a/test-fixtures/schemas/valid/radosgw-odf.yaml
+++ b/test-fixtures/schemas/valid/radosgw-odf.yaml
@@ -21,7 +21,7 @@ quayBackendRGWConfiguration:
   secret_key: EXAMPLE_SECRET_KEY
   bucket_name: quay-storage
   hostname: radosgw.enclave-test.nodns.in
-blockStorageBackend: odf
+storage_plugin: odf
 odfExternalConfig: >-
   [{"name": "external-cluster-user-command", "kind": "ConfigMap",
   "data": {"userKey": "AQBf0000000000000000000000==", "userID": "ocs-client"}}]


### PR DESCRIPTION
The schema validation playbook was never validating user config files —
passing -e@config/global.yaml only loaded variables into scope, it did
not trigger any schema check. Unknown properties like a mistyped key
were silently accepted.

Fix by loading all user config files through load-vars.yaml and validating
their merged content. Split validation into two tags: validate-config
(config files, run by bootstrap.sh)and test-fixtures (test fixtures, run by CI
only).

Since we are honouring schema properly, missing properties have been added
so that this doesn't break any current installation and we have removed
the unused blockStorageBackend alias.

VAST schema has been added to avoid changes that will potentially break
working deployments. Documentation has been left out for a subsequent PR
to avoid cluttering this patch any further.

validate schema tests now have no_log as they can leak secrets. A task
to upload redacted config files have been added to be able to inspect
the configuration if something breaks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed deprecated blockStorageBackend; use storage_plugin.

* **New Features**
  * Added vast-csi support and required VAST fields.
  * New vars: enabled_plugins, pullSecretPath, and disconnected cache registry fields.
  * Redfish BMC addresses may include optional :port.

* **Tests**
  * Expanded/updated schema fixtures and validation coverage (valid/invalid cases).

* **Chores**
  * Consolidated schema validation flow and updated validation tags.
  * CI artifact collection now includes redacted enclave config files.

* **Documentation**
  * Documented quayBackendLocalStorageConfiguration and Redfish ip:port behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/enclave/pull/376?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->