### PR TITLE
OSAC-1046: Fix schema validation when networkConfig is present

### DIFF
--- a/schemas/definitions.yaml
+++ b/schemas/definitions.yaml
@@ -87,8 +87,18 @@ definitions:
       macAddress:
         "$ref": "#/definitions/macAddress"
       mapInterfaces:
-        type: object
         description: Interface mapping configuration
+        type: array
+        items:
+          type: object
+          required:
+              - name
+              - macAddress
+          properties:
+            name:
+              type: string
+            macAddress:
+              "$ref": "#/definitions/macAddress"
       name:
         "$ref": "#/definitions/nonEmptyString"
       networkConfig:
@@ -103,11 +113,27 @@ definitions:
       rootDisk:
         "$ref": "#/definitions/nonEmptyString"
     required:
-      - ipAddress
-      - macAddress
       - name
       - redfish
       - redfishPassword
       - redfishUser
       - rootDisk
-
+    oneOf:
+      - required:
+          - ipAddress
+          - macAddress
+        not:
+          anyOf:
+            - required:
+              - networkConfig
+            - required:
+              - mapInterfaces
+      - required:
+          - networkConfig
+          - mapInterfaces
+        not:
+          anyOf:
+            - required:
+              - ipAddress
+            - required:
+              - macAddress

--- a/test-fixtures/schemas/global/invalid/duplicated-network-config.yaml
+++ b/test-fixtures/schemas/global/invalid/duplicated-network-config.yaml
@@ -1,11 +1,13 @@
 ---
-# Fixture: both sshPubKey and sshPubPath provided
-# Expected failure: oneOf requires exactly one of sshPubKey or sshPubPath
+# Invalid fixture: Only one of the network configuration methods should be present for a host
+# Expected failure: Both pairs of [ macAddress, ipAddress ] and [ mapInterfaces, networkConfig ]
+#                   are present for a host at the same time
+#
 workingDir: /home/enclave
 baseDomain: enclave-test.nodns.in
 clusterName: mgmt
 machineNetwork: 192.168.2.0/24
-apiVIP: 192.168.2.201
+apiVIP: 192.168.1.110
 ingressVIP: 192.168.2.202
 defaultDNS: 9.30.31.32
 defaultGateway: 192.168.2.10
@@ -17,16 +19,39 @@ quayPassword: YOUR_QUAY_PASSWORD
 quayBackend: LocalStorage
 storage_plugin: lvms
 pullSecret: {"auths":{}}
-sshPubKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7 user@host"
 sshPubPath: /home/enclave/.ssh/id_rsa.pub
 agent_hosts:
   - name: mgmt-ctl01
     macAddress: 0c:c4:7a:62:fe:ec
     ipAddress: 192.168.2.24
-    redfish: 192.168.1.101
+    redfish: 192.168.2.101
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
     redfishPassword: YOUR_REDFISH_PASSWORD
+    mapInterfaces:
+      - name: eth0
+        macAddress: 0c:c4:7a:62:fe:ec
+    networkConfig:
+      interfaces:
+      - name: eth0
+        state: up
+        mtu: 9000
+        ipv4:
+          auto-dns: false
+          address:
+          - ip: 192.168.2.101
+            prefix-length: 24
+          enabled: true
+      dns-resolver:
+        config:
+          server:
+          - 192.168.2.1
+      routes:
+        config:
+        - destination: 0.0.0.0/0
+          metric: 100
+          next-hop-address: 192.168.2.1
+          next-hop-interface: eth0
   - name: mgmt-ctl02
     macAddress: 0c:c4:7a:62:fe:ed
     ipAddress: 192.168.2.25
@@ -41,3 +66,4 @@ agent_hosts:
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
     redfishPassword: YOUR_REDFISH_PASSWORD
+

--- a/test-fixtures/schemas/global/invalid/extra-ipAddress-while-NMState.yaml
+++ b/test-fixtures/schemas/global/invalid/extra-ipAddress-while-NMState.yaml
@@ -1,11 +1,10 @@
 ---
-# Fixture: both sshPubKey and sshPubPath provided
-# Expected failure: oneOf requires exactly one of sshPubKey or sshPubPath
+# Invalid fixture: If NMState config is present (networkConfig and mapInterface) ipAddress should NOT be defined
 workingDir: /home/enclave
 baseDomain: enclave-test.nodns.in
 clusterName: mgmt
 machineNetwork: 192.168.2.0/24
-apiVIP: 192.168.2.201
+apiVIP: 192.168.1.110
 ingressVIP: 192.168.2.202
 defaultDNS: 9.30.31.32
 defaultGateway: 192.168.2.10
@@ -17,16 +16,38 @@ quayPassword: YOUR_QUAY_PASSWORD
 quayBackend: LocalStorage
 storage_plugin: lvms
 pullSecret: {"auths":{}}
-sshPubKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7 user@host"
 sshPubPath: /home/enclave/.ssh/id_rsa.pub
 agent_hosts:
   - name: mgmt-ctl01
-    macAddress: 0c:c4:7a:62:fe:ec
     ipAddress: 192.168.2.24
-    redfish: 192.168.1.101
+    redfish: 192.168.2.101
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
     redfishPassword: YOUR_REDFISH_PASSWORD
+    mapInterfaces:
+      - name: eth0
+        macAddress: 0c:c4:7a:62:fe:ec
+    networkConfig:
+      interfaces:
+      - name: eth0
+        state: up
+        mtu: 9000
+        ipv4:
+          auto-dns: false
+          address:
+          - ip: 192.168.2.101
+            prefix-length: 24
+          enabled: true
+      dns-resolver:
+        config:
+          server:
+          - 192.168.2.1
+      routes:
+        config:
+        - destination: 0.0.0.0/0
+          metric: 100
+          next-hop-address: 192.168.2.1
+          next-hop-interface: eth0
   - name: mgmt-ctl02
     macAddress: 0c:c4:7a:62:fe:ed
     ipAddress: 192.168.2.25
