### PR TITLE
Fix OSUS graph-builder TLS trust for disconnected Quay registry

### DIFF
--- a/operators/cincinnati-operator/tasks.yaml
+++ b/operators/cincinnati-operator/tasks.yaml
@@ -1,4 +1,9 @@
 ---
+# UpdateService requires image.config additionalTrustedCA with updateservice-registry
+# before graph-builder can scrape the mirrored release repository over TLS.
+- name: Trust Quay registry CA in image.config for UpdateService
+  ansible.builtin.include_tasks: ../../playbooks/tasks/trust_quay_registry_ca_for_image_config.yaml
+
 - name: Create OpenShift Update Service application object
   environment:
     KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
@@ -18,11 +23,6 @@
   retries: "{{ k8s_retries }}"
   delay: "{{ k8s_delay }}"
   until: r_update_service is success
-
-# UpdateService requires image.config cluster additionalTrustedCA (RegistryCACertFound).
-# Cincinnati is configured before quay_disconnected_finish, so trust the Quay registry CA here.
-- name: Trust Quay registry CA in image.config for UpdateService
-  ansible.builtin.include_tasks: ../../playbooks/tasks/trust_quay_registry_ca_for_image_config.yaml
 
 - name: Wait for UpdateService registry CA condition
   environment:

--- a/playbooks/tasks/trust_quay_registry_ca_for_image_config.yaml
+++ b/playbooks/tasks/trust_quay_registry_ca_for_image_config.yaml
@@ -1,31 +1,34 @@
 ---
 # Trust the internal Quay registry TLS cert for image pulls and UpdateService.
-# Nodes and the Cincinnati operator pull from the Quay route (default ingress cert);
-# image.config.openshift.io cluster must reference a ConfigMap with that CA.
-
-- name: Get ingress CA (signs default router/Quay route cert)
-  ansible.builtin.shell: |
-    {{ workingDir }}/bin/oc get secret router-ca -n openshift-ingress-operator -o jsonpath='{.data.tls\.crt}' | base64 -d
-  environment:
-    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
-  register: quay_registry_ingress_ca
-  changed_when: false
-  failed_when: false
+# OSUS graph-builder reads updateservice-registry from the image.config additionalTrustedCA
+# ConfigMap; nodes use the registry hostname key.
 
 - name: Set Quay registry hostname for image trust
   ansible.builtin.set_fact:
     quay_registry_hostname: "registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}"
 
-# UpdateService operator reads updateservice-registry; nodes use the registry hostname key.
+- name: Resolve Quay registry CA PEM for trust ConfigMap
+  ansible.builtin.command:
+    argv:
+      - enclave-reconcile
+      - resolve-quay-registry-ca
+      - --hostname
+      - "{{ quay_registry_hostname }}"
+      - --oc
+      - "{{ workingDir }}/bin/oc"
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  register: quay_registry_ca_resolved
+  changed_when: false
+
+# UpdateService operator requires updateservice-registry; nodes use the registry hostname key.
 - name: Set Quay registry CA ConfigMap data keys
   ansible.builtin.set_fact:
     quay_registry_ca_configmap_data: >-
       {{ {
-        quay_registry_hostname: quay_registry_ingress_ca.stdout,
-        'updateservice-registry': quay_registry_ingress_ca.stdout
+        quay_registry_hostname: quay_registry_ca_resolved.stdout,
+        'updateservice-registry': quay_registry_ca_resolved.stdout
       } }}
-  when: >-
-    quay_registry_ingress_ca.rc == 0 and quay_registry_ingress_ca.stdout | trim | length > 0
 
 - name: Get current image config additionalTrustedCA ConfigMap name
   ansible.builtin.shell: |
@@ -36,9 +39,7 @@
   changed_when: false
   failed_when: false
 
-- name: Create ConfigMap with Quay registry CA for image pulls
-  when: >-
-    quay_registry_ingress_ca.rc == 0 and quay_registry_ingress_ca.stdout | trim | length > 0
+- name: Create or update ConfigMap with Quay registry CA for image pulls
   kubernetes.core.k8s:
     state: present
     definition:
@@ -52,11 +53,10 @@
     KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
 
 - name: Add Quay registry CA to existing additionalTrustedCA ConfigMap
-  when: >-
-    quay_registry_ingress_ca.rc == 0 and quay_registry_ingress_ca.stdout | trim | length > 0
-    and (image_config_trusted_ca_name.rc == 0)
-    and (image_config_trusted_ca_name.stdout | trim | length > 0)
-    and (image_config_trusted_ca_name.stdout | trim != 'quay-registry-ca')
+  when:
+    - image_config_trusted_ca_name.rc == 0
+    - image_config_trusted_ca_name.stdout | trim | length > 0
+    - image_config_trusted_ca_name.stdout | trim != 'quay-registry-ca'
   kubernetes.core.k8s:
     state: patched
     kind: ConfigMap
@@ -69,10 +69,9 @@
     KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
 
 - name: Patch image config to reference Quay registry CA ConfigMap
-  when: >-
-    quay_registry_ingress_ca.rc == 0 and quay_registry_ingress_ca.stdout | trim | length > 0
-    and (image_config_trusted_ca_name.rc == 0)
-    and (image_config_trusted_ca_name.stdout | trim | length == 0)
+  when:
+    - image_config_trusted_ca_name.rc == 0
+    - image_config_trusted_ca_name.stdout | trim | length == 0
   kubernetes.core.k8s:
     state: patched
     kind: Image
@@ -86,3 +85,18 @@
           name: quay-registry-ca
   environment:
     KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+
+- name: Restart UpdateService deployment to reload registry CA trust
+  ansible.builtin.command:
+    argv:
+      - "{{ workingDir }}/bin/oc"
+      - rollout
+      - restart
+      - deployment/service
+      - -n
+      - openshift-update-service
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  register: r_updateservice_rollout_restart
+  changed_when: r_updateservice_rollout_restart.rc == 0
+  failed_when: false

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -11,6 +11,7 @@ from reconcile.cluster_upgrade import (
     reconcile as cluster_upgrade_reconcile,
 )
 from reconcile.operator_versions import reconcile as operator_versions_reconcile
+from reconcile.quay_registry_ca import reconcile as quay_registry_ca_reconcile
 
 LOG_LEVELS = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 
@@ -30,6 +31,22 @@ def cli(log_level: str) -> None:
         datefmt="%Y-%m-%dT%H:%M:%S",
         stream=sys.stdout,
     )
+
+
+@cli.command("resolve-quay-registry-ca")
+@click.option("--hostname", required=True, help="Quay registry route hostname.")
+@click.option(
+    "--oc",
+    default="oc",
+    show_default=True,
+    help="Path to the oc binary.",
+)
+def resolve_quay_registry_ca(hostname: str, oc: str) -> None:
+    """Print the CA PEM that trusts the Quay registry route TLS certificate."""
+    try:
+        quay_registry_ca_reconcile(hostname, oc=oc)
+    except RuntimeError as exc:
+        raise click.ClickException(str(exc)) from exc
 
 
 @cli.command()

