### PR TITLE
OSAC-955: Add generic Helm image extraction for plugin mirroring

### DIFF
--- a/docs/PLUGIN_ARCHITECTURE.md
+++ b/docs/PLUGIN_ARCHITECTURE.md
@@ -75,7 +75,7 @@ registries:
 | `additionalImages` | Extra images to include in the plugin's oc-mirror image set. |
 | `blockedImages` | Images to exclude from mirroring (by tag, digest, or pattern). |
 | `requires` | Declarative requirements validated at load time, before any deployment work begins. See [Load-Time Validation](#load-time-validation). |
-| `helm` | List of Helm charts to install after operators, before `tasks/deploy.yaml`. Supports local charts and remote repos. Each entry specifies `release`, `namespace`, and optional `repo`, `version`, and values template. |
+| `helm` | List of Helm charts to install after operators, before `tasks/deploy.yaml`. Supports local charts and remote repos. Each entry specifies `release`, `namespace`, and optional `repo`, `version`, values template, and `extractImages`. When `extractImages: true` is set on a local chart, `helm template` is run before mirroring to discover container image references and merge them into `additionalImages` automatically. |
 
 The plugin descriptor is validated by JSON Schema (`schemas/plugin.yaml`) during `make validate`. The validator (`make validate-plugins`) also checks directory structure.
 
@@ -91,17 +91,20 @@ Here's what runs and in what order:
  3. Validate requirements          <- assert requires.vars and requires.files
  4. tasks/early-validate.yaml     <- custom validation (no cluster access)
  5. tasks/pre-validate.yaml       <- "is the cluster ready for me?"
- 6. Mirror (plugin-mode only)      <- template imageset, run oc-mirror, apply manifests
- 7. Install operators              <- from plugin.yaml operators list (if installOperators != false)
- 8. tasks/post-operators.yaml     <- "set up infrastructure that Helm or deploy needs"
- 9. Deploy Helm charts             <- from plugin.yaml helm list (values templates rendered here)
-10. tasks/deploy.yaml             <- "create my CRs"
-11. tasks/post-validate.yaml      <- "did it work?"
+ 6. Extract Helm images            <- helm template on charts with extractImages: true, merge into additionalImages
+ 7. Mirror (plugin-mode only)      <- template imageset, run oc-mirror, apply manifests
+ 8. Install operators              <- from plugin.yaml operators list (if installOperators != false)
+ 9. tasks/post-operators.yaml     <- "set up infrastructure that Helm or deploy needs"
+10. Deploy Helm charts             <- from plugin.yaml helm list (values templates rendered here)
+11. tasks/deploy.yaml             <- "create my CRs"
+12. tasks/post-validate.yaml      <- "did it work?"
 ```
 
 Steps 3-4 are the load-time validation gate. If any declared requirement is missing or the early-validate script fails, the plugin fails immediately -- before mirroring, operator installation, or deployment. Note that `early-validate.yaml` runs before the cluster exists, so it cannot use KUBECONFIG. Use it for config format checks, external connectivity validation, or other pre-flight logic.
 
-Step 8 (`post-operators.yaml`) is useful for plugins that need to set up infrastructure after operators are installed but before Helm charts or deploy tasks run. For example, a plugin might use this hook to create a CR instance and extract credentials that the Helm values template depends on. Facts set in `post-operators.yaml` are available to later steps because all hooks run in the same Ansible play via `include_tasks`.
+Step 6 runs `helm template` (with chart defaults, no custom values) on local charts that have `extractImages: true`. The discovered image references are merged into `additionalImages` before mirroring. This is opt-in because `helm template` can fail if sub-chart dependencies aren't populated. Remote charts (with `repo` set) are skipped.
+
+Step 9 (`post-operators.yaml`) is useful for plugins that need to set up infrastructure after operators are installed but before Helm charts or deploy tasks run. For example, a plugin might use this hook to create a CR instance and extract credentials that the Helm values template depends on. Facts set in `post-operators.yaml` are available to later steps because all hooks run in the same Ansible play via `include_tasks`.
 
 Separately, during Quay operator setup:
 
@@ -338,7 +341,7 @@ requires:
 5. Add `requires` to declare variables or files that must exist at load time
 6. Add `tasks/early-validate.yaml` for custom pre-flight checks that don't need cluster access (optional)
 7. Add `tasks/post-operators.yaml` for setup needed after operators but before Helm or deploy (optional)
-8. Add `helm` list if you need Helm chart deployments, with chart sources under `charts/` or from a remote `repo`
+8. Add `helm` list if you need Helm chart deployments, with chart sources under `charts/` or from a remote `repo`. Set `extractImages: true` on local charts to auto-discover container images for mirroring
 9. Add `tasks/deploy.yaml` with your post-operator (or post-Helm) setup logic
 10. Add `tasks/quay.yaml` if your plugin provides storage for Quay
 11. Run `make validate-plugins` to verify

--- a/playbooks/tasks/deploy_plugin.yaml
+++ b/playbooks/tasks/deploy_plugin.yaml
@@ -114,6 +114,20 @@
   when: lookup('ansible.builtin.fileglob', plugin_dir ~ '/tasks/pre-validate.yaml') | length > 0
   tags: pre-validate
 
+- name: Extract images from Helm charts for mirroring
+  ansible.builtin.include_tasks:
+    file: tasks/helm_extract_images.yaml
+    apply:
+      tags: mirror
+  when:
+    - plugin.helm is defined
+    - plugin.helm
+      | selectattr('extractImages', 'defined')
+      | selectattr('extractImages', 'equalto', true)
+      | rejectattr('repo', 'defined')
+      | list | length > 0
+  tags: mirror
+
 - name: Set catalog image and mirror defaults
   set_fact:
     catalog_image: "{{ rh_operator_catalog }}"

--- a/playbooks/tasks/helm_extract_images.yaml
+++ b/playbooks/tasks/helm_extract_images.yaml
@@ -1,0 +1,40 @@
+---
+# Extract container image references from local Helm charts that have
+# extractImages: true and merge them into plugin.additionalImages.
+#
+# Required variables: plugin, plugin_dir, workingDir
+#
+# This task file is included from deploy_plugin.yaml before the mirror step.
+# It runs `helm template` with chart defaults (no custom values) to discover
+# upstream image references that need mirroring in disconnected environments.
+
+- name: "HelmExtract | Filter qualifying charts"
+  ansible.builtin.set_fact:
+    _helm_extract_charts: >-
+      {{ plugin.helm
+         | selectattr('extractImages', 'defined')
+         | selectattr('extractImages', 'equalto', true)
+         | rejectattr('repo', 'defined')
+         | list }}
+
+- name: "HelmExtract | Process charts"
+  ansible.builtin.include_tasks:
+    file: tasks/helm_extract_single.yaml
+  loop: "{{ _helm_extract_charts }}"
+  loop_control:
+    loop_var: _extract_chart
+    label: "{{ _extract_chart.release }}"
+
+- name: "HelmExtract | Merge extracted images into plugin.additionalImages"
+  ansible.builtin.set_fact:
+    plugin: >-
+      {{ plugin | combine({
+           'additionalImages': (plugin.additionalImages | default([]) + _helm_all_extracted_images | default([]))
+                               | unique | sort
+         }) }}
+  when: _helm_all_extracted_images | default([]) | length > 0
+
+- name: "HelmExtract | Show extracted images"
+  ansible.builtin.debug:
+    msg: "Extracted {{ _helm_all_extracted_images | default([]) | length }} image(s) from Helm charts: {{ _helm_all_extracted_images | default([]) }}"
+  when: _helm_all_extracted_images | default([]) | length > 0

--- a/playbooks/tasks/helm_extract_single.yaml
+++ b/playbooks/tasks/helm_extract_single.yaml
@@ -1,0 +1,52 @@
+---
+# Extract container images from a single local Helm chart via helm template.
+#
+# Required loop_var: _extract_chart (helm entry with extractImages: true)
+# Required variables: plugin_dir, workingDir
+
+- name: "HelmExtract | Set chart path for {{ _extract_chart.release }}"
+  ansible.builtin.set_fact:
+    _extract_chart_path: >-
+      {{ plugin_dir ~ '/' ~ (_extract_chart.chart | default('charts/' ~ _extract_chart.release)) }}
+
+- name: "HelmExtract | Verify chart exists: {{ _extract_chart.release }}"
+  ansible.builtin.stat:
+    path: "{{ _extract_chart_path }}"
+  register: _r_extract_chart_stat
+
+- name: "HelmExtract | Assert chart exists: {{ _extract_chart.release }}"
+  ansible.builtin.assert:
+    that: _r_extract_chart_stat.stat.exists
+    fail_msg: >-
+      Helm chart not found at {{ _extract_chart_path }}.
+      Cannot extract images for release '{{ _extract_chart.release }}'.
+
+- name: "HelmExtract | Run helm template: {{ _extract_chart.release }}"
+  ansible.builtin.command:
+    cmd: >-
+      {{ workingDir }}/bin/helm template _extract {{ _extract_chart_path }}
+  register: _r_helm_template
+  failed_when: false
+  changed_when: false
+
+- name: "HelmExtract | Fail on template error: {{ _extract_chart.release }}"
+  ansible.builtin.fail:
+    msg: >-
+      helm template failed for chart '{{ _extract_chart.release }}' at {{ _extract_chart_path }}.
+      If the chart has sub-chart dependencies, run 'helm dependency build' first.
+      Error: {{ _r_helm_template.stderr | default('unknown') }}
+  when: _r_helm_template.rc != 0
+
+- name: "HelmExtract | Parse images from template output: {{ _extract_chart.release }}"
+  ansible.builtin.set_fact:
+    _chart_images: >-
+      {{ _r_helm_template.stdout_lines
+         | select('match', '^\s*image:\s*')
+         | map('regex_replace', '^\s*image:\s*["'']?([^"''\s]+)["'']?\s*$', '\1')
+         | reject('match', '^\s*$')
+         | unique | sort | list }}
+
+- name: "HelmExtract | Accumulate images from {{ _extract_chart.release }}"
+  ansible.builtin.set_fact:
+    _helm_all_extracted_images: >-
+      {{ (_helm_all_extracted_images | default([])) + _chart_images }}

--- a/schemas/plugin.yaml
+++ b/schemas/plugin.yaml
@@ -199,6 +199,12 @@ definitions:
       wait:
         type: boolean
         description: "Pass --wait. Default: true."
+      extractImages:
+        type: boolean
+        description: >-
+          Extract container image references from the chart's default values
+          via helm template and merge into additionalImages for mirroring.
+          Only works for local charts (repo must not be set). Default: false.
     required:
       - release
       - namespace


### PR DESCRIPTION
## Summary

- Add opt-in `extractImages: true` flag on `helm[]` entries in the plugin schema
- Before mirroring, run `helm template` on qualifying local charts using chart defaults to discover container image references
- Merge extracted images into `plugin.additionalImages` (deduplicated), eliminating the need to manually hardcode images already declared in chart defaults
- Local charts only — entries with `repo` set are skipped; charts without `extractImages` are unaffected

## Test plan

- [ ] `scripts/verification/validate_plugins.sh` passes for all plugins
- [ ] Schema validation accepts `extractImages: true` on helm entries
- [ ] Test with `plugins/helm-test`: add `extractImages: true`, verify chart image is extracted and merged into additionalImages
- [ ] Verify remote charts (with `repo:`) are skipped
- [ ] Verify charts without `extractImages` are skipped
- [ ] Full disconnected deploy test with a plugin using `extractImages: true`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic extraction of container images from local Helm charts when enabled via the chart's extractImages flag; extracted images are merged into the mirroring list.
* **Documentation**
  * Plugin docs and lifecycle steps updated to describe the extractImages option and the new "Extract Helm images" step (local charts only).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/enclave/pull/388?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->