### PR TITLE
Add reconcile/ to E2E trigger paths

### DIFF
--- a/.github/workflows/e2e-deployment.yml
+++ b/.github/workflows/e2e-deployment.yml
@@ -80,6 +80,7 @@ jobs:
             e2e:
               - 'playbooks/**'
               - 'scripts/**'
+              - 'reconcile/**'
               - 'Makefile'
               - 'Makefile.ci'
               - 'config/**'

--- a/.github/workflows/e2e-deployment.yml
+++ b/.github/workflows/e2e-deployment.yml
@@ -80,7 +80,7 @@ jobs:
             e2e:
               - 'playbooks/**'
               - 'scripts/**'
-              - 'reconcile/**'
+              - 'src/**'
               - 'Makefile'
               - 'Makefile.ci'
               - 'config/**'


### PR DESCRIPTION
## Summary
Add `reconcile/**` to the E2E workflow path filter to ensure changes to deployment CLI tools trigger end-to-end tests.

## Motivation
The `reconcile/` directory contains CLI tools used during deployment:
- `operator-versions` - reconciles operator versions from plugin descriptors, defaults, or explicit flags
- `mgmt-cluster-version` - upgrades the management cluster OpenShift version  
- `resolve-quay-registry-ca` - resolves Quay registry CA certificates

Changes to these tools should be validated with E2E tests since they're invoked during actual deployments. Currently, only changes to playbooks, scripts, plugins, etc. trigger E2E tests, causing CLI changes to skip validation.

## Changes
- Added `- 'reconcile/**'` to the `e2e:` path filter in `.github/workflows/e2e-deployment.yml`

## Testing
Once merged, PRs that modify `reconcile/` files will trigger E2E tests to validate deployment tooling changes.

Assisted-by: Claude Code <noreply@anthropic.com>