### PR TITLE
Add AAP plugin for Ansible Automation Platform deployment

### DIFF
--- a/config/global.example.yaml
+++ b/config/global.example.yaml
@@ -129,7 +129,7 @@ storage_plugin: lvms
 # Path to the AAP license manifest.zip file on the Landing Zone.
 # See https://github.com/osac-project/osac-installer#obtaining-an-aap-license-subscription-manifest
 #
-# aap_license_file: "/path/to/aap-license.zip"
+# aapLicenseFile: "/path/to/aap-license.zip"
 
 # ============================================================================
 # OpenShift Deployment Configuration (optional)

--- a/config/global.example.yaml
+++ b/config/global.example.yaml
@@ -124,6 +124,14 @@ storage_plugin: lvms
 #       protocol: nfs
 
 # ============================================================================
+# AAP Plugin Configuration (required when aap plugin is enabled)
+# ============================================================================
+# Path to the AAP license manifest.zip file on the Landing Zone.
+# See https://github.com/osac-project/osac-installer#obtaining-an-aap-license-subscription-manifest
+#
+# aap_license_file: "/path/to/aap-license.zip"
+
+# ============================================================================
 # OpenShift Deployment Configuration (optional)
 # All settings below have defaults. Uncomment only to override.
 # ============================================================================

--- a/plugins/aap/defaults.yaml
+++ b/plugins/aap/defaults.yaml
@@ -1,0 +1,12 @@
+---
+aap_name: aap
+aap_ns: ansible-aap
+aap_license_secret: aap-license
+aap_controller_disabled: false
+aap_eda_disabled: false
+aap_hub_disabled: true
+aap_image_pull_policy: IfNotPresent
+aap_lightspeed_disabled: true
+aap_no_log: true
+aap_redis_mode: standalone
+aap_route_tls_termination: Edge

--- a/plugins/aap/plugin.yaml
+++ b/plugins/aap/plugin.yaml
@@ -14,7 +14,7 @@ operators:
 
 requires:
   vars:
-    - name: aap_license_file
+    - name: aapLicenseFile
       description: "Path to AAP license manifest.zip file on the Landing Zone"
 
 defaults:

--- a/plugins/aap/plugin.yaml
+++ b/plugins/aap/plugin.yaml
@@ -16,16 +16,3 @@ requires:
   vars:
     - name: aapLicenseFile
       description: "Path to AAP license manifest.zip file on the Landing Zone"
-
-defaults:
-  aap_name: aap
-  aap_ns: ansible-aap
-  aap_license_secret: aap-license
-  aap_controller_disabled: false
-  aap_eda_disabled: false
-  aap_hub_disabled: true
-  aap_image_pull_policy: IfNotPresent
-  aap_lightspeed_disabled: true
-  aap_no_log: true
-  aap_redis_mode: standalone
-  aap_route_tls_termination: Edge

--- a/plugins/aap/plugin.yaml
+++ b/plugins/aap/plugin.yaml
@@ -1,0 +1,31 @@
+---
+name: aap
+type: addon
+order: 103
+
+operators:
+  - name: ansible-automation-platform-operator
+    version: 2.5.0-0.1777407881
+    channel: stable-2.5-cluster-scoped
+    init_version: 2.5.0-0.1777407881
+    namespace: ansible-aap
+    csvNames:
+      - aap-operator
+
+requires:
+  vars:
+    - name: aap_license_file
+      description: "Path to AAP license manifest.zip file on the Landing Zone"
+
+defaults:
+  aap_name: aap
+  aap_ns: ansible-aap
+  aap_license_secret: aap-license
+  aap_controller_disabled: false
+  aap_eda_disabled: false
+  aap_hub_disabled: true
+  aap_image_pull_policy: IfNotPresent
+  aap_lightspeed_disabled: true
+  aap_no_log: true
+  aap_redis_mode: standalone
+  aap_route_tls_termination: Edge

--- a/plugins/aap/schemas/config.yaml
+++ b/plugins/aap/schemas/config.yaml
@@ -1,0 +1,10 @@
+---
+"$schema": "http://json-schema.org/draft-07/schema"
+type: object
+additionalProperties: false
+properties:
+  aapLicenseFile:
+    "$ref": "#/definitions/nonEmptyString"
+    description: Path to AAP license manifest.zip file on the Landing Zone.
+required:
+  - aapLicenseFile

