### PR TITLE
OSAC-1238: Add mirror-upgrade tag to 02-mirror playbook

### DIFF
--- a/playbooks/02-mirror.yaml
+++ b/playbooks/02-mirror.yaml
@@ -53,7 +53,9 @@
               - disconnected | default(true) | bool
             fail_msg: "Phase 2 (Mirror) should only run in disconnected mode. Set disconnected=true in config/global.yaml"
             success_msg: "Running in disconnected mode - proceeding with mirroring"
-          tags: mirror-registry
+          tags:
+            - mirror-registry
+            - mirror-upgrade
 
         - name: Collect plugin operators for imageset
           ansible.builtin.include_tasks:

--- a/playbooks/02-mirror.yaml
+++ b/playbooks/02-mirror.yaml
@@ -14,6 +14,9 @@
 # Usage:
 #   ansible-playbook playbooks/02-mirror.yaml
 #
+#   # Upgrade mirror-registry
+#   ansible-playbook playbooks/02-mirror.yaml --tags mirror-upgrade
+#
 #   # Mirror images to datacenter cache
 #   ansible-playbook playbooks/02-mirror.yaml --tags mirror-cache
 
@@ -74,3 +77,12 @@
             apply:
               tags: mirror-registry
           tags: mirror-registry
+
+        - name: Include tasks for mirror-registry upgrade
+          ansible.builtin.include_tasks:
+            file: tasks/mirror_registry_upgrade.yaml
+            apply:
+              tags: mirror-upgrade
+          tags:
+            - mirror-upgrade
+            - never

--- a/playbooks/tasks/mirror_registry_upgrade.yaml
+++ b/playbooks/tasks/mirror_registry_upgrade.yaml
@@ -13,21 +13,6 @@
 
 - name: Upgrade mirror-registry
   block:
-    - name: Get mirror-registry binary version
-      ansible.builtin.command: |
-        {{ workingDir }}/bin/mirror-registry --version
-      register: r_mirror_registry_version
-      changed_when: false
-
-    - name: Get deployed Quay container image
-      containers.podman.podman_container_info:
-        name: quay-app
-      register: r_quay_container_info
-
-    - name: Extract current Quay image tag
-      ansible.builtin.set_fact:
-        current_quay_image: "{{ r_quay_container_info.containers[0].Image if r_quay_container_info.containers | length > 0 else '' }}"
-
     - name: Upgrade existing mirror-registry
       no_log: true
       ansible.builtin.command: |

--- a/playbooks/tasks/mirror_registry_upgrade.yaml
+++ b/playbooks/tasks/mirror_registry_upgrade.yaml
@@ -11,12 +11,10 @@
     fail_msg: "mirror-registry is not installed. Run with --tags mirror-registry first."
     success_msg: "mirror-registry is installed - proceeding with upgrade"
 
-- name: Upgrade mirror-registry
-  block:
-    - name: Upgrade existing mirror-registry
-      no_log: true
-      ansible.builtin.command: |
-        {{ workingDir }}/bin/mirror-registry upgrade --quayHostname "{{ quayHostname }}" --quayRoot {{ workingDir }}/data
-      register: r_mirror_registry_upgrade
-      changed_when: "'Upgrade complete' in r_mirror_registry_upgrade.stdout or 'upgraded' in r_mirror_registry_upgrade.stdout.lower()"
-      failed_when: r_mirror_registry_upgrade.rc != 0
+- name: Upgrade existing mirror-registry
+  no_log: true
+  ansible.builtin.command: |
+    {{ workingDir }}/bin/mirror-registry upgrade --quayHostname "{{ quayHostname }}" --quayRoot {{ workingDir }}/data
+  register: r_mirror_registry_upgrade
+  changed_when: "'Upgrade complete' in r_mirror_registry_upgrade.stdout or 'upgraded' in r_mirror_registry_upgrade.stdout.lower()"
+  failed_when: r_mirror_registry_upgrade.rc != 0

--- a/playbooks/tasks/mirror_registry_upgrade.yaml
+++ b/playbooks/tasks/mirror_registry_upgrade.yaml
@@ -13,10 +13,25 @@
 
 - name: Upgrade mirror-registry
   block:
