### PR TITLE
Remove empty defaults from Authorino plugin descriptor

### DIFF
--- a/plugins/authorino/plugin.yaml
+++ b/plugins/authorino/plugin.yaml
@@ -10,5 +10,3 @@ operators:
     init_version: 1.3.0
     namespace: authorino-operator
     global: true
-
-defaults: {}


### PR DESCRIPTION
## Summary
- Remove the unused empty `defaults: {}` field from the Authorino plugin descriptor
- The Authorino plugin has no default values; the empty field was unnecessary
- Part of the per-plugin validation cleanup (#404)

OSAC-927