### PR TITLE
Fix operator catalog source selection in connected mode

### DIFF
--- a/playbooks/tasks/configure_operator.yaml
+++ b/playbooks/tasks/configure_operator.yaml
@@ -91,7 +91,7 @@
         installPlanApproval: Automatic
         channel: "{{ operator.channel }}"
         name: "{{ operator.name }}"
-        source: "{{ operator.source | default(default_operator_source) if (disconnected | default(true)) else 'redhat-operators' }}"
+        source: "{{ operator.source | default(default_operator_source) if (disconnected | default(true) | bool) else 'redhat-operators' }}"
         sourceNamespace: openshift-marketplace
   register: r_sub_exists
   retries: "{{ k8s_retries }}"
@@ -114,7 +114,7 @@
         installPlanApproval: Manual
         channel: "{{ operator.channel }}"
         name: "{{ operator.name }}"
-        source: "{{ operator.source | default(default_operator_source) if (disconnected | default(true)) else 'redhat-operators' }}"
+        source: "{{ operator.source | default(default_operator_source) if (disconnected | default(true) | bool) else 'redhat-operators' }}"
         sourceNamespace: openshift-marketplace
         startingCSV: "{{ operator.csvNames | default([]) | first | default(operator.name) }}.v{{ operator.version | replace('+', '-') }}"
   register: r_sub_exists


### PR DESCRIPTION
## Summary
- Add `| bool` filter to the `disconnected` variable check in Subscription source Jinja2 expressions
- Without it, `-e disconnected=false` from the Makefile is passed as a string, which is truthy in Jinja2, causing the mirror catalog to be selected instead of `redhat-operators` in connected mode

## Test plan
- [x] Run `make deploy-plugin PLUGIN=<name> DISCONNECTED=false` and verify the Subscription source is `redhat-operators`
- [x] Verify disconnected mode still selects the mirror catalog source

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed operator subscription source selection logic to properly evaluate connectivity status and apply the correct operator source for both standard and manual subscription configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/enclave/pull/393?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->