### PR TITLE
Add CA Bundle distribution to trust-manager plugin

### DIFF
--- a/plugins/trust-manager/defaults.yaml
+++ b/plugins/trust-manager/defaults.yaml
@@ -2,3 +2,6 @@
 trust_manager_cluster_issuer: default-ca
 trust_manager_ca_issuer_duration: 87600h
 trust_manager_ca_issuer_renew_before: 8760h
+trust_manager_ca_bundle_name: ca-bundle
+trust_manager_ca_bundle_key: bundle.pem
+trust_manager_ca_bundle_label: enclave/ca-bundle

--- a/plugins/trust-manager/schemas/defaults.yaml
+++ b/plugins/trust-manager/schemas/defaults.yaml
@@ -9,10 +9,6 @@ required:
   - trust_manager_ca_bundle_name
   - trust_manager_ca_bundle_key
   - trust_manager_ca_bundle_label
-definitions:
-  nonEmptyString:
-    type: string
-    minLength: 1
 properties:
   trust_manager_cluster_issuer:
     "$ref": "#/definitions/nonEmptyString"

--- a/plugins/trust-manager/schemas/defaults.yaml
+++ b/plugins/trust-manager/schemas/defaults.yaml
@@ -6,6 +6,13 @@ required:
   - trust_manager_cluster_issuer
   - trust_manager_ca_issuer_duration
   - trust_manager_ca_issuer_renew_before
+  - trust_manager_ca_bundle_name
+  - trust_manager_ca_bundle_key
+  - trust_manager_ca_bundle_label
+definitions:
+  nonEmptyString:
+    type: string
+    minLength: 1
 properties:
   trust_manager_cluster_issuer:
     "$ref": "#/definitions/nonEmptyString"
@@ -16,3 +23,12 @@ properties:
   trust_manager_ca_issuer_renew_before:
     type: string
     description: How long before expiry the CA certificate is renewed (e.g. 8760h for 1 year).
+  trust_manager_ca_bundle_name:
+    "$ref": "#/definitions/nonEmptyString"
+    description: Name of the ConfigMap distributed by the trust-manager Bundle CR.
+  trust_manager_ca_bundle_key:
+    "$ref": "#/definitions/nonEmptyString"
+    description: Key within the ConfigMap containing the PEM-encoded CA certificate.
+  trust_manager_ca_bundle_label:
+    "$ref": "#/definitions/nonEmptyString"
+    description: Label key used in the Bundle namespaceSelector. Namespaces with this label set to "true" receive the CA bundle.

--- a/plugins/trust-manager/tasks/deploy.yaml
+++ b/plugins/trust-manager/tasks/deploy.yaml
@@ -63,3 +63,24 @@
 - name: Debug CA issuer status
   ansible.builtin.debug:
     msg: "ClusterIssuer {{ trust_manager_cluster_issuer }} is ready"
+
+- name: Wait for CA Bundle to be synced
+  kubernetes.core.k8s_info:
+    api_version: trust.cert-manager.io/v1alpha1
+    kind: Bundle
+    name: "{{ trust_manager_ca_bundle_name }}"
+  register: __r_ca_bundle
+  retries: 30
+  delay: 10
+  until:
+    - __r_ca_bundle.resources | length > 0
+    - __r_ca_bundle.resources[0].status.conditions
+      | default([])
+      | selectattr('type', 'equalto', 'Synced')
+      | selectattr('status', 'equalto', 'True')
+      | list
+      | length > 0
+
+- name: Debug CA Bundle status
+  ansible.builtin.debug:
+    msg: "CA Bundle {{ trust_manager_ca_bundle_name }} is synced"

--- a/plugins/trust-manager/templates/ca-issuer.yaml.j2
+++ b/plugins/trust-manager/templates/ca-issuer.yaml.j2
@@ -37,3 +37,21 @@ metadata:
 spec:
   ca:
     secretName: {{ trust_manager_cluster_issuer }}-secret
+
+---
+# Bundle distributes the CA certificate as a ConfigMap to labeled namespaces
+apiVersion: trust.cert-manager.io/v1alpha1
+kind: Bundle
+metadata:
+  name: {{ trust_manager_ca_bundle_name }}
+spec:
+  sources:
+    - secret:
+        name: {{ trust_manager_cluster_issuer }}-secret
+        key: ca.crt
+  target:
+    configMap:
+      key: {{ trust_manager_ca_bundle_key }}
+    namespaceSelector:
+      matchLabels:
+        {{ trust_manager_ca_bundle_label }}: "true"

--- a/plugins/trust-manager/test-fixtures/schemas/defaults/valid/base.yaml
+++ b/plugins/trust-manager/test-fixtures/schemas/defaults/valid/base.yaml
@@ -2,3 +2,6 @@
 trust_manager_cluster_issuer: default-ca
 trust_manager_ca_issuer_duration: 87600h
 trust_manager_ca_issuer_renew_before: 8760h
+trust_manager_ca_bundle_name: ca-bundle
+trust_manager_ca_bundle_key: bundle.pem
+trust_manager_ca_bundle_label: enclave/ca-bundle


### PR DESCRIPTION
## Summary

- Adds a trust-manager `Bundle` CR that distributes the cluster CA certificate as a ConfigMap (`ca-bundle`) to namespaces labeled with `enclave/ca-bundle: "true"`
- Consuming plugins (e.g. OSAC) opt in by labeling their namespaces — no cross-plugin variable dependencies
- Adds three new configurable variables: `trust_manager_ca_bundle_name`, `trust_manager_ca_bundle_key`, `trust_manager_ca_bundle_label`

## Motivation

The OSAC Helm chart expects a `ca-bundle` ConfigMap containing the cluster CA cert (`service.certs.caBundle.configMap`). Without this Bundle CR, the ConfigMap doesn't exist and pods fail to mount it. This mirrors the CA trust distribution pattern from osac-installer (`ca-trust-bundle.yaml`), using label-based namespace targeting instead of hardcoded namespace selectors.

## Changes

| File | Change |
|------|--------|
| `plugins/trust-manager/defaults.yaml` | Add `trust_manager_ca_bundle_name`, `trust_manager_ca_bundle_key`, `trust_manager_ca_bundle_label` |
| `plugins/trust-manager/schemas/defaults.yaml` | Add schema for new variables with `nonEmptyString` validation |
| `plugins/trust-manager/templates/ca-issuer.yaml.j2` | Append `Bundle` CR with `namespaceSelector.matchLabels` |
| `plugins/trust-manager/tasks/deploy.yaml` | Wait for Bundle `Synced=True` condition |
| `plugins/trust-manager/test-fixtures/schemas/defaults/valid/base.yaml` | Add new fields to valid fixture |

## Test plan

- [x] `make -f Makefile.ci validate-yaml` passes
- [x] `make -f Makefile.ci validate-plugins` passes (schema fixtures valid/invalid)
- [x] `make -f Makefile.ci validate-ansible` passes
- [x] Deploy trust-manager plugin on test cluster — Bundle CR created, syncs to labeled namespaces
- [x] Label a namespace with `enclave/ca-bundle: "true"` — `ca-bundle` ConfigMap appears

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enable automatic CA bundle distribution to target namespaces via label selector.
  * Publish cluster issuer CA into ConfigMaps so certificates can be shared across namespaces.
  * New configuration options to set bundle name, certificate data key, and namespace label selector.

* **Tests**
  * Test fixtures expanded to cover the new CA bundle configuration parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->