### PR TITLE
[schema] if catalog is not redhat - plugin type must not be foundation

### DIFF
--- a/schemas/plugin.yaml
+++ b/schemas/plugin.yaml
@@ -277,3 +277,12 @@ properties:
 required:
   - name
   - type
+# if plugin type is foundation - catalog must be redhat
+if:
+  properties:
+    type:
+      const: foundation
+then:
+  properties:
+    catalog:
+      const: redhat

--- a/schemas/plugin.yaml
+++ b/schemas/plugin.yaml
@@ -277,12 +277,18 @@ properties:
 required:
   - name
   - type
-# if plugin type is foundation - catalog must be redhat
+# if catalog is not redhat - type must not be foundation
 if:
   properties:
-    type:
-      const: foundation
+    catalog:
+      not:
+        const: redhat
+  required:
+    - catalog
 then:
   properties:
-    catalog:
-      const: redhat
+    type:
+      not:
+        const: foundation
+  required:
+    - type


### PR DESCRIPTION
in #385 we implemented core mirroring for foundation plugins only. this is because in #318 we only implemented support for redhat index image.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened plugin validation: when a plugin declares a catalog that is present and is not `redhat`, the plugin `type` must be provided and cannot be `foundation`. This prevents incompatible plugin configurations and reduces validation-related failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/enclave/pull/390?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->