### PR TITLE
Makefile.ci: auto-manage dev-scripts clone lifecycle

### DIFF
--- a/.github/actions/preflight-checks/action.yml
+++ b/.github/actions/preflight-checks/action.yml
@@ -28,25 +28,11 @@ runs:
   steps:
     - name: Run preflight checks
       shell: bash
+      env:
+        PREFLIGHT_TITLE: ${{ inputs.title }}
+        PREFLIGHT_CHECK_PULL_SECRET: ${{ inputs.check-pull-secret }}
+        PREFLIGHT_CHECK_SYSTEM_RESOURCES: ${{ inputs.check-system-resources }}
+        PREFLIGHT_CHECK_LIBVIRT: ${{ inputs.check-libvirt }}
+        PREFLIGHT_DEPLOYMENT_MODE: ${{ inputs.deployment-mode }}
       run: |
-        # Build arguments for the script based on inputs (using array for safety)
-        ARGS=(--title "${{ inputs.title }}")
-
-        if [ "${{ inputs.check-pull-secret }}" = "true" ]; then
-          ARGS+=(--check-pull-secret)
-        fi
-
-        if [ "${{ inputs.check-system-resources }}" = "true" ]; then
-          ARGS+=(--check-system-resources)
-        fi
-
-        if [ "${{ inputs.check-libvirt }}" = "true" ]; then
-          ARGS+=(--check-libvirt)
-        fi
-
-        if [ -n "${{ inputs.deployment-mode }}" ]; then
-          ARGS+=(--deployment-mode "${{ inputs.deployment-mode }}")
-        fi
-
-        # Call the preflight checks script
-        ./scripts/setup/preflight_checks.sh "${ARGS[@]}"
+        make -f Makefile.ci preflight-checks

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -29,7 +29,6 @@ jobs:
     timeout-minutes: 30
 
     env:
-      DEV_SCRIPTS_PATH: ${{ vars.DEV_SCRIPTS_PATH }}
       WORKING_DIR: ${{ vars.WORKING_DIR }}
       CLEANUP_LEVEL: ${{ inputs.cleanup_level || 'standard' }}
 
@@ -65,13 +64,12 @@ jobs:
           echo "## Running Standard Cleanup" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          # Clean up Enclave test infrastructure using make clean
-          if [ -d "$DEV_SCRIPTS_PATH" ]; then
-            echo "Running: make clean" >> $GITHUB_STEP_SUMMARY
-            make -f Makefile.ci clean || true
+          # Clean up Enclave test infrastructure using make clean (best-effort)
+          echo "Running: make clean" >> $GITHUB_STEP_SUMMARY
+          if make -f Makefile.ci clean; then
             echo "✅ Standard cleanup complete" >> $GITHUB_STEP_SUMMARY
           else
-            echo "⚠️ DEV_SCRIPTS_PATH not found: $DEV_SCRIPTS_PATH" >> $GITHUB_STEP_SUMMARY
+            echo "⚠️ Standard cleanup encountered errors (see logs)" >> $GITHUB_STEP_SUMMARY
           fi
 
       - name: Deep cleanup

--- a/.github/workflows/disconnected-dry-run.yml
+++ b/.github/workflows/disconnected-dry-run.yml
@@ -46,7 +46,6 @@ jobs:
     timeout-minutes: 120
 
     env:
-      DEV_SCRIPTS_PATH: ${{ vars.DEV_SCRIPTS_PATH }}
       BASE_WORKING_DIR: ${{ vars.BASE_WORKING_DIR }}
       PULL_SECRET: ${{ secrets.PULL_SECRET }}
       ENCLAVE_DEPLOYMENT_MODE: disconnected

--- a/.github/workflows/e2e-deployment.yml
+++ b/.github/workflows/e2e-deployment.yml
@@ -170,7 +170,6 @@ jobs:
       cancel-in-progress: false
 
     env:
-      DEV_SCRIPTS_PATH: ${{ vars.DEV_SCRIPTS_PATH }}
       BASE_WORKING_DIR: ${{ vars.BASE_WORKING_DIR }}
       PULL_SECRET: ${{ secrets.PULL_SECRET }}
       ENCLAVE_DEPLOYMENT_MODE: connected
@@ -257,7 +256,7 @@ jobs:
       - name: Generate Ironic ISO server TLS certificate
         id: generate_ironic_cert
         if: env.ENCLAVE_IRONIC_HTTPS == 'true'