--- a/plugins/aap/schemas/defaults.yaml
+++ b/plugins/aap/schemas/defaults.yaml
@@ -1,0 +1,41 @@
+---
+"$schema": "http://json-schema.org/draft-07/schema"
+type: object
+additionalProperties: false
+properties:
+  aap_name:
+    "$ref": "#/definitions/nonEmptyString"
+    description: Name of the AAP instance.
+  aap_ns:
+    "$ref": "#/definitions/nonEmptyString"
+    description: Namespace for the AAP deployment.
+  aap_license_secret:
+    "$ref": "#/definitions/nonEmptyString"
+    description: Name of the Kubernetes secret holding the AAP license.
+  aap_controller_disabled:
+    type: boolean
+    description: Disable the Automation Controller component.
+  aap_eda_disabled:
+    type: boolean
+    description: Disable the Event-Driven Ansible component.
+  aap_hub_disabled:
+    type: boolean
+    description: Disable the Automation Hub component.
+  aap_image_pull_policy:
+    type: string
+    enum: [Always, IfNotPresent, Never]
+    description: Image pull policy for AAP pods.
+  aap_lightspeed_disabled:
+    type: boolean
+    description: Disable the Ansible Lightspeed component.
+  aap_no_log:
+    type: boolean
+    description: Suppress sensitive log output.
+  aap_redis_mode:
+    type: string
+    enum: [standalone, cluster]
+    description: Redis deployment mode.
+  aap_route_tls_termination:
+    type: string
+    enum: [Edge, Passthrough, Reencrypt]
+    description: TLS termination type for AAP routes.

--- a/plugins/aap/tasks/deploy.yaml
+++ b/plugins/aap/tasks/deploy.yaml
@@ -1,0 +1,159 @@
+---
+- name: Wait for AAP operator deployment (Available=True)
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: automation-controller-operator-controller-manager
+    namespace: "{{ aap_ns }}"
+  register: __r_aap_operator_deploy
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until:
+    - __r_aap_operator_deploy.resources | length > 0
+    - __r_aap_operator_deploy.resources[0].status.conditions | default([])
+      | selectattr('type', 'equalto', 'Available')
+      | selectattr('status', 'equalto', 'True')
+      | list | length > 0
+
+- name: Read AAP license file
+  ansible.builtin.slurp:
+    src: "{{ aap_license_file }}"
+  register: __r_aap_license_content
+  no_log: true
+
+- name: Create AAP license Secret
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: "{{ aap_license_secret }}"
+        namespace: "{{ aap_ns }}"
+      type: Opaque
+      data:
+        manifest.zip: "{{ __r_aap_license_content.content }}"
+  register: __r_aap_license
+  no_log: true
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: __r_aap_license is success
+
+- name: Deploy AnsibleAutomationPlatform CR
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: aap.ansible.com/v1alpha1
+      kind: AnsibleAutomationPlatform
+      metadata:
+        name: "{{ aap_name }}"
+        namespace: "{{ aap_ns }}"
+      spec:
+        controller:
+          disabled: "{{ aap_controller_disabled }}"
+        eda:
+          disabled: "{{ aap_eda_disabled }}"
+        hub:
+          disabled: "{{ aap_hub_disabled }}"
+        image_pull_policy: "{{ aap_image_pull_policy }}"
+        lightspeed:
+          disabled: "{{ aap_lightspeed_disabled }}"
+        no_log: "{{ aap_no_log }}"
+        redis_mode: "{{ aap_redis_mode }}"
+        route_tls_termination_mechanism: "{{ aap_route_tls_termination }}"
+  register: __r_deploy_aap
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: __r_deploy_aap is success
+
+- name: Wait for AnsibleAutomationPlatform reconciliation (Successful=True)
+  kubernetes.core.k8s_info:
+    api_version: aap.ansible.com/v1alpha1
+    kind: AnsibleAutomationPlatform
+    name: "{{ aap_name }}"
+    namespace: "{{ aap_ns }}"
+  register: __r_aap_resource
+  retries: 60
+  delay: 30
+  until:
+    - __r_aap_resource.resources | length > 0
+    - __r_aap_resource.resources[0].status.conditions | default([])
+      | selectattr('type', 'equalto', 'Successful')
+      | selectattr('status', 'equalto', 'True')
+      | list | length > 0
+    - __r_aap_resource.resources[0].status.conditions | default([])
+      | selectattr('type', 'equalto', 'Failure')
+      | selectattr('status', 'equalto', 'True')
+      | list | length == 0
+
+- name: Wait for AutomationController (Successful=True)
+  kubernetes.core.k8s_info:
+    api_version: automationcontroller.ansible.com/v1beta1
+    kind: AutomationController
+    namespace: "{{ aap_ns }}"
+  register: __r_aap_controller
+  retries: 60
+  delay: 30
+  until:
+    - __r_aap_controller.resources | length > 0
+    - __r_aap_controller.resources[0].status.conditions | default([])
+      | selectattr('type', 'equalto', 'Successful')
+      | selectattr('status', 'equalto', 'True')
+      | list | length > 0
+  when: not aap_controller_disabled
+
+- name: Wait for EDA (Successful=True)
+  kubernetes.core.k8s_info:
+    api_version: eda.ansible.com/v1alpha1
+    kind: EDA
+    namespace: "{{ aap_ns }}"
+  register: __r_aap_eda
+  retries: 60
+  delay: 30
+  until:
+    - __r_aap_eda.resources | length > 0
+    - __r_aap_eda.resources[0].status.conditions | default([])
+      | selectattr('type', 'equalto', 'Successful')
+      | selectattr('status', 'equalto', 'True')
+      | list | length > 0
+  when: not aap_eda_disabled
+
+- name: Wait for AutomationHub (Successful=True)
+  kubernetes.core.k8s_info:
+    api_version: automationhub.ansible.com/v1beta1
+    kind: AutomationHub
+    namespace: "{{ aap_ns }}"
+  register: __r_aap_hub
+  retries: 60
+  delay: 30
+  until:
+    - __r_aap_hub.resources | length > 0
+    - __r_aap_hub.resources[0].status.conditions | default([])
+      | selectattr('type', 'equalto', 'Successful')
+      | selectattr('status', 'equalto', 'True')
+      | list | length > 0
+  when: not aap_hub_disabled
+
+- name: Debug AnsibleAutomationPlatform component status
+  vars:
+    __controller_status: >-
+      {{ __r_aap_controller.resources[0].status.conditions | default([])
+         | selectattr('type', 'equalto', 'Successful')
+         | map(attribute='status') | first | default('Unknown')
+         if not aap_controller_disabled else 'disabled' }}
+    __eda_status: >-
+      {{ __r_aap_eda.resources[0].status.conditions | default([])
+         | selectattr('type', 'equalto', 'Successful')
+         | map(attribute='status') | first | default('Unknown')
+         if not aap_eda_disabled else 'disabled' }}
+    __hub_status: >-
+      {{ __r_aap_hub.resources[0].status.conditions | default([])
+         | selectattr('type', 'equalto', 'Successful')
+         | map(attribute='status') | first | default('Unknown')
+         if not aap_hub_disabled else 'disabled' }}
+  ansible.builtin.debug:
+    msg:
+      - "AnsibleAutomationPlatform {{ aap_name }} is ready in {{ aap_ns }} namespace"
+      - "Controller: {{ __controller_status }}"
+      - "EDA: {{ __eda_status }}"
+      - "Hub: {{ __hub_status }}"

