### PR TITLE
Remove -e@ extra vars so storage_plugin gets unioned into enabled_plugins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ validate-config:
 	@bash ./validations.sh --global-vars $(GLOBAL_VARS) --certs-vars $(CERTS_VARS)
 
 validate-schema:
-	@$(AP) playbooks/validate-schema.yaml -e@$(GLOBAL_VARS) -e@$(CERTS_VARS) --tags validate-config
+	@$(AP) playbooks/validation/validate-schema.yaml --tags validate-config
 
 # Deploy targets
 deploy-cluster:
@@ -120,7 +120,7 @@ deploy-cluster-day2:
 	@$(AP) playbooks/06-day2.yaml $(AP_FLAGS)
 
 deploy-cluster-discovery:
-	@$(AP) playbooks/07-configure-discovery.yaml $(AP_FLAGS) -e@$(CLOUD_INFRA_VARS)
+	@$(AP) playbooks/07-configure-discovery.yaml $(AP_FLAGS)
 
 deploy-cluster-connected:
 	@$(MAKE) deploy-cluster DISCONNECTED=false

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,6 @@
 WORKING_DIR ?= $(HOME)
 DISCONNECTED ?= true
 PLUGIN ?=
-GLOBAL_VARS ?= config/global.yaml
-CERTS_VARS ?= config/certificates.yaml
-CLOUD_INFRA_VARS ?= config/cloud_infra.yaml
 
 # Ansible
 AP = ansible-playbook
@@ -64,9 +61,6 @@ help:
 	@echo "  WORKING_DIR      - Working directory (default: $$HOME)"
 	@echo "  DISCONNECTED     - Disconnected mode (default: true)"
 	@echo "  PLUGIN           - Plugin name for deploy-plugin target"
-	@echo "  GLOBAL_VARS      - Path to global vars file (default: config/global.yaml)"
-	@echo "  CERTS_VARS       - Path to certificates vars file (default: config/certificates.yaml)"
-	@echo "  CLOUD_INFRA_VARS - Path to cloud infra vars file (default: config/cloud_infra.yaml)"
 	@echo ""
 	@echo "Current values:"
 	@echo "  WORKING_DIR=$(WORKING_DIR)"
@@ -89,7 +83,7 @@ setup-ansible:
 
 # Validation targets
 validate-config:
-	@bash ./validations.sh --global-vars $(GLOBAL_VARS) --certs-vars $(CERTS_VARS)
+	@bash ./validations.sh
 
 validate-schema:
 	@$(AP) playbooks/validation/validate-schema.yaml --tags validate-config
@@ -142,10 +136,10 @@ mirror-plugin:
 
 # Convenience targets
 bootstrap:
-	@bash ./bootstrap.sh --global-vars $(GLOBAL_VARS) --certs-vars $(CERTS_VARS)
+	@bash ./bootstrap.sh
 
 sync:
