### PR TITLE
Add trust_manager_cluster_issuer variable in trust-manager plugin

### DIFF
--- a/plugins/trust-manager/defaults.yaml
+++ b/plugins/trust-manager/defaults.yaml
@@ -1,3 +1,4 @@
 ---
+trust_manager_cluster_issuer: default-ca
 trust_manager_ca_issuer_duration: 87600h
 trust_manager_ca_issuer_renew_before: 8760h

--- a/plugins/trust-manager/schemas/defaults.yaml
+++ b/plugins/trust-manager/schemas/defaults.yaml
@@ -3,9 +3,13 @@
 type: object
 additionalProperties: false
 required:
+  - trust_manager_cluster_issuer
   - trust_manager_ca_issuer_duration
   - trust_manager_ca_issuer_renew_before
 properties:
+  trust_manager_cluster_issuer:
+    "$ref": "#/definitions/nonEmptyString"
+    description: Name of the ClusterIssuer created by the trust-manager plugin.
   trust_manager_ca_issuer_duration:
     type: string
     description: Lifetime of the CA certificate issued by the self-signed issuer (e.g. 87600h for 10 years).

--- a/plugins/trust-manager/tasks/deploy.yaml
+++ b/plugins/trust-manager/tasks/deploy.yaml
@@ -47,10 +47,10 @@
   kubernetes.core.k8s_info:
     api_version: cert-manager.io/v1
     kind: ClusterIssuer
-    name: default-ca
+    name: "{{ trust_manager_cluster_issuer }}"
   register: __r_cluster_issuer
-  retries: 30
-  delay: "{{ k8s_delay }}"
+  retries: 60
+  delay: 15
   until:
     - __r_cluster_issuer.resources | length > 0
     - __r_cluster_issuer.resources[0].status.conditions
@@ -62,4 +62,4 @@
 
 - name: Debug CA issuer status
   ansible.builtin.debug:
-    msg: "ClusterIssuer default-ca is ready"
+    msg: "ClusterIssuer {{ trust_manager_cluster_issuer }} is ready"

--- a/plugins/trust-manager/templates/ca-issuer.yaml.j2
+++ b/plugins/trust-manager/templates/ca-issuer.yaml.j2
@@ -13,12 +13,12 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: default-ca-cert
+  name: {{ trust_manager_cluster_issuer }}-cert
   namespace: cert-manager
 spec:
   isCA: true
-  commonName: default-ca
-  secretName: default-ca
+  commonName: {{ trust_manager_cluster_issuer }}
+  secretName: {{ trust_manager_cluster_issuer }}-secret
   duration: {{ trust_manager_ca_issuer_duration }}
   renewBefore: {{ trust_manager_ca_issuer_renew_before }}
   privateKey:
@@ -33,7 +33,7 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: default-ca
+  name: {{ trust_manager_cluster_issuer }}
 spec:
   ca:
-    secretName: default-ca
+    secretName: {{ trust_manager_cluster_issuer }}-secret

--- a/plugins/trust-manager/test-fixtures/schemas/defaults/valid/base.yaml
+++ b/plugins/trust-manager/test-fixtures/schemas/defaults/valid/base.yaml
@@ -1,3 +1,4 @@
 ---
+trust_manager_cluster_issuer: default-ca
 trust_manager_ca_issuer_duration: 87600h
 trust_manager_ca_issuer_renew_before: 8760h


### PR DESCRIPTION
## Summary

- Add `trust_manager_cluster_issuer` variable (defaults to `default-ca`) so downstream plugins do not depend on a hardcoded ClusterIssuer name
- Suffix the CA Secret name with `-secret` to distinguish it from the ClusterIssuer resource
- Increase ClusterIssuer wait retries to 60x15s (15 min) to accommodate slow CertificateRequest approval on Red Hat cert-manager operator
- Update defaults, schema, template, deploy task, and test fixtures

## Test plan

- [x] `make -f Makefile.ci validate-plugins` passes
- [x] `make -f Makefile.ci validate-yaml` passes
- [x] Schema test fixtures: valid base passes, invalid fixtures fail
- [x] Deploy with `ENABLED_PLUGINS=lvms,trust-manager` on a test cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trust-manager plugin cluster issuer naming is now configurable. Users can customize the cluster issuer name per deployment instead of relying on hardcoded defaults, supporting diverse deployment scenarios.

* **Improvements**
  * Deployment procedures updated to support parameterized cluster issuer configurations, enhancing flexibility across different setup requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->