--- a/plugins/aap/tasks/deploy.yaml
+++ b/plugins/aap/tasks/deploy.yaml
@@ -17,7 +17,7 @@
 
 - name: Read AAP license file
   ansible.builtin.slurp:
-    src: "{{ aap_license_file }}"
+    src: "{{ aapLicenseFile }}"
   register: __r_aap_license_content
   no_log: true
 

--- a/plugins/aap/tasks/pre-validate.yaml
+++ b/plugins/aap/tasks/pre-validate.yaml
@@ -1,0 +1,15 @@
+---
+- name: Check AAP license file exists
+  ansible.builtin.stat:
+    path: "{{ aap_license_file | default('') }}"
+  register: __r_aap_license_stat
+  when: aap_license_file is defined and aap_license_file | length > 0
+
+- name: Fail if AAP license file not found
+  ansible.builtin.fail:
+    msg: >-
+      AAP license file not found at {{ aap_license_file }}.
+      Set aap_license_file to the path of your AAP license manifest.zip.
+  when: >
+    aap_license_file is not defined or
+    not (__r_aap_license_stat.stat.exists | default(false))

--- a/plugins/aap/tasks/pre-validate.yaml
+++ b/plugins/aap/tasks/pre-validate.yaml
@@ -1,15 +1,36 @@
 ---
 - name: Check AAP license file exists
   ansible.builtin.stat:
-    path: "{{ aap_license_file | default('') }}"
+    path: "{{ aapLicenseFile | default('') }}"
   register: __r_aap_license_stat
-  when: aap_license_file is defined and aap_license_file | length > 0
+  when:
+    - aapLicenseFile is defined
+    - aapLicenseFile | length > 0
 
 - name: Fail if AAP license file not found
   ansible.builtin.fail:
     msg: >-
-      AAP license file not found at {{ aap_license_file }}.
-      Set aap_license_file to the path of your AAP license manifest.zip.
+      AAP license file not found at
+      {{ aapLicenseFile | default('unspecified') }}.
+      Set aapLicenseFile to the path of your
+      AAP license manifest ZIP file.
   when: >
