### PR TITLE
Add authorino plugin for Authorino operator deployment

### DIFF
--- a/plugins/authorino/plugin.yaml
+++ b/plugins/authorino/plugin.yaml
@@ -8,6 +8,7 @@ operators:
     version: 1.3.0
     channel: stable
     init_version: 1.3.0
-    namespace: openshift-operators
+    namespace: authorino-operator
+    global: true
 
 defaults: {}

--- a/plugins/authorino/plugin.yaml
+++ b/plugins/authorino/plugin.yaml
@@ -1,0 +1,13 @@
+---
+name: authorino
+type: addon
+order: 102
+
+operators:
+  - name: authorino-operator
+    version: 1.3.0
+    channel: stable
+    init_version: 1.3.0
+    namespace: openshift-operators
+
+defaults: {}

--- a/plugins/authorino/tasks/deploy.yaml
+++ b/plugins/authorino/tasks/deploy.yaml
@@ -1,0 +1,20 @@
+---
+- name: Wait for Authorino operator deployment (Available=True)
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: authorino-operator
+    namespace: openshift-operators
+  register: __r_authorino_deploy
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until:
+    - __r_authorino_deploy.resources | length > 0
+    - __r_authorino_deploy.resources[0].status.conditions | default([])
+      | selectattr('type', 'equalto', 'Available')
+      | selectattr('status', 'equalto', 'True')
+      | list | length > 0
+
+- name: Debug Authorino operator status
+  ansible.builtin.debug:
+    msg: "Authorino operator deployment is ready in openshift-operators namespace"

--- a/plugins/authorino/tasks/deploy.yaml
+++ b/plugins/authorino/tasks/deploy.yaml
@@ -4,7 +4,7 @@
     api_version: apps/v1
     kind: Deployment
     name: authorino-operator
-    namespace: openshift-operators
+    namespace: authorino-operator
   register: __r_authorino_deploy
   retries: "{{ k8s_retries }}"
   delay: "{{ k8s_delay }}"
@@ -17,4 +17,4 @@
 
 - name: Debug Authorino operator status
   ansible.builtin.debug:
-    msg: "Authorino operator deployment is ready in openshift-operators namespace"
+    msg: "Authorino operator deployment is ready in authorino-operator namespace"


### PR DESCRIPTION
Installs the Authorino operator (v1.3.0, stable channel) from the redhat-operators catalog and waits for the deployment to be Available.

OSAC-927

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Authorino operator (version 1.3.0) as an available addon plugin for enhanced authorization and authentication capabilities

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/enclave/pull/384?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->