### PR TITLE
Add --plugin option to operator-versions reconcile command

### DIFF
--- a/.github/workflows/e2e-deployment.yml
+++ b/.github/workflows/e2e-deployment.yml
@@ -80,6 +80,7 @@ jobs:
             e2e:
               - 'playbooks/**'
               - 'scripts/**'
+              - 'reconcile/**'
               - 'Makefile'
               - 'Makefile.ci'
               - 'config/**'

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -50,7 +50,13 @@ def resolve_quay_registry_ca(hostname: str, oc: str) -> None:
 
 
 def _reconcile_operators_from_list(operators: list[dict], dry_run: bool) -> None:
-    """Reconcile operator versions from a list of operator definitions."""
+    """Reconcile operator versions from a list of operator definitions.
+
+    Args:
+        operators: List of operator definitions, each with 'name', 'version', 'namespace',
+            and optionally 'csvNames'.
+        dry_run: If True, only print what would be done without making changes.
+    """
     for op in operators:
         csv_names_list: list[str] = op.get("csvNames") or [op["name"]]
         operator_versions_reconcile(
@@ -59,7 +65,29 @@ def _reconcile_operators_from_list(operators: list[dict], dry_run: bool) -> None
 
 
 def _load_plugin_operators(plugin_name: str) -> list[dict]:
-    """Load operator definitions from a plugin descriptor."""
+    """Load operator definitions from a plugin descriptor.
+
+    Args:
+        plugin_name: Name of the plugin (must be a simple name without path separators).
+
+    Returns:
+        List of operator definitions from the plugin's plugin.yaml file.
+
+    Raises:
+        click.ClickException: If plugin_name contains invalid characters, plugin not found,
+            YAML parsing fails, installOperators is false, or no operators defined.
+    """
+    # Validate plugin_name to prevent path traversal attacks
+    if (
+        not plugin_name
+        or "/" in plugin_name
+        or "\\" in plugin_name
+        or ".." in plugin_name
+    ):
+        raise click.ClickException(
+            f"Invalid plugin name: {plugin_name!r}. Plugin name must be a simple name without path separators or '..'."
+        )
+
     plugin_path = (
         Path(__file__).resolve().parent.parent / "plugins" / plugin_name / "plugin.yaml"
     )
@@ -70,8 +98,10 @@ def _load_plugin_operators(plugin_name: str) -> list[dict]:
         raise click.ClickException(
             f"{plugin_path} not found; check plugin name or run from repo root"
         ) from exc
-    except yaml.YAMLError as exc:
-        raise click.ClickException(f"Failed to parse {plugin_path}: {exc}") from exc
+    except yaml.YAMLError:
+        raise click.ClickException(
+            f"Failed to parse {plugin_path}: invalid YAML syntax"
+        ) from None
 
     if plugin_data.get("installOperators") is False:
         raise click.ClickException(
@@ -87,7 +117,14 @@ def _load_plugin_operators(plugin_name: str) -> list[dict]:
 
 
 def _load_defaults_operators() -> list[dict]:
-    """Load operator definitions from defaults/operators.yaml."""
+    """Load operator definitions from defaults/operators.yaml.
+
+    Returns:
+        List of operator definitions from defaults/operators.yaml.
+
+    Raises:
+        click.ClickException: If file not found, YAML parsing fails, or 'operators' key missing.
+    """
     defaults_path = (
         Path(__file__).resolve().parent.parent / "defaults" / "operators.yaml"
     )
@@ -98,8 +135,14 @@ def _load_defaults_operators() -> list[dict]:
         raise click.ClickException(
             f"{defaults_path} not found; run from the repo root"
         ) from exc
-    except (yaml.YAMLError, KeyError) as exc:
-        raise click.ClickException(f"Failed to parse {defaults_path}: {exc}") from exc
+    except yaml.YAMLError:
+        raise click.ClickException(
+            f"Failed to parse {defaults_path}: invalid YAML syntax"
+        ) from None
+    except KeyError as exc:
+        raise click.ClickException(
+            f"Failed to parse {defaults_path}: missing 'operators' key"
+        ) from exc
 
 
 @cli.command()
@@ -210,10 +253,10 @@ def mgmt_cluster_version(
             raise click.ClickException(
                 f"{defaults_path} not found; run from the repo root"
             ) from exc
-        except yaml.YAMLError as exc:
+        except yaml.YAMLError:
             raise click.ClickException(
-                f"Failed to parse {defaults_path}: {exc}"
-            ) from exc
+                f"Failed to parse {defaults_path}: invalid YAML syntax"
+            ) from None
 
         openshift_versions: list[dict[str, object]] = platforms.get(
             "openshift_versions", []

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -73,6 +73,11 @@ def _load_plugin_operators(plugin_name: str) -> list[dict]:
     except yaml.YAMLError as exc:
         raise click.ClickException(f"Failed to parse {plugin_path}: {exc}") from exc
 
+    if plugin_data.get("installOperators") is False:
+        raise click.ClickException(
+            f"Plugin {plugin_name} has installOperators set to false"
+        )
+
     operators = plugin_data.get("operators", [])
     if not operators:
         raise click.ClickException(

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -49,6 +49,54 @@ def resolve_quay_registry_ca(hostname: str, oc: str) -> None:
         raise click.ClickException(str(exc)) from exc
 
 
+def _reconcile_operators_from_list(operators: list[dict], dry_run: bool) -> None:
+    """Reconcile operator versions from a list of operator definitions."""
+    for op in operators:
+        csv_names_list: list[str] = op.get("csvNames") or [op["name"]]
+        operator_versions_reconcile(
+            op["version"], op["namespace"], csv_names_list, dry_run
+        )
+
+
+def _load_plugin_operators(plugin_name: str) -> list[dict]:
+    """Load operator definitions from a plugin descriptor."""
+    plugin_path = (
+        Path(__file__).resolve().parent.parent / "plugins" / plugin_name / "plugin.yaml"
+    )
+    try:
+        with plugin_path.open(encoding="utf-8") as fh:
+            plugin_data = yaml.safe_load(fh)
+    except FileNotFoundError as exc:
+        raise click.ClickException(
+            f"{plugin_path} not found; check plugin name or run from repo root"
+        ) from exc
+    except yaml.YAMLError as exc:
+        raise click.ClickException(f"Failed to parse {plugin_path}: {exc}") from exc
+
+    operators = plugin_data.get("operators", [])
+    if not operators:
+        raise click.ClickException(
+            f"Plugin {plugin_name} has no operators defined in {plugin_path}"
+        )
+    return operators
+
+
+def _load_defaults_operators() -> list[dict]:
+    """Load operator definitions from defaults/operators.yaml."""
+    defaults_path = (
+        Path(__file__).resolve().parent.parent / "defaults" / "operators.yaml"
+    )
+    try:
+        with defaults_path.open(encoding="utf-8") as fh:
+            return yaml.safe_load(fh)["operators"]
+    except FileNotFoundError as exc:
+        raise click.ClickException(
+            f"{defaults_path} not found; run from the repo root"
+        ) from exc
+    except (yaml.YAMLError, KeyError) as exc:
+        raise click.ClickException(f"Failed to parse {defaults_path}: {exc}") from exc
+
+
 @cli.command()
 @click.option("--name", help="Operator package name")
 @click.option("--version", help="Operator version")
@@ -63,7 +111,11 @@ def resolve_quay_registry_ca(hostname: str, oc: str) -> None:
     "--use-defaults",
     is_flag=True,
     default=False,
-    help="Load all operators from defaults/operators.yaml (mutually exclusive with --name, --version, --namespace, --csv-name)",
+    help="Load all operators from defaults/operators.yaml (mutually exclusive with --name, --version, --namespace, --csv-name, --plugin)",
+)
+@click.option(
+    "--plugin",
+    help="Load operators from a plugin descriptor in plugins/<name>/plugin.yaml (mutually exclusive with --name, --version, --namespace, --csv-name, --use-defaults)",
 )
 @click.option("--dry-run/--no-dry-run", default=False)
 def operator_versions(
@@ -72,45 +124,37 @@ def operator_versions(
     namespace: str,
     csv_names: tuple[str, ...],
     use_defaults: bool,
+    plugin: str,
     dry_run: bool,
 ) -> None:
-    if use_defaults and any([name, version, namespace, csv_names]):
+    if use_defaults and any([name, version, namespace, csv_names, plugin]):
         raise click.UsageError(
-            "--use-defaults is mutually exclusive with --name, --version, --namespace, --csv-name"
+            "--use-defaults is mutually exclusive with --name, --version, --namespace, --csv-name, --plugin"
         )
 
-    if not use_defaults:
-        missing = [
-            f"--{f}"
-            for f, v in [("name", name), ("version", version), ("namespace", namespace)]
-            if not v
-        ]
-        if missing:
-            raise click.UsageError(f"Missing option(s): {', '.join(missing)}")
-        operator_versions_reconcile(
-            version, namespace, list(csv_names) or [name], dry_run
+    if plugin and any([name, version, namespace, csv_names]):
+        raise click.UsageError(
+            "--plugin is mutually exclusive with --name, --version, --namespace, --csv-name"
         )
+
+    if plugin:
+        operators = _load_plugin_operators(plugin)
+        _reconcile_operators_from_list(operators, dry_run)
         return
 
-    defaults_path = (
-        Path(__file__).resolve().parent.parent / "defaults" / "operators.yaml"
-    )
-    try:
-        with defaults_path.open(encoding="utf-8") as fh:
-            operators = yaml.safe_load(fh)["operators"]
-    except FileNotFoundError as exc:
-        raise click.ClickException(
-            f"{defaults_path} not found; run from the repo root"
-        ) from exc
-    except (yaml.YAMLError, KeyError) as exc:
-        raise click.ClickException(f"Failed to parse {defaults_path}: {exc}") from exc
+    if use_defaults:
+        operators = _load_defaults_operators()
+        _reconcile_operators_from_list(operators, dry_run)
+        return
 
-    for op in operators:
-        op_name: str = op["name"]
-        op_csv_names: list[str] = op.get("csvNames") or [op_name]
-        operator_versions_reconcile(
-            op["version"], op["namespace"], op_csv_names, dry_run
-        )
+    missing = [
+        f"--{f}"
+        for f, v in [("name", name), ("version", version), ("namespace", namespace)]
+        if not v
+    ]
+    if missing:
+        raise click.UsageError(f"Missing option(s): {', '.join(missing)}")
+    operator_versions_reconcile(version, namespace, list(csv_names) or [name], dry_run)
 
 
 @cli.command()

--- a/reconcile/tests/test_cli.py
+++ b/reconcile/tests/test_cli.py
@@ -283,3 +283,21 @@ def test_operator_versions_plugin_install_operators_false(
     result = CliRunner().invoke(cli, ["operator-versions", "--plugin", "test-plugin"])
     assert result.exit_code != 0
     assert "installOperators set to false" in result.output
+
+
+def test_operator_versions_plugin_path_traversal_double_dot() -> None:
+    result = CliRunner().invoke(cli, ["operator-versions", "--plugin", "../../../etc"])
+    assert result.exit_code != 0
+    assert "Invalid plugin name" in result.output
+
+
+def test_operator_versions_plugin_path_traversal_slash() -> None:
+    result = CliRunner().invoke(cli, ["operator-versions", "--plugin", "foo/bar"])
+    assert result.exit_code != 0
+    assert "Invalid plugin name" in result.output
+
+
+def test_operator_versions_plugin_path_traversal_backslash() -> None:
+    result = CliRunner().invoke(cli, ["operator-versions", "--plugin", "foo\\bar"])
+    assert result.exit_code != 0
+    assert "Invalid plugin name" in result.output

--- a/reconcile/tests/test_cli.py
+++ b/reconcile/tests/test_cli.py
@@ -59,6 +59,7 @@ def test_operator_versions_help() -> None:
     assert "--csv-name" in result.output
     assert "--dry-run" in result.output
     assert "--use-defaults" in result.output
+    assert "--plugin" in result.output
     assert "--operators" not in result.output
 
 
@@ -213,3 +214,58 @@ def test_mgmt_cluster_version_neither_version_nor_defaults() -> None:
     result = CliRunner().invoke(cli, ["mgmt-cluster-version"])
     assert result.exit_code != 0
     assert "Either --version or --use-defaults" in result.output
+
+
+def test_operator_versions_plugin_calls_reconcile_per_operator(
+    mocker: MockerFixture,
+) -> None:
+    mock_reconcile = mocker.patch("reconcile.cli.operator_versions_reconcile")
+    dry_run = True
+    result = CliRunner().invoke(
+        cli, ["operator-versions", "--plugin", "lvms", "--dry-run"]
+    )
+    assert result.exit_code == 0, result.output
+    mock_reconcile.assert_called_once_with(
+        "4.20.0", "openshift-storage", ["lvms-operator"], dry_run
+    )
+
+
+def test_operator_versions_plugin_multiple_operators(mocker: MockerFixture) -> None:
+    mock_reconcile = mocker.patch("reconcile.cli.operator_versions_reconcile")
+    result = CliRunner().invoke(
+        cli, ["operator-versions", "--plugin", "odf", "--dry-run"]
+    )
+    assert result.exit_code == 0, result.output
+    assert mock_reconcile.call_count >= 1
+
+
+def test_operator_versions_plugin_mutual_exclusive_name() -> None:
+    result = CliRunner().invoke(
+        cli, ["operator-versions", "--plugin", "lvms", "--name", "foo"]
+    )
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output
+
+
+def test_operator_versions_plugin_mutual_exclusive_use_defaults() -> None:
+    result = CliRunner().invoke(
+        cli, ["operator-versions", "--plugin", "lvms", "--use-defaults"]
+    )
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output
+
+
+def test_operator_versions_plugin_not_found() -> None:
+    result = CliRunner().invoke(cli, ["operator-versions", "--plugin", "nonexistent"])
+    assert result.exit_code != 0
+    assert "not found" in result.output
+
+
+def test_operator_versions_plugin_no_operators(mocker: MockerFixture) -> None:
+    mocker.patch(
+        "pathlib.Path.open",
+        mocker.mock_open(read_data="name: test-plugin\ntype: addon\norder: 1\n"),
+    )
+    result = CliRunner().invoke(cli, ["operator-versions", "--plugin", "test-plugin"])
+    assert result.exit_code != 0
+    assert "no operators defined" in result.output

--- a/reconcile/tests/test_cli.py
+++ b/reconcile/tests/test_cli.py
@@ -269,3 +269,17 @@ def test_operator_versions_plugin_no_operators(mocker: MockerFixture) -> None:
     result = CliRunner().invoke(cli, ["operator-versions", "--plugin", "test-plugin"])
     assert result.exit_code != 0
     assert "no operators defined" in result.output
+
+
+def test_operator_versions_plugin_install_operators_false(
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch(
+        "pathlib.Path.open",
+        mocker.mock_open(
+            read_data="name: test-plugin\ntype: addon\norder: 1\ninstallOperators: false\n"
+        ),
+    )
+    result = CliRunner().invoke(cli, ["operator-versions", "--plugin", "test-plugin"])
+    assert result.exit_code != 0
+    assert "installOperators set to false" in result.output


### PR DESCRIPTION
Add support for loading operator definitions from plugin descriptors via a new --plugin option. This allows reconciling operator versions for all operators defined in a plugin without manually specifying each operator's details.

The implementation extracts operator configuration loading into helper functions to reduce complexity and avoid code duplication between --use-defaults and --plugin code paths.

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--plugin` option to the `operator-versions` command to load operator definitions from a plugin descriptor file.

* **Changes**
  * Option validation now enforces mutual exclusivity: `--plugin` cannot be used with `--name`, `--version`, `--namespace`, or `--csv-name`.
  * `--use-defaults` is now mutually exclusive with `--plugin` and direct flags.
  * Improved error messages for plugin and defaults YAML loading failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->