@@ -41,3 +62,4 @@ agent_hosts:
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
     redfishPassword: YOUR_REDFISH_PASSWORD
+

--- a/test-fixtures/schemas/global/invalid/extra-macAddress-while-NMState.yaml
+++ b/test-fixtures/schemas/global/invalid/extra-macAddress-while-NMState.yaml
@@ -1,11 +1,10 @@
 ---
-# Fixture: both sshPubKey and sshPubPath provided
-# Expected failure: oneOf requires exactly one of sshPubKey or sshPubPath
+# Invalid fixture: If NMState config is present (networkConfig and mapInterface) macAddress should NOT be defined
 workingDir: /home/enclave
 baseDomain: enclave-test.nodns.in
 clusterName: mgmt
 machineNetwork: 192.168.2.0/24
-apiVIP: 192.168.2.201
+apiVIP: 192.168.1.110
 ingressVIP: 192.168.2.202
 defaultDNS: 9.30.31.32
 defaultGateway: 192.168.2.10
@@ -17,16 +16,38 @@ quayPassword: YOUR_QUAY_PASSWORD
 quayBackend: LocalStorage
 storage_plugin: lvms
 pullSecret: {"auths":{}}
-sshPubKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7 user@host"
 sshPubPath: /home/enclave/.ssh/id_rsa.pub
 agent_hosts:
   - name: mgmt-ctl01
     macAddress: 0c:c4:7a:62:fe:ec
-    ipAddress: 192.168.2.24
-    redfish: 192.168.1.101
+    redfish: 192.168.2.101
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
     redfishPassword: YOUR_REDFISH_PASSWORD
+    mapInterfaces:
+      - name: eth0
+        macAddress: 0c:c4:7a:62:fe:ec
+    networkConfig:
+      interfaces:
+      - name: eth0
+        state: up
+        mtu: 9000
+        ipv4:
+          auto-dns: false
+          address:
+          - ip: 192.168.2.101
+            prefix-length: 24
+          enabled: true
+      dns-resolver:
+        config:
+          server:
+          - 192.168.2.1
+      routes:
+        config:
+        - destination: 0.0.0.0/0
+          metric: 100
+          next-hop-address: 192.168.2.1
+          next-hop-interface: eth0
   - name: mgmt-ctl02
     macAddress: 0c:c4:7a:62:fe:ed
     ipAddress: 192.168.2.25
@@ -41,3 +62,4 @@ agent_hosts:
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
     redfishPassword: YOUR_REDFISH_PASSWORD
+

--- a/test-fixtures/schemas/global/invalid/extra-mapInterfaces-while-no-NMState.yaml
+++ b/test-fixtures/schemas/global/invalid/extra-mapInterfaces-while-no-NMState.yaml
@@ -1,11 +1,10 @@
 ---
-# Fixture: both sshPubKey and sshPubPath provided
-# Expected failure: oneOf requires exactly one of sshPubKey or sshPubPath
+# Invalid fixture: If configuring the network with ipAddress and macAddress (no NMState), no mapInterfaces should be present
 workingDir: /home/enclave
 baseDomain: enclave-test.nodns.in
 clusterName: mgmt
 machineNetwork: 192.168.2.0/24
-apiVIP: 192.168.2.201
+apiVIP: 192.168.1.110
 ingressVIP: 192.168.2.202
 defaultDNS: 9.30.31.32
 defaultGateway: 192.168.2.10
@@ -17,16 +16,18 @@ quayPassword: YOUR_QUAY_PASSWORD
 quayBackend: LocalStorage
 storage_plugin: lvms
 pullSecret: {"auths":{}}
-sshPubKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7 user@host"
 sshPubPath: /home/enclave/.ssh/id_rsa.pub
 agent_hosts:
   - name: mgmt-ctl01
     macAddress: 0c:c4:7a:62:fe:ec
     ipAddress: 192.168.2.24
-    redfish: 192.168.1.101
+    redfish: 192.168.2.101
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
     redfishPassword: YOUR_REDFISH_PASSWORD
+    mapInterfaces:
+      - name: eth0
+        macAddress: 0c:c4:7a:62:fe:ec
   - name: mgmt-ctl02
     macAddress: 0c:c4:7a:62:fe:ed
     ipAddress: 192.168.2.25
@@ -41,3 +42,4 @@ agent_hosts:
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
     redfishPassword: YOUR_REDFISH_PASSWORD
+

--- a/test-fixtures/schemas/global/invalid/extra-networkConfig-while-no-NMState.yaml
+++ b/test-fixtures/schemas/global/invalid/extra-networkConfig-while-no-NMState.yaml
@@ -1,11 +1,10 @@
 ---
-# Fixture: both sshPubKey and sshPubPath provided
-# Expected failure: oneOf requires exactly one of sshPubKey or sshPubPath
+# Invalid fixture: If configuring the network with ipAddress and macAddress (no NMState), no networkConfig should be present
 workingDir: /home/enclave
 baseDomain: enclave-test.nodns.in
 clusterName: mgmt
 machineNetwork: 192.168.2.0/24
-apiVIP: 192.168.2.201
+apiVIP: 192.168.1.110
 ingressVIP: 192.168.2.202
 defaultDNS: 9.30.31.32
 defaultGateway: 192.168.2.10
@@ -17,16 +16,36 @@ quayPassword: YOUR_QUAY_PASSWORD
 quayBackend: LocalStorage
 storage_plugin: lvms
 pullSecret: {"auths":{}}
-sshPubKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7 user@host"
 sshPubPath: /home/enclave/.ssh/id_rsa.pub
 agent_hosts:
   - name: mgmt-ctl01
     macAddress: 0c:c4:7a:62:fe:ec
     ipAddress: 192.168.2.24
-    redfish: 192.168.1.101
+    redfish: 192.168.2.101
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
     redfishPassword: YOUR_REDFISH_PASSWORD
