### PR TITLE
introduce default openshift version

### DIFF
--- a/defaults/platforms.yaml
+++ b/defaults/platforms.yaml
@@ -1,6 +1,5 @@
 ---
-mgmt_openshift_version: 4.20.21
-
 openshift_versions:
 - version: 4.20.8
 - version: 4.20.21
+  default: true

--- a/playbooks/common/load-vars.yaml
+++ b/playbooks/common/load-vars.yaml
@@ -30,6 +30,10 @@
   ansible.builtin.set_fact:
     enabled_plugins: "{{ enabled_plugins | union([storage_plugin]) }}"
 
+- name: Set Management cluster OpenShift version from default
+  ansible.builtin.set_fact:
+    mgmt_openshift_version: "{{ (openshift_versions | selectattr('default', 'defined') | selectattr('default', 'equalto', true) | first).version }}"
+
 - name: Override OpenShift versions on fresh install
   ansible.builtin.set_fact:
     openshift_versions: "{{ [{'version': mgmt_openshift_version}] }}"

--- a/playbooks/validation/tasks/defaults_schema_validation.yaml
+++ b/playbooks/validation/tasks/defaults_schema_validation.yaml
@@ -76,8 +76,8 @@
 - name: Include deployment vars
   ansible.builtin.include_vars: ../../defaults/platforms.yaml
 
-- name: Validate mgmt_openshift_version is in the versions list
+- name: Validate a single default version is in the versions list
   ansible.builtin.assert:
     that:
-      - mgmt_openshift_version in (openshift_versions | map(attribute='version') | list)
-    fail_msg: "mgmt_openshift_version {{ mgmt_openshift_version }} is not in the openshift_versions list!"
+      - openshift_versions | selectattr('default', 'defined') | selectattr('default', 'equalto', true) | list | length == 1
+    fail_msg: "a single default version is required in the openshift_versions list!"

--- a/schemas/platforms.yaml
+++ b/schemas/platforms.yaml
@@ -5,9 +5,6 @@ type: object
 
 additionalProperties: false
 properties:
-  mgmt_openshift_version:
-    type: string
-    description: Management cluster OpenShift version
   openshift_versions:
     type: array
     minItems: 1
@@ -18,8 +15,10 @@ properties:
         version:
           type: string
           description: OpenShift version to be available
+        default:
+          type: boolean
+          description: Default OpenShift version
       required:
       - version
 required:
-- mgmt_openshift_version
 - openshift_versions


### PR DESCRIPTION
a minor change to reduce required variables. leads to a different experience in managing multiple openshift versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Default OpenShift version is now designated within the versions list instead of a separate top‑level setting.
* **Bug Fix**
  * Validation now enforces exactly one version marked as the default and updates the error message accordingly.
* **Schema**
  * Top‑level default field removed; per‑version entries support an optional default flag.
* **Chore**
  * Runtime logic updated to read the designated default from the versions list.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/enclave/pull/379?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->