### PR TITLE
Fix subscription issues

### DIFF
--- a/.github/workflows/disconnected-dry-run.yml
+++ b/.github/workflows/disconnected-dry-run.yml
@@ -93,6 +93,11 @@ jobs:
           echo "✅ Infrastructure created" >> $GITHUB_STEP_SUMMARY
 
       - name: Provision Landing Zone
+        env:
+          LZ_CLOUD_IMAGE_URL: ${{ vars.LZ_CLOUD_IMAGE_URL }}
+          LZ_CLOUD_IMAGE_NAME: ${{ vars.LZ_CLOUD_IMAGE_NAME }}
+          LZ_RHSM_ORG: ${{ secrets.LZ_RHSM_ORG }}
+          LZ_RHSM_ACTIVATION_KEY: ${{ secrets.LZ_RHSM_ACTIVATION_KEY }}
         run: |
           echo "## Provisioning Landing Zone" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/scripts/infrastructure/provision_landing_zone.sh
+++ b/scripts/infrastructure/provision_landing_zone.sh
@@ -76,7 +76,7 @@ echo ""
 # Create working directory
 info "Creating working directory: $LZ_WORKING_DIR"
 sudo mkdir -p "$LZ_WORKING_DIR"
-sudo chown $USER:$USER "$LZ_WORKING_DIR"
+sudo chown "$USER":"$USER" "$LZ_WORKING_DIR"
 
 # Copy cloud image from cache or download
 # Each job gets its own copy to avoid I/O conflicts during parallel execution