-        run: ./scripts/deployment/generate_ironic_cert.sh
+        run: make -f Makefile.ci generate-ironic-cert
 
       - name: Setup Ceph on Landing Zone
         if: env.STORAGE_PLUGIN == 'odf'
@@ -575,7 +574,6 @@ jobs:
       cancel-in-progress: false
 
     env:
-      DEV_SCRIPTS_PATH: ${{ vars.DEV_SCRIPTS_PATH }}
       BASE_WORKING_DIR: ${{ vars.BASE_WORKING_DIR }}
       PULL_SECRET: ${{ secrets.PULL_SECRET }}
       ENCLAVE_DEPLOYMENT_MODE: disconnected
@@ -661,7 +659,7 @@ jobs:
       - name: Generate Ironic ISO server TLS certificate
         id: generate_ironic_cert
         if: env.ENCLAVE_IRONIC_HTTPS == 'true'
-        run: ./scripts/deployment/generate_ironic_cert.sh
+        run: make -f Makefile.ci generate-ironic-cert
 
       - name: Setup Ceph on Landing Zone
         if: env.STORAGE_PLUGIN == 'odf'

--- a/.github/workflows/infra-verify.yml
+++ b/.github/workflows/infra-verify.yml
@@ -19,7 +19,6 @@ jobs:
     timeout-minutes: 120
 
     env:
-      DEV_SCRIPTS_PATH: ${{ vars.DEV_SCRIPTS_PATH }}
       BASE_WORKING_DIR: ${{ vars.BASE_WORKING_DIR }}
       PULL_SECRET: ${{ secrets.PULL_SECRET }}
       # Bypass CI_TOKEN requirement (we only use dev-scripts for infra, not cluster install)

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -4,8 +4,14 @@
 # Adds CI-only infrastructure, validation, and image build targets
 
 # CI Configuration (set before include so these defaults take precedence)
-DEV_SCRIPTS_PATH ?=
+DEV_SCRIPTS_REPO   ?= https://github.com/openshift-metal3/dev-scripts
+DEV_SCRIPTS_BRANCH ?= master
 WORKING_DIR ?= /opt/dev-scripts
+
+# Path to dev-scripts checkout; defaults to WORKING_DIR/dev-scripts-CLUSTER_NAME.
+# export makes the value visible to all recipe shells and recursive make invocations.
+DEV_SCRIPTS_PATH ?= $(WORKING_DIR)/dev-scripts-$(ENCLAVE_CLUSTER_NAME)
+export DEV_SCRIPTS_PATH
 
 # Cluster name for parallel execution isolation (can be overridden)
 ENCLAVE_CLUSTER_NAME ?= enclave-test
@@ -31,7 +37,8 @@ include Makefile
         verify clean verify-cluster verify-cleanup \
         generate-cluster-name setup-working-dir collect-step-logs \
         preflight-checks collect-artifacts-basic collect-artifacts-deployment \
-        collect-artifacts-full ci-flow-connected ci-flow-disconnected
+        collect-artifacts-full ci-flow-connected ci-flow-disconnected \
+	generate-ironic-cert setup-dev-scripts clean-infra clean-dev-scripts \
 
 # Override default help to show both LZ and CI targets
 help:
@@ -81,6 +88,9 @@ help:
 	@echo "  make -f Makefile.ci verify-cleanup                   - Verify infrastructure cleanup"
 	@echo ""
 	@echo "CI Helper targets:"
+	@echo "  make -f Makefile.ci setup-dev-scripts                - Clone dev-scripts and write pull secret"
+	@echo "  make -f Makefile.ci clean-infra                      - Tear down infrastructure (keep dev-scripts clone)"
+	@echo "  make -f Makefile.ci clean-dev-scripts                - Tear down infrastructure and remove dev-scripts clone"
 	@echo "  make -f Makefile.ci generate-cluster-name            - Generate unique cluster name"
 	@echo "  make -f Makefile.ci setup-working-dir                - Setup cluster-specific working directory"
 	@echo "  make -f Makefile.ci collect-step-logs                - Collect logs from dev-scripts and cluster"
@@ -108,13 +118,15 @@ help:
 	@echo "Plugin deployment (via SSH to Landing Zone):"
 	@echo "  make -f Makefile.ci deploy-plugin PLUGIN=<name>      - Deploy a specific plugin"
 	@echo ""
-	@echo "Required configuration for CI targets:"
-	@echo "  DEV_SCRIPTS_PATH  - Path to dev-scripts installation (must be set)"
-	@echo ""
 	@echo "Optional configuration:"
