### PR TITLE
Fix code scanning alerts for missing workflow permissions

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -16,6 +16,9 @@ on:
     # Weekly scheduled cleanup - Sunday at 4 AM UTC
     - cron: '0 4 * * 0'
 
+permissions:
+  contents: read
+
 # CRITICAL: Cleanup must wait for all other jobs to complete
 # Uses global concurrency group to prevent cleanup during active tests
 concurrency:

--- a/.github/workflows/infra-verify.yml
+++ b/.github/workflows/infra-verify.yml
@@ -7,6 +7,9 @@ on:
   merge_group:
     types: [checks_requested]
 
+permissions:
+  contents: read
+
 # Cancel previous runs when a PR is updated
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}


### PR DESCRIPTION
## Summary
Add explicit permissions declarations to GitHub Actions workflows to resolve code scanning security alerts.

## Changes
- Add `permissions: contents: read` to `infra-verify.yml`
- Add `permissions: contents: read` to `cleanup.yml`

## Motivation
GitHub Actions security best practices recommend explicitly declaring the minimum permissions required for each workflow. This follows the principle of least privilege and resolves two open code scanning alerts:
- [Alert #40](https://github.com/rh-ecosystem-edge/enclave/security/code-scanning/40): `.github/workflows/infra-verify.yml` missing permissions
- [Alert #39](https://github.com/rh-ecosystem-edge/enclave/security/code-scanning/39): `.github/workflows/cleanup.yml` missing permissions

Both workflows only require read access to repository contents, so this change aligns with their actual usage while improving security posture.

## Test plan
- [x] Workflows validated with YAML linting
- [ ] CI validation will run on this PR to verify workflows still function correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)