### PR TITLE
OSAC-669: Apply PinnedImageSet to handle LZ registry failover

### DIFF
--- a/config/global.example.yaml
+++ b/config/global.example.yaml
@@ -120,6 +120,10 @@ storage_plugin: lvms
 # Log level for oc-mirror (default: info, options: trace, debug, info, error)
 # ocMirrorLogLevel: debug
 
+# Apply master PinnedImageSet after Quay mirror (default: true). Set false to skip
+# post-mirror prefetch pinning (e.g. faster iteration or when MCO pin step is unwanted).
+# quayPinnedImageSetEnabled: false
+
 # Additional NTP sources for cluster nodes (no additional servers by default)
 # defaultNtpServers:
 #  - YOUR_NTP_SERVER_1

--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -322,6 +322,23 @@ defaultNtpServers:
 - Only needed when cluster nodes cannot reach the default public NTP pool
 - Useful in air-gapped or firewalled environments
 
+#### `quayPinnedImageSetEnabled`
+
+**Description**: Controls whether the post-mirror master `PinnedImageSet` is generated and applied after Quay image mirroring.
+
+**Type**: Boolean (optional)
+
+**Default**: `true`
+
+**Example**:
+```yaml
+quayPinnedImageSetEnabled: false
+```
+
+**Notes**:
+- Set to `false` when you want to skip post-mirror prefetch pinning.
+- This setting is ignored when `mirror_dry_run` is enabled.
+
 ### Hardware Configuration
 
 #### `agent_hosts`
@@ -1349,6 +1366,7 @@ lzBmcIP: 100.64.1.10
 # masterMaxPods: 250 # Default: 500
 # diskEncryption: true  # Default: false (set to true to enable TPM v2 encryption)
 # ocMirrorLogLevel: debug  # Default: info
+# quayPinnedImageSetEnabled: false  # Default: true (set false to skip post-mirror pinning)
 # defaultNtpServers:  # No additional servers by default
 #  - YOUR_NTP_SERVER_1
 #  - YOUR_NTP_SERVER_2

--- a/operators/quay-operator/quay_disconnected_finish.yaml
+++ b/operators/quay-operator/quay_disconnected_finish.yaml
@@ -1,6 +1,7 @@
 ---
-# Quay disconnected tasks: imageset for oc-mirror and mirror run.
-# This file is included only when disconnected | default(true).
+# Quay disconnected finish: wait for oc-mirror, apply IDMS/ITMS and registry CA trust,
+# then optionally generate/apply master PinnedImageSet (post-mirror so prefetch trusts Quay).
+# PinnedImageSet is skipped when mirror_dry_run or quayPinnedImageSetEnabled is false.
 
 - name: Wait for async oc-mirror to quay
   ansible.builtin.include_tasks: "../../playbooks/tasks/background_task_wait.yaml"
@@ -12,14 +13,17 @@
     path: "{{ lookup('env','HOME') }}/.config/containers/registries.conf"
     state: absent
 
-- name: Apply release signature ConfigMap
-  ansible.builtin.command:
-    cmd: |
-      {{ workingDir }}/bin/oc apply -f {{ workingDir }}/config/oc-mirror-workspace-quay/working-dir/cluster-resources/signature-configmap.yaml
-  environment:
-    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
-
 # Apply oc-mirror-generated IDMS/ITMS to the cluster (fallback to internal Quay when LZ fails)
 # and add the Quay registry CA to image.config so nodes trust the registry for image pulls.
 - name: Apply Quay mirrors and trust registry CA for image pulls
   ansible.builtin.include_tasks: quay_disconnected_mirrors.yaml
+
+- name: Generate and apply master PinnedImageSet from images on master nodes
+  ansible.builtin.include_tasks: quay_pinnedimageset.yaml
+  when: >-
+    (
+      quayPinnedImageSetEnabled
+      | default(quay_pinnedimageset_enabled | default(true))
+      | bool
+    )
+    and not (mirror_dry_run | default(false) | bool)