+    networkConfig:
+      interfaces:
+      - name: eth0
+        state: up
+        mtu: 9000
+        ipv4:
+          auto-dns: false
+          address:
+          - ip: 192.168.2.101
+            prefix-length: 24
+          enabled: true
+      dns-resolver:
+        config:
+          server:
+          - 192.168.2.1
+      routes:
+        config:
+        - destination: 0.0.0.0/0
+          metric: 100
+          next-hop-address: 192.168.2.1
+          next-hop-interface: eth0
   - name: mgmt-ctl02
     macAddress: 0c:c4:7a:62:fe:ed
     ipAddress: 192.168.2.25
@@ -41,3 +60,4 @@ agent_hosts:
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
     redfishPassword: YOUR_REDFISH_PASSWORD
+

--- a/test-fixtures/schemas/global/invalid/invalid-additional-property.yaml
+++ b/test-fixtures/schemas/global/invalid/invalid-additional-property.yaml
@@ -14,7 +14,7 @@ defaultPrefix: 24
 rendezvousIP: 192.168.2.24
 lzBmcIP: 100.64.1.10
 quayUser: admin
-quayPassword: password
+quayPassword: YOUR_QUAY_PASSWORD
 quayBackend: LocalStorage
 storage_plugin: lvms
 pullSecret: {"auths":{}}
@@ -26,18 +26,18 @@ agent_hosts:
     redfish: 192.168.1.101
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
   - name: mgmt-ctl02
     macAddress: 0c:c4:7a:62:fe:ed
     ipAddress: 192.168.2.25
     redfish: 192.168.1.102
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
   - name: mgmt-ctl03
     macAddress: 0c:c4:7a:62:fe:ee
     ipAddress: 192.168.2.26
     redfish: 192.168.1.103
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD

--- a/test-fixtures/schemas/global/invalid/invalid-empty-ssh-pub-key.yaml
+++ b/test-fixtures/schemas/global/invalid/invalid-empty-ssh-pub-key.yaml
@@ -13,7 +13,7 @@ defaultPrefix: 24
 rendezvousIP: 192.168.2.24
 lzBmcIP: 100.64.1.10
 quayUser: admin
-quayPassword: password
+quayPassword: YOUR_QUAY_PASSWORD
 quayBackend: LocalStorage
 storage_plugin: lvms
 pullSecret: {"auths":{}}
@@ -25,18 +25,18 @@ agent_hosts:
     redfish: 192.168.1.101
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
   - name: mgmt-ctl02
     macAddress: 0c:c4:7a:62:fe:ed
     ipAddress: 192.168.2.25
     redfish: 192.168.1.102
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
   - name: mgmt-ctl03
     macAddress: 0c:c4:7a:62:fe:ee
     ipAddress: 192.168.2.26
     redfish: 192.168.1.103
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD

--- a/test-fixtures/schemas/global/invalid/invalid-empty-string.yaml
+++ b/test-fixtures/schemas/global/invalid/invalid-empty-string.yaml
@@ -13,7 +13,7 @@ defaultPrefix: 24
 rendezvousIP: 192.168.2.24
 lzBmcIP: 100.64.1.10
 quayUser: admin
-quayPassword: password
+quayPassword: YOUR_QUAY_PASSWORD
 quayBackend: LocalStorage
 storage_plugin: lvms
 pullSecret: {"auths":{}}
@@ -25,18 +25,18 @@ agent_hosts:
     redfish: 192.168.1.101
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
   - name: mgmt-ctl02
     macAddress: 0c:c4:7a:62:fe:ed
     ipAddress: 192.168.2.25
     redfish: 192.168.1.102
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
   - name: mgmt-ctl03
     macAddress: 0c:c4:7a:62:fe:ee
     ipAddress: 192.168.2.26
     redfish: 192.168.1.103
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD

--- a/test-fixtures/schemas/global/invalid/invalid-enum.yaml
+++ b/test-fixtures/schemas/global/invalid/invalid-enum.yaml
@@ -13,7 +13,7 @@ defaultPrefix: 24
 rendezvousIP: 192.168.2.24
 lzBmcIP: 100.64.1.10
 quayUser: admin
-quayPassword: password
+quayPassword: YOUR_QUAY_PASSWORD
 quayBackend: LocalStorage
 storage_plugin: nfs
 pullSecret: {"auths":{}}
@@ -25,19 +25,19 @@ agent_hosts:
     redfish: 192.168.1.101
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
   - name: mgmt-ctl02
     macAddress: 0c:c4:7a:62:fe:ed
     ipAddress: 192.168.2.25
     redfish: 192.168.1.102
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
   - name: mgmt-ctl03
     macAddress: 0c:c4:7a:62:fe:ee
     ipAddress: 192.168.2.26
     redfish: 192.168.1.103
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
 

--- a/test-fixtures/schemas/global/invalid/invalid-ip.yaml
+++ b/test-fixtures/schemas/global/invalid/invalid-ip.yaml
@@ -13,7 +13,7 @@ defaultPrefix: 24
 rendezvousIP: 192.168.2.24
 lzBmcIP: 100.64.1.10
 quayUser: admin
-quayPassword: password
+quayPassword: YOUR_QUAY_PASSWORD
 quayBackend: LocalStorage
 storage_plugin: lvms
 pullSecret: {"auths":{}}
@@ -25,19 +25,19 @@ agent_hosts:
     redfish: 192.168.1.101
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
   - name: mgmt-ctl02
     macAddress: 0c:c4:7a:62:fe:ed
     ipAddress: 192.168.2.25
     redfish: 192.168.1.102
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
   - name: mgmt-ctl03
     macAddress: 0c:c4:7a:62:fe:ee
     ipAddress: 192.168.2.26
     redfish: 192.168.1.103
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
 

--- a/test-fixtures/schemas/global/invalid/invalid-mapInterfaces-macAddress.yaml
+++ b/test-fixtures/schemas/global/invalid/invalid-mapInterfaces-macAddress.yaml
@@ -1,11 +1,11 @@
 ---