-	@echo "  WORKING_DIR       - Working directory (default: /opt/dev-scripts)"
+	@echo "  DEV_SCRIPTS_REPO   - dev-scripts repo to clone (default: https://github.com/openshift-metal3/dev-scripts)"
+	@echo "  DEV_SCRIPTS_BRANCH - branch, tag, or SHA to check out (default: master; master = shallow clone)"
+	@echo "  DEV_SCRIPTS_PATH   - where to clone dev-scripts (default: WORKING_DIR/dev-scripts-CLUSTER_NAME)"
+	@echo "  WORKING_DIR        - Working directory (default: /opt/dev-scripts)"
 	@echo ""
 	@echo "Current values:"
+	@echo "  DEV_SCRIPTS_REPO=$(DEV_SCRIPTS_REPO)"
+	@echo "  DEV_SCRIPTS_BRANCH=$(DEV_SCRIPTS_BRANCH)"
 	@echo "  DEV_SCRIPTS_PATH=$(DEV_SCRIPTS_PATH)"
 	@echo "  WORKING_DIR=$(WORKING_DIR)"
 	@echo "  BASE_WORKING_DIR=$(BASE_WORKING_DIR)"
@@ -126,7 +138,6 @@ help:
 	@echo ""
 	@echo "Example workflow (full deployment):"
 	@echo "  make -f Makefile.ci validate                # Validate code quality"
-	@echo "  export DEV_SCRIPTS_PATH=/path/to/dev-scripts"
 	@echo "  export BASE_WORKING_DIR=/opt/clusters"
 	@echo "  export CI_TOKEN=your-token"
 	@echo ""
@@ -139,91 +150,91 @@ help:
 	@echo "  make -f Makefile.ci ci-flow-connected          # Runs all steps above automatically"
 	@echo ""
 	@echo "Requirements for CI targets:"
-	@echo "  - dev-scripts with infra_only target support"
+	@echo "  - git (to clone dev-scripts)"
 	@echo "  - libvirt installed and running"
 	@echo "  - Sufficient resources (64GB+ RAM recommended)"
 	@echo "  - CI_TOKEN environment variable set"
 
 # --- Override deploy targets to use SSH-based scripts ---
 
-deploy-cluster:
+deploy-cluster: setup-dev-scripts
 	@echo "=========================================="
 	@echo "Deploying OpenShift Cluster with Enclave Lab"
 	@echo "=========================================="
 	@echo ""
 	@./scripts/deployment/deploy_cluster.sh
 
-deploy-cluster-setup:
+deploy-cluster-setup: setup-dev-scripts
 	@echo "=========================================="
 	@echo "Setup environment on Landing Zone"
 	@echo "=========================================="
 	@echo ""
 	@./scripts/deployment/deploy_bootstrap_step.sh setup
 
-deploy-cluster-validate:
+deploy-cluster-validate: setup-dev-scripts
 	@echo "=========================================="
 	@echo "Validate configuration"
 	@echo "=========================================="
 	@echo ""
 	@./scripts/deployment/deploy_bootstrap_step.sh validate
 
-deploy-cluster-prepare:
+deploy-cluster-prepare: setup-dev-scripts
 	@echo "=========================================="
 	@echo "Phase 1: Prepare - Download dependency content"
 	@echo "=========================================="
 	@echo ""
 	@./scripts/deployment/deploy_bootstrap_step.sh download-content
 
-deploy-cluster-mirror:
+deploy-cluster-mirror: setup-dev-scripts
 	@echo "=========================================="
 	@echo "Phase 2: Mirror - Build local cache"
 	@echo "=========================================="
 	@echo ""
 	@./scripts/deployment/deploy_bootstrap_step.sh build-cache
 
-deploy-cluster-acquire-hardware:
+deploy-cluster-acquire-hardware: setup-dev-scripts
 	@echo "=========================================="
 	@echo "Phase 3a: Acquire and validate hardware"
 	@echo "=========================================="
 	@echo ""
 	@./scripts/deployment/deploy_bootstrap_step.sh acquire-hardware
 
-deploy-cluster-install:
+deploy-cluster-install: setup-dev-scripts
 	@echo "=========================================="
 	@echo "Phase 3b: Deploy OpenShift cluster"
 	@echo "=========================================="
 	@echo ""
 	@./scripts/deployment/deploy_bootstrap_step.sh deploy
 
