### PR TITLE
Add RHBK plugin for Red Hat Build of Keycloak deployment

### DIFF
--- a/config/plugins/rhbk.example.yaml
+++ b/config/plugins/rhbk.example.yaml
@@ -1,0 +1,16 @@
+---
+##############################################################################
+# RHBK PLUGIN CONFIGURATION TEMPLATE
+# Instructions: Copy this file to 'config/plugins/rhbk.yaml' and set values.
+# All fields are optional; defaults are shown below.
+##############################################################################
+
+# Number of Keycloak replicas.
+# rhbk_instances: 1
+
+# Deploy a PostgreSQL StatefulSet alongside Keycloak.
+# Set to false if using an external database.
+# rhbk_deploy_database: true
+
+# PVC size for the PostgreSQL data volume.
+# rhbk_db_size: 5Gi

--- a/plugins/rhbk/defaults.yaml
+++ b/plugins/rhbk/defaults.yaml
@@ -1,10 +1,10 @@
 ---
 rhbk_ns: keycloak
 rhbk_name: keycloak
-rhbk_hostname: ""
 rhbk_instances: 1
 rhbk_deploy_database: true
 rhbk_db_name: keycloak-database
 rhbk_db_image: registry.redhat.io/rhel9/postgresql-15:9.8
 rhbk_db_size: 5Gi
 rhbk_db_username: keycloak
+rhbk_cluster_issuer: default-ca

--- a/plugins/rhbk/defaults.yaml
+++ b/plugins/rhbk/defaults.yaml
@@ -5,5 +5,6 @@ rhbk_hostname: ""
 rhbk_instances: 1
 rhbk_deploy_database: true
 rhbk_db_name: keycloak-database
+rhbk_db_image: registry.redhat.io/rhel9/postgresql-15:9.8
 rhbk_db_size: 5Gi
 rhbk_db_username: keycloak

--- a/plugins/rhbk/defaults.yaml
+++ b/plugins/rhbk/defaults.yaml
@@ -1,0 +1,9 @@
+---
+rhbk_ns: keycloak
+rhbk_name: keycloak
+rhbk_hostname: ""
+rhbk_instances: 1
+rhbk_deploy_database: true
+rhbk_db_name: keycloak-database
+rhbk_db_size: 5Gi
+rhbk_db_username: keycloak

--- a/plugins/rhbk/plugin.yaml
+++ b/plugins/rhbk/plugin.yaml
@@ -5,9 +5,9 @@ order: 101
 
 operators:
   - name: rhbk-operator
-    version: 26.4.12-opr.1
+    version: 26.6.2-opr.1
     channel: stable-v26
-    init_version: 26.4.12-opr.1
+    init_version: 26.6.2-opr.1
     namespace: keycloak
     csvNames:
       - rhbk-operator

--- a/plugins/rhbk/plugin.yaml
+++ b/plugins/rhbk/plugin.yaml
@@ -11,3 +11,6 @@ operators:
     namespace: keycloak
     csvNames:
       - rhbk-operator
+
+additionalImages:
+  - registry.redhat.io/rhel9/postgresql-15:9.8

--- a/plugins/rhbk/plugin.yaml
+++ b/plugins/rhbk/plugin.yaml
@@ -5,9 +5,9 @@ order: 101
 
 operators:
   - name: rhbk-operator
-    version: 26.4.12
+    version: 26.4.12-opr.1
     channel: stable-v26
-    init_version: 26.4.12
+    init_version: 26.4.12-opr.1
     namespace: keycloak
     csvNames:
       - rhbk-operator

--- a/plugins/rhbk/plugin.yaml
+++ b/plugins/rhbk/plugin.yaml
@@ -1,0 +1,13 @@
+---
+name: rhbk
+type: addon
+order: 101
+
+operators:
+  - name: rhbk-operator
+    version: 26.4.12
+    channel: stable-v26
+    init_version: 26.4.12
+    namespace: keycloak
+    csvNames:
+      - rhbk-operator

--- a/plugins/rhbk/schemas/config.yaml
+++ b/plugins/rhbk/schemas/config.yaml
@@ -11,5 +11,5 @@ properties:
     type: boolean
     description: Deploy a PostgreSQL StatefulSet alongside Keycloak.
   rhbk_db_size:
