### PR TITLE
vast-csi plugin foundation -> addon

### DIFF
--- a/plugins/vast-csi/plugin.yaml
+++ b/plugins/vast-csi/plugin.yaml
@@ -1,6 +1,6 @@
 ---
 name: vast-csi
-type: foundation
+type: addon
 order: 10
 
 catalog: certified


### PR DESCRIPTION
after #385, in which we implemented core mirroring for foundation plugins only, in #390 we are enforcing that foundation plugins are only using the redhat catalog. this plugin is using the certified catalog.

this PR changes the plugin type from foundation to addon. this means it can not be installed prior to quay (and can not be used as the quay storage) at the current implementation.