### PR TITLE
OSAC-1301: Ensure enclave CLI is installed during sync

### DIFF
--- a/sync.sh
+++ b/sync.sh
@@ -71,6 +71,11 @@ done
 
 step_done
 
+echo "Configuring environment .. "  | tee -a ${log}
+    sudo bash -e ./setup_env.sh 2>&1 | tee -a ${log}
+    bash -e ./setup_ansible.sh 2>&1 | tee -a ${log}
+step_done
+
 echo "Validating Config .. " | tee -a ${log}
     ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/validation/validate-schema.yaml -e fresh=false --tags validate-config
     bash ./validations.sh 2>&1 | tee -a ${log}


### PR DESCRIPTION
## Summary
- Add environment configuration step in sync.sh to ensure enclave CLI is installed before validation
- Required for upgrade process documented in docs/UPGRADE.md which uses `enclave reconcile` commands

## Changes
- Call `setup_env.sh` to install system prerequisites 
- Call `setup_ansible.sh` to install enclave CLI via `uv tool install`

## Test plan
- [ ] Run sync.sh and verify enclave CLI is available after environment setup
- [ ] Verify validation steps succeed after environment setup
- [ ] Test upgrade workflow from docs/UPGRADE.md

## Related
- Subtask of OSAC-670 (Enclave content management and upgrade strategy)
- https://redhat.atlassian.net/browse/OSAC-1301

🤖 Generated with [Claude Code](https://claude.com/claude-code)