### PR TITLE
Add sshPubKey as alternative to sshPubPath

### DIFF
--- a/playbooks/common/load-vars.yaml
+++ b/playbooks/common/load-vars.yaml
@@ -14,6 +14,19 @@
   ansible.builtin.include_vars: "{{ item }}"
   loop: "{{ user_config_files }}"
 
+- name: Write SSH public key to file if content provided
+  when: sshPubKey is defined and sshPubKey | length > 0
+  block:
+    - name: Write sshPubKey content to file
+      ansible.builtin.copy:
+        content: "{{ sshPubKey }}\n"
+        dest: "{{ workingDir }}/config/ssh-pub-key.pub"
+        mode: "0644"
+
+    - name: Set sshPubPath from written file
+      ansible.builtin.set_fact:
+        sshPubPath: "{{ workingDir }}/config/ssh-pub-key.pub"
+
 - name: Include common configuration
   ansible.builtin.include_vars: "../../defaults/{{ config_file }}"
   loop:

--- a/schemas/variables.yaml
+++ b/schemas/variables.yaml
@@ -134,6 +134,9 @@ properties:
     "$ref": "#/definitions/nonEmptyString"
   rendezvousIP:
     "$ref": "#/definitions/ipv4Address"
+  sshPubKey:
+    type: string
+    description: SSH public key content (e.g. ssh-rsa AAAA...). If set, overrides sshPubPath.
   sshPubPath:
     "$ref": "#/definitions/nonEmptyString"
   ironicHTTPSCertificate:
@@ -257,8 +260,11 @@ required:
   - quayPassword
   - quayUser
   - rendezvousIP
-  - sshPubPath
   - workingDir
+
+anyOf:
+  - required: [sshPubKey]
+  - required: [sshPubPath]
 
 allOf:
   - if:


### PR DESCRIPTION
Accept SSH public key content directly in the config (sshPubKey field) as an alternative to providing a file path (sshPubPath). When sshPubKey is set, load-vars writes the content to a file and sets sshPubPath automatically.

Either sshPubKey or sshPubPath must be provided (anyOf in schema). This enables the wizard to accept key content from the user without needing to manage file paths in what would be a remote host.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for providing an SSH public key directly in configuration, which overrides path-based references when specified
  * Updated validation to allow users to provide either an SSH public key value or a path to one

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/enclave/pull/401?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->