-    "$ref": "#/definitions/nonEmptyString"
+    "$ref": "#/definitions/k8sQuantity"
     description: PVC size for the PostgreSQL data volume.

--- a/plugins/rhbk/schemas/config.yaml
+++ b/plugins/rhbk/schemas/config.yaml
@@ -1,0 +1,15 @@
+---
+"$schema": "http://json-schema.org/draft-07/schema"
+type: object
+additionalProperties: false
+properties:
+  rhbk_instances:
+    type: integer
+    minimum: 1
+    description: Number of Keycloak replicas.
+  rhbk_deploy_database:
+    type: boolean
+    description: Deploy a PostgreSQL StatefulSet alongside Keycloak.
+  rhbk_db_size:
+    "$ref": "#/definitions/nonEmptyString"
+    description: PVC size for the PostgreSQL data volume.

--- a/plugins/rhbk/schemas/defaults.yaml
+++ b/plugins/rhbk/schemas/defaults.yaml
@@ -2,6 +2,16 @@
 "$schema": "http://json-schema.org/draft-07/schema"
 type: object
 additionalProperties: false
+required:
+  - rhbk_ns
+  - rhbk_name
+  - rhbk_instances
+  - rhbk_deploy_database
+  - rhbk_db_name
+  - rhbk_db_image
+  - rhbk_db_size
+  - rhbk_db_username
+  - rhbk_cluster_issuer
 properties:
   rhbk_ns:
     "$ref": "#/definitions/nonEmptyString"
@@ -9,11 +19,6 @@ properties:
   rhbk_name:
     "$ref": "#/definitions/nonEmptyString"
     description: Name of the Keycloak CR instance.
-  rhbk_hostname:
-    type: string
-    description: >-
-      Keycloak hostname for ingress. Empty string means auto-detect
-      from cluster ingress domain.
   rhbk_instances:
     type: integer
     minimum: 1
@@ -33,3 +38,6 @@ properties:
   rhbk_db_username:
     "$ref": "#/definitions/nonEmptyString"
     description: PostgreSQL database username.
+  rhbk_cluster_issuer:
+    "$ref": "#/definitions/nonEmptyString"
+    description: Name of the ClusterIssuer used to issue the Keycloak TLS certificate.

--- a/plugins/rhbk/schemas/defaults.yaml
+++ b/plugins/rhbk/schemas/defaults.yaml
@@ -33,7 +33,7 @@ properties:
     "$ref": "#/definitions/nonEmptyString"
     description: PostgreSQL container image for the database.
   rhbk_db_size:
-    "$ref": "#/definitions/nonEmptyString"
+    "$ref": "#/definitions/k8sQuantity"
     description: PVC size for the PostgreSQL data volume.
   rhbk_db_username:
     "$ref": "#/definitions/nonEmptyString"

--- a/plugins/rhbk/schemas/defaults.yaml
+++ b/plugins/rhbk/schemas/defaults.yaml
@@ -24,6 +24,9 @@ properties:
   rhbk_db_name:
     "$ref": "#/definitions/nonEmptyString"
     description: Name of the PostgreSQL StatefulSet and Service.
+  rhbk_db_image:
+    "$ref": "#/definitions/nonEmptyString"
+    description: PostgreSQL container image for the database.
   rhbk_db_size:
     "$ref": "#/definitions/nonEmptyString"
     description: PVC size for the PostgreSQL data volume.

--- a/plugins/rhbk/schemas/defaults.yaml
+++ b/plugins/rhbk/schemas/defaults.yaml
@@ -1,0 +1,32 @@
+---
+"$schema": "http://json-schema.org/draft-07/schema"
+type: object
+additionalProperties: false
+properties:
+  rhbk_ns:
+    "$ref": "#/definitions/nonEmptyString"
+    description: Namespace for the RHBK deployment.
+  rhbk_name:
+    "$ref": "#/definitions/nonEmptyString"
+    description: Name of the Keycloak CR instance.
+  rhbk_hostname:
+    type: string
+    description: >-
+      Keycloak hostname for ingress. Empty string means auto-detect
+      from cluster ingress domain.
+  rhbk_instances:
+    type: integer
+    minimum: 1
+    description: Number of Keycloak replicas.
+  rhbk_deploy_database:
+    type: boolean
+    description: Deploy a PostgreSQL StatefulSet alongside Keycloak.
+  rhbk_db_name:
+    "$ref": "#/definitions/nonEmptyString"
+    description: Name of the PostgreSQL StatefulSet and Service.
+  rhbk_db_size:
+    "$ref": "#/definitions/nonEmptyString"
+    description: PVC size for the PostgreSQL data volume.
+  rhbk_db_username:
+    "$ref": "#/definitions/nonEmptyString"
+    description: PostgreSQL database username.

