### PR TITLE
fix cert-manager webhook OOM by increasing memory limit

### DIFF
--- a/operators/openshift-cert-manager-operator/tasks.yaml
+++ b/operators/openshift-cert-manager-operator/tasks.yaml
@@ -38,11 +38,11 @@
               overrideReplicas: "{{ cert_manager_webhook_replicas }}"
               overrideResources:
                 limits:
-                  cpu: 500m
+                  cpu: 20m
                   memory: 128Mi
                 requests:
-                  cpu: 250m
-                  memory: 100Mi
+                  cpu: 20m
+                  memory: 128Mi
 
     - name: Read back CertManager CR
       kubernetes.core.k8s_info:

--- a/operators/openshift-cert-manager-operator/tasks.yaml
+++ b/operators/openshift-cert-manager-operator/tasks.yaml
@@ -38,11 +38,11 @@
               overrideReplicas: "{{ cert_manager_webhook_replicas }}"
               overrideResources:
                 limits:
-                  cpu: 20m
-                  memory: 32Mi
+                  cpu: 500m
+                  memory: 128Mi
                 requests:
-                  cpu: 20m
-                  memory: 32Mi
+                  cpu: 250m
+                  memory: 100Mi
 
     - name: Read back CertManager CR
       kubernetes.core.k8s_info:


### PR DESCRIPTION
## Summary

- The cert-manager webhook memory limit was set to 32Mi, causing OOM kills and admission webhook timeouts that broke CertificateRequest approval.
- Increased webhook memory from 32Mi to 128Mi (both request and limit).
- CPU unchanged (20m), Guaranteed QoS preserved (requests == limits).

## Test plan

- [x] Verified cert-manager webhook pods no longer OOM crash on openshift-qe-002
- [x] Verified CertificateRequest approval works correctly
- [x] Verified ClusterIssuer reaches Ready state

🤖 Generated with [Claude Code](https://claude.com/claude-code)