+    - name: Get mirror-registry binary version
+      ansible.builtin.command: |
+        {{ workingDir }}/bin/mirror-registry --version
+      register: r_mirror_registry_version
+      changed_when: false
+
+    - name: Get deployed Quay container image
+      containers.podman.podman_container_info:
+        name: quay-app
+      register: r_quay_container_info
+
+    - name: Extract current Quay image tag
+      ansible.builtin.set_fact:
+        current_quay_image: "{{ r_quay_container_info.containers[0].Image if r_quay_container_info.containers | length > 0 else '' }}"
+
     - name: Upgrade existing mirror-registry
       no_log: true
       ansible.builtin.command: |
         {{ workingDir }}/bin/mirror-registry upgrade --quayHostname "{{ quayHostname }}" --quayRoot {{ workingDir }}/data
       register: r_mirror_registry_upgrade
-      changed_when: r_mirror_registry_upgrade.rc == 0
+      changed_when: "'Upgrade complete' in r_mirror_registry_upgrade.stdout or 'upgraded' in r_mirror_registry_upgrade.stdout.lower()"
       failed_when: r_mirror_registry_upgrade.rc != 0

--- a/playbooks/tasks/mirror_registry_upgrade.yaml
+++ b/playbooks/tasks/mirror_registry_upgrade.yaml
@@ -1,0 +1,20 @@
+---
+- name: Gather facts on a specific container
+  containers.podman.podman_container_info:
+    name: quay-app
+  register: r_container_quay_app
+
+- name: Verify mirror-registry is installed
+  ansible.builtin.assert:
+    that:
+      - r_container_quay_app.containers | default([]) | length > 0
+    fail_msg: "mirror-registry is not installed. Run with --tags mirror-registry first."
+    success_msg: "mirror-registry is installed - proceeding with upgrade"
+
+- name: Upgrade mirror-registry
+  block:
+    - name: Upgrade existing mirror-registry
+      no_log: true
+      ansible.builtin.command: |
+        {{ workingDir }}/bin/mirror-registry upgrade --quayHostname "{{ quayHostname }}" --quayRoot {{ workingDir }}/data
+      register: r_mirror_registry_upgrade

--- a/playbooks/tasks/mirror_registry_upgrade.yaml
+++ b/playbooks/tasks/mirror_registry_upgrade.yaml
@@ -18,3 +18,5 @@
       ansible.builtin.command: |
         {{ workingDir }}/bin/mirror-registry upgrade --quayHostname "{{ quayHostname }}" --quayRoot {{ workingDir }}/data
       register: r_mirror_registry_upgrade
+      changed_when: r_mirror_registry_upgrade.rc == 0
+      failed_when: r_mirror_registry_upgrade.rc != 0


### PR DESCRIPTION
## Summary
Add dedicated `mirror-upgrade` tag for upgrading existing mirror-registry installations in the 02-mirror playbook.

## Changes
- Created new task file `playbooks/tasks/mirror_registry_upgrade.yaml` for upgrade operations
- Added upgrade task include to `playbooks/02-mirror.yaml` with `mirror-upgrade` tag
- Tagged with `never` so it only runs when explicitly requested via `--tags mirror-upgrade`
- Updated playbook documentation with usage example

## Usage
```bash
# Upgrade existing mirror-registry
ansible-playbook playbooks/02-mirror.yaml --tags mirror-upgrade
```

## Test plan
- [ ] Verify fresh installation works unchanged: `ansible-playbook playbooks/02-mirror.yaml`
- [ ] Verify upgrade works when mirror-registry exists: `ansible-playbook playbooks/02-mirror.yaml --tags mirror-upgrade`
- [ ] Verify upgrade task fails gracefully when mirror-registry is not installed

Resolves: [OSAC-1238](https://redhat.atlassian.net/browse/OSAC-1238)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mirror-registry upgrade capability accessible via the `mirror-upgrade` tag, enabling users to upgrade their mirror registry through the automation playbook.
  * The upgrade workflow includes validation checks to verify container status and executes the upgrade with appropriate configuration for registry paths and hostname settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->