-deploy-cluster-post-install:
+deploy-cluster-post-install: setup-dev-scripts
 	@echo "=========================================="
 	@echo "Phase 4: Post-Install - Cluster configuration"
 	@echo "=========================================="
 	@echo ""
 	@./scripts/deployment/deploy_bootstrap_step.sh post-install
 
-deploy-cluster-operators:
+deploy-cluster-operators: setup-dev-scripts
 	@echo "=========================================="
 	@echo "Phase 5: Operators - Install and configure operators"
 	@echo "=========================================="
 	@echo ""
 	@./scripts/deployment/deploy_bootstrap_step.sh operators
 
-deploy-cluster-day2:
+deploy-cluster-day2: setup-dev-scripts
 	@echo "=========================================="
 	@echo "Phase 6: Day-2 - Advanced features and policies"
 	@echo "=========================================="
 	@echo ""
 	@./scripts/deployment/deploy_bootstrap_step.sh day2
 
-deploy-cluster-discovery:
+deploy-cluster-discovery: setup-dev-scripts
 	@echo "=========================================="
 	@echo "Phase 7: Configure Discovery - Hardware discovery"
 	@echo "=========================================="
 	@echo ""
 	@./scripts/deployment/deploy_bootstrap_step.sh discovery
 
-deploy-plugin:
+deploy-plugin: setup-dev-scripts
 	@./scripts/deployment/deploy_plugin.sh $(PLUGIN)
 
 # --- Validation targets (CI only) ---
@@ -328,10 +339,28 @@ test-ci-image:
 build-push-ci-image: build-ci-image push-ci-image
 	@echo "CI image built and pushed successfully!"
 
+# --- dev-scripts lifecycle targets ---
+
+# Clone dev-scripts and write pull secret (idempotent — skips clone if already present)
+setup-dev-scripts: export DEV_SCRIPTS_REPO   := $(DEV_SCRIPTS_REPO)
+setup-dev-scripts: export DEV_SCRIPTS_BRANCH := $(DEV_SCRIPTS_BRANCH)
+setup-dev-scripts: export WORKING_DIR        := $(WORKING_DIR)
+setup-dev-scripts:
+	@./scripts/setup/setup_dev_scripts.sh
+
+# Tear down test infrastructure (VMs, networks, BMC) — keeps the dev-scripts clone
+clean-infra:
+	@./scripts/cleanup/cleanup.sh
+
+# Remove the dev-scripts clone (always after infrastructure teardown)
+clean-dev-scripts: export WORKING_DIR := $(WORKING_DIR)
+clean-dev-scripts: clean-infra
+	@./scripts/cleanup/remove_dev_scripts.sh
+
 # --- CI Infrastructure targets ---
 
 # Create test infrastructure
-environment:
+environment: setup-dev-scripts
 	@echo "=========================================="
 	@echo "Creating Enclave test environment"
 	@echo "=========================================="
@@ -344,11 +373,9 @@ environment:
 	@echo ""
 	@echo "Step 3: Creating infrastructure (VMs, networks, BMC)..."
 	@echo "  (Using lock to prevent conflicts with parallel runners)"
-	@if [ -z "$(DEV_SCRIPTS_PATH)" ]; then \
-		echo "Error: DEV_SCRIPTS_PATH is not set. Set it to the path of your dev-scripts installation."; \
-		exit 1; \
-	fi
-	@./scripts/utils/with_libvirt_lock.sh sh -c "cd $(DEV_SCRIPTS_PATH) && CONFIG=$(CONFIG_NAME) make infra_only && $(CURDIR)/scripts/infrastructure/configure_gpu_passthrough.sh"
+	@./scripts/utils/with_libvirt_lock.sh sh -c \
+	    "cd \"$(DEV_SCRIPTS_PATH)\" && CONFIG=$(CONFIG_NAME) make infra_only && \
+	     \"$(CURDIR)/scripts/infrastructure/configure_gpu_passthrough.sh\""
 	@echo ""
 	@echo "Step 4: Verifying networks were created..."
 	@./scripts/infrastructure/verify_networks.sh
@@ -374,7 +401,7 @@ environment:
 	@echo "=========================================="
 
 # Provision Landing Zone VM with CentOS Stream 10
-provision-landing-zone:
+provision-landing-zone: setup-dev-scripts
 	@echo "=========================================="
 	@echo "Provisioning Landing Zone VM"
 	@echo "=========================================="
@@ -389,7 +416,7 @@ provision-landing-zone:
 	@echo "=========================================="
 
 # Verify Landing Zone VM
