### PR TITLE
E2e test env

### DIFF
--- a/Makefile.ci
+++ b/Makefile.ci
@@ -513,6 +513,10 @@ e2e-test-env:
 
 # Deploy and verify OpenShift cluster (assumes e2e-test-env has been run)
 e2e-deploy-cluster:
+	@if [ ! -f "$(ENVIRONMENT_JSON)" ]; then \
+		echo "Error: Environment not prepared. Run 'make -f Makefile.ci e2e-test-env' first."; \
+		exit 1; \
+	fi
 	@echo "=========================================="
 	@echo "Deploying and verifying OpenShift cluster"
 	@echo "=========================================="

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -31,7 +31,8 @@ include Makefile
         verify clean verify-cluster verify-cleanup \
         generate-cluster-name setup-working-dir collect-step-logs \
         preflight-checks collect-artifacts-basic collect-artifacts-deployment \
-        collect-artifacts-full ci-flow-connected ci-flow-disconnected
+        collect-artifacts-full e2e-test-env e2e-deploy-cluster \
+        ci-flow-connected ci-flow-disconnected
 
 # Override default help to show both LZ and CI targets
 help:
@@ -90,6 +91,8 @@ help:
 	@echo "  make -f Makefile.ci collect-artifacts-full           - Collect all artifacts"
 	@echo ""
 	@echo "Local CI Testing targets:"
+	@echo "  make -f Makefile.ci e2e-test-env                     - Prepare test environment (infra + LZ + enclave, no cluster deploy)"
+	@echo "  make -f Makefile.ci e2e-deploy-cluster               - Deploy and verify OpenShift cluster"
 	@echo "  make -f Makefile.ci ci-flow-connected                - Run full CI flow locally (connected mode)"
 	@echo "  make -f Makefile.ci ci-flow-disconnected             - Run full CI flow locally (disconnected mode)"
 	@echo ""
@@ -482,10 +485,11 @@ collect-artifacts-deployment:
 collect-artifacts-full:
 	@./scripts/verification/collect_ci_artifacts.sh full artifacts
 
-# Full CI flow for local testing
-ci-flow-connected:
+# Prepare test environment: infrastructure + Landing Zone + Enclave Lab installed
+# Use this as a standalone target when an external project (e.g. wizard) drives cluster deployment
+e2e-test-env:
 	@echo "=========================================="
-	@echo "Running full CI flow (connected mode)"
+	@echo "Preparing e2e test environment"
 	@echo "=========================================="
 	@echo ""
 	@$(MAKE) -f Makefile.ci preflight-checks
@@ -494,8 +498,39 @@ ci-flow-connected:
 	@$(MAKE) -f Makefile.ci provision-landing-zone
 	@$(MAKE) -f Makefile.ci install-enclave
 	@$(MAKE) -f Makefile.ci setup-ceph
+	@echo ""
+	@echo "=========================================="
+	@echo "Test environment ready!"
+	@echo "=========================================="
+	@echo ""
+	@echo "Landing Zone IP: $$(./scripts/utils/get_landing_zone_ip.sh 2>/dev/null || echo '<run verify-landing-zone>')"
+	@echo "Cluster name:    $(ENCLAVE_CLUSTER_NAME)"
+	@echo "Working dir:     $(WORKING_DIR)"
+	@echo "Config files on LZ:"
+	@echo "  /home/cloud-user/enclave/config/global.yaml"
+	@echo "  /home/cloud-user/enclave/config/certificates.yaml"
+	@echo "  /home/cloud-user/enclave/config/cloud_infra.yaml"
+
+# Deploy and verify OpenShift cluster (assumes e2e-test-env has been run)
+e2e-deploy-cluster:
+	@echo "=========================================="
+	@echo "Deploying and verifying OpenShift cluster"
+	@echo "=========================================="
+	@echo ""
 	@$(MAKE) -f Makefile.ci deploy-cluster
 	@$(MAKE) -f Makefile.ci verify-cluster
+	@echo ""
+	@echo "=========================================="
+	@echo "Cluster deployment complete!"
+	@echo "=========================================="
+
+ci-flow-connected:
+	@echo "=========================================="
+	@echo "Running full CI flow (connected mode)"
+	@echo "=========================================="
+	@echo ""
+	@$(MAKE) -f Makefile.ci e2e-test-env
+	@$(MAKE) -f Makefile.ci e2e-deploy-cluster
 	@echo ""
 	@echo "=========================================="
 	@echo "CI flow complete!"

--- a/docs/LOCAL_TESTING.md
+++ b/docs/LOCAL_TESTING.md
@@ -27,6 +27,9 @@ make ci-flow-connected
 
 # Or disconnected mode (full validation)
 make ci-flow-disconnected
+
+# Or just prepare the environment (no cluster deployment)
+make -f Makefile.ci e2e-test-env
 ```
 
 The flow automatically:
@@ -125,6 +128,42 @@ export DEV_SCRIPTS_PATH=/path/to/dev-scripts
 export BASE_WORKING_DIR=/opt/clusters
 
 make ci-flow-connected
+```
+
+### Environment Only (For External Projects)
+
+Prepare infrastructure, Landing Zone, and Enclave Lab without deploying a cluster. Use this when another project (e.g. an installation wizard) drives cluster deployment:
+
+```bash
+export DEV_SCRIPTS_PATH=/path/to/dev-scripts
+export BASE_WORKING_DIR=/opt/clusters
+
+# Prepare environment (connected mode)
+make -f Makefile.ci e2e-test-env
+
+# Or disconnected mode
+ENCLAVE_DEPLOYMENT_MODE=disconnected make -f Makefile.ci e2e-test-env
+```
+
+**What happens:**
+1. Preflight checks validate environment
+2. Generates unique cluster name
+3. Creates cluster-specific working directory
+4. Creates VMs, networks, and BMC emulation
+5. Provisions Landing Zone VM with CentOS Stream 10
+6. Installs Enclave Lab on Landing Zone
+7. Prints summary with Landing Zone IP and config paths
+
+**Duration:** ~30-40 minutes (connected), ~50-60 minutes (disconnected)
+
+After completion, the Landing Zone has:
+- Enclave Lab at `/home/cloud-user/enclave/`
+- Configuration at `/home/cloud-user/enclave/config/global.yaml`
+- All dependencies installed and BMC emulator running
+
+To later deploy the cluster manually:
+```bash
+make -f Makefile.ci e2e-deploy-cluster
 ```
 
 ## Individual Components

--- a/docs/LOCAL_TESTING.md
+++ b/docs/LOCAL_TESTING.md
@@ -162,6 +162,7 @@ After completion, the Landing Zone has:
 - All dependencies installed and BMC emulator running
 
 To later deploy the cluster manually:
+
 ```bash
 make -f Makefile.ci e2e-deploy-cluster
 ```


### PR DESCRIPTION
Enable makefile to prepare the env only
This will be useful for the wizard's e2e to leverage the current system

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local CI targets to prepare a test environment separately and to deploy/verify the cluster.

* **Chores**
  * Refactored CI flow to call the new environment-prep and deploy targets for improved modularity and reuse.
  * Updated help output to list the new targets under local CI testing.

* **Documentation**
  * Added environment-only testing guidance and updated local testing docs with the new workflow and follow-up steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/enclave/pull/411?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->