### PR TITLE
Migrate trust-manager plugin to per-plugin defaults system

### DIFF
--- a/plugins/trust-manager/defaults.yaml
+++ b/plugins/trust-manager/defaults.yaml
@@ -1,0 +1,3 @@
+---
+trust_manager_ca_issuer_duration: 87600h
+trust_manager_ca_issuer_renew_before: 8760h

--- a/plugins/trust-manager/plugin.yaml
+++ b/plugins/trust-manager/plugin.yaml
@@ -10,7 +10,3 @@ helm:
     version: v0.20.0
     namespace: cert-manager
     createNamespace: false
-
-defaults:
-  ca_issuer_duration: 87600h   # 10 years
-  ca_issuer_renew_before: 8760h  # 1 year

--- a/plugins/trust-manager/schemas/defaults.yaml
+++ b/plugins/trust-manager/schemas/defaults.yaml
@@ -2,6 +2,9 @@
 "$schema": "http://json-schema.org/draft-07/schema"
 type: object
 additionalProperties: false
+required:
+  - trust_manager_ca_issuer_duration
+  - trust_manager_ca_issuer_renew_before
 properties:
   trust_manager_ca_issuer_duration:
     type: string

--- a/plugins/trust-manager/schemas/defaults.yaml
+++ b/plugins/trust-manager/schemas/defaults.yaml
@@ -1,0 +1,11 @@
+---
+"$schema": "http://json-schema.org/draft-07/schema"
+type: object
+additionalProperties: false
+properties:
+  trust_manager_ca_issuer_duration:
+    type: string
+    description: Lifetime of the CA certificate issued by the self-signed issuer (e.g. 87600h for 10 years).
+  trust_manager_ca_issuer_renew_before:
+    type: string
+    description: How long before expiry the CA certificate is renewed (e.g. 8760h for 1 year).

--- a/plugins/trust-manager/templates/ca-issuer.yaml.j2
+++ b/plugins/trust-manager/templates/ca-issuer.yaml.j2
@@ -19,8 +19,8 @@ spec:
   isCA: true
   commonName: default-ca
   secretName: default-ca
-  duration: {{ ca_issuer_duration }}
-  renewBefore: {{ ca_issuer_renew_before }}
+  duration: {{ trust_manager_ca_issuer_duration }}
+  renewBefore: {{ trust_manager_ca_issuer_renew_before }}
   privateKey:
     algorithm: RSA
     size: 4096

--- a/plugins/trust-manager/test-fixtures/schemas/defaults/invalid/missing-required.yaml
+++ b/plugins/trust-manager/test-fixtures/schemas/defaults/invalid/missing-required.yaml
@@ -1,0 +1,2 @@
+---
+trust_manager_ca_issuer_duration: 87600h

--- a/plugins/trust-manager/test-fixtures/schemas/defaults/invalid/unknown-property.yaml
+++ b/plugins/trust-manager/test-fixtures/schemas/defaults/invalid/unknown-property.yaml
@@ -1,0 +1,3 @@
+---
+trust_manager_ca_issuer_duration: 87600h
+unknownField: this-should-fail

--- a/plugins/trust-manager/test-fixtures/schemas/defaults/valid/base.yaml
+++ b/plugins/trust-manager/test-fixtures/schemas/defaults/valid/base.yaml
@@ -1,0 +1,3 @@
+---
+trust_manager_ca_issuer_duration: 87600h
+trust_manager_ca_issuer_renew_before: 8760h


### PR DESCRIPTION
Move ca_issuer_duration and ca_issuer_renew_before out of the plugin.yaml defaults block into a standalone defaults.yaml with the required trust_manager_ prefix. Add a JSON Schema for the defaults and test fixtures. Update the ca-issuer Jinja2 template to use the renamed variables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added schema validation for trust-manager configuration parameters.
  * Introduced configurable CA issuer certificate duration (default: 10 years) and renewal period (default: 1 year) settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->