--- a/plugins/rhbk/tasks/deploy.yaml
+++ b/plugins/rhbk/tasks/deploy.yaml
@@ -1,0 +1,264 @@
+---
+- name: Detect cluster ingress domain
+  kubernetes.core.k8s_info:
+    api_version: config.openshift.io/v1
+    kind: Ingress
+    name: cluster
+  register: __r_ingress_config
+  when: rhbk_hostname | length == 0
+
+- name: Set Keycloak hostname from cluster ingress domain
+  ansible.builtin.set_fact:
+    rhbk_hostname: "keycloak.{{ __r_ingress_config.resources[0].spec.domain }}"
+  when: rhbk_hostname | length == 0
+
+- name: Ensure namespace exists
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: "{{ rhbk_ns }}"
+  register: __r_rhbk_ns
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: __r_rhbk_ns is success
+
+- name: Generate database password
+  ansible.builtin.set_fact:
+    __rhbk_db_password: "{{ lookup('password', '/dev/null length=24 chars=ascii_letters,digits') }}"
+  when: rhbk_deploy_database
+  no_log: true
+
+- name: Create database credentials Secret
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: "{{ rhbk_db_name }}-credentials"
+        namespace: "{{ rhbk_ns }}"
+      type: Opaque
+      stringData:
+        username: "{{ rhbk_db_username }}"
+        password: "{{ __rhbk_db_password }}"
+  register: __r_db_secret
+  no_log: true
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: __r_db_secret is success
+  when: rhbk_deploy_database
+
+- name: Create TLS Certificate for Keycloak
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: cert-manager.io/v1
+      kind: Certificate
+      metadata:
+        name: rhbk-tls
+        namespace: "{{ rhbk_ns }}"
+      spec:
+        secretName: rhbk-tls
+        issuerRef:
+          kind: ClusterIssuer
+          name: default-ca
+        dnsNames:
+          - "{{ rhbk_hostname }}"
+        privateKey:
+          rotationPolicy: Always
+  register: __r_rhbk_cert
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: __r_rhbk_cert is success
+
+- name: Deploy PostgreSQL Service
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: "{{ rhbk_db_name }}"
+        namespace: "{{ rhbk_ns }}"
+      spec:
+        selector:
+          app: "{{ rhbk_db_name }}"
+        ports:
+          - name: postgres
+            port: 5432
+            targetPort: 5432
+  register: __r_db_svc
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: __r_db_svc is success
+  when: rhbk_deploy_database
+
+- name: Deploy PostgreSQL StatefulSet
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: "{{ rhbk_db_name }}"
+        namespace: "{{ rhbk_ns }}"
+      spec:
+        serviceName: "{{ rhbk_db_name }}"
+        replicas: 1
+        selector:
+          matchLabels:
+            app: "{{ rhbk_db_name }}"
+        template:
+          metadata:
+            labels:
+              app: "{{ rhbk_db_name }}"
+          spec:
+            containers:
+              - name: postgresql
+                image: registry.redhat.io/rhel9/postgresql-15:latest
+                ports:
+                  - containerPort: 5432
+                env:
+                  - name: POSTGRESQL_USER
+                    valueFrom:
+                      secretKeyRef:
+                        name: "{{ rhbk_db_name }}-credentials"
+                        key: username
+                  - name: POSTGRESQL_PASSWORD
+                    valueFrom:
+                      secretKeyRef:
+                        name: "{{ rhbk_db_name }}-credentials"
+                        key: password
+                  - name: POSTGRESQL_DATABASE
+                    value: keycloak
+                volumeMounts:
+                  - name: data
+                    mountPath: /var/lib/pgsql/data
+                readinessProbe:
+                  exec:
+                    command:
+                      - /usr/libexec/check-container
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                livenessProbe:
+                  exec:
+                    command:
+                      - /usr/libexec/check-container
+                      - --live
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+        volumeClaimTemplates:
+          - metadata:
+              name: data
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: "{{ rhbk_db_size }}"
+  register: __r_db_sts
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: __r_db_sts is success
+  when: rhbk_deploy_database
+
+- name: Wait for PostgreSQL ready
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: StatefulSet
+    name: "{{ rhbk_db_name }}"
+    namespace: "{{ rhbk_ns }}"
+  register: __r_db_ready
+  retries: 30
+  delay: 10
+  until:
+    - __r_db_ready.resources | length > 0
+    - __r_db_ready.resources[0].status.readyReplicas | default(0) | int > 0
+  when: rhbk_deploy_database
+
+- name: Wait for Keycloak CRD to be registered
+  kubernetes.core.k8s_info:
+    api_version: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    name: keycloaks.k8s.keycloak.org
+  register: __r_keycloak_crd
+  retries: 60
+  delay: 10
+  until:
+    - __r_keycloak_crd.resources | default([]) | length > 0
+
+- name: Deploy Keycloak CR (with database)
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: k8s.keycloak.org/v2alpha1
+      kind: Keycloak
+      metadata:
+        name: "{{ rhbk_name }}"
+        namespace: "{{ rhbk_ns }}"
+      spec:
+        instances: "{{ rhbk_instances }}"
+        hostname:
+          hostname: "{{ rhbk_hostname }}"
+        http:
+          tlsSecret: rhbk-tls
+        db:
+          vendor: postgres
+          host: "{{ rhbk_db_name }}"
+          port: 5432
+          database: keycloak
+          usernameSecret:
+            name: "{{ rhbk_db_name }}-credentials"
+            key: username
+          passwordSecret:
+            name: "{{ rhbk_db_name }}-credentials"
+            key: password
+  register: __r_keycloak
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: __r_keycloak is success
+  when: rhbk_deploy_database
+
+- name: Deploy Keycloak CR (external database)
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: k8s.keycloak.org/v2alpha1
+      kind: Keycloak
+      metadata:
+        name: "{{ rhbk_name }}"
+        namespace: "{{ rhbk_ns }}"
+      spec:
+        instances: "{{ rhbk_instances }}"
+        hostname:
+          hostname: "{{ rhbk_hostname }}"
+        http:
+          tlsSecret: rhbk-tls
+  register: __r_keycloak
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: __r_keycloak is success
+  when: not rhbk_deploy_database
+
+- name: Wait for Keycloak CR ready
+  kubernetes.core.k8s_info:
+    api_version: k8s.keycloak.org/v2alpha1
+    kind: Keycloak
+    name: "{{ rhbk_name }}"
+    namespace: "{{ rhbk_ns }}"
+  register: __r_keycloak_status
+  retries: 60
+  delay: 15
+  until:
+    - __r_keycloak_status.resources | length > 0
+    - __r_keycloak_status.resources[0].status.conditions | default([])
+      | selectattr('type', 'equalto', 'Ready')
+      | selectattr('status', 'equalto', 'True')
+      | list | length > 0
+
+- name: Debug Keycloak status
+  ansible.builtin.debug:
+    msg: "Keycloak {{ rhbk_name }} is ready at https://{{ rhbk_hostname }} in {{ rhbk_ns }} namespace"

