### PR TITLE
Fix file validation when condition re-evaluation

### DIFF
--- a/playbooks/tasks/deploy_plugin.yaml
+++ b/playbooks/tasks/deploy_plugin.yaml
@@ -107,19 +107,18 @@
 
 - name: Validate plugin requirements (files)
   ansible.builtin.assert:
-    that: r_required_files.results[ansible_loop.index0].stat.exists
+    that: item.stat.exists
     fail_msg: >-
-      Plugin '{{ plugin.name }}' requires file '{{ item.path }}' but it was not found at
-      {{ plugin_dir }}/{{ item.path }}.
-      {{ item.description | default('') }}
-  loop: "{{ plugin.requires.files | default([]) }}"
+      Plugin '{{ plugin.name }}' requires file '{{ item.item.path }}' but it was not found at
+      {{ plugin_dir }}/{{ item.item.path }}.
+      {{ item.item.description | default('') }}
+  loop: "{{ r_required_files.results }}"
   loop_control:
-    label: "{{ item.path }}"
-    extended: true
+    label: "{{ item.item.path }}"
   when:
     - plugin.requires is defined
     - plugin.requires.files is defined
-    - item.when | default(true) | bool
+    - not item.skipped | default(false)
   tags: always
 
 - name: Run pre-validate


### PR DESCRIPTION
## Summary

Fixes a pre-existing issue where the file validation task re-evaluates `item.when` instead of checking whether the stat task actually ran.

## Problem

The current code loops over `plugin.requires.files` and checks `item.when | default(true) | bool`, which re-evaluates the condition. This could lead to inconsistency if variables change between the stat task and the validation task.

## Solution

- Loop over `r_required_files.results` directly instead of using `ansible_loop.index0`
- Check `not item.skipped | default(false)` to rely on the actual stat task outcome
- Simplifies the code and makes it more reliable

## Changes

```yaml
# Before
loop: "{{ plugin.requires.files | default([]) }}"
when:
  - item.when | default(true) | bool
that: r_required_files.results[ansible_loop.index0].stat.exists

# After  
loop: "{{ r_required_files.results }}"
when:
  - not item.skipped | default(false)
that: item.stat.exists
```

This matches the pattern that will be used in #435 for resource validation.

## Testing

- [ ] Existing plugins with file requirements still validate correctly
- [ ] Conditional file requirements (with `when` clauses) work as expected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)