--- a/operators/quay-operator/quay_pinnedimageset.yaml
+++ b/operators/quay-operator/quay_pinnedimageset.yaml
@@ -1,0 +1,42 @@
+---
+# quay_pinnedimageset.yaml — disconnected Quay finish: master PinnedImageSet from on-node images.
+#
+# Flow:
+#   - Load vars (so this file can run when the operator play omits it).
+#   - Collect digest pull specs (crictl repoDigests) from all master nodes via oc debug.
+#   - Render/apply PinnedImageSet for masters (images already on disk, hence MCO pin step should be fast).
+#   - Note: single manifest images are excluded (as MCO prefetch uses podman manifest inspect, which exits with error 125).
+
+- name: Load deployment and global configuration
+  ansible.builtin.include_tasks:
+    file: ../../playbooks/common/load-vars.yaml
+
+- name: Collect digest image refs present on master nodes
+  ansible.builtin.include_tasks:
+    file: ../../playbooks/tasks/collect_master_node_image_digests.yaml
+
+- name: Show master PinnedImageSet image count
+  ansible.builtin.debug:
+    msg: >-
+      PinnedImageSet will pin {{ pinned_images | default([]) | length }} digest refs
+      collected from {{ r_pinned_master_nodes.resources | default([]) | length }} master node(s).
+
+- name: Generate master PinnedImageSet manifest
+  ansible.builtin.template:
+    src: "../../templates/pinnedimageset.yaml.j2"
+    dest: "{{ workingDir }}/config/pinnedimageset-master.yaml"
+  vars:
+    role: master
+    images: "{{ pinned_images | default([]) }}"
+  when: pinned_images | default([]) | length > 0
+
+- name: Apply master PinnedImageSet to cluster
+  ansible.builtin.command:
+    argv:
+      - "{{ workingDir }}/bin/oc"
+      - apply
+      - -f
+      - "{{ workingDir }}/config/pinnedimageset-master.yaml"
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  when: pinned_images | default([]) | length > 0

--- a/playbooks/tasks/collect_master_node_image_digests.yaml
+++ b/playbooks/tasks/collect_master_node_image_digests.yaml
@@ -1,0 +1,102 @@
+---
+# collect_master_node_image_digests.yaml — digest pull specs from images on all master nodes.
+#
+# Sets:
+#   pinned_images — unique digest pull specs (PinnedImageSet API format).
+
+- name: List master nodes for image collection
+  kubernetes.core.k8s_info:
+    kind: Node
+    label_selectors:
+      - node-role.kubernetes.io/master
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  register: r_pinned_master_nodes
+
+- name: Fail when no master nodes found for image collection
+  ansible.builtin.fail:
+    msg: "No master nodes matched node-role.kubernetes.io/master; cannot collect images for PinnedImageSet."
+  when: r_pinned_master_nodes.resources | default([]) | length == 0
+
+# Per-node collection via enclave tools (see tools/node_image_digests.py).
+- name: Collect container image digest refs from each master node
+  ansible.builtin.command:
+    argv:
+      - enclave
+      - tools
+      - collect-node-image-digests
+      - --node
+      - "{{ item.metadata.name }}"
+      - --oc
+      - "{{ workingDir }}/bin/oc"
+      - --raw-output-file
+      - "{{ workingDir }}/config/pinned-image-digests-{{ item.metadata.name }}.log"
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  loop: "{{ r_pinned_master_nodes.resources }}"
+  register: r_master_crictl_digests
+  changed_when: false
+  ignore_errors: true
+  loop_control:
+    label: "{{ item.metadata.name }}"
+
+- name: Build pinned image list from master node crictl output
+  ansible.builtin.set_fact:
+    pinned_images: >-
+      {{
+        (r_master_crictl_digests.results | default([])
+        | map(attribute='stdout_lines')
+        | flatten
+        | map('trim')
+        | select()
+        | unique
+        | list)
+      }}
+
+- name: Identify failed or empty master node image collection results
+  ansible.builtin.set_fact:
+    _pinned_collection_failed_nodes: >-
+      {{
+        r_master_crictl_digests.results | default([])
+        | selectattr('failed', 'equalto', true)
+        | list
+      }}
+    _pinned_collection_empty_nodes: >-
+      {{
+        r_master_crictl_digests.results | default([])
+        | rejectattr('failed', 'equalto', true)
+        | selectattr('stdout_lines', 'defined')
+        | selectattr('stdout_lines', 'equalto', [])
+        | list
+      }}
+    _pinned_collection_has_issues: >-
+      {{
+        (r_master_crictl_digests.results | default([]) | selectattr('failed', 'equalto', true) | list | length > 0)
+        or (
+          r_master_crictl_digests.results | default([])
+          | rejectattr('failed', 'equalto', true)
+          | selectattr('stdout_lines', 'defined')
+          | selectattr('stdout_lines', 'equalto', [])
+          | list
+          | length > 0
+        )
+        or (pinned_images | default([]) | length == 0)
+      }}
+
+- name: Fail when master node image digest collection failed or incomplete
+  ansible.builtin.fail:
+    msg: >-
+      Master node image digest collection failed or produced no usable digest refs.
+      Failed nodes:
+      {{ _pinned_collection_failed_nodes | map(attribute='item.metadata.name') | list }}
+      Nodes with empty output:
+      {{ _pinned_collection_empty_nodes | map(attribute='item.metadata.name') | list }}
+      Unique digest refs collected: {{ pinned_images | default([]) | length }}.
+  when: _pinned_collection_has_issues | default(false) | bool
+
+- name: Write collected master image digests for diagnostics
+  ansible.builtin.copy:
+    content: "{{ pinned_images | join('\n') }}\n"
+    dest: "{{ workingDir }}/config/pinned-images-master.txt"
+    mode: "0644"
+  when: pinned_images | default([]) | length > 0