--- a/plugins/rhbk/tasks/deploy.yaml
+++ b/plugins/rhbk/tasks/deploy.yaml
@@ -133,6 +133,7 @@
             labels:
               app: "{{ rhbk_db_name }}"
           spec:
+            automountServiceAccountToken: false
             containers:
               - name: postgresql
                 image: "{{ rhbk_db_image }}"

--- a/plugins/rhbk/tasks/deploy.yaml
+++ b/plugins/rhbk/tasks/deploy.yaml
@@ -25,9 +25,24 @@
   delay: "{{ k8s_delay }}"
   until: __r_rhbk_ns is success
 
-- name: Generate database password
+- name: Read existing database credentials Secret
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    name: "{{ rhbk_db_name }}-credentials"
+    namespace: "{{ rhbk_ns }}"
+  register: __r_existing_db_secret
+  when: rhbk_deploy_database
+  no_log: true
+
+- name: Set database password from existing Secret or generate new one
   ansible.builtin.set_fact:
-    __rhbk_db_password: "{{ lookup('password', '/dev/null length=24 chars=ascii_letters,digits') }}"
+    __rhbk_db_password: >-
+      {{
+        (__r_existing_db_secret.resources[0].data.password | b64decode)
+        if (__r_existing_db_secret.resources | default([]) | length > 0)
+        else lookup('password', '/dev/null length=24 chars=ascii_letters,digits')
+      }}
   when: rhbk_deploy_database
   no_log: true
 
