### PR TITLE
support certified catalog for foundation plugins

### DIFF
--- a/operators/quay-operator/quay_disconnected_start.yaml
+++ b/operators/quay-operator/quay_disconnected_start.yaml
@@ -17,6 +17,12 @@
     regexp: 'catalog: {{ quayHostname }}:8443/redhat/redhat-operator-index'
     replace: "catalog: {{ quayHostname }}:8443/redhat/{{ mirror_rh_operator_catalog }}"
 
+- name: Replace certified-operator-index with internal mirror
+  ansible.builtin.replace:
+    path: "{{ workingDir }}/config/imagesetconfiguration.internal.yaml"
+    regexp: 'catalog: {{ quayHostname }}:8443/redhat/certified-operator-index'
+    replace: "catalog: {{ quayHostname }}:8443/redhat/{{ mirror_certified_rh_operator_catalog }}"
+
 - name: Ensure .config/containers/ exists
   ansible.builtin.file:
     path: "{{ lookup('env','HOME') }}/.config/containers/"

--- a/playbooks/02-mirror.yaml
+++ b/playbooks/02-mirror.yaml
@@ -60,7 +60,7 @@
 
     - name: Combine core operators with core plugin operators
       set_fact:
-        catalog_operators: "{{ {'core': operators} | combine(_core_plugin_operators | default({})) }}"
+        catalog_operators: "{{ {'core': {'operators': operators, 'catalog': 'redhat'}} | combine(_core_plugin_operators | default({})) }}"
       tags: mirror-registry
 
     - name: Include tasks for mirror-registry

--- a/playbooks/tasks/collect_core_plugin_operators.yaml
+++ b/playbooks/tasks/collect_core_plugin_operators.yaml
@@ -31,11 +31,13 @@
          | selectattr('name', 'in', enabled_plugins)
          | list }}
   ansible.builtin.set_fact:
-    _core_plugin_operators: >-
-      {{ _foundation
-         | selectattr('operators', 'defined')
-         | items2dict(key_name='name', value_name='operators') }}
+    _core_plugin_operators: |-
+      {% set tmp = {} %}
+      {% for p in _foundation if p.operators is defined %}
+      {% set _ = tmp.update({p.name: {'operators': p.operators, 'catalog': p.catalog | default('redhat')}}) %}
+      {% endfor %}
+      {{ tmp }}
 
 - name: Display plugin operators to mirror
   ansible.builtin.debug:
-    msg: "Plugin operators to include in imageset: {{ _core_plugin_operators.values() | flatten | map(attribute='name') | list }}"
+    msg: "Plugin operators to include in imageset: {{ _core_plugin_operators.values() | map(attribute='operators') | flatten | map(attribute='name') | list }}"

--- a/playbooks/tasks/mirror_registry.yaml
+++ b/playbooks/tasks/mirror_registry.yaml
@@ -55,11 +55,15 @@
       --dest-tls-verify=false \
       --retry-times {{ ocMirrorRetryTimes }} \
       --retry-delay {{ ocMirrorRetryDelay }} \
-      docker://{{ rh_operator_catalog }}:{{ rh_operator_catalog_version }} \
-      docker://{{ quayHostname }}:8443/redhat/redhat-operator-index{{ (item == 'core') | ternary('', '-' ~ item) }}:{{ rh_operator_catalog_version }}
-  loop: "{{ catalog_operators.keys() | list }}"
+      docker://{{ _src_catalog }}:{{ _version }} \
+      docker://{{ quayHostname }}:8443/redhat/{{ _dest_catalog }}:{{ _version }}
+  vars:
+    _src_catalog: "{{ certified_operator_catalog if item.value.catalog == 'certified' else rh_operator_catalog }}"
+    _dest_catalog: "{{ mirror_certified_rh_operator_catalog if item.value.catalog == 'certified' else mirror_rh_operator_catalog }}{{ (item.key == 'core') | ternary('', '-' ~ item.key) }}"
+    _version: "{{ certified_operator_catalog_version if item.value.catalog == 'certified' else rh_operator_catalog_version }}"
+  loop: "{{ catalog_operators | dict2items }}"
   loop_control:
-    label: "{{ item }}"
+    label: "{{ item.key }}"
   register: skopeo_result
   changed_when: "'Copying blob' in skopeo_result.stdout"
   retries: "{{ 1 if (mirror_dry_run | default(false) | bool) else ocMirrorAnsibleRetries }}"
@@ -75,7 +79,13 @@
   ansible.builtin.replace:
     path: "{{ workingDir }}/config/imagesetconfiguration.yaml"
     regexp: 'catalog: {{ rh_operator_catalog }}'
-    replace: "catalog: {{ quayHostname }}:8443/redhat/redhat-operator-index"
+    replace: "catalog: {{ quayHostname }}:8443/redhat/{{ mirror_rh_operator_catalog }}"
+
+- name: Replace registry.redhat.io with certified-operator-index in mirror-registry
+  ansible.builtin.replace:
+    path: "{{ workingDir }}/config/imagesetconfiguration.yaml"
+    regexp: 'catalog: {{ certified_operator_catalog }}'
+    replace: "catalog: {{ quayHostname }}:8443/redhat/{{ mirror_certified_rh_operator_catalog }}"
 
 - name: Ensure oc-mirror log directory exists
   ansible.builtin.file:

--- a/playbooks/tasks/template_validation/test_imagesetconfiguration.yaml
+++ b/playbooks/tasks/template_validation/test_imagesetconfiguration.yaml
@@ -4,8 +4,8 @@
 
 - name: Render imagesetconfiguration.yaml for each storage backend
   vars:
-    _core_plugin_operators: "{{ {item.name: item.operators} }}"
-    catalog_operators: "{{ {'core': operators} | combine(_core_plugin_operators) }}"
+    _core_plugin_operators: "{{ {item.name: {'operators': item.operators, 'catalog': item.catalog | default('redhat')}} }}"
+    catalog_operators: "{{ {'core': {'operators': operators, 'catalog': 'redhat'}} | combine(_core_plugin_operators) }}"
   ansible.builtin.template:
     src: ../../templates/imagesetconfiguration.yaml.j2
     dest: "{{ temp_dir.path }}/imagesetconfiguration-{{ item.name }}.yaml"

--- a/plugins/vast-csi/plugin.yaml
+++ b/plugins/vast-csi/plugin.yaml
@@ -1,6 +1,6 @@
 ---
 name: vast-csi
-type: addon
+type: foundation
 order: 10
 
 catalog: certified

--- a/templates/imagesetconfiguration.yaml.j2
+++ b/templates/imagesetconfiguration.yaml.j2
@@ -26,16 +26,19 @@ mirror:
 {% endfor %}
     graph: true
   operators:
-{% for c_name, c_operators in catalog_operators.items() %}
+{% for c_name, c_catalog_operators in catalog_operators.items() %}
 {% if c_name == 'core' %}
     - catalog: {{ rh_operator_catalog }}:{{ rh_operator_catalog_version }}
       targetCatalog: redhat/{{ mirror_rh_operator_catalog }}
+{% elif c_catalog_operators.catalog == 'certified' %}
+    - catalog: {{ certified_operator_catalog }}-{{ c_name }}:{{ certified_operator_catalog_version }}
+      targetCatalog: redhat/{{ mirror_certified_rh_operator_catalog }}-{{ c_name }}
 {% else %}
     - catalog: {{ rh_operator_catalog }}-{{ c_name }}:{{ rh_operator_catalog_version }}
       targetCatalog: redhat/{{ mirror_rh_operator_catalog }}-{{ c_name }}
 {% endif %}
       packages:
-{% for operator in c_operators %}
+{% for operator in c_catalog_operators.operators %}
 {% set additional_operator_names = operator.csvNames if (operator.csvMirror | default(false) | bool) else [] %}
 {% for operator_name in [operator.name] + additional_operator_names %}
         - name: {{ operator_name }}


### PR DESCRIPTION
part of https://redhat.atlassian.net/browse/OSAC-875

follows up on #385

to be able to use vast-csi as a storage plugin for quay it needs to be a foundation plugin.

this PR adds required pieces to support certified catalog as a foundation plugin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for mirroring certified Red Hat operators separately with distinct catalog identification in disconnected environments.

* **Changes**
  * VAST-CSI plugin reclassified from addon to foundation plugin.
  * Enhanced operator catalog configuration to better distinguish between standard and certified operator sources during registry mirroring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->