-verify-landing-zone:
+verify-landing-zone: setup-dev-scripts
 	@echo "=========================================="
 	@echo "Verifying Landing Zone VM"
 	@echo "=========================================="
@@ -397,7 +424,7 @@ verify-landing-zone:
 	@./scripts/verification/verify_landing_zone.sh
 
 # Install Enclave Lab on Landing Zone VM
-install-enclave:
+install-enclave: setup-dev-scripts
 	@echo "=========================================="
 	@echo "Installing Enclave Lab on Landing Zone"
 	@echo "=========================================="
@@ -412,7 +439,7 @@ install-enclave:
 	@echo "=========================================="
 
 # Verify Enclave Lab installation
-verify-enclave-installation:
+verify-enclave-installation: setup-dev-scripts
 	@echo "=========================================="
 	@echo "Verifying Enclave Lab Installation"
 	@echo "=========================================="
@@ -420,7 +447,7 @@ verify-enclave-installation:
 	@./scripts/verification/verify_enclave_installation.sh
 
 # Setup Ceph on Landing Zone (only when STORAGE_PLUGIN=odf)
-setup-ceph:
+setup-ceph: setup-dev-scripts
 	@if [ "$${STORAGE_PLUGIN:-lvms}" = "odf" ]; then \
 		echo "=========================================="; \
 		echo "Setting up Ceph on Landing Zone for ODF"; \
@@ -432,7 +459,7 @@ setup-ceph:
 	fi
 
 # Verify Ceph on Landing Zone (only when STORAGE_PLUGIN=odf)
-verify-ceph:
+verify-ceph: setup-dev-scripts
 	@if [ "$${STORAGE_PLUGIN:-lvms}" = "odf" ]; then \
 		echo "=========================================="; \
 		echo "Verifying Ceph on Landing Zone"; \
@@ -444,13 +471,12 @@ verify-ceph:
 	fi
 
 # Verify infrastructure
-verify:
+verify: setup-dev-scripts
 	@echo "Verifying infrastructure..."
 	@./scripts/verification/verify_infrastructure.sh
 
-# Clean up infrastructure
-clean:
-	@./scripts/cleanup/cleanup.sh
+# Clean up infrastructure and remove dev-scripts clone
+clean: clean-infra clean-dev-scripts
 
 # Verification targets
 verify-cluster:
@@ -466,7 +492,7 @@ generate-cluster-name:
 setup-working-dir:
 	@./scripts/setup/setup_working_dir.sh
 
-collect-step-logs:
+collect-step-logs: setup-dev-scripts
 	@./scripts/verification/collect_step_logs.sh step-logs
 
 preflight-checks:
@@ -504,3 +530,6 @@ ci-flow-connected:
 ci-flow-disconnected:
 	@echo "Running full CI flow (disconnected mode)"
 	@ENCLAVE_DEPLOYMENT_MODE=disconnected $(MAKE) -f Makefile.ci ci-flow-connected
+
+generate-ironic-cert: setup-dev-scripts
+	@./scripts/deployment/generate_ironic_cert.sh

--- a/scripts/cleanup/remove_dev_scripts.sh
+++ b/scripts/cleanup/remove_dev_scripts.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Remove the dev-scripts clone directory
+#
+# Validates that DEV_SCRIPTS_PATH is within WORKING_DIR before deletion
+# to prevent accidental removal of arbitrary paths.
+#
+# Environment Variables:
+#   DEV_SCRIPTS_PATH - directory to remove (required, exported by Makefile.ci)
+#   WORKING_DIR      - parent boundary for the path check (required, exported by Makefile.ci)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+ENCLAVE_DIR="$(cd -- "${SCRIPT_DIR}/../.." &>/dev/null && pwd)"
+
+source "${ENCLAVE_DIR}/scripts/lib/output.sh"
+source "${ENCLAVE_DIR}/scripts/lib/validation.sh"
+
+require_env_var "DEV_SCRIPTS_PATH"
+require_env_var "WORKING_DIR"
+
+if [ ! -d "${DEV_SCRIPTS_PATH}" ]; then
+    info "dev-scripts directory not found, nothing to remove: ${DEV_SCRIPTS_PATH}"
+    exit 0
+fi
+
+real_working_dir="$(realpath "${WORKING_DIR}")"
+real_dev_scripts_path="$(realpath "${DEV_SCRIPTS_PATH}")"
+
+case "${real_dev_scripts_path}" in
+    "${real_working_dir}/"*) ;;
+    *) error "DEV_SCRIPTS_PATH (${DEV_SCRIPTS_PATH}) is outside WORKING_DIR (${WORKING_DIR}), aborting removal"; exit 1 ;;
+esac
+
+info "Removing dev-scripts clone: ${DEV_SCRIPTS_PATH}"
+rm -rf "${DEV_SCRIPTS_PATH}"
+success "dev-scripts clone removed"