-	@bash ./sync.sh $(GLOBAL_VARS) $(CERTS_VARS)
+	@bash ./sync.sh
 
 python-format:
 	@uv run ruff format reconcile/

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -197,9 +197,7 @@ step_setup() {
 
 step_validate() {
     echo "Validating Config .. "  | tee -a ${log}
-    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/validation/validate-schema.yaml $EXTRA_VARS \
-        -e@$global_vars -e@$certs_vars -e@$cloud_infra_vars \
-        --tags validate-config
+    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/validation/validate-schema.yaml $EXTRA_VARS --tags validate-config
     bash ./validations.sh --global-vars $global_vars --certs-vars $certs_vars 2>&1 | tee -a ${log}
     step_done
 }
@@ -207,8 +205,8 @@ step_validate() {
 step_download_content() {
     echo "Downloading Deps Content .. " | tee -a ${log}
     # Download control binaries (oc, helm, etc.) first - required by download-content tasks
-    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/01-prepare.yaml -e@$global_vars -e@$certs_vars $EXTRA_VARS --tags download-control-binaries
-    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/01-prepare.yaml -e@$global_vars -e@$certs_vars $EXTRA_VARS --tags download-content
+    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/01-prepare.yaml $EXTRA_VARS --tags download-control-binaries
+    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/01-prepare.yaml $EXTRA_VARS --tags download-content
     step_done
 }
 
@@ -217,47 +215,47 @@ step_build_cache() {
     if [ "$is_disconnected" = false ]; then
         echo "Connected mode - skipping mirror registry setup" | tee -a ${log}
     else
-        ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/02-mirror.yaml -e@$global_vars -e@$certs_vars $EXTRA_VARS --tags mirror-registry
+        ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/02-mirror.yaml $EXTRA_VARS --tags mirror-registry
     fi
-    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/03-deploy.yaml -e@$global_vars -e@$certs_vars $EXTRA_VARS --tags configure-abi
+    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/03-deploy.yaml $EXTRA_VARS --tags configure-abi
     step_done
 }
 
 step_acquire_hardware() {
     echo "Acquiring Hardware .. " | tee -a ${log}
     # setup content for and boot machines
-    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/03-deploy.yaml -e@$global_vars -e@$certs_vars $EXTRA_VARS --tags hardware,pre-install-validate
+    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/03-deploy.yaml $EXTRA_VARS --tags hardware,pre-install-validate
     step_done
 }
 
 step_deploy() {
     echo "Deploying management cluster .. " | tee -a ${log}
     # deploy Red Hat payload cluster
-    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/03-deploy.yaml -e@$global_vars -e@$certs_vars $EXTRA_VARS --tags wait-deployment
+    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/03-deploy.yaml $EXTRA_VARS --tags wait-deployment
     step_done
 }
 
 step_post_install() {
     echo "Post install config.. " | tee -a ${log}
     # Apply SSL certificates
-    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/04-post-install.yaml -e@$global_vars -e@$certs_vars $EXTRA_VARS --tags post-install-config
+    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/04-post-install.yaml $EXTRA_VARS --tags post-install-config
     step_done
 }
 
 step_operators() {
     echo "Deploying management apps  .. " | tee -a ${log}
     # deploy Red Hat payload cluster
-    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/05-operators.yaml -e@$global_vars -e@$certs_vars $EXTRA_VARS --tags operators
+    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/05-operators.yaml $EXTRA_VARS --tags operators
     step_done
 }
 
 step_day2() {
     echo "Clair disconnected .." | tee -a ${log}
-    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/06-day2.yaml -e@$global_vars -e@$certs_vars $EXTRA_VARS --tags clair-disconnected
+    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/06-day2.yaml $EXTRA_VARS --tags clair-disconnected
     step_done
 
     echo "Catalog source ACM policy .." | tee -a ${log}
-    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/06-day2.yaml -e@$global_vars -e@$certs_vars $EXTRA_VARS --tags acm-policy-catalogsources
+    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/06-day2.yaml $EXTRA_VARS --tags acm-policy-catalogsources
     step_done
 }
 
@@ -270,8 +268,8 @@ step_discovery() {
 
     echo "Start discovering nodes.. " | tee -a ${log}
     if [ -f $cloud_infra_vars ]; then
-        if ! ANSIBLE_LOG_PATH=${log} ansible-playbook -e @$global_vars -e @$certs_vars -e @$cloud_infra_vars $EXTRA_VARS playbooks/07-configure-discovery.yaml; then
-            echo -e "\\033[31m WARNING! \033[0m  Discovery hosts has failed, please check config and rerun: ANSIBLE_LOG_PATH=${log} ansible-playbook -e @$global_vars -e @$certs_vars -e @$cloud_infra_vars playbooks/07-configure-discovery.yaml"
+        if ! ANSIBLE_LOG_PATH=${log} ansible-playbook $EXTRA_VARS playbooks/07-configure-discovery.yaml; then
+            echo -e "\\033[31m WARNING! \033[0m  Discovery hosts has failed, please check config and rerun: ANSIBLE_LOG_PATH=${log} ansible-playbook $EXTRA_VARS playbooks/07-configure-discovery.yaml"
         fi
     fi
     step_done

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -6,8 +6,6 @@ usage() {
     echo "Usage: $0 [OPTIONS]"
     echo ""
     echo "Options:"
-    echo "  --global-vars FILE    Path to global vars file (default: config/global.yaml)"
-    echo "  --certs-vars FILE     Path to certificates vars file (default: config/certificates.yaml)"
     echo "  --step STEP           Run a single step instead of all steps"
     echo "  --non-interactive     Skip interactive prompts"
     echo "  -h, --help            Show this help message"
@@ -27,22 +25,17 @@ usage() {
     exit "${1:-0}"
 }
 
+# Config file paths — single source of truth is load-vars.yaml inside playbooks.
+# These are only used for shell-level checks and getValue before Ansible runs.
 global_vars=config/global.yaml
 certs_vars=config/certificates.yaml
 cloud_infra_vars=config/cloud_infra.yaml
+
 run_step=""
 non_interactive=false
 
 while [[ $# -gt 0 ]]; do
     case $1 in
-        --global-vars)
-            global_vars="$2"
-            shift 2
-            ;;
-        --certs-vars)
-            certs_vars="$2"
-            shift 2
-            ;;
         --step)
             run_step="$2"
             shift 2
@@ -89,11 +82,6 @@ echo " "
 echo "This script is designed to be re-run on demand "
 echo "NOTE: Every run will destroy the entire cloud  "
 echo "      Some functions will reuse local caches   "
-echo ""
-echo "Config files:"
-echo "  Global vars:  $global_vars"
-echo "  Certificates: $certs_vars"
-echo "  Cloud infra:  $cloud_infra_vars"
 echo ""
 
 getValue(){
@@ -198,7 +186,7 @@ step_setup() {
 step_validate() {
     echo "Validating Config .. "  | tee -a ${log}
     ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/validation/validate-schema.yaml $EXTRA_VARS --tags validate-config
-    bash ./validations.sh --global-vars $global_vars --certs-vars $certs_vars 2>&1 | tee -a ${log}
+    bash ./validations.sh 2>&1 | tee -a ${log}
     step_done
 }
 

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -796,13 +796,13 @@ Each node in `discovery_hosts` requires:
 
 2. **Run the discovery playbook**:
    ```bash
-   ansible-playbook -e @config/global.yaml -e @config/certificates.yaml -e @config/cloud_infra.yaml playbooks/07-configure-discovery.yaml
+   ansible-playbook playbooks/07-configure-discovery.yaml
    ```
 
    Or if you're on the Landing Zone and Enclave is installed:
    ```bash
    cd /home/cloud-user/enclave
-   ansible-playbook -e @config/global.yaml -e @config/certificates.yaml -e @config/cloud_infra.yaml playbooks/07-configure-discovery.yaml
+   ansible-playbook playbooks/07-configure-discovery.yaml
    ```
 
 ### What the Discovery Process Does

--- a/docs/LOCAL_TESTING.md
+++ b/docs/LOCAL_TESTING.md
@@ -717,7 +717,7 @@ bash -x ./scripts/infrastructure/provision_landing_zone.sh
 # For Ansible (on Landing Zone)
 ssh cloud-user@$LZ_IP
 cd /home/cloud-user/enclave
-ansible-playbook -vvv -e@config/global.yaml -e@config/certificates.yaml -e@config/cloud_infra.yaml playbooks/main.yaml
+ansible-playbook -vvv playbooks/main.yaml
 ```
 
 **Collect logs for troubleshooting:**

--- a/playbooks/01-prepare.yaml
+++ b/playbooks/01-prepare.yaml
@@ -9,13 +9,11 @@
 # - Additional content images
 #
 # Usage:
-#   ansible-playbook playbooks/01-prepare.yaml -e workingDir=/home/cloud-user
+#   ansible-playbook playbooks/01-prepare.yaml
 
 - name: Phase 1 - Prepare environment
   hosts: localhost
   gather_facts: false
-  environment:
-    PATH: "{{ workingDir }}/bin:{{ lookup('env', 'PATH') }}"
   tasks:
     - name: Load common variables
       ansible.builtin.include_tasks:
@@ -24,38 +22,42 @@
           tags: always
       tags: always
 
-    - name: Validate enabled plugin requirements
-      ansible.builtin.include_tasks:
-        file: tasks/validate_enabled_plugins.yaml
-        apply:
+    - name: Execute tasks with workingDir in PATH
+      environment:
+        PATH: "{{ workingDir }}/bin:{{ lookup('env', 'PATH') }}"
+      block:
+        - name: Validate enabled plugin requirements
+          ansible.builtin.include_tasks:
+            file: tasks/validate_enabled_plugins.yaml
+            apply:
+              tags: always
           tags: always
-      tags: always
 
-    - name: Ensure pull secret directory exists
-      ansible.builtin.file:
-        path: "{{ pullSecretPath | dirname }}"
-        state: directory
-        mode: "0700"
-      tags: always
+        - name: Ensure pull secret directory exists
+          ansible.builtin.file:
+            path: "{{ pullSecretPath | dirname }}"
+            state: directory
+            mode: "0700"
+          tags: always
 
-    - name: Write pull secret to file
-      no_log: true
-      ansible.builtin.copy:
-        content: "{{ pullSecret | to_json }}"
-        dest: "{{ pullSecretPath }}"
-        mode: "0600"
-      tags: always
+        - name: Write pull secret to file
+          no_log: true
+          ansible.builtin.copy:
+            content: "{{ pullSecret | to_json }}"
+            dest: "{{ pullSecretPath }}"
+            mode: "0600"
+          tags: always
 
-    - name: Download control binaries
-      ansible.builtin.include_tasks:
-        file: tasks/download_control_binaries.yaml
-        apply:
+        - name: Download control binaries
+          ansible.builtin.include_tasks:
+            file: tasks/download_control_binaries.yaml
+            apply:
+              tags: download-control-binaries
           tags: download-control-binaries
-      tags: download-control-binaries
 
-    - name: Download content
-      ansible.builtin.include_tasks:
-        file: tasks/download_content.yaml
-        apply:
+        - name: Download content
+          ansible.builtin.include_tasks:
+            file: tasks/download_content.yaml
+            apply:
+              tags: download-content
           tags: download-content
-      tags: download-content

--- a/playbooks/02-mirror.yaml
+++ b/playbooks/02-mirror.yaml
@@ -28,18 +28,21 @@
           tags: always
       tags: always
 
+    - name: Include tasks for mirror-cache
+      ansible.builtin.include_tasks:
+        file: tasks/mirror_cache.yaml
+        apply:
+          tags: mirror-cache
+          environment:
+            PATH: "{{ workingDir }}/bin:{{ lookup('env', 'PATH') }}"
+      tags:
+        - mirror-cache
+        - never
+
     - name: Execute tasks with workingDir in PATH
       environment:
         PATH: "{{ workingDir }}/bin:{{ lookup('env', 'PATH') }}"
       block:
-        - name: Include tasks for mirror-cache
-          ansible.builtin.include_tasks:
-            file: tasks/mirror_cache.yaml
-            apply:
-              tags: mirror-cache
-          tags:
-            - mirror-cache
-            - never
 
         - name: Verify disconnected mode
           ansible.builtin.assert:

--- a/playbooks/02-mirror.yaml
+++ b/playbooks/02-mirror.yaml
@@ -12,16 +12,14 @@
 # IMPORTANT: This phase requires significant disk space (~150GB+) and time (~30+ minutes)
 #
 # Usage:
-#   ansible-playbook playbooks/02-mirror.yaml -e workingDir=/home/cloud-user
+#   ansible-playbook playbooks/02-mirror.yaml
 #
 #   # Mirror images to datacenter cache
-#   ansible-playbook playbooks/02-mirror.yaml -e workingDir=/home/cloud-user --tags mirror-cache
+#   ansible-playbook playbooks/02-mirror.yaml --tags mirror-cache
 
 - name: Phase 2 - Mirror registry setup
   hosts: localhost
   gather_facts: false
-  environment:
-    PATH: "{{ workingDir }}/bin:{{ lookup('env', 'PATH') }}"
   tasks:
     - name: Load common variables
       ansible.builtin.include_tasks:
@@ -30,42 +28,46 @@
           tags: always
       tags: always
 
-    - name: Include tasks for mirror-cache
-      ansible.builtin.include_tasks:
-        file: tasks/mirror_cache.yaml
-        apply:
-          tags: mirror-cache
-      tags:
-        - mirror-cache
-        - never
+    - name: Execute tasks with workingDir in PATH
+      environment:
+        PATH: "{{ workingDir }}/bin:{{ lookup('env', 'PATH') }}"
+      block:
+        - name: Include tasks for mirror-cache
+          ansible.builtin.include_tasks:
+            file: tasks/mirror_cache.yaml
+            apply:
+              tags: mirror-cache
+          tags:
+            - mirror-cache
+            - never
 
-    - name: Verify disconnected mode
-      ansible.builtin.assert:
-        that:
-          - disconnected | default(true) | bool
-        fail_msg: "Phase 2 (Mirror) should only run in disconnected mode. Set disconnected=true in config/global.yaml"
-        success_msg: "Running in disconnected mode - proceeding with mirroring"
-      tags: mirror-registry
+        - name: Verify disconnected mode
+          ansible.builtin.assert:
+            that:
+              - disconnected | default(true) | bool
+            fail_msg: "Phase 2 (Mirror) should only run in disconnected mode. Set disconnected=true in config/global.yaml"
+            success_msg: "Running in disconnected mode - proceeding with mirroring"
+          tags: mirror-registry
 
-    - name: Collect plugin operators for imageset
-      ansible.builtin.include_tasks:
-        file: tasks/collect_core_plugin_operators.yaml
-        apply:
+        - name: Collect plugin operators for imageset
+          ansible.builtin.include_tasks:
+            file: tasks/collect_core_plugin_operators.yaml
+            apply:
+              tags:
+                - mirror-registry
+                - mirror-plugins
           tags:
             - mirror-registry
             - mirror-plugins
-      tags:
-        - mirror-registry
-        - mirror-plugins
 
-    - name: Combine core operators with core plugin operators
-      set_fact:
-        catalog_operators: "{{ {'core': {'operators': operators, 'catalog': 'redhat'}} | combine(_core_plugin_operators | default({})) }}"
-      tags: mirror-registry
-
-    - name: Include tasks for mirror-registry
-      ansible.builtin.include_tasks:
-        file: tasks/mirror_registry.yaml
-        apply:
+        - name: Combine core operators with core plugin operators
+          set_fact:
+            catalog_operators: "{{ {'core': {'operators': operators, 'catalog': 'redhat'}} | combine(_core_plugin_operators | default({})) }}"
           tags: mirror-registry
-      tags: mirror-registry
+
+        - name: Include tasks for mirror-registry
+          ansible.builtin.include_tasks:
+            file: tasks/mirror_registry.yaml
+            apply:
+              tags: mirror-registry
+          tags: mirror-registry

--- a/playbooks/03-deploy.yaml
+++ b/playbooks/03-deploy.yaml
@@ -15,13 +15,11 @@
 # - Clean up Ironic
 #
 # Usage:
-#   ansible-playbook playbooks/03-deploy.yaml -e workingDir=/home/cloud-user [-e disconnected=false]
+#   ansible-playbook playbooks/03-deploy.yaml [-e disconnected=false]
 
 - name: Phase 3 - Deploy OpenShift cluster
   hosts: localhost
   gather_facts: false
-  environment:
-    PATH: "{{ workingDir }}/bin:{{ lookup('env', 'PATH') }}"
   tasks:
     - name: Load common variables
       ansible.builtin.include_tasks:
@@ -30,55 +28,59 @@
           tags: always
       tags: always
 
-    - name: Display deployment mode
-      ansible.builtin.debug:
-        msg: "Deploying in {{ 'disconnected' if (disconnected | default(true)) else 'connected' }} mode"
-      tags: always
+    - name: Execute tasks with workingDir in PATH
+      environment:
+        PATH: "{{ workingDir }}/bin:{{ lookup('env', 'PATH') }}"
+      block:
+        - name: Display deployment mode
+          ansible.builtin.debug:
+            msg: "Deploying in {{ 'disconnected' if (disconnected | default(true)) else 'connected' }} mode"
+          tags: always
 
-    - name: Include tasks for OCP ABI
-      ansible.builtin.include_tasks:
-        file: tasks/configure_ocp_abi.yaml
-        apply:
+        - name: Include tasks for OCP ABI
+          ansible.builtin.include_tasks:
+            file: tasks/configure_ocp_abi.yaml
+            apply:
+              tags: configure-abi
           tags: configure-abi
-      tags: configure-abi
 
-    - name: Setup Ironic for hardware configuration
-      ansible.builtin.include_tasks:
-        file: tasks/configure_hardware_ironic_setup.yaml
-        apply:
+        - name: Setup Ironic for hardware configuration
+          ansible.builtin.include_tasks:
+            file: tasks/configure_hardware_ironic_setup.yaml
+            apply:
+              tags: hardware
           tags: hardware
-      tags: hardware
 
-    - name: Configure and boot hosts via Ironic
-      loop: "{{ agent_hosts }}"
-      loop_control:
-        loop_var: agent_host
-      ansible.builtin.include_tasks:
-        file: tasks/configure_hardware_ironic_boot.yaml
-        apply:
+        - name: Configure and boot hosts via Ironic
+          loop: "{{ agent_hosts }}"
+          loop_control:
+            loop_var: agent_host
+          ansible.builtin.include_tasks:
+            file: tasks/configure_hardware_ironic_boot.yaml
+            apply:
+              tags: hardware
           tags: hardware
-      tags: hardware
 
-    - name: Wait for all hosts to reach active state
-      loop: "{{ agent_hosts }}"
-      loop_control:
-        loop_var: agent_host
-      ansible.builtin.include_tasks:
-        file: tasks/configure_hardware_ironic_wait.yaml
-        apply:
+        - name: Wait for all hosts to reach active state
+          loop: "{{ agent_hosts }}"
+          loop_control:
+            loop_var: agent_host
+          ansible.builtin.include_tasks:
+            file: tasks/configure_hardware_ironic_wait.yaml
+            apply:
+              tags: hardware
           tags: hardware
-      tags: hardware
 
-    - name: Pre-install validate plugins
-      ansible.builtin.include_tasks:
-        file: tasks/pre_install_validate_plugins.yaml
-        apply:
+        - name: Pre-install validate plugins
+          ansible.builtin.include_tasks:
+            file: tasks/pre_install_validate_plugins.yaml
+            apply:
+              tags: pre-install-validate
           tags: pre-install-validate
-      tags: pre-install-validate
 
-    - name: Wait for deployment
-      ansible.builtin.include_tasks:
-        file: tasks/wait_for_deployment.yaml
-        apply:
+        - name: Wait for deployment
+          ansible.builtin.include_tasks:
+            file: tasks/wait_for_deployment.yaml
+            apply:
+              tags: wait-deployment
           tags: wait-deployment
-      tags: wait-deployment

--- a/playbooks/04-post-install.yaml
+++ b/playbooks/04-post-install.yaml
@@ -8,13 +8,11 @@
 # - API server health checks
 #
 # Usage:
-#   ansible-playbook playbooks/04-post-install.yaml -e workingDir=/home/cloud-user
+#   ansible-playbook playbooks/04-post-install.yaml
 
 - name: Phase 4 - Post-installation configuration
   hosts: localhost
   gather_facts: false
-  environment:
-    PATH: "{{ workingDir }}/bin:{{ lookup('env', 'PATH') }}"
   tasks:
     - name: Load common variables
       ansible.builtin.include_tasks:
@@ -23,14 +21,18 @@
           tags: always
       tags: always
 
-    - name: Display post-install mode
-      ansible.builtin.debug:
-        msg: "Running post-install configuration in {{ 'disconnected' if (disconnected | default(true)) else 'connected' }} mode"
-      tags: always
+    - name: Execute tasks with workingDir in PATH
+      environment:
+        PATH: "{{ workingDir }}/bin:{{ lookup('env', 'PATH') }}"
+      block:
+        - name: Display post-install mode
+          ansible.builtin.debug:
+            msg: "Running post-install configuration in {{ 'disconnected' if (disconnected | default(true)) else 'connected' }} mode"
+          tags: always
 
-    - name: Post-install configurations
-      ansible.builtin.include_tasks:
-        file: tasks/post_install_config.yaml
-        apply:
+        - name: Post-install configurations
+          ansible.builtin.include_tasks:
+            file: tasks/post_install_config.yaml
+            apply:
+              tags: post-install-config
           tags: post-install-config
-      tags: post-install-config

--- a/playbooks/05-operators.yaml
+++ b/playbooks/05-operators.yaml
@@ -13,13 +13,11 @@
 #   operators and Quay mirroring are complete.
 #
 # Usage:
-#   ansible-playbook playbooks/05-operators.yaml -e workingDir=/home/cloud-user [-e disconnected=false]
+#   ansible-playbook playbooks/05-operators.yaml [-e disconnected=false]
 
 - name: Phase 5 - Operator installation
   hosts: localhost
   gather_facts: false
-  environment:
-    PATH: "{{ workingDir }}/bin:{{ lookup('env', 'PATH') }}"
   tasks:
     - name: Load common variables
       ansible.builtin.include_tasks:
@@ -28,72 +26,76 @@
           tags: always
       tags: always
 
-    - name: Display operator installation mode
-      ansible.builtin.debug:
-        msg: "Installing operators in {{ 'disconnected' if (disconnected | default(true)) else 'connected' }} mode"
-      tags: always
-
-    - name: Disable default operator catalog sources
-      when: disconnected | default(true) | bool
-      ansible.builtin.command: |
-        {{ workingDir }}/bin/oc patch OperatorHub cluster --type=merge -p='{"spec":{"disableAllDefaultSources":true}}'
+    - name: Execute tasks with workingDir in PATH
       environment:
-        KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
-      register: r_patch_operatorhub
-      changed_when: "'(no change)' not in r_patch_operatorhub.stdout"
-      tags:
-        - foundation-plugins
-        - operators
+        PATH: "{{ workingDir }}/bin:{{ lookup('env', 'PATH') }}"
+      block:
+        - name: Display operator installation mode
+          ansible.builtin.debug:
+            msg: "Installing operators in {{ 'disconnected' if (disconnected | default(true)) else 'connected' }} mode"
+          tags: always
 
-    - name: Configure seed operators
-      ansible.builtin.include_tasks:
-        file: tasks/configure_operators.yaml
-        apply:
-          tags: operators
-      vars:
-        target_operators: "{{ operators | selectattr('seed', 'true') | list }}"
-      tags: operators
-
-    - name: Auto-discover and deploy foundation plugins
-      ansible.builtin.include_tasks:
-        file: tasks/deploy_plugins.yaml
-        apply:
+        - name: Disable default operator catalog sources
+          when: disconnected | default(true) | bool
+          ansible.builtin.command: |
+            {{ workingDir }}/bin/oc patch OperatorHub cluster --type=merge -p='{"spec":{"disableAllDefaultSources":true}}'
+          environment:
+            KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+          register: r_patch_operatorhub
+          changed_when: "'(no change)' not in r_patch_operatorhub.stdout"
           tags:
             - foundation-plugins
             - operators
-      vars:
-        plugin_type: foundation
-      tags:
-        - foundation-plugins
-        - operators
 
-    - name: Configure remaining operators
-      ansible.builtin.include_tasks:
-        file: tasks/configure_operators.yaml
-        apply:
+        - name: Configure seed operators
+          ansible.builtin.include_tasks:
+            file: tasks/configure_operators.yaml
+            apply:
+              tags: operators
+          vars:
+            target_operators: "{{ operators | selectattr('seed', 'true') | list }}"
           tags: operators
-      vars:
-        target_operators: "{{ operators | rejectattr('seed', 'sameas', true) | list }}"
-      tags: operators
 
-    - name: Finish quay mirroring task while disconnected
-      when: disconnected | default(true) | bool
-      ansible.builtin.include_tasks:
-        file: ../operators/quay-operator/quay_disconnected_finish.yaml
-        apply:
+        - name: Auto-discover and deploy foundation plugins
+          ansible.builtin.include_tasks:
+            file: tasks/deploy_plugins.yaml
+            apply:
+              tags:
+                - foundation-plugins
+                - operators
+          vars:
+            plugin_type: foundation
+          tags:
+            - foundation-plugins
+            - operators
+
+        - name: Configure remaining operators
+          ansible.builtin.include_tasks:
+            file: tasks/configure_operators.yaml
+            apply:
+              tags: operators
+          vars:
+            target_operators: "{{ operators | rejectattr('seed', 'sameas', true) | list }}"
           tags: operators
-      tags: operators
 
-    - name: Auto-discover and deploy addon plugins
-      ansible.builtin.include_tasks:
-        file: tasks/deploy_plugins.yaml
-        apply:
+        - name: Finish quay mirroring task while disconnected
+          when: disconnected | default(true) | bool
+          ansible.builtin.include_tasks:
+            file: ../operators/quay-operator/quay_disconnected_finish.yaml
+            apply:
+              tags: operators
+          tags: operators
+
+        - name: Auto-discover and deploy addon plugins
+          ansible.builtin.include_tasks:
+            file: tasks/deploy_plugins.yaml
+            apply:
+              tags:
+                - addon-plugins
+                - operators
+          vars:
+            plugin_type: addon
+            plugin_mirror: true
           tags:
             - addon-plugins
             - operators
-      vars:
-        plugin_type: addon
-        plugin_mirror: true
-      tags:
-        - addon-plugins
-        - operators

--- a/playbooks/06-day2.yaml
+++ b/playbooks/06-day2.yaml
@@ -7,15 +7,13 @@
 # - ACM policies for mirrored catalogsources (disconnected only)
 #
 # Usage:
-#   ansible-playbook playbooks/06-day2.yaml -e workingDir=/home/cloud-user [-e disconnected=false]
-#   ansible-playbook playbooks/06-day2.yaml -e workingDir=/home/cloud-user --tags clair-disconnected
-#   ansible-playbook playbooks/06-day2.yaml -e workingDir=/home/cloud-user --tags acm-policy-catalogsources
+#   ansible-playbook playbooks/06-day2.yaml [-e disconnected=false]
+#   ansible-playbook playbooks/06-day2.yaml --tags clair-disconnected
+#   ansible-playbook playbooks/06-day2.yaml --tags acm-policy-catalogsources
 
 - name: Phase 6 - Day-2 operations
   hosts: localhost
   gather_facts: false
-  environment:
-    PATH: "{{ workingDir }}/bin:{{ lookup('env', 'PATH') }}"
   tasks:
     - name: Load common variables
       ansible.builtin.include_tasks:
@@ -24,81 +22,85 @@
           tags: always
       tags: always
 
-    - name: Display day-2 mode
-      ansible.builtin.debug:
-        msg: "Running day-2 operations in {{ 'disconnected' if (disconnected | default(true)) else 'connected' }} mode"
-      tags: always
+    - name: Execute tasks with workingDir in PATH
+      environment:
+        PATH: "{{ workingDir }}/bin:{{ lookup('env', 'PATH') }}"
+      block:
+        - name: Display day-2 mode
+          ansible.builtin.debug:
+            msg: "Running day-2 operations in {{ 'disconnected' if (disconnected | default(true)) else 'connected' }} mode"
+          tags: always
 
-    - name: Configure Quay in disconnected environments
-      when: disconnected | default(true)
-      ansible.builtin.include_tasks:
-        file: ../operators/quay-operator/quay_disconnected_start.yaml
-        apply:
+        - name: Configure Quay in disconnected environments
+          when: disconnected | default(true)
+          ansible.builtin.include_tasks:
+            file: ../operators/quay-operator/quay_disconnected_start.yaml
+            apply:
+              tags: quay-disconnected
+              environment:
+                KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
           tags: quay-disconnected
-          environment:
-            KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
-      tags: quay-disconnected
 
-    - name: Configure ACM ClusterImageSets
-      ansible.builtin.include_tasks:
-        file: ../operators/advanced-cluster-management/acm_cis.yaml
-        apply:
+        - name: Configure ACM ClusterImageSets
+          ansible.builtin.include_tasks:
+            file: ../operators/advanced-cluster-management/acm_cis.yaml
+            apply:
+              tags: acm-cis
+              environment:
+                KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
           tags: acm-cis
-          environment:
-            KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
-      tags: acm-cis
 
-    - name: Configure OpenShift Pipelines
-      ansible.builtin.include_tasks:
-        file: ../operators/openshift-pipelines-operator-rh/tasks.yaml
-        apply:
+        - name: Configure OpenShift Pipelines
+          ansible.builtin.include_tasks:
+            file: ../operators/openshift-pipelines-operator-rh/tasks.yaml
+            apply:
+              tags: openshift-pipelines
+              environment:
+                KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
           tags: openshift-pipelines
-          environment:
-            KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
-      tags: openshift-pipelines
 
-    - name: Configure Clair in disconnected environments
-      when: disconnected | default(true)
-      ansible.builtin.include_tasks:
-        file: ../operators/quay-operator/clair_disconnected.yaml
-        apply:
+        - name: Configure Clair in disconnected environments
+          when: disconnected | default(true)
+          ansible.builtin.include_tasks:
+            file: ../operators/quay-operator/clair_disconnected.yaml
+            apply:
+              tags: clair-disconnected
+              environment:
+                KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
           tags: clair-disconnected
-          environment:
-            KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
-      tags: clair-disconnected
 
-    - name: Mirrored catalogsource configuration ACM policy
-      when: disconnected | default(true)
-      vars:
-        short_version_dot: "{{ openshift_version.version.split('.')[:2] | join('.') }}"
-        short_version_dash: "{{ openshift_version.version.split('.')[:2] | join('-') }}"
-      ansible.builtin.include_tasks:
-        file: tasks/catalogsource.yaml
-        apply:
+        - name: Mirrored catalogsource configuration ACM policy
+          when: disconnected | default(true)
+          vars:
+            short_version_dot: "{{ openshift_version.version.split('.')[:2] | join('.') }}"
+            short_version_dash: "{{ openshift_version.version.split('.')[:2] | join('-') }}"
+          ansible.builtin.include_tasks:
+            file: tasks/catalogsource.yaml
+            apply:
+              tags: acm-policy-catalogsources
+              environment:
+                KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+          loop: "{{ openshift_versions }}"
+          loop_control:
+            loop_var: openshift_version
           tags: acm-policy-catalogsources
-          environment:
-            KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
-      loop: "{{ openshift_versions }}"
-      loop_control:
-        loop_var: openshift_version
-      tags: acm-policy-catalogsources
 
-    - name: Finish Quay configuration in disconnected environments
-      when: disconnected | default(true)
-      ansible.builtin.include_tasks:
-        file: ../operators/quay-operator/quay_disconnected_finish.yaml
-        apply:
+        - name: Finish Quay configuration in disconnected environments
+          when: disconnected | default(true)
+          ansible.builtin.include_tasks:
+            file: ../operators/quay-operator/quay_disconnected_finish.yaml
+            apply:
+              tags: quay-disconnected
+              environment:
+                KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
           tags: quay-disconnected
-          environment:
-            KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
-      tags: quay-disconnected
 
-    - name: Management cluster upgrade
-      ansible.builtin.include_tasks:
-        file: tasks/mgmt_cluster_upgrade.yaml
-        apply:
-          tags: mgmt-cluster-upgrade
-          environment:
-            KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
-      tags:
-        - mgmt-cluster-upgrade
+        - name: Management cluster upgrade
+          ansible.builtin.include_tasks:
+            file: tasks/mgmt_cluster_upgrade.yaml
+            apply:
+              tags: mgmt-cluster-upgrade
+              environment:
+                KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+          tags:
+            - mgmt-cluster-upgrade

--- a/playbooks/validation/validate-mirror.yaml
+++ b/playbooks/validation/validate-mirror.yaml
@@ -10,13 +10,11 @@
 # - Rendered imagesetconfiguration.yaml
 #
 # Usage (on Landing Zone after Phase 2):
-#   ansible-playbook playbooks/validation/validate-mirror.yaml -e @phase_vars.yaml
+#   ansible-playbook playbooks/validation/validate-mirror.yaml
 
 - name: Validate Mirror Artifacts
   hosts: localhost
   gather_facts: false
-  environment:
-    PATH: "{{ workingDir }}/bin:{{ lookup('env', 'PATH') }}"
   tasks:
     - name: Load common variables
       ansible.builtin.include_tasks:
@@ -25,9 +23,13 @@
           tags: always
       tags: always
 
-    - name: Include mirror validation tasks
-      ansible.builtin.include_tasks:
-        file: ../tasks/mirror_validation.yaml
-        apply:
+    - name: Execute tasks with workingDir in PATH
+      environment:
+        PATH: "{{ workingDir }}/bin:{{ lookup('env', 'PATH') }}"
+      block:
+        - name: Include mirror validation tasks
+          ansible.builtin.include_tasks:
+            file: ../tasks/mirror_validation.yaml
+            apply:
+              tags: mirror-validation
           tags: mirror-validation
-      tags: mirror-validation

--- a/scripts/verification/verify_enclave_installation.sh
+++ b/scripts/verification/verify_enclave_installation.sh
@@ -336,7 +336,7 @@ echo ""
 info "To run Enclave Lab:"
 info "  ssh $LZ_SSH"
 info "  cd $LZ_ENCLAVE_DIR"
-info "  ansible-playbook -e@config/global.yaml -e@config/certificates.yaml -e@config/cloud_infra.yaml playbooks/main.yaml"
+info "  ansible-playbook playbooks/main.yaml"
 echo ""
 
 # Exit with failure if any tests failed

--- a/sync.sh
+++ b/sync.sh
@@ -69,26 +69,26 @@ done
 step_done
 
 echo "Validating Config .. " | tee -a ${log}
-    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/validation/validate-schema.yaml -e fresh=false -e@$global_vars -e@$certs_vars --tags validate-config
+    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/validation/validate-schema.yaml -e fresh=false --tags validate-config
     bash ./validations.sh --global-vars $global_vars --certs-vars $certs_vars 2>&1 | tee -a ${log}
 step_done
 
 echo "Building local cache .. " | tee -a ${log}
-    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/02-mirror.yaml -e fresh=false -e@$global_vars -e@$certs_vars --tags mirror-registry
+    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/02-mirror.yaml -e fresh=false --tags mirror-registry
 step_done
 
 echo "Quay disconnected .." | tee -a ${log}
-    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/06-day2.yaml -e fresh=false -e@$global_vars -e@$certs_vars --tags quay-disconnected
+    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/06-day2.yaml -e fresh=false --tags quay-disconnected
 step_done
 
 echo "Clair disconnected .." | tee -a ${log}
-    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/06-day2.yaml -e fresh=false -e@$global_vars -e@$certs_vars --tags clair-disconnected
+    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/06-day2.yaml -e fresh=false --tags clair-disconnected
 step_done
 
 echo "ACM ClusterImageSets .." | tee -a ${log}
-    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/06-day2.yaml -e fresh=false -e@$global_vars -e@$certs_vars --tags acm-cis
+    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/06-day2.yaml -e fresh=false --tags acm-cis
 step_done
 
 echo "OpenShift Pipelines .." | tee -a ${log}
-    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/06-day2.yaml -e fresh=false -e@$global_vars -e@$certs_vars --tags openshift-pipelines
+    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/06-day2.yaml -e fresh=false --tags openshift-pipelines
 step_done

--- a/sync.sh
+++ b/sync.sh
@@ -2,6 +2,11 @@
 set -o pipefail
 set -e
 
+# Config file paths — single source of truth is load-vars.yaml inside playbooks.
+# These are only used for shell-level checks and getValue before Ansible runs.
+global_vars=config/global.yaml
+certs_vars=config/certificates.yaml
+
 getValue(){
     python -c 'import sys, yaml, json; print(json.dumps(yaml.safe_load(sys.stdin)))' < $global_vars \
         | jq -r $1
@@ -12,8 +17,6 @@ step_done(){
     date | tee -a ${log}
 }
 
-global_vars=${1:-config/global.yaml}
-certs_vars=${2:-config/certificates.yaml}
 workingDir=$(getValue .workingDir)
 lck=~/.lck-rh-lz
 DSTAMP=$(date +%Y%m%d_%H%M%S)
@@ -70,7 +73,7 @@ step_done
 
 echo "Validating Config .. " | tee -a ${log}
     ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/validation/validate-schema.yaml -e fresh=false --tags validate-config
-    bash ./validations.sh --global-vars $global_vars --certs-vars $certs_vars 2>&1 | tee -a ${log}
+    bash ./validations.sh 2>&1 | tee -a ${log}
 step_done
 
 echo "Building local cache .. " | tee -a ${log}

--- a/validations.sh
+++ b/validations.sh
@@ -1,38 +1,9 @@
 #!/bin/bash
 
-usage() {
-    echo "Usage: $0 [OPTIONS]"
-    echo ""
-    echo "Options:"
-    echo "  --global-vars FILE    Path to global vars file (default: config/global.yaml)"
-    echo "  --certs-vars FILE     Path to certificates vars file (default: config/certificates.yaml)"
-    echo "  -h, --help            Show this help message"
-    exit "${1:-0}"
-}
-
+# Config file paths — single source of truth matching load-vars.yaml
 global_vars=config/global.yaml
 certs_vars=config/certificates.yaml
 cloud_infra_vars=config/cloud_infra.yaml
-
-while [[ $# -gt 0 ]]; do
-    case $1 in
-        --global-vars)
-            global_vars="$2"
-            shift 2
-            ;;
-        --certs-vars)
-            certs_vars="$2"
-            shift 2
-            ;;
-        -h|--help)
-            usage
-            ;;
-        *)
-            echo "Error: Unknown option '$1'"
-            usage 1
-            ;;
-    esac
-done
 
 getValue(){
     python -c 'import sys, yaml, json; print(json.dumps(yaml.safe_load(sys.stdin)))' < $vars_rendered \


### PR DESCRIPTION
## Summary
- Remove `-e@$global_vars -e@$certs_vars` (and `-e @$cloud_infra_vars`) from all `ansible-playbook` calls in `bootstrap.sh`, `sync.sh`, and `Makefile`
- All playbooks already load these config files internally via `include_vars` in `load-vars.yaml` — the `-e@` flags were redundant and harmful
- Update docs and verification scripts to stop showing the stale pattern
- Fix incorrect playbook path in Makefile `validate-schema` target (`playbooks/validate-schema.yaml` → `playbooks/validation/validate-schema.yaml`)

## Root Cause
Ansible extra vars (`-e@`) have the highest precedence and are immutable. The `set_fact` in `load-vars.yaml` that unions `storage_plugin` into `enabled_plugins` was silently ignored because `enabled_plugins` was locked by the extra vars. Removing the `-e@` flags lets `include_vars` load the config (lower precedence), allowing `set_fact` to modify `enabled_plugins` as intended.

## Files Changed
- `bootstrap.sh` — 12 ansible-playbook calls
- `sync.sh` — 6 ansible-playbook calls
- `Makefile` — `validate-schema` and `deploy-cluster-discovery` targets
- `docs/LOCAL_TESTING.md` — example command
- `docs/DEPLOYMENT_GUIDE.md` — two example commands
- `scripts/verification/validate.sh` — `validate_json_schema()` call
- `scripts/verification/verify_enclave_installation.sh` — printed instruction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed CLI options for supplying config files; config paths are now fixed and managed internally.
  * Tooling now invokes validation/bootstrap/sync/discovery without extra config-file arguments and logs remain preserved.
  * PATH overrides are no longer applied globally; they are scoped to specific task blocks to reduce side effects.

* **Documentation**
  * Updated guides and examples to show simplified commands without explicit config extra-vars.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->