### PR TITLE
reconcile cli: add --use-defaults option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,10 +45,10 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.sdist]
-only-include = ["reconcile", "defaults/operators.yaml"]
+only-include = ["reconcile", "defaults/operators.yaml", "defaults/platforms.yaml"]
 
 [tool.hatch.build.targets.wheel]
-only-include = ["reconcile", "defaults/operators.yaml"]
+only-include = ["reconcile", "defaults/operators.yaml", "defaults/platforms.yaml"]
 
 [tool.ruff]
 line-length = 88

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 from pathlib import Path
+from typing import cast
 
 import click
 import yaml
@@ -96,7 +97,15 @@ def operator_versions(
 
 
 @cli.command()
-@click.argument("version")
+@click.option(
+    "--version", "version", default=None, help="OpenShift version to upgrade to"
+)
+@click.option(
+    "--use-defaults",
+    is_flag=True,
+    default=False,
+    help="Load the default version from defaults/platforms.yaml (mutually exclusive with --version)",
+)
 @click.option("--dry-run/--no-dry-run", default=False)
 @click.option(
     "--timeout-minutes",
@@ -111,10 +120,54 @@ def operator_versions(
     help="Sleep interval between polling attempts in seconds (default: 60)",
 )
 def mgmt_cluster_version(
-    version: str, dry_run: bool, timeout_minutes: int, sleep_interval: int
+    version: str | None,
+    use_defaults: bool,
+    dry_run: bool,
+    timeout_minutes: int,
+    sleep_interval: int,
 ) -> None:
+    if use_defaults and version:
+        raise click.UsageError("--use-defaults is mutually exclusive with --version")
+
+    if not use_defaults and not version:
+        raise click.UsageError("Either --version or --use-defaults must be provided")
+
+    resolved_version: str
+    if use_defaults:
+        defaults_path = (
+            Path(__file__).resolve().parent.parent / "defaults" / "platforms.yaml"
+        )
+        try:
+            with defaults_path.open(encoding="utf-8") as fh:
+                platforms = yaml.safe_load(fh)
+        except FileNotFoundError as exc:
+            raise click.ClickException(
+                f"{defaults_path} not found; run from the repo root"
+            ) from exc
+        except yaml.YAMLError as exc:
+            raise click.ClickException(
+                f"Failed to parse {defaults_path}: {exc}"
+            ) from exc
+
+        openshift_versions: list[dict[str, object]] = platforms.get(
+            "openshift_versions", []
+        )
+        default_entry = next(
+            (v for v in openshift_versions if v.get("default") is True), None
+        )
+        if default_entry is None:
+            raise click.ClickException(
+                "No default version found in defaults/platforms.yaml; "
+                "set 'default: true' on one entry"
+            )
+        resolved_version = str(default_entry["version"])
+    else:
+        resolved_version = cast("str", version)
+
     try:
-        cluster_upgrade_reconcile(version, dry_run, timeout_minutes, sleep_interval)
+        cluster_upgrade_reconcile(
+            resolved_version, dry_run, timeout_minutes, sleep_interval
+        )
     except (ClusterUpgradeError, RuntimeError, TimeoutError) as e:
         raise click.ClickException(str(e)) from e
 

--- a/reconcile/tests/test_cli.py
+++ b/reconcile/tests/test_cli.py
@@ -28,6 +28,8 @@ def test_operator_versions_help() -> None:
 def test_mgmt_cluster_version_help() -> None:
     result = CliRunner().invoke(cli, ["mgmt-cluster-version", "--help"])
     assert result.exit_code == 0
+    assert "--version" in result.output
+    assert "--use-defaults" in result.output
     assert "--timeout-minutes" in result.output
     assert "--sleep-interval" in result.output
 
@@ -140,3 +142,37 @@ def test_operator_versions_missing_required_without_defaults() -> None:
     result = CliRunner().invoke(cli, ["operator-versions", "--name", "foo"])
     assert result.exit_code != 0
     assert "Missing option" in result.output
+
+
+def test_mgmt_cluster_version_with_version(mocker: MockerFixture) -> None:
+    mock_reconcile = mocker.patch("reconcile.cli.cluster_upgrade_reconcile")
+    dry_run = True
+    result = CliRunner().invoke(
+        cli, ["mgmt-cluster-version", "--version", "4.20.21", "--dry-run"]
+    )
+    assert result.exit_code == 0, result.output
+    mock_reconcile.assert_called_once_with("4.20.21", dry_run, 180, 60)
+
+
+def test_mgmt_cluster_version_use_defaults(mocker: MockerFixture) -> None:
+    mock_reconcile = mocker.patch("reconcile.cli.cluster_upgrade_reconcile")
+    dry_run = True
+    result = CliRunner().invoke(
+        cli, ["mgmt-cluster-version", "--use-defaults", "--dry-run"]
+    )
+    assert result.exit_code == 0, result.output
+    mock_reconcile.assert_called_once_with("4.20.21", dry_run, 180, 60)
+
+
+def test_mgmt_cluster_version_use_defaults_mutual_exclusive_version() -> None:
+    result = CliRunner().invoke(
+        cli, ["mgmt-cluster-version", "--use-defaults", "--version", "4.20.8"]
+    )
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output
+
+
+def test_mgmt_cluster_version_neither_version_nor_defaults() -> None:
+    result = CliRunner().invoke(cli, ["mgmt-cluster-version"])
+    assert result.exit_code != 0
+    assert "Either --version or --use-defaults" in result.output


### PR DESCRIPTION
Replace the positional version argument with --version and add a mutually exclusive --use-defaults flag that resolves the target version from the default: true entry in defaults/platforms.yaml. Either option must be provided.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--use-defaults` flag to automatically use the default OpenShift version from configuration
  * Changed `--version` parameter from required to optional

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/enclave/pull/417?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->