--- a/schemas/global.yaml
+++ b/schemas/global.yaml
@@ -69,6 +69,12 @@ properties:
     "$ref": "#/definitions/cidr"
   ocMirrorLogLevel:
     "$ref": "#/definitions/ocMirrorLogLevel"
+  quayPinnedImageSetEnabled:
+    type: boolean
+    default: true
+    description: >-
+      Whether to apply a master PinnedImageSet after Quay mirror sync.
+      Set to false to skip post-mirror image prefetch pinning.
   odfExternalConfig:
     type: string
     description: ODF external cluster configuration JSON string

--- a/scripts/deployment/deploy_phase.sh
+++ b/scripts/deployment/deploy_phase.sh
@@ -123,6 +123,12 @@ if [ "${ENCLAVE_MIRROR_DRY_RUN:-}" = "true" ]; then
 "
 fi
 
+# Disable Quay PinnedImageSet apply after mirror if requested
+if [ "${ENCLAVE_QUAY_PINNEDIMAGESET_ENABLED:-}" = "false" ]; then
+    EXTRA_VARS_CONTENT="${EXTRA_VARS_CONTENT}quayPinnedImageSetEnabled: false
+"
+fi
+
 # Load ODF external config and Quay RGW config (from env vars or LZ files)
 if [ "${STORAGE_PLUGIN:-}" = "odf" ]; then
     source "${ENCLAVE_DIR}/scripts/lib/odf.sh"

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -9,6 +9,8 @@ def test_cli_help() -> None:
     result = CliRunner().invoke(cli, ["--help"])
     assert result.exit_code == 0
     assert "Reconcile CLI" in result.output
+    assert "resolve-quay-registry-ca" not in result.output
+    assert "collect-node-image-digests" not in result.output
 
 
 def test_operator_versions_help() -> None:

