### PR TITLE
Add NetworkPolicy for RHBK PostgreSQL database

### DIFF
--- a/plugins/rhbk/tasks/deploy.yaml
+++ b/plugins/rhbk/tasks/deploy.yaml
@@ -111,6 +111,35 @@
   until: __r_db_svc is success
   when: rhbk_deploy_database
 
+- name: Restrict PostgreSQL ingress to Keycloak pods only
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      metadata:
+        name: allow-keycloak-to-db
+        namespace: "{{ rhbk_ns }}"
+      spec:
+        podSelector:
+          matchLabels:
+            app: "{{ rhbk_db_name }}"
+        ingress:
+          - from:
+              - podSelector:
+                  matchLabels:
+                    app: "{{ rhbk_name }}"
+            ports:
+              - protocol: TCP
+                port: 5432
+        policyTypes:
+          - Ingress
+  register: __r_db_netpol
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: __r_db_netpol is success
+  when: rhbk_deploy_database
+
 - name: Deploy PostgreSQL StatefulSet
   kubernetes.core.k8s:
     state: present


### PR DESCRIPTION
## Summary

- Add a NetworkPolicy to restrict PostgreSQL ingress to Keycloak pods only
- Only pods with label `app=keycloak` can reach the database on port 5432
- Prevents lateral access from other workloads in the cluster

Depends on #429

## Test plan

- [x] NetworkPolicy created successfully on test cluster
- [x] Keycloak CR remains `Ready=True` (database connectivity works)
- [x] Random pod (`ubi-minimal`) blocked from reaching PostgreSQL port 5432

🤖 Generated with [Claude Code](https://claude.com/claude-code)