@@ -49,7 +64,9 @@
   retries: "{{ k8s_retries }}"
   delay: "{{ k8s_delay }}"
   until: __r_db_secret is success
-  when: rhbk_deploy_database
+  when:
+    - rhbk_deploy_database
+    - __r_existing_db_secret.resources | default([]) | length == 0
 
 - name: Create TLS Certificate for Keycloak
   kubernetes.core.k8s:
@@ -118,7 +135,7 @@
           spec:
             containers:
               - name: postgresql
-                image: registry.redhat.io/rhel9/postgresql-15:latest
+                image: "{{ rhbk_db_image }}"
                 ports:
                   - containerPort: 5432
                 env:
@@ -134,6 +151,19 @@
                         key: password
                   - name: POSTGRESQL_DATABASE
                     value: keycloak
+                securityContext:
+                  runAsNonRoot: true
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                      - ALL
+                resources:
+                  requests:
+                    cpu: 100m
+                    memory: 256Mi
+                  limits:
+                    cpu: 500m
+                    memory: 512Mi
                 volumeMounts:
                   - name: data
                     mountPath: /var/lib/pgsql/data

--- a/plugins/rhbk/tasks/deploy.yaml
+++ b/plugins/rhbk/tasks/deploy.yaml
@@ -5,12 +5,10 @@
     kind: Ingress
     name: cluster
   register: __r_ingress_config
-  when: rhbk_hostname | length == 0
 
 - name: Set Keycloak hostname from cluster ingress domain
   ansible.builtin.set_fact:
     rhbk_hostname: "keycloak.{{ __r_ingress_config.resources[0].spec.domain }}"
-  when: rhbk_hostname | length == 0
 
 - name: Ensure namespace exists
   kubernetes.core.k8s:
@@ -81,7 +79,7 @@
         secretName: rhbk-tls
         issuerRef:
           kind: ClusterIssuer
-          name: default-ca
+          name: "{{ rhbk_cluster_issuer }}"
         dnsNames:
           - "{{ rhbk_hostname }}"
         privateKey:

--- a/plugins/rhbk/tasks/deploy.yaml
+++ b/plugins/rhbk/tasks/deploy.yaml
@@ -166,7 +166,7 @@
                     memory: 512Mi
                 volumeMounts:
                   - name: data
-                    mountPath: /var/lib/pgsql/data
+                    mountPath: /var/lib/pgsql
                   - name: tmp
                     mountPath: /tmp
                   - name: run-postgresql
@@ -233,13 +233,13 @@
   kubernetes.core.k8s:
     state: present
     definition:
-      apiVersion: k8s.keycloak.org/v2alpha1
+      apiVersion: k8s.keycloak.org/v2beta1
       kind: Keycloak
       metadata:
         name: "{{ rhbk_name }}"
         namespace: "{{ rhbk_ns }}"
       spec:
-        instances: "{{ rhbk_instances | int }}"
+        instances: "{{ rhbk_instances }}"
         hostname:
           hostname: "{{ rhbk_hostname }}"
         http:
@@ -265,13 +265,13 @@
   kubernetes.core.k8s:
     state: present
     definition:
-      apiVersion: k8s.keycloak.org/v2alpha1
+      apiVersion: k8s.keycloak.org/v2beta1
       kind: Keycloak
       metadata:
         name: "{{ rhbk_name }}"
         namespace: "{{ rhbk_ns }}"
       spec:
-        instances: "{{ rhbk_instances | int }}"
+        instances: "{{ rhbk_instances }}"
         hostname:
           hostname: "{{ rhbk_hostname }}"
         http:
@@ -284,7 +284,7 @@
 
 - name: Wait for Keycloak CR ready
   kubernetes.core.k8s_info:
-    api_version: k8s.keycloak.org/v2alpha1
+    api_version: k8s.keycloak.org/v2beta1
     kind: Keycloak
     name: "{{ rhbk_name }}"
     namespace: "{{ rhbk_ns }}"

--- a/plugins/rhbk/tasks/deploy.yaml
+++ b/plugins/rhbk/tasks/deploy.yaml
@@ -152,6 +152,7 @@
                     value: keycloak
                 securityContext:
                   runAsNonRoot: true
+                  readOnlyRootFilesystem: true
                   allowPrivilegeEscalation: false
                   capabilities:
                     drop:
@@ -166,6 +167,10 @@
                 volumeMounts:
                   - name: data
                     mountPath: /var/lib/pgsql/data
+                  - name: tmp
+                    mountPath: /tmp
+                  - name: run-postgresql
+                    mountPath: /var/run/postgresql
                 readinessProbe:
                   exec:
                     command:
@@ -179,6 +184,11 @@
                       - --live
                   initialDelaySeconds: 30
                   periodSeconds: 10
+            volumes:
+              - name: tmp
+                emptyDir: {}
+              - name: run-postgresql
+                emptyDir: {}
         volumeClaimTemplates:
           - metadata:
               name: data
@@ -229,7 +239,7 @@
         name: "{{ rhbk_name }}"
         namespace: "{{ rhbk_ns }}"
       spec:
-        instances: "{{ rhbk_instances }}"
+        instances: "{{ rhbk_instances | int }}"
         hostname:
           hostname: "{{ rhbk_hostname }}"
         http:
@@ -261,7 +271,7 @@
         name: "{{ rhbk_name }}"
         namespace: "{{ rhbk_ns }}"
       spec:
-        instances: "{{ rhbk_instances }}"
+        instances: "{{ rhbk_instances | int }}"
         hostname:
           hostname: "{{ rhbk_hostname }}"
         http:

--- a/plugins/rhbk/tasks/pre-validate.yaml
+++ b/plugins/rhbk/tasks/pre-validate.yaml
@@ -1,0 +1,51 @@
+---
+- name: Check cert-manager CRD exists
+  kubernetes.core.k8s_info:
+    api_version: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    name: certificates.cert-manager.io
+  register: __r_cert_manager_crd
+
+- name: Fail if cert-manager CRD is not installed
+  ansible.builtin.fail:
+    msg: "certificates.cert-manager.io CRD not found. cert-manager must be installed before rhbk."
+  when: __r_cert_manager_crd.resources | length == 0
+
+- name: Check cert-manager controller is running
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: cert-manager
+    namespace: cert-manager
+  register: __r_cert_manager_deploy
+
+- name: Fail if cert-manager controller is not running
+  ansible.builtin.fail:
+    msg: "cert-manager controller deployment is not available. cert-manager must be running before rhbk."
+  when: >
+    __r_cert_manager_deploy.resources | length == 0 or
+    __r_cert_manager_deploy.resources[0].status.availableReplicas | default(0) | int == 0
+
+- name: Check default-ca ClusterIssuer exists
+  kubernetes.core.k8s_info:
+    api_version: cert-manager.io/v1
+    kind: ClusterIssuer
+    name: default-ca
+  register: __r_ca_issuer
+  failed_when: false
+
+- name: Fail if default-ca ClusterIssuer is not ready
+  ansible.builtin.fail:
+    msg: >-
+      ClusterIssuer default-ca not found, not ready, or cert-manager API is unavailable.
+      The trust-manager plugin must be deployed before rhbk.
+  when: >
+    __r_ca_issuer.failed | default(false) or
+    __r_ca_issuer.resources | default([]) | length == 0 or
+    (
+      __r_ca_issuer.resources | default([]) | length > 0 and
+      (__r_ca_issuer.resources[0].status.conditions | default([])
+      | selectattr('type', 'equalto', 'Ready')
+      | selectattr('status', 'equalto', 'True')
+      | list | length == 0)
+    )

