### PR TITLE
Fix AWS CLI install failure when already present

### DIFF
--- a/setup_env.sh
+++ b/setup_env.sh
@@ -28,7 +28,7 @@ AWSCLI_TMP=$(mktemp -d)
 trap 'rm -rf "${AWSCLI_TMP}"' EXIT
 curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o "${AWSCLI_TMP}/awscliv2.zip"
 unzip -q "${AWSCLI_TMP}/awscliv2.zip" -d "${AWSCLI_TMP}"
-"${AWSCLI_TMP}/aws/install"
+"${AWSCLI_TMP}/aws/install" --update
 
 systemctl enable --now httpd
 mkdir -p /var/www/html


### PR DESCRIPTION
## Summary
- Pass `--update` to the AWS CLI installer in `setup_env.sh` so it works for both fresh installs and existing installations
- Without this flag, the installer exits 1 when `/usr/local/aws-cli/v2/current` exists, which breaks `bootstrap.sh` under `set -e`

## Test plan
- [x] Run `setup_env.sh` on a host with AWS CLI already installed — should succeed
- [x] Run `setup_env.sh` on a fresh host — should still install normally
- [x] Run full `bootstrap.sh` past the setup step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AWS CLI installation process to include dependency updates during environment setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/enclave/pull/406?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->