### PR TITLE
Add CNV plugin for OpenShift Virtualization deployment

### DIFF
--- a/defaults/operators.yaml
+++ b/defaults/operators.yaml
@@ -111,5 +111,3 @@ operators:
     global: true
     csvNames:
       - metallb-operator
-    extraMirrorPackages:
-      - kubevirt-hyperconverged

--- a/defaults/operators.yaml
+++ b/defaults/operators.yaml
@@ -111,3 +111,5 @@ operators:
     global: true
     csvNames:
       - metallb-operator
+    extraMirrorPackages:
+      - kubevirt-hyperconverged

--- a/plugins/cnv/plugin.yaml
+++ b/plugins/cnv/plugin.yaml
@@ -11,5 +11,3 @@ operators:
     namespace: openshift-cnv
     csvNames:
       - kubevirt-hyperconverged-operator
-
-defaults: {}

--- a/plugins/cnv/plugin.yaml
+++ b/plugins/cnv/plugin.yaml
@@ -1,0 +1,15 @@
+---
+name: cnv
+type: addon
+order: 104
+
+operators:
+  - name: kubevirt-hyperconverged
+    version: 4.20.14
+    channel: stable
+    init_version: 4.20.14
+    namespace: openshift-cnv
+    csvNames:
+      - kubevirt-hyperconverged-operator
+
+defaults: {}

--- a/plugins/cnv/tasks/deploy.yaml
+++ b/plugins/cnv/tasks/deploy.yaml
@@ -1,0 +1,47 @@
+---
+- name: Wait for HyperConverged CRD to be registered
+  kubernetes.core.k8s_info:
+    api_version: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    name: hyperconvergeds.hco.kubevirt.io
+  register: __r_cnv_crd
+  retries: 60
+  delay: 10
+  until:
+    - __r_cnv_crd.resources | default([]) | length > 0
+
+- name: Deploy HyperConverged CR
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: hco.kubevirt.io/v1beta1
+      kind: HyperConverged
+      metadata:
+        name: kubevirt-hyperconverged
+        namespace: openshift-cnv
+      spec: {}
+  register: __r_cnv_hco
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: __r_cnv_hco is success
+
+- name: Wait for HyperConverged CR (Available=True)
+  kubernetes.core.k8s_info:
+    api_version: hco.kubevirt.io/v1beta1
+    kind: HyperConverged
+    name: kubevirt-hyperconverged
+    namespace: openshift-cnv
+  register: __r_cnv_hco_status
+  retries: 90
+  delay: 30
+  until:
+    - __r_cnv_hco_status is not failed
+    - __r_cnv_hco_status.resources | default([]) | length > 0
+    - __r_cnv_hco_status.resources[0].status.conditions | default([])
+      | selectattr('type', 'equalto', 'Available')
+      | selectattr('status', 'equalto', 'True')
+      | list | length > 0
+
+- name: Debug HyperConverged status
+  ansible.builtin.debug:
+    msg: "HyperConverged is available in openshift-cnv namespace"


### PR DESCRIPTION
Installs the kubevirt-hyperconverged operator (v4.20.14, stable channel) and deploys the HyperConverged CR.

Removes kubevirt-hyperconverged from metallb extraMirrorPackages since mirroring is now handled by the plugin.

OSAC-930

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CNV virtualization plugin with automated operator deployment, resource configuration, and health status verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->