--- a/reconcile/quay_registry_ca.py
+++ b/reconcile/quay_registry_ca.py
@@ -1,0 +1,133 @@
+"""Resolve the CA PEM used to trust the Quay registry route for OSUS and image pulls."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import logging
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_TLS_CONNECT_TIMEOUT_SECONDS = 60
+_OC_COMMAND_TIMEOUT_SECONDS = 30
+_OPENSSL_VERIFY_TIMEOUT_SECONDS = 10
+_PEM_BLOCK = re.compile(
+    r"-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----",
+    re.DOTALL,
+)
+
+
+def pem_blocks(pem_text: str) -> list[str]:
+    return _PEM_BLOCK.findall(pem_text or "")
+
+
+def get_router_ca_pem(*, oc: str = "oc") -> str:
+    try:
+        result = subprocess.run(
+            [
+                oc,
+                "get",
+                "secret",
+                "router-ca",
+                "-n",
+                "openshift-ingress-operator",
+                "-o",
+                "jsonpath={.data.tls\\.crt}",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_OC_COMMAND_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        msg = "oc get secret router-ca timed out"
+        raise RuntimeError(msg) from exc
+    except OSError as exc:
+        msg = f"{oc} not found"
+        raise RuntimeError(msg) from exc
+    if result.returncode != 0 or not result.stdout.strip():
+        return ""
+    try:
+        return base64.b64decode(result.stdout).decode("utf-8")
+    except (binascii.Error, UnicodeDecodeError) as exc:
+        msg = f"invalid router-ca secret: {exc}"
+        raise RuntimeError(msg) from exc
+
+
+def fetch_tls_chain_pem(hostname: str, *, port: int = 443) -> str:
+    try:
+        result = subprocess.run(
+            [
+                "openssl",
+                "s_client",
+                "-connect",
+                f"{hostname}:{port}",
+                "-servername",
+                hostname,
+                "-showcerts",
+            ],
+            input="",
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_TLS_CONNECT_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        msg = f"openssl s_client timed out connecting to {hostname}:{port}"
+        raise RuntimeError(msg) from exc
+    except OSError as exc:
+        msg = "openssl not found"
+        raise RuntimeError(msg) from exc
+    return "\n".join(pem_blocks(result.stdout + result.stderr))
+
+
+def _openssl_verify(ca_pem: str, cert_pem: str) -> bool:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        work = Path(tmpdir)
+        ca_path = work / "ca.pem"
+        cert_path = work / "cert.pem"
+        ca_path.write_text(ca_pem, encoding="utf-8")
+        cert_path.write_text(cert_pem, encoding="utf-8")
+        try:
+            result = subprocess.run(
+                ["openssl", "verify", "-CAfile", str(ca_path), str(cert_path)],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=_OPENSSL_VERIFY_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired as exc:
+            msg = "openssl verify timed out"
+            raise RuntimeError(msg) from exc
+        except OSError as exc:
+            msg = "openssl not found"
+            raise RuntimeError(msg) from exc
+    return result.returncode == 0
+
+
+def resolve_registry_ca_pem(hostname: str, *, oc: str = "oc") -> str:
+    """Return PEM for the CA that should trust the registry route certificate."""
+    router_ca = get_router_ca_pem(oc=oc).strip()
+    chain = pem_blocks(fetch_tls_chain_pem(hostname))
+    if not chain:
+        if router_ca:
+            return f"{router_ca}\n"
+        msg = f"unable to resolve registry CA for {hostname}"
+        raise RuntimeError(msg)
+
+    leaf = chain[0]
+    if router_ca and _openssl_verify(router_ca, leaf):
+        logger.debug("using router-ca to trust %s", hostname)
+        return f"{router_ca}\n"
+
+    logger.debug("using TLS chain root to trust %s", hostname)
+    return f"{chain[-1]}\n"
+
+
+def reconcile(hostname: str, *, oc: str = "oc") -> None:
+    sys.stdout.write(resolve_registry_ca_pem(hostname, oc=oc))

--- a/reconcile/tests/test_cli.py
+++ b/reconcile/tests/test_cli.py
@@ -13,6 +13,43 @@ def test_cli_help() -> None:
     assert "Reconcile CLI" in result.output
 
 
+def test_resolve_quay_registry_ca_help() -> None:
+    result = CliRunner().invoke(cli, ["resolve-quay-registry-ca", "--help"])
+    assert result.exit_code == 0
+    assert "--hostname" in result.output
+
+
+def test_resolve_quay_registry_ca_forwards_args(mocker: MockerFixture) -> None:
+    mock_reconcile = mocker.patch("reconcile.cli.quay_registry_ca_reconcile")
+    result = CliRunner().invoke(
+        cli,
+        [
+            "resolve-quay-registry-ca",
+            "--hostname",
+            "registry.example.com",
+            "--oc",
+            "/usr/bin/oc",
+        ],
+    )
+    assert result.exit_code == 0
+    mock_reconcile.assert_called_once_with("registry.example.com", oc="/usr/bin/oc")
+
+
+def test_resolve_quay_registry_ca_runtime_error(mocker: MockerFixture) -> None:
+    mocker.patch(
+        "reconcile.cli.quay_registry_ca_reconcile",
+        side_effect=RuntimeError(
+            "unable to resolve registry CA for registry.example.com"
+        ),
+    )
+    result = CliRunner().invoke(
+        cli,
+        ["resolve-quay-registry-ca", "--hostname", "registry.example.com"],
+    )
+    assert result.exit_code != 0
+    assert "unable to resolve registry CA for registry.example.com" in result.output
+
+
 def test_operator_versions_help() -> None:
     result = CliRunner().invoke(cli, ["operator-versions", "--help"])
     assert result.exit_code == 0

--- a/reconcile/tests/test_quay_registry_ca.py
+++ b/reconcile/tests/test_quay_registry_ca.py
@@ -1,0 +1,131 @@
+from subprocess import CompletedProcess, TimeoutExpired
+
+import pytest
+from pytest_mock import MockerFixture
+
+from reconcile.quay_registry_ca import (
+    _openssl_verify,
+    fetch_tls_chain_pem,
+    get_router_ca_pem,
+    pem_blocks,
+    resolve_registry_ca_pem,
+)
+
+_LEAF = """-----BEGIN CERTIFICATE-----
+leaf
+-----END CERTIFICATE-----"""
+_ROOT = """-----BEGIN CERTIFICATE-----
+root
+-----END CERTIFICATE-----"""
+_ROUTER_CA = """-----BEGIN CERTIFICATE-----
+router-ca
+-----END CERTIFICATE-----"""
+
+
+def test_fetch_tls_chain_pem_timeout_raises_runtime_error(
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch(
+        "reconcile.quay_registry_ca.subprocess.run",
+        side_effect=TimeoutExpired(cmd=["openssl", "s_client"], timeout=60),
+    )
+    with pytest.raises(RuntimeError, match="openssl s_client timed out connecting to"):
+        fetch_tls_chain_pem("registry.example.com")
+
+
+def test_get_router_ca_pem_invalid_base64_raises_runtime_error(
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch(
+        "reconcile.quay_registry_ca.subprocess.run",
+        return_value=CompletedProcess(
+            args=["oc"], returncode=0, stdout="not-valid-base64!!!"
+        ),
+    )
+    with pytest.raises(RuntimeError, match="invalid router-ca secret"):
+        get_router_ca_pem()
+
+
+def test_get_router_ca_pem_missing_oc_raises_runtime_error(
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch(
+        "reconcile.quay_registry_ca.subprocess.run",
+        side_effect=FileNotFoundError(2, "No such file or directory", "/bin/oc"),
+    )
+    with pytest.raises(RuntimeError, match="/bin/oc not found"):
+        get_router_ca_pem(oc="/bin/oc")
+
+
+def test_fetch_tls_chain_pem_missing_openssl_raises_runtime_error(
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch(
+        "reconcile.quay_registry_ca.subprocess.run",
+        side_effect=FileNotFoundError(2, "No such file or directory", "openssl"),
+    )
+    with pytest.raises(RuntimeError, match="openssl not found"):
+        fetch_tls_chain_pem("registry.example.com")
+
+
+def test_openssl_verify_missing_openssl_raises_runtime_error(
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch(
+        "reconcile.quay_registry_ca.subprocess.run",
+        side_effect=FileNotFoundError(2, "No such file or directory", "openssl"),
+    )
+    with pytest.raises(RuntimeError, match="openssl not found"):
+        _openssl_verify(_ROUTER_CA, _LEAF)
+
+
+def test_pem_blocks_splits_multiple_certificates() -> None:
+    chain = f"{_LEAF}\n{_ROOT}\n"
+    assert pem_blocks(chain) == [_LEAF, _ROOT]
+
+
+def test_resolve_registry_ca_pem_uses_router_ca_when_it_verifies(
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch(
+        "reconcile.quay_registry_ca.get_router_ca_pem", return_value=_ROUTER_CA
+    )
+    mocker.patch(
+        "reconcile.quay_registry_ca.fetch_tls_chain_pem",
+        return_value=f"{_LEAF}\n{_ROOT}\n",
+    )
+    mocker.patch("reconcile.quay_registry_ca._openssl_verify", return_value=True)
+    assert resolve_registry_ca_pem("registry.example.com") == f"{_ROUTER_CA.strip()}\n"
+
+
+def test_resolve_registry_ca_pem_falls_back_to_chain_root(
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch(
+        "reconcile.quay_registry_ca.get_router_ca_pem", return_value=_ROUTER_CA
+    )
+    mocker.patch(
+        "reconcile.quay_registry_ca.fetch_tls_chain_pem",
+        return_value=f"{_LEAF}\n{_ROOT}\n",
+    )
+    mocker.patch("reconcile.quay_registry_ca._openssl_verify", return_value=False)
+    assert resolve_registry_ca_pem("registry.example.com") == f"{_ROOT.strip()}\n"
+
+
+def test_resolve_registry_ca_pem_empty_chain_uses_router_ca_fallback(
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch(
+        "reconcile.quay_registry_ca.get_router_ca_pem", return_value=_ROUTER_CA
+    )
+    mocker.patch("reconcile.quay_registry_ca.fetch_tls_chain_pem", return_value="")
+    assert resolve_registry_ca_pem("registry.example.com") == f"{_ROUTER_CA.strip()}\n"
+
+
+def test_resolve_registry_ca_pem_empty_chain_without_router_ca_raises(
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch("reconcile.quay_registry_ca.get_router_ca_pem", return_value="")
+    mocker.patch("reconcile.quay_registry_ca.fetch_tls_chain_pem", return_value="")
+    with pytest.raises(RuntimeError, match="unable to resolve registry CA"):
+        resolve_registry_ca_pem("registry.example.com")


### PR DESCRIPTION
Cincinnati graph-builder failed to scrape release metadata from the Quay route with certificate verify failed (self signed certificate in chain) because the updateservice-registry CA in image.config was missing[1] or did not match the certificate actually presented by the registry. Thus, 'update-service' pods fail to start[2].

Apply Quay registry CA trust before creating UpdateService, resolve the correct CA PEM via enclave-reconcile resolve-quay-registry-ca (router-ca when it verifies the live leaf, otherwise the chain root) Then ensure the openshift-config ConfigMap includes updateservice-registry, and restart the OSUS deployment so graph-builder reloads trust.

[1]
```
cincinnati::plugins::internal::graph_builder::commons] unable to process
certificate ca-bundle.trust.crt: builder error: error:0909006C:PEM
routines:get_name:no start line:crypto/pem/pem_lib.c:745:Expecting: CERTIFICATE
```

[2]
```
$ oc -n openshift-update-service get pod
NAME                                      READY   STATUS                   RESTARTS         AGE
graph-data-tag-digest                     0/1     ContainerStatusUnknown   1                50m
service-5785cb4d7c-q4hdf                  0/2     Running                  24 (57s ago)     131m
service-5785cb4d7c-vfffw                  0/2     Running                  23 (3m27s ago)   131m
service-bd8f457f8-h4j2p                   0/2     Running                  36 (57s ago)     3h35m
updateservice-operator-787f968c77-8nwtf   1/1     Running                  0                10m
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI command to resolve the Quay registry CA certificate.

* **Improvements**
  * Registry CA trust is applied earlier in the UpdateService workflow.
  * Cluster image CA wiring now updates or sets the trusted CA config as needed.
  * UpdateService deployment is restarted to pick up updated CA trust.
  * CA retrieval uses a dedicated resolution step for registry routes.

* **Tests**
  * Added CLI and CA-resolution unit tests covering success, failures, timeouts, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->