### PR TITLE
OSAC-1241: Upgrade mirror-registry to v2.0.10

### DIFF
--- a/defaults/control_binaries.yaml
+++ b/defaults/control_binaries.yaml
@@ -7,8 +7,8 @@ control_binaries:
     url: "https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/helm/3.17.1/helm-linux-amd64"
     checksum: "sha256:ef6c04f6a748d0f1d624a94a56dc0db83f8d70a65e3dbb19e94107126efcc5fd"
   mirror_registry:
-    url: "https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/mirror-registry/1.3.11/mirror-registry.tar.gz"
-    checksum: "sha256:b2fbf8b13d794cdebb8baee48afbfa78d13c4d76a1c60fc99d52c3c9abd31cf1"
+    url: "https://mirror.openshift.com/pub/cgw/mirror-registry/2.0.10/mirror-registry-amd64.tar.gz"
+    checksum: "sha256:7a910e1c7f5306a7d0973da4cb83b25ba1269e895e27136ac678a293dd63c386"
   oc_mirror:
     url: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.20.15/oc-mirror.tar.gz"
     checksum: "sha256:59791d2e6b84ee380bc6a180e4e5e2006590ca1e0f146b0176819386e11e26d1"


### PR DESCRIPTION
## Summary

Upgrade mirror-registry binary from version 1.3.11 to 2.0.10.

## Changes

- Update mirror_registry_version from 1.3.11 to 2.0.10 in `defaults/control_binaries.yaml`
- Change source URL from developers.redhat.com to mirror.openshift.com
- Update to use -amd64 architecture suffix explicitly
- Update SHA256 checksum to match official release

## Benefits

- Latest features and bug fixes from v2.0.x series
- Improved stability and performance
- Security updates

## Test plan

- [ ] Verify download succeeds: `ansible-playbook playbooks/01-prepare.yaml`
- [ ] Verify checksum matches: `sha256sum {{ workingDir }}/dist/mirror-registry-amd64.tar.gz`
- [ ] Check version: `{{ workingDir }}/bin/mirror-registry version`
- [ ] Test mirror-registry installation: `ansible-playbook playbooks/02-mirror.yaml`

## References

- Release: https://mirror.openshift.com/pub/openshift-v4/clients/mirror-registry/2.0.10/
- Jira: [OSAC-1241](https://redhat.atlassian.net/browse/OSAC-1241)