-# Fixture: both sshPubKey and sshPubPath provided
-# Expected failure: oneOf requires exactly one of sshPubKey or sshPubPath
+# Invalid fixture: An entry in agent_hosts[].mapInterfaces[].macAddress has an invalid macAddress
+# Expected failure: macAddress is not a valid MAC address
 workingDir: /home/enclave
 baseDomain: enclave-test.nodns.in
 clusterName: mgmt
 machineNetwork: 192.168.2.0/24
-apiVIP: 192.168.2.201
+apiVIP: 192.168.1.110
 ingressVIP: 192.168.2.202
 defaultDNS: 9.30.31.32
 defaultGateway: 192.168.2.10
@@ -17,16 +17,38 @@ quayPassword: YOUR_QUAY_PASSWORD
 quayBackend: LocalStorage
 storage_plugin: lvms
 pullSecret: {"auths":{}}
-sshPubKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7 user@host"
 sshPubPath: /home/enclave/.ssh/id_rsa.pub
 agent_hosts:
   - name: mgmt-ctl01
-    macAddress: 0c:c4:7a:62:fe:ec
-    ipAddress: 192.168.2.24
-    redfish: 192.168.1.101
+    redfish: 192.168.2.101
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
     redfishPassword: YOUR_REDFISH_PASSWORD
+    mapInterfaces:
+      - name: eth0
+        macAddress: not-a-mac
+    networkConfig:
+      interfaces:
+      - name: eth0
+        state: up
+        mtu: 9000
+        ipv4:
+          auto-dns: false
+          address:
+          - ip: 192.168.2.101
+            prefix-length: 24
+          enabled: true
+      dns-resolver:
+        config:
+          server:
+          - 192.168.2.1
+      routes:
+        config:
+        - destination: 0.0.0.0/0
+          metric: 100
+          next-hop-address: 192.168.2.1
+          next-hop-interface: eth0
+
   - name: mgmt-ctl02
     macAddress: 0c:c4:7a:62:fe:ed
     ipAddress: 192.168.2.25
@@ -41,3 +63,4 @@ agent_hosts:
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
     redfishPassword: YOUR_REDFISH_PASSWORD
+

--- a/test-fixtures/schemas/global/invalid/invalid-port.yaml
+++ b/test-fixtures/schemas/global/invalid/invalid-port.yaml
@@ -13,7 +13,7 @@ defaultPrefix: 24
 rendezvousIP: 192.168.2.24
 lzBmcIP: 100.64.1.10
 quayUser: admin
-quayPassword: password
+quayPassword: YOUR_QUAY_PASSWORD
 quayBackend: RadosGWStorage
 quayBackendRGWConfiguration:
   access_key: EXAMPLE_ACCESS_KEY
@@ -31,19 +31,19 @@ agent_hosts:
     redfish: 192.168.1.101
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
   - name: mgmt-ctl02
     macAddress: 0c:c4:7a:62:fe:ed
     ipAddress: 192.168.2.25
     redfish: 192.168.1.102
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
   - name: mgmt-ctl03
     macAddress: 0c:c4:7a:62:fe:ee
     ipAddress: 192.168.2.26
     redfish: 192.168.1.103
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
 

--- a/test-fixtures/schemas/global/invalid/invalid-rgw-unknown-key.yaml
+++ b/test-fixtures/schemas/global/invalid/invalid-rgw-unknown-key.yaml
@@ -13,7 +13,7 @@ defaultPrefix: 24
 rendezvousIP: 192.168.2.24
 lzBmcIP: 100.64.1.10
 quayUser: admin
-quayPassword: password
+quayPassword: YOUR_QUAY_PASSWORD
 quayBackend: RadosGWStorage
 storage_plugin: lvms
 pullSecret: {"auths":{}}
@@ -31,18 +31,18 @@ agent_hosts:
     redfish: 192.168.1.101
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
   - name: mgmt-ctl02
     macAddress: 0c:c4:7a:62:fe:ed
     ipAddress: 192.168.2.25
     redfish: 192.168.1.102
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
   - name: mgmt-ctl03
     macAddress: 0c:c4:7a:62:fe:ee
     ipAddress: 192.168.2.26
     redfish: 192.168.1.103
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD

--- a/test-fixtures/schemas/global/invalid/invalid-storage-path.yaml
+++ b/test-fixtures/schemas/global/invalid/invalid-storage-path.yaml
@@ -14,7 +14,7 @@ defaultPrefix: 24
 rendezvousIP: 192.168.2.24
 lzBmcIP: 100.64.1.10
 quayUser: admin
-quayPassword: password
+quayPassword: YOUR_QUAY_PASSWORD
 quayBackend: RadosGWStorage
 quayBackendRGWConfiguration:
   access_key: EXAMPLE_ACCESS_KEY
@@ -32,19 +32,19 @@ agent_hosts:
     redfish: 192.168.1.101
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
   - name: mgmt-ctl02
     macAddress: 0c:c4:7a:62:fe:ed
     ipAddress: 192.168.2.25
     redfish: 192.168.1.102
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
   - name: mgmt-ctl03
     macAddress: 0c:c4:7a:62:fe:ee
     ipAddress: 192.168.2.26
     redfish: 192.168.1.103
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
 

--- a/test-fixtures/schemas/global/invalid/malformed-mapInterfaces.yaml
+++ b/test-fixtures/schemas/global/invalid/malformed-mapInterfaces.yaml
@@ -1,11 +1,11 @@
 ---
-# Fixture: both sshPubKey and sshPubPath provided
-# Expected failure: oneOf requires exactly one of sshPubKey or sshPubPath
+# Invalid fixture: An agent_host has wrong format of mapInterfaces
+# Expected failure: mapInterfaces should be an array
 workingDir: /home/enclave
 baseDomain: enclave-test.nodns.in
 clusterName: mgmt
 machineNetwork: 192.168.2.0/24
-apiVIP: 192.168.2.201
+apiVIP: 192.168.1.110
 ingressVIP: 192.168.2.202
 defaultDNS: 9.30.31.32
 defaultGateway: 192.168.2.10
@@ -17,16 +17,38 @@ quayPassword: YOUR_QUAY_PASSWORD
 quayBackend: LocalStorage
 storage_plugin: lvms
 pullSecret: {"auths":{}}
-sshPubKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7 user@host"
 sshPubPath: /home/enclave/.ssh/id_rsa.pub
 agent_hosts:
   - name: mgmt-ctl01
-    macAddress: 0c:c4:7a:62:fe:ec
-    ipAddress: 192.168.2.24
-    redfish: 192.168.1.101
+    redfish: 192.168.2.101
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
     redfishPassword: YOUR_REDFISH_PASSWORD
+    mapInterfaces:
+      name: eth0
+      macAddress: 0c:c4:7a:62:fe:ec
+    networkConfig:
+      interfaces:
+      - name: eth0
+        state: up
+        mtu: 9000
+        ipv4:
+          auto-dns: false
+          address:
+          - ip: 192.168.2.101
+            prefix-length: 24
+          enabled: true
+      dns-resolver:
+        config:
+          server:
+          - 192.168.2.1
+      routes:
+        config:
+        - destination: 0.0.0.0/0
+          metric: 100
+          next-hop-address: 192.168.2.1
+          next-hop-interface: eth0
+
   - name: mgmt-ctl02
     macAddress: 0c:c4:7a:62:fe:ed
     ipAddress: 192.168.2.25
@@ -41,3 +63,4 @@ agent_hosts:
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
     redfishPassword: YOUR_REDFISH_PASSWORD
+

--- a/test-fixtures/schemas/global/invalid/missing-ip.yaml
+++ b/test-fixtures/schemas/global/invalid/missing-ip.yaml
@@ -1,11 +1,11 @@
 ---
-# Fixture: both sshPubKey and sshPubPath provided
-# Expected failure: oneOf requires exactly one of sshPubKey or sshPubPath
+# Invalid fixture: missing ipAddress in agent_hosts
+# Expected failure: ipAddress of one host in agent_hosts is missing, and no networkConfig is provided
 workingDir: /home/enclave
 baseDomain: enclave-test.nodns.in
 clusterName: mgmt
 machineNetwork: 192.168.2.0/24
-apiVIP: 192.168.2.201
+apiVIP: 192.168.1.110
 ingressVIP: 192.168.2.202
 defaultDNS: 9.30.31.32
 defaultGateway: 192.168.2.10
@@ -17,12 +17,10 @@ quayPassword: YOUR_QUAY_PASSWORD
 quayBackend: LocalStorage
 storage_plugin: lvms
 pullSecret: {"auths":{}}
-sshPubKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7 user@host"
 sshPubPath: /home/enclave/.ssh/id_rsa.pub
 agent_hosts:
   - name: mgmt-ctl01
     macAddress: 0c:c4:7a:62:fe:ec
-    ipAddress: 192.168.2.24
     redfish: 192.168.1.101
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
@@ -41,3 +39,4 @@ agent_hosts:
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
     redfishPassword: YOUR_REDFISH_PASSWORD
+

--- a/test-fixtures/schemas/global/invalid/missing-macAddress.yaml
+++ b/test-fixtures/schemas/global/invalid/missing-macAddress.yaml
@@ -1,11 +1,11 @@
 ---
-# Fixture: both sshPubKey and sshPubPath provided
-# Expected failure: oneOf requires exactly one of sshPubKey or sshPubPath
+# Invalid fixture: missing macAddress in agent_hosts
+# Expected failure: macAddress of one host in agent_hosts is missing, and no networkConfig is provided
 workingDir: /home/enclave
 baseDomain: enclave-test.nodns.in
 clusterName: mgmt
 machineNetwork: 192.168.2.0/24
-apiVIP: 192.168.2.201
+apiVIP: 192.168.1.110
 ingressVIP: 192.168.2.202
 defaultDNS: 9.30.31.32
 defaultGateway: 192.168.2.10
@@ -17,11 +17,9 @@ quayPassword: YOUR_QUAY_PASSWORD
 quayBackend: LocalStorage
 storage_plugin: lvms
 pullSecret: {"auths":{}}
-sshPubKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7 user@host"
 sshPubPath: /home/enclave/.ssh/id_rsa.pub
 agent_hosts:
   - name: mgmt-ctl01
-    macAddress: 0c:c4:7a:62:fe:ec
     ipAddress: 192.168.2.24
     redfish: 192.168.1.101
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
@@ -41,3 +39,4 @@ agent_hosts:
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
     redfishPassword: YOUR_REDFISH_PASSWORD
+

--- a/test-fixtures/schemas/global/invalid/missing-mapInterfaces.yaml
+++ b/test-fixtures/schemas/global/invalid/missing-mapInterfaces.yaml
@@ -1,11 +1,11 @@
 ---
-# Fixture: both sshPubKey and sshPubPath provided
-# Expected failure: oneOf requires exactly one of sshPubKey or sshPubPath
+# Invalid fixture: networkConfig is present, but no mapInterfaces is present
+# Expected failure: mapInterfaces should be present when networkConfig is present
 workingDir: /home/enclave
 baseDomain: enclave-test.nodns.in
 clusterName: mgmt
 machineNetwork: 192.168.2.0/24
-apiVIP: 192.168.2.201
+apiVIP: 192.168.1.110
 ingressVIP: 192.168.2.202
 defaultDNS: 9.30.31.32
 defaultGateway: 192.168.2.10
@@ -17,16 +17,35 @@ quayPassword: YOUR_QUAY_PASSWORD
 quayBackend: LocalStorage
 storage_plugin: lvms
 pullSecret: {"auths":{}}
-sshPubKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7 user@host"
 sshPubPath: /home/enclave/.ssh/id_rsa.pub
 agent_hosts:
   - name: mgmt-ctl01
-    macAddress: 0c:c4:7a:62:fe:ec
-    ipAddress: 192.168.2.24
-    redfish: 192.168.1.101
+    redfish: 192.168.2.101
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
     redfishPassword: YOUR_REDFISH_PASSWORD