-    aap_license_file is not defined or
+    aapLicenseFile is not defined or
     not (__r_aap_license_stat.stat.exists | default(false))
+
+- name: Fail if AAP license path is not a regular file
+  ansible.builtin.fail:
+    msg: "AAP license path is not a regular file: {{ aapLicenseFile }}"
+  when:
+    - __r_aap_license_stat.stat.exists | default(false)
+    - not (__r_aap_license_stat.stat.isreg | default(false))
+
+- name: Verify AAP license file is a valid ZIP archive
+  ansible.builtin.command:
+    argv:
+      - unzip
+      - -t
+      - "{{ aapLicenseFile }}"
+  register: __r_aap_license_zip_check
+  changed_when: false
+  failed_when: __r_aap_license_zip_check.rc != 0

--- a/plugins/aap/test-fixtures/schemas/config/invalid/empty-license.yaml
+++ b/plugins/aap/test-fixtures/schemas/config/invalid/empty-license.yaml
@@ -1,0 +1,4 @@
+---
+# Fixture: aapLicenseFile must be non-empty
+# Expected failure: minLength violation
+aapLicenseFile: ""

--- a/plugins/aap/test-fixtures/schemas/config/invalid/missing-license.yaml
+++ b/plugins/aap/test-fixtures/schemas/config/invalid/missing-license.yaml
@@ -1,0 +1,4 @@
+---
+# Fixture: aapLicenseFile is required
+# Expected failure: missing required property
+{}

--- a/plugins/aap/test-fixtures/schemas/config/valid/base.yaml
+++ b/plugins/aap/test-fixtures/schemas/config/valid/base.yaml
@@ -1,0 +1,2 @@
+---
+aapLicenseFile: /home/cloud-user/enclave/config/aap-license.zip

--- a/plugins/aap/test-fixtures/schemas/defaults/invalid/unknown-property.yaml
+++ b/plugins/aap/test-fixtures/schemas/defaults/invalid/unknown-property.yaml
@@ -1,0 +1,5 @@
+---
+# Fixture: unknown top-level property
+# Expected failure: additionalProperties is false
+aap_name: aap
+unknownField: this-should-fail

--- a/plugins/aap/test-fixtures/schemas/defaults/valid/base.yaml
+++ b/plugins/aap/test-fixtures/schemas/defaults/valid/base.yaml
@@ -1,0 +1,12 @@
+---
+aap_name: aap
+aap_ns: ansible-aap
+aap_license_secret: aap-license
+aap_controller_disabled: false
+aap_eda_disabled: false
+aap_hub_disabled: true
+aap_image_pull_policy: IfNotPresent
+aap_lightspeed_disabled: true
+aap_no_log: true
+aap_redis_mode: standalone
+aap_route_tls_termination: Edge

--- a/schemas/global.yaml
+++ b/schemas/global.yaml
@@ -207,6 +207,9 @@ properties:
     required:
       - subnet_cidr
       - ip_ranges
+  aap_license_file:
+    "$ref": "#/definitions/nonEmptyString"
+    description: Path to AAP license manifest.zip file on the Landing Zone
   workingDir:
     "$ref": "#/definitions/nonEmptyString"
 

--- a/schemas/global.yaml
+++ b/schemas/global.yaml
@@ -207,7 +207,7 @@ properties:
     required:
       - subnet_cidr
       - ip_ranges
-  aap_license_file:
+  aapLicenseFile:
     "$ref": "#/definitions/nonEmptyString"
     description: Path to AAP license manifest.zip file on the Landing Zone
   workingDir:


### PR DESCRIPTION
Deploys the AAP operator and AnsibleAutomationPlatform CR with configurable components (controller, EDA, hub, lightspeed).

Requires `aapLicenseFile` pointing to a valid manifest.zip on the Landing Zone. The plugin validates the file exists and is a valid ZIP before deployment, then waits for full reconciliation.

### Changes

- **Plugin descriptor** (`plugin.yaml`): operator subscription (stable-2.5-cluster-scoped), required `aapLicenseFile` var
- **Defaults** (`defaults.yaml`): externalized defaults following PR #404 pattern — component toggles, redis mode, TLS termination, image pull policy
- **Schema validation** (`schemas/config.yaml`, `schemas/defaults.yaml`): JSON schema for user config and defaults with test fixtures
- **Pre-validation** (`tasks/pre-validate.yaml`): checks license file exists and is a valid ZIP archive
- **Deployment** (`tasks/deploy.yaml`): creates license secret, deploys AnsibleAutomationPlatform CR, waits for Available condition
- **Global schema**: adds `aapLicenseFile` as `nonEmptyString`

OSAC-931