--- a/scripts/cleanup/remove_dev_scripts.sh
+++ b/scripts/cleanup/remove_dev_scripts.sh
@@ -24,13 +24,7 @@ if [ ! -d "${DEV_SCRIPTS_PATH}" ]; then
     exit 0
 fi
 
-real_working_dir="$(realpath "${WORKING_DIR}")"
-real_dev_scripts_path="$(realpath "${DEV_SCRIPTS_PATH}")"
-
-case "${real_dev_scripts_path}" in
-    "${real_working_dir}/"*) ;;
-    *) error "DEV_SCRIPTS_PATH (${DEV_SCRIPTS_PATH}) is outside WORKING_DIR (${WORKING_DIR}), aborting removal"; exit 1 ;;
-esac
+require_path_within "${DEV_SCRIPTS_PATH}" "${WORKING_DIR}"
 
 info "Removing dev-scripts clone: ${DEV_SCRIPTS_PATH}"
 rm -rf "${DEV_SCRIPTS_PATH}"

--- a/scripts/lib/validation.sh
+++ b/scripts/lib/validation.sh
@@ -17,6 +17,7 @@
 #   require_command COMMAND [ERROR_MSG]       - Require command to be available in PATH
 #   require_file FILE_PATH [ERROR_MSG]        - Require file to exist
 #   require_dir DIR_PATH [ERROR_MSG]          - Require directory to exist
+#   require_path_within CHILD PARENT          - Require child path resolves inside parent
 #   validate_ip IP_ADDRESS                    - Validate IP address format
 
 # Require an environment variable to be set
@@ -97,6 +98,22 @@ require_dir() {
         echo "ERROR: $error_msg" >&2
         exit 1
     fi
+}
+
+# Require child_path to resolve strictly inside parent_path
+# Uses realpath -m so the child need not exist yet (covers setup before clone)
+# Args: $1 = child path   $2 = parent path
+# Exits with error if child is outside parent
+# Example: require_path_within "${DEV_SCRIPTS_PATH}" "${WORKING_DIR}"
+require_path_within() {
+    local child_path="$1" parent_path="$2"
+    local child_real parent_real
+    parent_real="$(realpath "${parent_path}")"
+    child_real="$(realpath -m "${child_path}")"
+    case "${child_real}" in
+        "${parent_real}/"*) ;;
+        *) echo "ERROR: ${child_path} is outside ${parent_path}" >&2; exit 1 ;;
+    esac
 }
 
 # Validate IP address format

--- a/scripts/setup/preflight_checks.sh
+++ b/scripts/setup/preflight_checks.sh
@@ -19,7 +19,7 @@
 #   WORKING_DIR - Cluster working directory (required)
 #   PULL_SECRET - OpenShift pull secret (required if --check-pull-secret)
 
-set +e  # Don't exit on first error, collect all failures
+set +e  # collect all failures rather than exiting on first error
 
 # Detect Enclave repository root
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
@@ -28,11 +28,19 @@ ENCLAVE_DIR="$(cd -- "${SCRIPT_DIR}/../.." &>/dev/null && pwd)"
 # Source shared utilities
 source "${ENCLAVE_DIR}/scripts/lib/output.sh"
 
+# Normalize a boolean string to lowercase true/false; reject any other value
+normalize_bool() {
+    case "${1,,}" in
+        true|false) printf '%s' "${1,,}" ;;
+        *) echo "ERROR: invalid boolean value '${1}' (expected true or false)" >&2; exit 1 ;;
+    esac
+}
+
 # Defaults — env vars take precedence over hardcoded defaults; CLI flags override both
 TITLE="${PREFLIGHT_TITLE:-Pre-flight Checks}"
