### PR TITLE
plugin validate dirname since basename is always plugin.yaml

### DIFF
--- a/playbooks/validation/tasks/defaults_schema_validation.yaml
+++ b/playbooks/validation/tasks/defaults_schema_validation.yaml
@@ -71,7 +71,7 @@
     engine: ansible.utils.jsonschema
   loop: "{{ r_plugin_files.files }}"
   loop_control:
-    label: "{{ item.path | basename }}"
+    label: "{{ item.path | dirname | basename }}"
 
 - name: Include deployment vars
   ansible.builtin.include_vars: ../../defaults/platforms.yaml


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved validation task output labeling to display plugin directory names instead of filenames, providing better context during schema validation processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/enclave/pull/389?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->