@@ -88,7 +88,7 @@ elif [[ "$CLOUD_IMAGE_URL" == file://* ]]; then
     cp "${CLOUD_IMAGE_URL#file://}" "${LZ_WORKING_DIR}/${CLOUD_IMAGE_NAME}"
 else
     info "Downloading cloud image: ${CLOUD_IMAGE_NAME}..."
-    wget -nv -O "${LZ_WORKING_DIR}/${CLOUD_IMAGE_NAME}" "$CLOUD_IMAGE_URL"
+    curl -fL --progress-bar -o "${LZ_WORKING_DIR}/${CLOUD_IMAGE_NAME}" "$CLOUD_IMAGE_URL"
 fi
 info "✓ Cloud image ready"
 
@@ -113,20 +113,6 @@ users:
 hostname: enclave-lz
 fqdn: enclave-lz.${CLUSTER_DOMAIN:-enclave-test.lab}
 
-packages:
-  - git
-  - vim
-  - curl
-  - wget
-  - jq
-  - python3
-  - python3-pip
-  - ansible-core
-
-runcmd:
-  - systemctl disable cloud-init
-  - touch /etc/cloud/cloud-init.disabled
-
 timezone: UTC
 
 ssh_pwauth: false
@@ -135,7 +121,8 @@ disable_root: true
 final_message: "Enclave Landing Zone VM is ready. Time: \$UPTIME"
 EOF
 
-# Conditionally add RHSM subscription for RHEL images
+# rh_subscription must appear before runcmd in the file so cloud-init registers
+# the system before the runcmd stage attempts to use subscription-manager
 if [ -n "${LZ_RHSM_ORG:-}" ] && [ -n "${LZ_RHSM_ACTIVATION_KEY:-}" ]; then
     info "Adding RHSM subscription to cloud-init configuration..."
     cat >> "${LZ_WORKING_DIR}/user-data" <<RHSM_EOF
@@ -145,6 +132,26 @@ rh_subscription:
   org: "${LZ_RHSM_ORG}"
 RHSM_EOF
 fi
+
+cat >> "${LZ_WORKING_DIR}/user-data" <<'EOF'
+
+runcmd:
+EOF
+
+if [ -n "${LZ_RHSM_ORG:-}" ] && [ -n "${LZ_RHSM_ACTIVATION_KEY:-}" ]; then
+    cat >> "${LZ_WORKING_DIR}/user-data" <<'RUNCMD_EOF'
+  - |
+    subscription-manager refresh
+    subscription-manager repos --disable='*-eus-*' --disable='*-debug-rpms' --disable='*-source-rpms'
+    dnf clean metadata
+RUNCMD_EOF
+fi
+
+cat >> "${LZ_WORKING_DIR}/user-data" <<'EOF'
+  - dnf install -y git
+  - systemctl disable cloud-init
+  - touch /etc/cloud/cloud-init.disabled
+EOF
 
 # Note: Skipping network-config - let cloud-init use DHCP from libvirt networks
 # This ensures the VM gets network connectivity quickly

--- a/scripts/runners/install_runner_ci_requirements.sh
+++ b/scripts/runners/install_runner_ci_requirements.sh
@@ -75,7 +75,6 @@ info "Step 2: Installing core system tools"
 sudo dnf install -y \
     git \
     curl \
-    wget \
     vim \
     make \
     tar \
@@ -107,7 +106,7 @@ else
     warning "shellcheck not available in repos, installing via binary..."
     # Install shellcheck from GitHub releases
     SHELLCHECK_VERSION="v0.10.0"
-    wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | tar -xJv
+    curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | tar -xJv
     sudo cp "shellcheck-${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/
     rm -rf "shellcheck-${SHELLCHECK_VERSION}"
     success "shellcheck installed from binary"

--- a/scripts/verification/verify_enclave_installation.sh
+++ b/scripts/verification/verify_enclave_installation.sh
@@ -162,7 +162,7 @@ fi
 
 # Test 4: Required tools installed
 info "Test 4: Checking required tools on Landing Zone..."
-REQUIRED_TOOLS=("git" "ansible" "python3" "curl" "jq" "podman" "httpd" "nmstatectl")
+REQUIRED_TOOLS=("git" "ansible-playbook" "python3" "curl" "jq" "podman" "httpd" "nmstatectl")
 for tool in "${REQUIRED_TOOLS[@]}"; do
     if ssh $SSH_OPTS "$LZ_SSH" "command -v $tool &>/dev/null"; then
         success "$tool is installed"

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -4,9 +4,9 @@ set -e
 
 # Install prerequisites
 dnf install -y \
-    awscli2 \
     bind-utils \
     curl \
+    jq \
     httpd \
     httpd-tools \
     ipcalc \
@@ -16,11 +16,19 @@ dnf install -y \
     openssl \
     podman \
     python3 \
-    python3-pip \
     rsync \
     skopeo \
     tar \
+    unzip \
     vim
+
+# Install AWS CLI v2 from official installer
+AWS_CLI_VERSION=2.34.53
+AWSCLI_TMP=$(mktemp -d)
+trap 'rm -rf "${AWSCLI_TMP}"' EXIT
+curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o "${AWSCLI_TMP}/awscliv2.zip"
+unzip -q "${AWSCLI_TMP}/awscliv2.zip" -d "${AWSCLI_TMP}"
+"${AWSCLI_TMP}/aws/install"
 
 systemctl enable --now httpd
 mkdir -p /var/www/html


### PR DESCRIPTION
* previous installation was failing due to 10.2 beta packages no longer available to us, either because they had been emptied or our subscription key didn't grant the right to download them anymore.
* In the debugging work, we replaced the subscription key and the current one doesn't have rights to get all the default repos, so we remove everything we can't get.
* that has an effect on aws_cli2, which we cannot download anymore. I've added a workaround to get it via the official aws cli page, but we may revisit this in the future.
* I've cleaned-up a bit duplication of packages installation so that we only install git in the LZ script, as it looks as a pre-requisite for the rest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved infrastructure provisioning reliability with updated download mechanisms
  * Refined prerequisite installation process with updated dependency handling and AWS CLI v2 setup
  * Enhanced required tools verification during enclave installation checks

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/enclave/pull/400?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->