--- a/src/tests/test_node_image_digests.py
+++ b/src/tests/test_node_image_digests.py
@@ -1,0 +1,188 @@
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from tools.node_image_digests import (
+    DEFAULT_PINNED_IMAGE_EXCLUDE_CONTAINS,
+    OC_DEBUG_CRICTL_TIMEOUT_SECONDS,
+    collect_node_image_digests,
+    extract_digest_refs_from_crictl_output,
+    main,
+    normalize_digest_ref,
+    parse_exclude_contains,
+    run_oc_debug_crictl_images,
+)
+
+_REGISTRY = "registry.example.com:5000"
+_IMAGE = "org/app"
+_DIGEST = "sha256:" + "a" * 64
+_REF = f"{_REGISTRY}/{_IMAGE}@{_DIGEST}"
+
+
+def test_normalize_digest_ref_lowercases_sha() -> None:
+    upper = f"{_REGISTRY}/{_IMAGE}@sha256:{'A' * 64}"
+    assert normalize_digest_ref(upper) == _REF
+
+
+def test_normalize_digest_ref_rejects_invalid() -> None:
+    assert normalize_digest_ref("") is None
+    assert normalize_digest_ref("<none>") is None
+    assert normalize_digest_ref("registry.example.com/app:latest") is None
+
+
+def test_normalize_digest_ref_allows_multi_segment_path() -> None:
+    deep_ref = f"{_REGISTRY}/org/sub-org/image@{_DIGEST}"
+    assert normalize_digest_ref(deep_ref) == deep_ref
+
+
+def test_normalize_digest_ref_logs_unsupported_name(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level("DEBUG")
+    invalid_name_ref = f"{_REGISTRY}/org//image@{_DIGEST}"
+    assert normalize_digest_ref(invalid_name_ref) is None
+    assert "unsupported image name" in caplog.text
+
+
+def test_parse_exclude_contains_defaults() -> None:
+    assert parse_exclude_contains(None) == list(DEFAULT_PINNED_IMAGE_EXCLUDE_CONTAINS)
+    assert parse_exclude_contains("") == list(DEFAULT_PINNED_IMAGE_EXCLUDE_CONTAINS)
+
+
+def test_parse_exclude_contains_rejects_invalid_json() -> None:
+    with pytest.raises(ValueError, match="invalid --exclude-contains JSON"):
+        parse_exclude_contains("not-json")
+
+
+def test_parse_exclude_contains_rejects_non_array() -> None:
+    with pytest.raises(TypeError, match="must be a JSON array"):
+        parse_exclude_contains('{"foo": "bar"}')
+
+
+def test_parse_exclude_contains_custom() -> None:
+    assert parse_exclude_contains('["foo/"]') == ["foo/"]
+
+
+def test_extract_digest_refs_from_crictl_output() -> None:
+    payload = [
+        {
+            "repoDigests": [
+                _REF,
+                f"{_REGISTRY}/{_IMAGE}@sha256:{'b' * 64}",
+            ],
+        }
+    ]
+    text = f"noise before\n{json.dumps(payload)}\n"
+    refs = extract_digest_refs_from_crictl_output(text, exclude_contains=[])
+    assert refs == [
+        f"{_REGISTRY}/{_IMAGE}@sha256:{'b' * 64}",
+    ]
+
+
+def test_extract_digest_refs_applies_exclude_contains() -> None:
+    payload = [{"repoDigests": [_REF]}]
+    refs = extract_digest_refs_from_crictl_output(
+        json.dumps(payload),
+        exclude_contains=["openshift-pipelines/"],
+    )
+    assert refs == [_REF]
+
+    excluded = extract_digest_refs_from_crictl_output(
+        json.dumps([
+            {
+                "repoDigests": [
+                    "registry.example.com:5000/openshift-pipelines/foo@" + _DIGEST
+                ]
+            }
+        ]),
+        exclude_contains=["openshift-pipelines/"],
+    )
+    assert excluded == []
+
+    lvms_catalog = (
+        "mirror.enclave-test.lab:8443/redhat/mirror-redhat-operators-lvms@" + _DIGEST
+    )
+    assert (
+        extract_digest_refs_from_crictl_output(
+            json.dumps([{"repoDigests": [lvms_catalog]}]),
+            exclude_contains=list(DEFAULT_PINNED_IMAGE_EXCLUDE_CONTAINS),
+        )
+        == []
+    )
+
+
+def test_extract_digest_refs_dict_wrapper() -> None:
+    payload = {"images": [{"repoDigests": [_REF]}]}
+    refs = extract_digest_refs_from_crictl_output(
+        json.dumps(payload), exclude_contains=[]
+    )
+    assert refs == [_REF]
+
+
+def test_run_oc_debug_crictl_images_timeout(mocker: MockerFixture) -> None:
+    mocker.patch(
+        "tools.node_image_digests.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(
+            cmd="oc", timeout=OC_DEBUG_CRICTL_TIMEOUT_SECONDS
+        ),
+    )
+    with pytest.raises(TimeoutError, match="timed out after"):
+        run_oc_debug_crictl_images(node="node-0", oc="oc")
+
+
+def test_collect_node_image_digests_calls_oc(mocker: MockerFixture) -> None:
+    mock_run = mocker.patch(
+        "tools.node_image_digests.run_oc_debug_crictl_images",
+        return_value=json.dumps([{"repoDigests": [_REF]}]),
+    )
+    result = collect_node_image_digests("node-0", oc="/bin/oc")
+    mock_run.assert_called_once_with(node="node-0", oc="/bin/oc")
+    assert result.refs == [_REF]
+
+
+def test_reconcile_emits_refs(
+    mocker: MockerFixture, capsys: pytest.CaptureFixture
+) -> None:
+    mocker.patch(
+        "tools.node_image_digests.collect_node_image_digests",
+        return_value=MagicMock(refs=[_REF], raw_output="raw"),
+    )
+    main("node-0", oc="oc", exclude_contains_raw="[]")
+    assert capsys.readouterr().out.strip() == _REF
+
+
+def test_reconcile_emits_raw_on_empty_refs(
+    mocker: MockerFixture, capsys: pytest.CaptureFixture
+) -> None:
+    mocker.patch(
+        "tools.node_image_digests.collect_node_image_digests",
+        return_value=MagicMock(refs=[], raw_output="crictl failed"),
+    )
+    main("node-0")
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "crictl failed"
+
+
+def test_reconcile_writes_raw_output_file_on_empty_refs(
+    mocker: MockerFixture,
+    capsys: pytest.CaptureFixture,
+    tmp_path: Path,
+) -> None:
+    mocker.patch(
+        "tools.node_image_digests.collect_node_image_digests",
+        return_value=MagicMock(refs=[], raw_output="crictl failed"),
+    )
+    raw_output_file = tmp_path / "collect" / "node-0.log"
+
+    main("node-0", raw_output_file=str(raw_output_file))
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "No digest refs were collected; raw output saved to" in captured.err
+    assert str(raw_output_file) in captured.err
+    assert raw_output_file.read_text(encoding="utf-8") == "crictl failed"

