### PR TITLE
plugins acm policies use catalog mirror #2

### DIFF
--- a/plugins/nvidia-gpu/files/09-policy-catalogsource.yaml.j2
+++ b/plugins/nvidia-gpu/files/09-policy-catalogsource.yaml.j2
@@ -28,10 +28,10 @@ spec:
             apiVersion: operators.coreos.com/v1alpha1
             kind: CatalogSource
             metadata:
-              name: {{ mirror_certified_rh_operator_catalog }}-nvidia-gpu
+              name: {{ catalog_mirror }}
               namespace: openshift-marketplace
             spec:
-              image: registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/redhat/{{ mirror_certified_rh_operator_catalog }}-nvidia-gpu:{{ certified_operator_catalog_version }}
+              image: registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/redhat/{{ catalog_mirror }}:{{ catalog_version }}
               sourceType: grpc
         - complianceType: musthave
           metadataComplianceType: musthave
@@ -39,7 +39,7 @@ spec:
             apiVersion: operators.coreos.com/v1alpha1
             kind: CatalogSource
             metadata:
-              name: {{ mirror_certified_rh_operator_catalog }}-nvidia-gpu
+              name: {{ catalog_mirror }}
               namespace: openshift-marketplace
             status:
               connectionState:

--- a/plugins/openshift-ai/files/09-policy-catalogsource.yaml.j2
+++ b/plugins/openshift-ai/files/09-policy-catalogsource.yaml.j2
@@ -28,10 +28,10 @@ spec:
             apiVersion: operators.coreos.com/v1alpha1
             kind: CatalogSource
             metadata:
-              name: {{ mirror_rh_operator_catalog }}-openshift-ai
+              name: {{ catalog_mirror }}
               namespace: openshift-marketplace
             spec:
-              image: registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/redhat/{{ mirror_rh_operator_catalog }}-openshift-ai:{{ rh_operator_catalog_version }}
+              image: registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/redhat/{{ catalog_mirror }}:{{ catalog_version }}
               sourceType: grpc
         - complianceType: musthave
           metadataComplianceType: musthave
@@ -39,7 +39,7 @@ spec:
             apiVersion: operators.coreos.com/v1alpha1
             kind: CatalogSource
             metadata:
-              name: {{ mirror_rh_operator_catalog }}-openshift-ai
+              name: {{ catalog_mirror }}
               namespace: openshift-marketplace
             status:
               connectionState:
@@ -62,7 +62,7 @@ spec:
               name: redhat-operators
               namespace: openshift-marketplace
             spec:
-              image: registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/redhat/{{ mirror_rh_operator_catalog }}-openshift-ai:{{ rh_operator_catalog_version }}
+              image: registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/redhat/{{ catalog_mirror }}:{{ catalog_version }}
               sourceType: grpc
         - complianceType: musthave
           metadataComplianceType: musthave


### PR DESCRIPTION
similar to #339

relies on: https://github.com/rh-ecosystem-edge/enclave/blob/56b41bf59e194a087a95be15bde8637a280dfe09/playbooks/tasks/deploy_plugin.yaml#L117-L131