### PR TITLE
Add sshPubKey as alternative to sshPubPath

### DIFF
--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -37,6 +37,7 @@ All configuration files in the `defaults/` directory are automatically loaded by
 
 1. [`config/global.yaml`](#configglobalyaml)
    - [Base Configuration](#base-configuration)
+   - [SSH Public Key Configuration](#ssh-public-key-configuration)
    - [Network Configuration](#network-configuration)
    - [Hardware Configuration](#hardware-configuration)
    - [Registry Configuration](#registry-configuration)
@@ -82,6 +83,41 @@ workingDir: "/home/enclave"
   - Cluster configuration (`{{ workingDir }}/ocp-cluster/`)
   - Registry data (`{{ workingDir }}/data/`)
   - Pull secrets (`{{ workingDir }}/config/pull-secret.json`)
+
+### SSH Public Key Configuration
+
+An SSH public key is required for accessing cluster nodes. You must provide **one** of the following:
+
+#### `sshPubKey`
+
+**Description**: SSH public key content as a string. When set, this takes precedence over `sshPubPath`. The key content is written to `{{ workingDir }}/config/ssh-pub-key.pub` at runtime and `sshPubPath` is set automatically.
+
+**Type**: String
+
+**Example**:
+```yaml
+sshPubKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7... user@host"
+```
+
+**Notes**:
+- Useful for the wizard, where the user can paste the key content directly instead of having to provide a file path on the remote host
+- If both `sshPubKey` and `sshPubPath` are set, `sshPubKey` overrides `sshPubPath`
+- The key must be in standard OpenSSH format (e.g. `ssh-rsa`, `ssh-ed25519`, `ecdsa-sha2-nistp256`)
+
+#### `sshPubPath`
+
+**Description**: Path to the SSH public key file on the deployment host.
+
+**Type**: String (file path)
+
+**Example**:
+```yaml
+sshPubPath: "{{ workingDir }}/.ssh/id_rsa.pub"
+```
+
+**Notes**:
+- The file must exist and be readable at deployment time
+- Not required when `sshPubKey` is set
 
 ### Network Configuration
 
@@ -1315,9 +1351,14 @@ lzBmcIP: 100.64.1.10
 #  - YOUR_NTP_SERVER_1
 #  - YOUR_NTP_SERVER_2
 
-# Pull Secret and SSH Public Key
+# Pull Secret
 pullSecret: '{"auths":{"cloud.openshift.com":{...},"quay.io":{...}}}'
 # pullSecretPath: "{{ workingDir }}/config/pull-secret.json"  # Default
+
+# SSH Public Key (provide one of the two options)
+# Option 1: Key content directly (useful for the wizard, avoids dealing with file paths on the remote host)
+# sshPubKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7... user@host"
+# Option 2: Path to key file
 sshPubPath: "{{ workingDir }}/.ssh/id_rsa.pub"
 
 # Storage Plugin

--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -95,6 +95,7 @@ An SSH public key is required for accessing cluster nodes. You must provide **on
 **Type**: String
 
 **Example**:
+
 ```yaml
 sshPubKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7... user@host"
 ```
@@ -111,6 +112,7 @@ sshPubKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7... user@host"
 **Type**: String (file path)
 
 **Example**:
+
 ```yaml
 sshPubPath: "{{ workingDir }}/.ssh/id_rsa.pub"
 ```

--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -102,7 +102,7 @@ sshPubKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7... user@host"
 
 **Notes**:
 - Useful for the wizard, where the user can paste the key content directly instead of having to provide a file path on the remote host
-- If both `sshPubKey` and `sshPubPath` are set, `sshPubKey` overrides `sshPubPath`
+- Mutually exclusive with `sshPubPath` — set one or the other, not both
 - The key must be in standard OpenSSH format (e.g. `ssh-rsa`, `ssh-ed25519`, `ecdsa-sha2-nistp256`)
 
 #### `sshPubPath`

--- a/playbooks/common/load-vars.yaml
+++ b/playbooks/common/load-vars.yaml
@@ -14,6 +14,25 @@
   ansible.builtin.include_vars: "{{ item }}"
   loop: "{{ user_config_files }}"
 
+- name: Write SSH public key to file if content provided
+  when: sshPubKey is defined and sshPubKey | length > 0
+  block:
+    - name: Ensure config directory exists
+      ansible.builtin.file:
+        path: "{{ workingDir }}/config"
+        state: directory
+        mode: "0750"
+
+    - name: Write sshPubKey content to file
+      ansible.builtin.copy:
+        content: "{{ sshPubKey }}\n"
+        dest: "{{ workingDir }}/config/ssh-pub-key.pub"
+        mode: "0644"
+
+    - name: Set sshPubPath from written file
+      ansible.builtin.set_fact:
+        sshPubPath: "{{ workingDir }}/config/ssh-pub-key.pub"
+
 - name: Include common configuration
   ansible.builtin.include_vars: "../../defaults/{{ config_file }}"
   loop:

--- a/schemas/global.yaml
+++ b/schemas/global.yaml
@@ -119,8 +119,7 @@ properties:
   rendezvousIP:
     "$ref": "#/definitions/ipv4Address"
   sshPubKey:
-    type: string
-    description: SSH public key content (e.g. ssh-rsa AAAA...). If set, overrides sshPubPath.
+    "$ref": "#/definitions/nonEmptyString"
   schemaValidationNoLog:
     type: boolean
     default: false

--- a/schemas/global.yaml
+++ b/schemas/global.yaml
@@ -118,6 +118,9 @@ properties:
     "$ref": "#/definitions/nonEmptyString"
   rendezvousIP:
     "$ref": "#/definitions/ipv4Address"
+  sshPubKey:
+    type: string
+    description: SSH public key content (e.g. ssh-rsa AAAA...). If set, overrides sshPubPath.
   schemaValidationNoLog:
     type: boolean
     default: false
@@ -229,8 +232,11 @@ required:
   - quayPassword
   - quayUser
   - rendezvousIP
-  - sshPubPath
   - workingDir
+
+anyOf:
+  - required: [sshPubKey]
+  - required: [sshPubPath]
 
 allOf:
   - if:

--- a/schemas/global.yaml
+++ b/schemas/global.yaml
@@ -233,7 +233,7 @@ required:
   - rendezvousIP
   - workingDir
 
-anyOf:
+oneOf:
   - required: [sshPubKey]
   - required: [sshPubPath]
 

--- a/test-fixtures/schemas/global/invalid/invalid-both-ssh-pub-key-and-path.yaml
+++ b/test-fixtures/schemas/global/invalid/invalid-both-ssh-pub-key-and-path.yaml
@@ -1,6 +1,6 @@
 ---
-# Fixture: sshPubKey inline content instead of sshPubPath
-# Validates that sshPubKey satisfies the oneOf requirement (mutually exclusive with sshPubPath)
+# Fixture: both sshPubKey and sshPubPath provided
+# Expected failure: oneOf requires exactly one of sshPubKey or sshPubPath
 workingDir: /home/enclave
 baseDomain: enclave-test.nodns.in
 clusterName: mgmt
@@ -18,6 +18,7 @@ quayBackend: LocalStorage
 storage_plugin: lvms
 pullSecret: {"auths":{}}
 sshPubKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7 user@host"
+sshPubPath: /home/enclave/.ssh/id_rsa.pub
 agent_hosts:
   - name: mgmt-ctl01
     macAddress: 0c:c4:7a:62:fe:ec

--- a/test-fixtures/schemas/global/invalid/invalid-empty-ssh-pub-key.yaml
+++ b/test-fixtures/schemas/global/invalid/invalid-empty-ssh-pub-key.yaml
@@ -1,0 +1,42 @@
+---
+# Fixture: empty sshPubKey must be rejected
+# Expected failure: sshPubKey must have minLength: 1 (nonEmptyString)
+workingDir: /home/enclave
+baseDomain: enclave-test.nodns.in
+clusterName: mgmt
+machineNetwork: 192.168.2.0/24
+apiVIP: 192.168.2.201
+ingressVIP: 192.168.2.202
+defaultDNS: 9.30.31.32
+defaultGateway: 192.168.2.10
+defaultPrefix: 24
+rendezvousIP: 192.168.2.24
+lzBmcIP: 100.64.1.10
+quayUser: admin
+quayPassword: password
+quayBackend: LocalStorage
+storage_plugin: lvms
+pullSecret: {"auths":{}}
+sshPubKey: ""
+agent_hosts:
+  - name: mgmt-ctl01
+    macAddress: 0c:c4:7a:62:fe:ec
+    ipAddress: 192.168.2.24
+    redfish: 192.168.1.101
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl02
+    macAddress: 0c:c4:7a:62:fe:ed
+    ipAddress: 192.168.2.25
+    redfish: 192.168.1.102
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl03
+    macAddress: 0c:c4:7a:62:fe:ee
+    ipAddress: 192.168.2.26
+    redfish: 192.168.1.103
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password

--- a/test-fixtures/schemas/global/valid/local-lvms-with-ssh-pub-key.yaml
+++ b/test-fixtures/schemas/global/valid/local-lvms-with-ssh-pub-key.yaml
@@ -1,0 +1,42 @@
+---
+# Fixture: sshPubKey inline content instead of sshPubPath
+# Validates that sshPubKey satisfies the anyOf requirement
+workingDir: /home/enclave
+baseDomain: enclave-test.nodns.in
+clusterName: mgmt
+machineNetwork: 192.168.2.0/24
+apiVIP: 192.168.2.201
+ingressVIP: 192.168.2.202
+defaultDNS: 9.30.31.32
+defaultGateway: 192.168.2.10
+defaultPrefix: 24
+rendezvousIP: 192.168.2.24
+lzBmcIP: 100.64.1.10
+quayUser: admin
+quayPassword: password
+quayBackend: LocalStorage
+storage_plugin: lvms
+pullSecret: {"auths":{}}
+sshPubKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7 user@host"
+agent_hosts:
+  - name: mgmt-ctl01
+    macAddress: 0c:c4:7a:62:fe:ec
+    ipAddress: 192.168.2.24
+    redfish: 192.168.1.101
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl02
+    macAddress: 0c:c4:7a:62:fe:ed
+    ipAddress: 192.168.2.25
+    redfish: 192.168.1.102
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password
+  - name: mgmt-ctl03
+    macAddress: 0c:c4:7a:62:fe:ee
+    ipAddress: 192.168.2.26
+    redfish: 192.168.1.103
+    rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
+    redfishUser: admin
+    redfishPassword: password


### PR DESCRIPTION
Accept SSH public key content directly in the config (sshPubKey field) as an alternative to providing a file path (sshPubPath). When sshPubKey is set, load-vars writes the content to a file and sets sshPubPath automatically.

Either sshPubKey or sshPubPath must be provided (anyOf in schema). This enables the wizard to accept key content from the user without needing to manage file paths on what would be a remote host.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for SSH public key configuration via either inline key content or a file path; inline keys are persisted at runtime and the path is set automatically.

* **Documentation**
  * Configuration reference updated with SSH Public Key section, examples, and TOC entry.

* **Tests**
  * Added schema test fixtures covering valid inline keys and invalid/ambiguous cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->