-CHECK_PULL_SECRET="${PREFLIGHT_CHECK_PULL_SECRET:-false}"
-CHECK_SYSTEM_RESOURCES="${PREFLIGHT_CHECK_SYSTEM_RESOURCES:-false}"
-CHECK_LIBVIRT="${PREFLIGHT_CHECK_LIBVIRT:-false}"
+CHECK_PULL_SECRET="$(normalize_bool "${PREFLIGHT_CHECK_PULL_SECRET:-false}")"
+CHECK_SYSTEM_RESOURCES="$(normalize_bool "${PREFLIGHT_CHECK_SYSTEM_RESOURCES:-false}")"
+CHECK_LIBVIRT="$(normalize_bool "${PREFLIGHT_CHECK_LIBVIRT:-false}")"
 DEPLOYMENT_MODE="${PREFLIGHT_DEPLOYMENT_MODE:-}"
 
 while [[ $# -gt 0 ]]; do
@@ -117,7 +125,7 @@ if [ "$CHECK_SYSTEM_RESOURCES" = true ]; then
     output "${GREEN}✅ Total RAM: ${TOTAL_RAM}GB${NC}"
 
     # Check disk space on WORKING_DIR if set, otherwise BASE_WORKING_DIR
-    CHECK_DIR="${WORKING_DIR:-${BASE_WORKING_DIR}}"
+    CHECK_DIR="${WORKING_DIR:-${BASE_WORKING_DIR:-}}"
     if [ -n "$CHECK_DIR" ]; then
         AVAILABLE_DISK_GB=$(df -B 1G --output=avail "$CHECK_DIR" 2>/dev/null | tail -n 1 | xargs)
         REQUIRED_DISK_GB=80

--- a/scripts/setup/preflight_checks.sh
+++ b/scripts/setup/preflight_checks.sh
@@ -28,12 +28,12 @@ ENCLAVE_DIR="$(cd -- "${SCRIPT_DIR}/../.." &>/dev/null && pwd)"
 # Source shared utilities
 source "${ENCLAVE_DIR}/scripts/lib/output.sh"
 
-# Parse command-line arguments
-TITLE="Pre-flight Checks"
-CHECK_PULL_SECRET=false
-CHECK_SYSTEM_RESOURCES=false
-CHECK_LIBVIRT=false
-DEPLOYMENT_MODE=""
+# Defaults — env vars take precedence over hardcoded defaults; CLI flags override both
+TITLE="${PREFLIGHT_TITLE:-Pre-flight Checks}"
+CHECK_PULL_SECRET="${PREFLIGHT_CHECK_PULL_SECRET:-false}"
+CHECK_SYSTEM_RESOURCES="${PREFLIGHT_CHECK_SYSTEM_RESOURCES:-false}"
+CHECK_LIBVIRT="${PREFLIGHT_CHECK_LIBVIRT:-false}"
+DEPLOYMENT_MODE="${PREFLIGHT_DEPLOYMENT_MODE:-}"
 
 while [[ $# -gt 0 ]]; do
     case $1 in

--- a/scripts/setup/setup_dev_scripts.sh
+++ b/scripts/setup/setup_dev_scripts.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Set up the dev-scripts directory for Enclave Lab
+#
+# Clones dev-scripts into DEV_SCRIPTS_PATH (idempotent) and writes
+# the OpenShift pull secret to the location dev-scripts expects.
+#
+# Environment Variables:
+#   DEV_SCRIPTS_PATH   - destination directory (required, exported by Makefile.ci)
+#   DEV_SCRIPTS_REPO   - repository URL (required, exported by Makefile.ci)
+#   DEV_SCRIPTS_BRANCH - branch / tag / SHA to check out (required, exported by Makefile.ci)
+#   PULL_SECRET        - OpenShift pull secret JSON content (required when pull_secret.json absent or to refresh)
+#   WORKING_DIR        - parent boundary for the path check (required, exported by Makefile.ci)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+ENCLAVE_DIR="$(cd -- "${SCRIPT_DIR}/../.." &>/dev/null && pwd)"
+
+source "${ENCLAVE_DIR}/scripts/lib/output.sh"
+source "${ENCLAVE_DIR}/scripts/lib/validation.sh"
+
+require_env_var "DEV_SCRIPTS_PATH"
+require_env_var "DEV_SCRIPTS_REPO"
+require_env_var "DEV_SCRIPTS_BRANCH"
+require_env_var "WORKING_DIR"
+
+real_working_dir="$(realpath "${WORKING_DIR}")"
+real_dev_scripts_path="$(realpath -m "${DEV_SCRIPTS_PATH}")"
+case "${real_dev_scripts_path}" in
+    "${real_working_dir}/"*) ;;
+    *) error "DEV_SCRIPTS_PATH (${DEV_SCRIPTS_PATH}) is outside WORKING_DIR (${WORKING_DIR})"; exit 1 ;;
+esac
+
+if [ ! -d "${DEV_SCRIPTS_PATH}" ]; then
+    info "Cloning dev-scripts (${DEV_SCRIPTS_BRANCH}) into ${DEV_SCRIPTS_PATH}..."
+    if [ "${DEV_SCRIPTS_BRANCH}" = "master" ]; then
+        git clone --depth=1 "${DEV_SCRIPTS_REPO}" "${DEV_SCRIPTS_PATH}"
+    else
+        git clone "${DEV_SCRIPTS_REPO}" "${DEV_SCRIPTS_PATH}"
+        git -C "${DEV_SCRIPTS_PATH}" checkout "${DEV_SCRIPTS_BRANCH}" || {
+            rm -rf "${DEV_SCRIPTS_PATH}"
+            error "Failed to checkout '${DEV_SCRIPTS_BRANCH}'; removed incomplete clone"
+            exit 1
+        }
+    fi
+    success "dev-scripts cloned"
+else
+    info "dev-scripts already present at ${DEV_SCRIPTS_PATH}"
+fi
+
+pull_secret_file="${DEV_SCRIPTS_PATH}/pull_secret.json"
+if [ ! -f "${pull_secret_file}" ] || [ -n "${PULL_SECRET:-}" ]; then
+    require_env_var "PULL_SECRET"
+    info "Writing pull secret to ${pull_secret_file}..."
+    umask 077
+    printf '%s' "${PULL_SECRET}" > "${pull_secret_file}"
+    success "Pull secret written"
+fi

--- a/scripts/setup/setup_dev_scripts.sh
+++ b/scripts/setup/setup_dev_scripts.sh
@@ -24,14 +24,10 @@ require_env_var "DEV_SCRIPTS_REPO"
 require_env_var "DEV_SCRIPTS_BRANCH"
 require_env_var "WORKING_DIR"
 
-real_working_dir="$(realpath "${WORKING_DIR}")"
-real_dev_scripts_path="$(realpath -m "${DEV_SCRIPTS_PATH}")"
-case "${real_dev_scripts_path}" in
-    "${real_working_dir}/"*) ;;
-    *) error "DEV_SCRIPTS_PATH (${DEV_SCRIPTS_PATH}) is outside WORKING_DIR (${WORKING_DIR})"; exit 1 ;;
-esac
+require_path_within "${DEV_SCRIPTS_PATH}" "${WORKING_DIR}"
 