--- a/plugins/rhbk/tasks/pre-validate.yaml
+++ b/plugins/rhbk/tasks/pre-validate.yaml
@@ -26,19 +26,19 @@
     __r_cert_manager_deploy.resources | length == 0 or
     __r_cert_manager_deploy.resources[0].status.availableReplicas | default(0) | int == 0
 
-- name: Check default-ca ClusterIssuer exists
+- name: Check ClusterIssuer exists
   kubernetes.core.k8s_info:
     api_version: cert-manager.io/v1
     kind: ClusterIssuer
-    name: default-ca
+    name: "{{ rhbk_cluster_issuer }}"
   register: __r_ca_issuer
   failed_when: false
 
-- name: Fail if default-ca ClusterIssuer is not ready
+- name: Fail if ClusterIssuer is not ready
   ansible.builtin.fail:
     msg: >-
-      ClusterIssuer default-ca not found, not ready, or cert-manager API is unavailable.
-      The trust-manager plugin must be deployed before rhbk.
+      ClusterIssuer {{ rhbk_cluster_issuer }} not found, not ready, or cert-manager API is unavailable.
+      A ClusterIssuer must be available before deploying rhbk.
   when: >
     __r_ca_issuer.failed | default(false) or
     __r_ca_issuer.resources | default([]) | length == 0 or

--- a/plugins/rhbk/test-fixtures/schemas/config/invalid/unknown-property.yaml
+++ b/plugins/rhbk/test-fixtures/schemas/config/invalid/unknown-property.yaml
@@ -1,0 +1,5 @@
+---
+# Fixture: unknown top-level property
+# Expected failure: additionalProperties is false
+rhbk_instances: 3
+unknownField: this-should-fail

--- a/plugins/rhbk/test-fixtures/schemas/config/valid/base.yaml
+++ b/plugins/rhbk/test-fixtures/schemas/config/valid/base.yaml
@@ -1,0 +1,4 @@
+---
+rhbk_instances: 3
+rhbk_deploy_database: true
+rhbk_db_size: 10Gi

--- a/plugins/rhbk/test-fixtures/schemas/defaults/invalid/unknown-property.yaml
+++ b/plugins/rhbk/test-fixtures/schemas/defaults/invalid/unknown-property.yaml
@@ -1,0 +1,5 @@
+---
+# Fixture: unknown top-level property
+# Expected failure: additionalProperties is false
+rhbk_ns: keycloak
+unknownField: this-should-fail

--- a/plugins/rhbk/test-fixtures/schemas/defaults/valid/base.yaml
+++ b/plugins/rhbk/test-fixtures/schemas/defaults/valid/base.yaml
@@ -1,10 +1,10 @@
 ---
 rhbk_ns: keycloak
 rhbk_name: keycloak
-rhbk_hostname: ""
 rhbk_instances: 1
 rhbk_deploy_database: true
 rhbk_db_name: keycloak-database
 rhbk_db_image: registry.redhat.io/rhel9/postgresql-15:9.8
 rhbk_db_size: 5Gi
 rhbk_db_username: keycloak
+rhbk_cluster_issuer: default-ca

--- a/plugins/rhbk/test-fixtures/schemas/defaults/valid/base.yaml
+++ b/plugins/rhbk/test-fixtures/schemas/defaults/valid/base.yaml
@@ -5,5 +5,6 @@ rhbk_hostname: ""
 rhbk_instances: 1
 rhbk_deploy_database: true
 rhbk_db_name: keycloak-database
+rhbk_db_image: registry.redhat.io/rhel9/postgresql-15:9.8
 rhbk_db_size: 5Gi
 rhbk_db_username: keycloak

--- a/plugins/rhbk/test-fixtures/schemas/defaults/valid/base.yaml
+++ b/plugins/rhbk/test-fixtures/schemas/defaults/valid/base.yaml
@@ -1,0 +1,9 @@
+---
+rhbk_ns: keycloak
+rhbk_name: keycloak
+rhbk_hostname: ""
+rhbk_instances: 1
+rhbk_deploy_database: true
+rhbk_db_name: keycloak-database
+rhbk_db_size: 5Gi
+rhbk_db_username: keycloak

