### PR TITLE
only mirror foundation plugins in core

### DIFF
--- a/playbooks/05-operators.yaml
+++ b/playbooks/05-operators.yaml
@@ -93,6 +93,7 @@
             - operators
       vars:
         plugin_type: addon
+        plugin_mirror: true
       tags:
         - addon-plugins
         - operators

--- a/playbooks/tasks/collect_core_plugin_operators.yaml
+++ b/playbooks/tasks/collect_core_plugin_operators.yaml
@@ -22,16 +22,17 @@
 
 - name: Build combined plugin operators dictionary
   vars:
-    _enabled: >-
+    _foundation: >-
       {{ r_cp_slurp.results
          | map(attribute='content')
          | map('b64decode')
          | map('from_yaml')
+         | selectattr('type', 'equalto', 'foundation')
          | selectattr('name', 'in', enabled_plugins)
          | list }}
   ansible.builtin.set_fact:
     _core_plugin_operators: >-
-      {{ _enabled
+      {{ _foundation
          | selectattr('operators', 'defined')
          | items2dict(key_name='name', value_name='operators') }}
 

--- a/playbooks/tasks/collect_plugin_registries.yaml
+++ b/playbooks/tasks/collect_plugin_registries.yaml
@@ -22,16 +22,17 @@
 
 - name: Build combined plugin registries list
   vars:
-    _enabled: >-
+    _foundation: >-
       {{ r_pr_slurp.results
          | map(attribute='content')
          | map('b64decode')
          | map('from_yaml')
+         | selectattr('type', 'equalto', 'foundation')
          | selectattr('name', 'in', enabled_plugins)
          | list }}
   ansible.builtin.set_fact:
     _core_plugin_registries: >-
-      {{ _enabled
+      {{ _foundation
          | selectattr('registries', 'defined')
          | map(attribute='registries')
          | flatten


### PR DESCRIPTION
with this change, only foundation plugins in `enabled_plugins` are mirrored as part of the core mirror.

addon plugins will be mirrored as part of their plugin deployment.

this is a behavior adjustment following #357

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined plugin deployment process with improved registry collection and operator configuration handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/enclave/pull/385?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->