### PR TITLE
Fix operator reconcile output not showing in Ansible logs

### DIFF
--- a/playbooks/tasks/configure_operator.yaml
+++ b/playbooks/tasks/configure_operator.yaml
@@ -146,12 +146,13 @@
     enclave-reconcile operator-versions --operators "{{ [operator] }}" --no-dry-run
   register: operator_update_result
 
-- name: Print the output
+- name: "Print Install Plan approval output ({{ operator.name }})"
   when:
     - r_sub_check.resources | length == 0
     - operator.namespace != "openshift-operators"
   ansible.builtin.debug:
-    var: operator_update_result.stdout_lines
+    # enclave-reconcile uses Python logging, which writes to stderr
+    var: operator_update_result.stderr_lines
 
 - name: "Get Installed CSV ({{ operator.name }})"
   when:


### PR DESCRIPTION
## Summary
- The `enclave-reconcile` script uses Python's `logging` module, which writes to stderr. The Ansible debug task was printing `stdout_lines`, which was always empty (`[]`). Changed to `stderr_lines` so the install plan approval output is actually visible in Ansible logs.
- Improved the task name from generic "Print the output" to include the operator name, consistent with other tasks in the file.

## Test plan
- [ ] Run an Enclave install and verify the "Print Install Plan approval output" task shows the reconcile log lines instead of an empty list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected operator configuration logging to capture output from the appropriate source stream, ensuring error messages are properly displayed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/enclave/pull/395?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->