### PR TITLE
fix plugin find path for validation

### DIFF
--- a/playbooks/validation/tasks/defaults_schema_validation.yaml
+++ b/playbooks/validation/tasks/defaults_schema_validation.yaml
@@ -58,7 +58,7 @@
 
 - name: Find all plugin.yaml files
   ansible.builtin.find:
-    paths: "{{ playbook_dir }}/../plugins"
+    paths: "{{ playbook_dir }}/../../plugins"
     patterns: "plugin.yaml"
     recurse: true
     depth: 2


### PR DESCRIPTION
currently not validating plugins:
```
TASK [Find all plugin.yaml files] **********************************************
Monday 25 May 2026  07:17:47 +0000 (0:00:00.062)       0:00:00.945 ************ 
Warning: : Skipped '/__w/enclave/enclave/playbooks/validation/../plugins' path
due to this access issue:
'/__w/enclave/enclave/playbooks/validation/../plugins' is not a directory
ok: [localhost]

TASK [Validate plugin schema: {{ item.path | regex_replace('.*/plugins/', 'plugins/') }}] ***
Monday 25 May 2026  07:17:47 +0000 (0:00:00.328)       0:00:01.274 ************ 
skipping: [localhost]
```
https://github.com/rh-ecosystem-edge/enclave/actions/runs/26388491819/job/77673449434?pr=390