--- a/schemas/definitions.yaml
+++ b/schemas/definitions.yaml
@@ -22,7 +22,7 @@ definitions:
     description: HTTP or HTTPS URL with a non-empty hostname
   k8sQuantity:
     type: string
-    pattern: "^[+-]?([0-9]+\\.?[0-9]*|\\.[0-9]+)([eE][+-]?[0-9]+|Ki|Mi|Gi|Ti|Pi|Ei|m|k|M|G|T|P|E)?$"
+    pattern: "^([0-9]+\\.?[0-9]*|\\.[0-9]+)([eE][+-]?[0-9]+|Ki|Mi|Gi|Ti|Pi|Ei|m|k|M|G|T|P|E)?$"
     description: A Kubernetes resource quantity (e.g. 5Gi, 100m, 512Mi)
   nonEmptyString:
     type: string

--- a/schemas/definitions.yaml
+++ b/schemas/definitions.yaml
@@ -20,6 +20,10 @@ definitions:
     type: string
     pattern: "^https?://[^/]"
     description: HTTP or HTTPS URL with a non-empty hostname
+  k8sQuantity:
+    type: string
+    pattern: "^[+-]?([0-9]+\\.?[0-9]*|\\.[0-9]+)([eE][+-]?[0-9]+|Ki|Mi|Gi|Ti|Pi|Ei|m|k|M|G|T|P|E)?$"
+    description: A Kubernetes resource quantity (e.g. 5Gi, 100m, 512Mi)
   nonEmptyString:
     type: string
     minLength: 1


### PR DESCRIPTION
## Summary

- Adds `plugins/rhbk/` plugin that deploys Red Hat Build of Keycloak via the `rhbk-operator` (OLM, `stable-v26` channel)
- Optionally deploys a PostgreSQL StatefulSet (`rhbk_deploy_database: true` by default)
- TLS via cert-manager `default-ca` ClusterIssuer (requires trust-manager plugin, order 100)
- Hostname always auto-detected from cluster ingress domain (`keycloak.<ingress_domain>`)
- No OSAC-specific realm configuration — OSAC experience configures Keycloak separately via `KeycloakRealmImport` CRs ([reference](https://github.com/osac-project/fulfillment-service/blob/main/docs/INSTALL.md#configure-the-keycloak-realm))
- Pre-validate checks: cert-manager CRD, cert-manager controller running, `default-ca` ClusterIssuer ready
- Includes defaults and config schema validation with test fixtures

### Plugin structure
```
plugins/rhbk/
  plugin.yaml                    # rhbk-operator, order 101
  defaults.yaml                  # rhbk_name=keycloak, rhbk_deploy_database=true, etc.
  schemas/defaults.yaml          # JSON Schema validation (all fields required)
  schemas/config.yaml            # Optional user-configurable: rhbk_instances, rhbk_deploy_database, rhbk_db_size
  tasks/pre-validate.yaml        # cert-manager + trust-manager dependency checks
  tasks/deploy.yaml              # hostname detection, DB, TLS cert, PostgreSQL, Keycloak CR
  test-fixtures/                 # Schema validation fixtures (defaults + config)
```

## Test plan

- [x] `make -f Makefile.ci validate-plugins` passes
- [x] `make -f Makefile.ci validate-yaml` passes
- [x] `make -f Makefile.ci validate-ansible` passes
- [x] Schema test fixtures: valid base passes, invalid unknown-property fails
- [x] Deploy with `ENABLED_PLUGINS=lvms,trust-manager,rhbk` on a test cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RHBK addon plugin to deploy Keycloak with configurable replicas, optional in‑cluster PostgreSQL, and cert-manager TLS support.
* **Configuration**
  * Default plugin settings and an example config template added; cluster issuer and DB defaults provided.
* **Schemas**
  * Validation schemas added/updated, including a Kubernetes quantity type for PVC sizing.
* **Tests**
  * Added valid/invalid schema fixtures for config and defaults.
* **Deployment**
  * Pre‑validation and deployment checks added to ensure cert-manager and resources are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->