### PR TITLE
Make vars schema validation logging configurable

### DIFF
--- a/playbooks/validation/tasks/variables_schema_validation.yaml
+++ b/playbooks/validation/tasks/variables_schema_validation.yaml
@@ -17,7 +17,7 @@
          | combine(lookup('ansible.builtin.file', item) | from_yaml) }}
   loop: "{{ user_config_files }}"
   when: user_config_files is defined
-  no_log: true
+  no_log: "{{ schemaValidationNoLog | default(false) }}"
 
 - name: Validate merged config against variables schema
   ansible.utils.validate:
@@ -25,4 +25,4 @@
     criteria: "{{ variables_schema }}"
     engine: ansible.utils.jsonschema
   when: merged_config is defined
-  no_log: true
+  no_log: "{{ schemaValidationNoLog | default(false) }}"

--- a/schemas/variables.yaml
+++ b/schemas/variables.yaml
@@ -142,6 +142,11 @@ properties:
   ironicHTTPSKey:
     type: string
     description: PEM-encoded private key for Ironic vmedia HTTPS certificate
+  schemaValidationNoLog:
+    type: boolean
+    description: >-
+      Whether to suppress schema validation task output (no_log). Default: false.
+      Set to true in CI to avoid leaking secrets in logs.
   sslAPICertificateFullChain:
     type: string
     description: PEM-encoded full certificate chain for API server

--- a/schemas/variables.yaml
+++ b/schemas/variables.yaml
@@ -144,6 +144,7 @@ properties:
     description: PEM-encoded private key for Ironic vmedia HTTPS certificate
   schemaValidationNoLog:
     type: boolean
+    default: false
     description: >-
       Whether to suppress schema validation task output (no_log). Default: false.
       Set to true in CI to avoid leaking secrets in logs.

--- a/scripts/infrastructure/generate_enclave_vars.sh
+++ b/scripts/infrastructure/generate_enclave_vars.sh
@@ -103,6 +103,7 @@ cat > "$GLOBAL_VARS_OUTPUT" <<EOF
 # Base Configuration
 # ============================================================================
 workingDir: "/home/cloud-user"
+schemaValidationNoLog: true
 
 # ============================================================================
 # Network Configuration


### PR DESCRIPTION
Add schemaValidationNoLog variable to control no_log behavior in schema validation tasks. Defaults to false so users see validation errors during installation. CI sets to true to prevent leaking secrets in build logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable setting to control schema-validation logging so validation steps can suppress output and avoid exposing secrets.
  * The environment/config generator now enables this suppression in generated configs by default (can be changed by users).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/enclave/pull/382?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->