### PR TITLE
Remove empty defaults properties from plugin.yaml

### DIFF
--- a/plugins/nvidia-gpu/plugin.yaml
+++ b/plugins/nvidia-gpu/plugin.yaml
@@ -12,8 +12,6 @@ operators:
 
 installOperators: false
 
-defaults: {}
-
 registries:
   - location: "nvcr.io/nvidia"
     mirror: "nvidia"

--- a/plugins/openshift-ai/plugin.yaml
+++ b/plugins/openshift-ai/plugin.yaml
@@ -39,8 +39,6 @@ operators:
 
 installOperators: false
 
-defaults: {}
-
 registries:
   - location: "registry.redhat.io/rhcl-1"
     mirror: "rhcl-1"


### PR DESCRIPTION
plugin.defaults is deprecated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authorino plugin is now enabled by default in deployments.

* **Chores**
  * Cleaned up configuration files by removing unnecessary empty configuration blocks from plugin settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->