-if [ ! -d "${DEV_SCRIPTS_PATH}" ]; then
+if [ ! -d "${DEV_SCRIPTS_PATH}/.git" ]; then
+    rm -rf "${DEV_SCRIPTS_PATH}"
     info "Cloning dev-scripts (${DEV_SCRIPTS_BRANCH}) into ${DEV_SCRIPTS_PATH}..."
     if [ "${DEV_SCRIPTS_BRANCH}" = "master" ]; then
         git clone --depth=1 "${DEV_SCRIPTS_REPO}" "${DEV_SCRIPTS_PATH}"
@@ -54,5 +50,6 @@ if [ ! -f "${pull_secret_file}" ] || [ -n "${PULL_SECRET:-}" ]; then
     info "Writing pull secret to ${pull_secret_file}..."
     umask 077
     printf '%s' "${PULL_SECRET}" > "${pull_secret_file}"
+    chmod 600 "${pull_secret_file}"
     success "Pull secret written"
 fi


### PR DESCRIPTION
Add clone-dev-scripts / clean-dev-scripts targets so the Makefile owns the dev-scripts clone. DEV_SCRIPTS_PATH defaults to WORKING_DIR/dev-scripts-CLUSTER_NAME and is exported to all child processes; DEV_SCRIPTS_BRANCH (default: master) selects the ref with a shallow clone for master. clone-dev-scripts is idempotent and wired as a prerequisite on every target that reads DEV_SCRIPTS_PATH. clean-dev-scripts depends on clean-infra to guarantee cleanup.sh runs before the clone is removed. Remove DEV_SCRIPTS_PATH from all workflow env blocks so the Makefile default is not bypassed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated dev-scripts repository setup and cleanup in CI pipelines, eliminating manual configuration requirements.
  * Improved workflow reliability with automatic dependency initialization before deployment and infrastructure verification steps.
  * Streamlined build and cleanup processes through unified setup mechanisms across all CI targets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/enclave/pull/412?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->