--- a/src/tests/test_tools_cli.py
+++ b/src/tests/test_tools_cli.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from click.testing import CliRunner
 from pytest_mock import MockerFixture
 
@@ -45,3 +47,37 @@ def test_resolve_quay_registry_ca_runtime_error(mocker: MockerFixture) -> None:
     )
     assert result.exit_code != 0
     assert "unable to resolve registry CA for registry.example.com" in result.output
+
+
+def test_collect_node_image_digests_help() -> None:
+    result = CliRunner().invoke(cli, ["collect-node-image-digests", "--help"])
+    assert result.exit_code == 0
+    assert "--node" in result.output
+    assert "--exclude-contains" in result.output
+    assert "--raw-output-file" in result.output
+
+
+def test_collect_node_image_digests_forwards_args(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    mock_main = mocker.patch("tools.cli.collect_node_image_digests_main")
+    raw_output_file = tmp_path / "node-0.log"
+    result = CliRunner().invoke(
+        cli,
+        [
+            "collect-node-image-digests",
+            "--node",
+            "node-0",
+            "--oc",
+            "/usr/bin/oc",
+            "--raw-output-file",
+            str(raw_output_file),
+        ],
+    )
+    assert result.exit_code == 0
+    mock_main.assert_called_once_with(
+        "node-0",
+        oc="/usr/bin/oc",
+        exclude_contains_raw=None,
+        raw_output_file=str(raw_output_file),
+    )

--- a/src/tools/cli.py
+++ b/src/tools/cli.py
@@ -1,5 +1,6 @@
 import click
 
+from tools.node_image_digests import main as collect_node_image_digests_main
 from tools.quay_registry_ca import main as quay_registry_ca_main
 
 
@@ -21,6 +22,42 @@ def resolve_quay_registry_ca(hostname: str, oc: str) -> None:
     try:
         quay_registry_ca_main(hostname, oc=oc)
     except RuntimeError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@cli.command("collect-node-image-digests")
+@click.option("--node", required=True, help="Node name.")
+@click.option(
+    "--oc",
+    default="oc",
+    show_default=True,
+    help="Path to the oc binary.",
+)
+@click.option(
+    "--exclude-contains",
+    default=None,
+    help="JSON array of substrings; matching digest refs are skipped.",
+)
+@click.option(
+    "--raw-output-file",
+    default=None,
+    help="File path for raw oc debug/crictl output when no digest refs are collected.",
+)
+def collect_node_image_digests(
+    node: str,
+    oc: str,
+    exclude_contains: str | None,
+    raw_output_file: str | None,
+) -> None:
+    """Collect digest pull specs from images on a node via oc debug + crictl."""
+    try:
+        collect_node_image_digests_main(
+            node,
+            oc=oc,
+            exclude_contains_raw=exclude_contains,
+            raw_output_file=raw_output_file,
+        )
+    except (TimeoutError, ValueError, TypeError) as exc:
         raise click.ClickException(str(exc)) from exc
 
 

--- a/src/tools/node_image_digests.py
+++ b/src/tools/node_image_digests.py
@@ -1,0 +1,274 @@
+"""Collect PinnedImageSet-format digest refs from crictl images JSON on a node."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+OC_DEBUG_CRICTL_TIMEOUT_SECONDS = 600
+
+# FQDN-style registry host (PinnedImageSet API).
+_OCI_NAME = re.compile(
+    r"^([a-zA-Z0-9-]+\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/[a-zA-Z0-9-_.]+(/[a-zA-Z0-9-_.]+)*$"
+)
+_DIGEST_REF = re.compile(r"^(.+)@(sha256:[a-fA-F0-9]{64})$")
+
+# Substring filters for digest refs to skip when building a PinnedImageSet list.
+# When crictl lists multiple repoDigests per image id, MCO prefetch runs
+# `podman manifest inspect`; these defaults avoid images that break or are not
+# worth pinning: openshift-pipelines/*, Cincinnati graph-data (/openshift/graph-image),
+# upstream OLM catalog indexes under /redhat/*-operator-index, disconnected mirrors of
+# those catalogs (mirror-redhat-operators, mirror-redhat-operators-<plugin>), and
+# /rhel9/support-tools (single-manifest refs that can cause prefetch exit 125).
+DEFAULT_PINNED_IMAGE_EXCLUDE_CONTAINS: tuple[str, ...] = (
+    "openshift-pipelines/",
+    "/openshift/graph-image",
+    "/redhat/community-operator-index",
+    "/redhat/certified-operator-index",
+    "/redhat/redhat-marketplace-index",
+    "/redhat/redhat-operator-index",
+    "mirror-redhat-operators",
+    "/rhel9/support-tools",
+)
+
+_REPO_DIGEST_KEYS = ("repoDigests", "repo_digests")
+_REPO_TAG_KEYS = ("repoTags", "repo_tags")
+
+
+@dataclass(frozen=True)
+class CollectResult:
+    """Digest refs extracted from a node plus the raw oc debug/crictl output."""
+
+    refs: list[str]
+    raw_output: str
+
+
+def parse_exclude_contains(raw: str | None) -> list[str]:
+    """Parse ``--exclude-contains`` JSON or return default substring filters."""
+    if raw is None or not str(raw).strip():
+        return list(DEFAULT_PINNED_IMAGE_EXCLUDE_CONTAINS)
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        msg = f"invalid --exclude-contains JSON: {raw!r}"
+        raise ValueError(msg) from exc
+    if not isinstance(parsed, list):
+        msg = (
+            f"--exclude-contains must be a JSON array, got {type(parsed).__name__}: "
+            f"{raw!r}"
+        )
+        raise TypeError(msg)
+    return [str(s) for s in parsed]
+
+
+def normalize_digest_ref(ref: str | None) -> str | None:
+    """Return a normalized digest pull spec, or None if the ref is invalid."""
+    ref = (ref or "").strip()
+    if not ref or ref == "<none>":
+        return None
+    match = _DIGEST_REF.match(ref)
+    if not match:
+        return None
+    name, digest = match.group(1), match.group(2)
+    digest = "sha256:" + digest.split(":", 1)[1].lower()
+    candidate = f"{name}@{digest}"
+    if _OCI_NAME.match(name):
+        return candidate
+    logger.debug("Skipping digest ref with unsupported image name: %s", name)
+    return None
+
+
+def is_excluded(ref: str, exclude_contains: list[str]) -> bool:
+    """Return True when ``ref`` contains any of the configured exclude substrings."""
+    return any(s and str(s) in ref for s in exclude_contains)
+
+
+def _parse_crictl_images_list(text: str) -> list[dict]:
+    match = re.search(r"\[\s*\{", text)
+    if not match:
+        return []
+    decoder = json.JSONDecoder()
+    try:
+        data, _ = decoder.raw_decode(text[match.start() :])
+    except json.JSONDecodeError:
+        return []
+    if isinstance(data, dict):
+        data = data.get("images") or data.get("Images") or []
+    if not isinstance(data, list):
+        return []
+    return [img for img in data if isinstance(img, dict)]
+
+
+def _refs_from_field(img: dict, keys: tuple[str, ...]) -> list[str]:
+    refs: list[str] = []
+    for key in keys:
+        for repo_ref in img.get(key) or []:
+            out = normalize_digest_ref(repo_ref)
+            if out:
+                refs.append(out)
+    return refs
+
+
+def _dedupe_ordered(values: list[str]) -> list[str]:
+    unique: list[str] = []
+    for value in values:
+        if value not in unique:
+            unique.append(value)
+    return unique
+
+
+def _select_repo_digests(rd_vals: list[str]) -> list[str]:
+    if not rd_vals:
+        return []
+    # crictl can report multiple repoDigests for one image ID (same image mirrored under
+    # different names). Keep only the last digest to avoid pinning redundant aliases.
+    return rd_vals if len(rd_vals) == 1 else [rd_vals[-1]]
+
+
+def _digest_refs_from_image(
+    img: dict,
+    excludes: list[str],
+    seen: set[str],
+) -> list[str]:
+    refs: list[str] = []
+
+    def emit(out: str) -> None:
+        if is_excluded(out, excludes) or out in seen:
+            return
+        seen.add(out)
+        refs.append(out)
+
+    raw_rd = _refs_from_field(img, _REPO_DIGEST_KEYS)
+    rd_vals = _dedupe_ordered(raw_rd)
+    had_digest_fields = bool(img.get("repoDigests") or img.get("repo_digests"))
+    for out in _select_repo_digests(rd_vals):
+        emit(out)
+    if had_digest_fields and rd_vals:
+        return refs
+    for out in _refs_from_field(img, _REPO_TAG_KEYS):
+        emit(out)
+    return refs
+
+
+def extract_digest_refs_from_crictl_output(
+    text: str,
+    exclude_contains: list[str] | None = None,
+) -> list[str]:
+    """Extract unique digest pull specs from ``crictl images -o json`` output.
+
+    Tolerates leading noise from ``oc debug``. Uses ``exclude_contains`` when
+    provided, otherwise ``DEFAULT_PINNED_IMAGE_EXCLUDE_CONTAINS``.
+    """
+    excludes = (
+        list(DEFAULT_PINNED_IMAGE_EXCLUDE_CONTAINS)
+        if exclude_contains is None
+        else exclude_contains
+    )
+    seen: set[str] = set()
+    refs: list[str] = []
+    for img in _parse_crictl_images_list(text):
+        refs.extend(_digest_refs_from_image(img, excludes, seen))
+    return refs
+
+
+def run_oc_debug_crictl_images(*, node: str, oc: str) -> str:
+    """Run ``oc debug`` on a node and return combined stdout/stderr from ``crictl images``.
+
+    Raises ``TimeoutError`` when the command exceeds ``OC_DEBUG_CRICTL_TIMEOUT_SECONDS``.
+    """
+    try:
+        result = subprocess.run(
+            [
+                oc,
+                "debug",
+                f"node/{node}",
+                "-n",
+                "default",
+                "--quiet",
+                "--",
+                "chroot",
+                "/host",
+                "/usr/bin/crictl",
+                "-r",
+                "unix:///var/run/crio/crio.sock",
+                "images",
+                "-o",
+                "json",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=OC_DEBUG_CRICTL_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        logger.exception(
+            "oc debug on node/%s timed out after %d seconds",
+            node,
+            OC_DEBUG_CRICTL_TIMEOUT_SECONDS,
+        )
+        msg = (
+            f"oc debug on node/{node} timed out after "
+            f"{OC_DEBUG_CRICTL_TIMEOUT_SECONDS} seconds"
+        )
+        raise TimeoutError(msg) from exc
+    return (result.stdout or "") + (result.stderr or "")
+
+
+def collect_node_image_digests(
+    node: str,
+    *,
+    oc: str = "oc",
+    exclude_contains: list[str] | None = None,
+) -> CollectResult:
+    """Collect PinnedImageSet-format digest refs from container images on a node."""
+    raw_output = run_oc_debug_crictl_images(node=node, oc=oc)
+    refs = extract_digest_refs_from_crictl_output(raw_output, exclude_contains)
+    logger.debug(
+        "node=%s collected %d digest ref(s) from %d byte(s) of crictl output",
+        node,
+        len(refs),
+        len(raw_output),
+    )
+    return CollectResult(refs=refs, raw_output=raw_output)
+
+
+def emit_collection_output(
+    result: CollectResult, *, raw_output_file: str | None = None
+) -> None:
+    """Write digest refs to stdout; on empty collection, persist or stream raw output.
+
+    When ``raw_output_file`` is set and no refs were collected, writes full crictl
+    output to that path and prints a short message to stderr instead of dumping it.
+    """
+    if not result.refs:
+        if raw_output_file:
+            output_path = Path(raw_output_file)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(result.raw_output, encoding="utf-8")
+            sys.stderr.write(
+                f"No digest refs were collected; raw output saved to {output_path}\n"
+            )
+        else:
+            sys.stderr.write(result.raw_output)
+    for ref in result.refs:
+        sys.stdout.write(f"{ref}\n")
+
+
+def main(
+    node: str,
+    *,
+    oc: str = "oc",
+    exclude_contains_raw: str | None = None,
+    raw_output_file: str | None = None,
+) -> None:
+    """CLI entry point: collect node image digests and emit stdout/stderr output."""
+    excludes = parse_exclude_contains(exclude_contains_raw)
+    result = collect_node_image_digests(node, oc=oc, exclude_contains=excludes)
+    emit_collection_output(result, raw_output_file=raw_output_file)

--- a/templates/pinnedimageset.yaml.j2
+++ b/templates/pinnedimageset.yaml.j2
@@ -1,0 +1,11 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: PinnedImageSet
+metadata:
+  name: {{ (role ~ '-pinned-images') | to_json }}
+  labels:
+    machineconfiguration.openshift.io/role: {{ role | to_json }}
+spec:
+  pinnedImages:
+{% for img in images %}
+  - name: {{ img | to_json }}
+{% endfor %}


### PR DESCRIPTION
To ensure the mgmt cluster can recover from node reboots and crashes even without an available registry, image resilience is necessary. This can be achieved by pinning the required images using the PinnedImageSet functionality, as detailed in the OpenShift documentation on Pinning and Preloading Images [*].
This action stops CRI-O from triggering Garbage Collection for the images, and thus ensuring the the required images exist for getting the cluster back to an healthy status.

[*] https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/machine_configuration/machine-config-pin-preload-images-about#machine-config-pin-preload-images-about

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional master PinnedImageSet applied after Quay mirror (can be skipped via config or during mirror dry-run).
  * Automatic per-master-node image digest collection and templating into a PinnedImageSet manifest.
  * New CLI command to collect node image digests and a template to render PinnedImageSet manifests.

* **Improvements**
  * Better per-node diagnostics, stricter failure conditions, deduplication and exclusion filtering, and clearer logging when results are empty or truncated.

* **Tests**
  * Added tests for digest parsing, exclusion rules, CLI behavior, timeout handling, and manifest rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/enclave/pull/381?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->