### PR TITLE
Fix openshift_versions override missing default attribute

### DIFF
--- a/playbooks/common/load-vars.yaml
+++ b/playbooks/common/load-vars.yaml
@@ -38,5 +38,5 @@
 
 - name: Override OpenShift versions on fresh install
   ansible.builtin.set_fact:
-    openshift_versions: "{{ [{'version': mgmt_openshift_version}] }}"
+    openshift_versions: "{{ [{'version': mgmt_openshift_version, 'default': true}] }}"
   when: fresh | default(true) | bool


### PR DESCRIPTION
## Summary

- The `set_fact` override in `load-vars.yaml:41` stripped the `default: true` attribute from the `openshift_versions` entry, introduced in #379
- When `main.yaml` runs all phases in a single `ansible-playbook` process, `set_fact` has higher precedence than `include_vars`, so subsequent phases see the overridden value without `default: true`
- This causes `selectattr('default', 'equalto', true)` at line 37 to return an empty sequence, failing with "No first item, sequence was empty"
- The fix preserves `default: true` in the override so the attribute survives across phases

## Why CI didn't catch this

CI runs individual phase targets (`deploy-cluster-validate`, `deploy-cluster-prepare`, etc.) as separate `ansible-playbook` processes — `set_fact` doesn't persist between them. The bug only manifests when running `main.yaml` as a single process (e.g. `make -f Makefile.ci deploy-cluster`).

## Test plan

- [x] Verify fix is safe for all deployment paths: CI (individual phases), `main.yaml` (single process), connected, disconnected
- [x] Run `make -f Makefile.ci deploy-cluster` end-to-end

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed fresh installations to properly designate the selected management OpenShift version as the default, ensuring consistent initial setup behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/enclave/pull/413?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->