+    networkConfig:
+      interfaces:
+      - name: eth0
+        state: up
+        mtu: 9000
+        ipv4:
+          auto-dns: false
+          address:
+          - ip: 192.168.2.101
+            prefix-length: 24
+          enabled: true
+      dns-resolver:
+        config:
+          server:
+          - 192.168.2.1
+      routes:
+        config:
+        - destination: 0.0.0.0/0
+          metric: 100
+          next-hop-address: 192.168.2.1
+          next-hop-interface: eth0
+
   - name: mgmt-ctl02
     macAddress: 0c:c4:7a:62:fe:ed
     ipAddress: 192.168.2.25
@@ -41,3 +60,4 @@ agent_hosts:
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
     redfishPassword: YOUR_REDFISH_PASSWORD
+

--- a/test-fixtures/schemas/global/invalid/missing-networkConfig.yaml
+++ b/test-fixtures/schemas/global/invalid/missing-networkConfig.yaml
@@ -1,11 +1,11 @@
 ---
-# Fixture: both sshPubKey and sshPubPath provided
-# Expected failure: oneOf requires exactly one of sshPubKey or sshPubPath
+# Invalid fixture: no ipAddress or networkConfig are present
+# Expected failure: one of  ipAddress or networkConfig should be present
 workingDir: /home/enclave
 baseDomain: enclave-test.nodns.in
 clusterName: mgmt
 machineNetwork: 192.168.2.0/24
-apiVIP: 192.168.2.201
+apiVIP: 192.168.1.110
 ingressVIP: 192.168.2.202
 defaultDNS: 9.30.31.32
 defaultGateway: 192.168.2.10
@@ -17,13 +17,10 @@ quayPassword: YOUR_QUAY_PASSWORD
 quayBackend: LocalStorage
 storage_plugin: lvms
 pullSecret: {"auths":{}}
-sshPubKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7 user@host"
 sshPubPath: /home/enclave/.ssh/id_rsa.pub
 agent_hosts:
   - name: mgmt-ctl01
-    macAddress: 0c:c4:7a:62:fe:ec
-    ipAddress: 192.168.2.24
-    redfish: 192.168.1.101
+    redfish: 192.168.2.101
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
     redfishPassword: YOUR_REDFISH_PASSWORD
@@ -41,3 +38,4 @@ agent_hosts:
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
     redfishPassword: YOUR_REDFISH_PASSWORD
+

--- a/test-fixtures/schemas/global/invalid/odf-without-external-config.yaml
+++ b/test-fixtures/schemas/global/invalid/odf-without-external-config.yaml
@@ -14,7 +14,7 @@ defaultPrefix: 24
 rendezvousIP: 192.168.2.24
 lzBmcIP: 100.64.1.10
 quayUser: admin
-quayPassword: password
+quayPassword: YOUR_QUAY_PASSWORD
 quayBackend: LocalStorage
 storage_plugin: odf
 pullSecret: {"auths":{}}
@@ -26,19 +26,19 @@ agent_hosts:
     redfish: 192.168.1.101
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
   - name: mgmt-ctl02
     macAddress: 0c:c4:7a:62:fe:ed
     ipAddress: 192.168.2.25
     redfish: 192.168.1.102
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
   - name: mgmt-ctl03
     macAddress: 0c:c4:7a:62:fe:ee
     ipAddress: 192.168.2.26
     redfish: 192.168.1.103
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
 

--- a/test-fixtures/schemas/global/invalid/radosgw-without-rgw-config.yaml
+++ b/test-fixtures/schemas/global/invalid/radosgw-without-rgw-config.yaml
@@ -14,7 +14,7 @@ defaultPrefix: 24
 rendezvousIP: 192.168.2.24
 lzBmcIP: 100.64.1.10
 quayUser: admin
-quayPassword: password
+quayPassword: YOUR_QUAY_PASSWORD
 quayBackend: RadosGWStorage
 storage_plugin: lvms
 pullSecret: {"auths":{}}
@@ -26,19 +26,19 @@ agent_hosts:
     redfish: 192.168.1.101
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
   - name: mgmt-ctl02
     macAddress: 0c:c4:7a:62:fe:ed
     ipAddress: 192.168.2.25
     redfish: 192.168.1.102
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
   - name: mgmt-ctl03
     macAddress: 0c:c4:7a:62:fe:ee
     ipAddress: 192.168.2.26
     redfish: 192.168.1.103
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
 

--- a/test-fixtures/schemas/global/invalid/redfish-invalid-port.yaml
+++ b/test-fixtures/schemas/global/invalid/redfish-invalid-port.yaml
@@ -13,7 +13,7 @@ defaultPrefix: 24
 rendezvousIP: 192.168.2.24
 lzBmcIP: 100.64.1.10
 quayUser: admin
-quayPassword: password
+quayPassword: YOUR_QUAY_PASSWORD
 quayBackend: LocalStorage
 storage_plugin: lvms
 pullSecret: {"auths":{}}
@@ -25,4 +25,4 @@ agent_hosts:
     redfish: 100.64.1.1:99999
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD

--- a/test-fixtures/schemas/global/valid/ipAddress.yaml
+++ b/test-fixtures/schemas/global/valid/ipAddress.yaml
@@ -1,11 +1,14 @@
 ---
-# Fixture: both sshPubKey and sshPubPath provided
-# Expected failure: oneOf requires exactly one of sshPubKey or sshPubPath
+# Fixture: Validate non NMState network configuration (no networkConfig)
+# Expects host to use ipAddress and macAddress for network configuration
+#   - Has ipAddress field
+#   - Has macAddress field
+#   - Does not have NMState config in networkConfig
 workingDir: /home/enclave
 baseDomain: enclave-test.nodns.in
 clusterName: mgmt
 machineNetwork: 192.168.2.0/24
-apiVIP: 192.168.2.201
+apiVIP: 192.168.1.110
 ingressVIP: 192.168.2.202
 defaultDNS: 9.30.31.32
 defaultGateway: 192.168.2.10
@@ -17,13 +20,12 @@ quayPassword: YOUR_QUAY_PASSWORD
 quayBackend: LocalStorage
 storage_plugin: lvms
 pullSecret: {"auths":{}}
-sshPubKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7 user@host"
 sshPubPath: /home/enclave/.ssh/id_rsa.pub
 agent_hosts:
   - name: mgmt-ctl01
     macAddress: 0c:c4:7a:62:fe:ec
     ipAddress: 192.168.2.24
-    redfish: 192.168.1.101
+    redfish: 192.168.2.101
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
     redfishPassword: YOUR_REDFISH_PASSWORD
@@ -41,3 +43,4 @@ agent_hosts:
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
     redfishPassword: YOUR_REDFISH_PASSWORD
+

--- a/test-fixtures/schemas/global/valid/local-lvms-redfish-with-port.yaml
+++ b/test-fixtures/schemas/global/valid/local-lvms-redfish-with-port.yaml
@@ -13,7 +13,7 @@ defaultPrefix: 24
 rendezvousIP: 192.168.2.24
 lzBmcIP: 100.64.1.10
 quayUser: admin
-quayPassword: password
+quayPassword: YOUR_QUAY_PASSWORD
 quayBackend: LocalStorage
 storage_plugin: lvms
 pullSecret: {"auths":{}}
@@ -25,18 +25,18 @@ agent_hosts:
     redfish: 100.64.1.1:8008
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
   - name: mgmt-ctl02
     macAddress: 0c:c4:7a:62:fe:ed
     ipAddress: 192.168.2.25
     redfish: 100.64.1.1:8008
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
   - name: mgmt-ctl03
     macAddress: 0c:c4:7a:62:fe:ee
     ipAddress: 192.168.2.26
     redfish: 100.64.1.1:8008
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD

--- a/test-fixtures/schemas/global/valid/local-lvms-with-ssh-pub-key.yaml
+++ b/test-fixtures/schemas/global/valid/local-lvms-with-ssh-pub-key.yaml
@@ -13,7 +13,7 @@ defaultPrefix: 24
 rendezvousIP: 192.168.2.24
 lzBmcIP: 100.64.1.10
 quayUser: admin
-quayPassword: password
+quayPassword: YOUR_QUAY_PASSWORD
 quayBackend: LocalStorage
 storage_plugin: lvms
 pullSecret: {"auths":{}}
@@ -25,18 +25,18 @@ agent_hosts:
     redfish: 192.168.1.101
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
   - name: mgmt-ctl02
     macAddress: 0c:c4:7a:62:fe:ed
     ipAddress: 192.168.2.25
     redfish: 192.168.1.102
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
   - name: mgmt-ctl03
     macAddress: 0c:c4:7a:62:fe:ee
     ipAddress: 192.168.2.26
     redfish: 192.168.1.103
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD

--- a/test-fixtures/schemas/global/valid/local-lvms.yaml
+++ b/test-fixtures/schemas/global/valid/local-lvms.yaml
@@ -14,7 +14,7 @@ defaultPrefix: 24
 rendezvousIP: 192.168.2.24
 lzBmcIP: 100.64.1.10
 quayUser: admin
-quayPassword: password
+quayPassword: YOUR_QUAY_PASSWORD
 quayBackend: LocalStorage
 storage_plugin: lvms
 pullSecret: {"auths":{}}
@@ -26,19 +26,19 @@ agent_hosts:
     redfish: 192.168.1.101
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
   - name: mgmt-ctl02
     macAddress: 0c:c4:7a:62:fe:ed
     ipAddress: 192.168.2.25
     redfish: 192.168.1.102
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
   - name: mgmt-ctl03
     macAddress: 0c:c4:7a:62:fe:ee
     ipAddress: 192.168.2.26
     redfish: 192.168.1.103
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
 

--- a/test-fixtures/schemas/global/valid/local-odf.yaml
+++ b/test-fixtures/schemas/global/valid/local-odf.yaml
@@ -14,7 +14,7 @@ defaultPrefix: 24
 rendezvousIP: 192.168.2.24
 lzBmcIP: 100.64.1.10
 quayUser: admin
-quayPassword: password
+quayPassword: YOUR_QUAY_PASSWORD
 quayBackend: LocalStorage
 storage_plugin: odf
 odfExternalConfig: >-
@@ -29,19 +29,19 @@ agent_hosts:
     redfish: 192.168.1.101
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
   - name: mgmt-ctl02
     macAddress: 0c:c4:7a:62:fe:ed
     ipAddress: 192.168.2.25
     redfish: 192.168.1.102
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
   - name: mgmt-ctl03
     macAddress: 0c:c4:7a:62:fe:ee
     ipAddress: 192.168.2.26
     redfish: 192.168.1.103
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
 

--- a/test-fixtures/schemas/global/valid/local-vast-csi.yaml
+++ b/test-fixtures/schemas/global/valid/local-vast-csi.yaml
@@ -14,7 +14,7 @@ defaultPrefix: 24
 rendezvousIP: 192.168.2.24
 lzBmcIP: 100.64.1.10
 quayUser: admin
-quayPassword: password
+quayPassword: YOUR_QUAY_PASSWORD
 quayBackend: LocalStorage
 storage_plugin: vast-csi
 pullSecret: {"auths":{}}
@@ -26,18 +26,18 @@ agent_hosts:
     redfish: 192.168.1.101
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
   - name: mgmt-ctl02
     macAddress: 0c:c4:7a:62:fe:ed
     ipAddress: 192.168.2.25
     redfish: 192.168.1.102
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
   - name: mgmt-ctl03
     macAddress: 0c:c4:7a:62:fe:ee
     ipAddress: 192.168.2.26
     redfish: 192.168.1.103
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD

--- a/test-fixtures/schemas/global/valid/networkConfig.yaml
+++ b/test-fixtures/schemas/global/valid/networkConfig.yaml
@@ -1,11 +1,15 @@
 ---
-# Fixture: both sshPubKey and sshPubPath provided
-# Expected failure: oneOf requires exactly one of sshPubKey or sshPubPath
+# Fixture: Validate that nmstate style configuration validation works
+# Expects that ipAddress and macAddress are not present on a host in agent_hosts, while networkConfig and mapInterfaces are:
+#   - Does not have ipAddress field
+#   - Does not have macAddress field
+#   - Has NMState config in networkConfig
+#   - Has mapInterfaces
 workingDir: /home/enclave
 baseDomain: enclave-test.nodns.in
 clusterName: mgmt
 machineNetwork: 192.168.2.0/24
-apiVIP: 192.168.2.201
+apiVIP: 192.168.1.110
 ingressVIP: 192.168.2.202
 defaultDNS: 9.30.31.32
 defaultGateway: 192.168.2.10
@@ -17,16 +21,38 @@ quayPassword: YOUR_QUAY_PASSWORD
 quayBackend: LocalStorage
 storage_plugin: lvms
 pullSecret: {"auths":{}}
-sshPubKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7 user@host"
 sshPubPath: /home/enclave/.ssh/id_rsa.pub
 agent_hosts:
   - name: mgmt-ctl01
-    macAddress: 0c:c4:7a:62:fe:ec
-    ipAddress: 192.168.2.24
-    redfish: 192.168.1.101
+    redfish: 192.168.2.101
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
     redfishPassword: YOUR_REDFISH_PASSWORD
+    mapInterfaces:
+      - name: eth0
+        macAddress: 0c:c4:7a:62:fe:ec
+    networkConfig:
+      interfaces:
+      - name: eth0
+        state: up
+        mtu: 9000
+        ipv4:
+          auto-dns: false
+          address:
+          - ip: 192.168.2.101
+            prefix-length: 24
+          enabled: true
+      dns-resolver:
+        config:
+          server:
+          - 192.168.2.1
+      routes:
+        config:
+        - destination: 0.0.0.0/0
+          metric: 100
+          next-hop-address: 192.168.2.1
+          next-hop-interface: eth0
+
   - name: mgmt-ctl02
     macAddress: 0c:c4:7a:62:fe:ed
     ipAddress: 192.168.2.25
@@ -41,3 +67,4 @@ agent_hosts:
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
     redfishPassword: YOUR_REDFISH_PASSWORD
+

--- a/test-fixtures/schemas/global/valid/radosgw-lvms-all-optionals.yaml
+++ b/test-fixtures/schemas/global/valid/radosgw-lvms-all-optionals.yaml
@@ -22,7 +22,7 @@ defaultNtpServers:
   - 192.168.2.5
   - 192.168.2.6
 quayUser: admin
-quayPassword: password
+quayPassword: YOUR_QUAY_PASSWORD
 quayBackend: RadosGWStorage
 quayBackendRGWConfiguration:
   access_key: EXAMPLE_ACCESS_KEY
@@ -45,7 +45,7 @@ agent_hosts:
     redfish: 192.168.1.101
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
     bmcSystemId: "1"
   - name: mgmt-ctl02
     macAddress: 0c:c4:7a:62:fe:ed
@@ -53,7 +53,7 @@ agent_hosts:
     redfish: 192.168.1.102
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
     bmcSystemId: "2"
   - name: mgmt-ctl03
     macAddress: 0c:c4:7a:62:fe:ee
@@ -61,5 +61,5 @@ agent_hosts:
     redfish: 192.168.1.103
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
     bmcSystemId: "3"

--- a/test-fixtures/schemas/global/valid/radosgw-odf.yaml
+++ b/test-fixtures/schemas/global/valid/radosgw-odf.yaml
@@ -14,7 +14,7 @@ defaultPrefix: 24
 rendezvousIP: 192.168.2.24
 lzBmcIP: 100.64.1.10
 quayUser: admin
-quayPassword: password
+quayPassword: YOUR_QUAY_PASSWORD
 quayBackend: RadosGWStorage
 quayBackendRGWConfiguration:
   access_key: EXAMPLE_ACCESS_KEY
@@ -34,19 +34,19 @@ agent_hosts:
     redfish: 192.168.1.101
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
   - name: mgmt-ctl02
     macAddress: 0c:c4:7a:62:fe:ed
     ipAddress: 192.168.2.25
     redfish: 192.168.1.102
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
   - name: mgmt-ctl03
     macAddress: 0c:c4:7a:62:fe:ee
     ipAddress: 192.168.2.26
     redfish: 192.168.1.103
     rootDisk: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: admin
-    redfishPassword: password
+    redfishPassword: YOUR_REDFISH_PASSWORD
 

--- a/validations.sh
+++ b/validations.sh
@@ -326,15 +326,11 @@ validation_section nmstate
 
 if [[ $(getValue .agent_hosts | jq '[.[] | select(has("networkConfig"))] | length') -gt 0 ]]; then
     for agent in $(getValue .agent_hosts | jq -r ".[] | .name"); do
-        agent_host=$(getValue .agent_hosts | jq -r '.[] | select(.name=="'"$agent"'")')
+        agent_host=$(getValue .agent_hosts | jq --arg agent $agent -r '.[] | select(.name==$agent)')
         hasNetworkConfig=$(jq 'has("networkConfig")' <<< "$agent_host")
-        hasMapInterfaces=$(jq 'has("mapInterfaces")' <<< "$agent_host")
         if [[ $hasNetworkConfig == false ]]; then
             validation pass $agent "Host $agent has no networkConfig. Skipping validation"
             continue
-        fi
-        if [[ $hasMapInterfaces == false ]]; then
-            validation fail $agent "Host $agent has networkConfig but no mapInterfaces"
         fi
 
         if ! jq .networkConfig <<< "$agent_host" | toYaml | nmstatectl validate -q > /dev/null; then


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Host validation enforces two mutually exclusive networking styles: either IP+MAC or NMState-style network config with interface mappings (interface entries now require name and valid MAC).
  * NMState validation skips hosts that lack NMState data instead of failing them.

* **Tests**
  * Added many new valid/invalid schema fixtures covering missing/extra fields, malformed or duplicated interface mappings, and mixed/missing network configurations.
  * Replaced hardcoded credentials in fixtures with placeholder secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->