### PR TITLE
Use OperatorPolicy for fleet operator version control

### DIFF
--- a/docs/PLUGIN_ARCHITECTURE.md
+++ b/docs/PLUGIN_ARCHITECTURE.md
@@ -70,9 +70,9 @@ registries:
 | `type` | `foundation` -- deploys before core operators (storage, networking). `addon` -- deploys after core operators and Quay mirroring. |
 | `order` | Deploy order among same-type plugins. Lower = first. LVMS is 10, ODF is 10. |
 | `catalog` | Operator catalog name (`redhat` or `certified`). Defaults to `redhat`. |
-| `operators` | List of OLM operators to install. Each entry is passed to `configure_operator.yaml`. |
-| `installOperators` | Set to `false` to skip operator installation (mirror-only plugins). Defaults to `true`. |
-| `clusterSelector` | Label-matching expressions to identify and select specific managed clusters for deploying the plugin (using ACM policies). |
+| `operators` | List of OLM operators to install. Each entry is passed to `configure_operator.yaml`. When combined with `clusterSelector` and `installOperators: false`, operators are deployed to spoke clusters via ACM OperatorPolicy for version control. |
+| `installOperators` | Set to `false` to deploy operators to fleet via ACM policies instead of installing on hub. Requires `clusterSelector`. Defaults to `true`. |
+| `clusterSelector` | Label-matching expressions to identify and select specific managed clusters for deploying the plugin (using ACM policies). When defined with `installOperators: false`, creates ACM policies using OperatorPolicy for version-controlled fleet deployment. |
 | `defaults` | Variables loaded into Ansible scope before tasks run. Alternative to `defaults.yaml` — cannot use both. All top-level property names must be prefixed with the plugin name (e.g. `lvmsDefaults`, not just `Defaults`). DO NOT USE, this property has been deprecated.|
 | `registries` | Registry mirror entries for MCE patching and `registries.conf`. |
 | `additionalImages` | Extra images to include in the plugin's oc-mirror image set. |

--- a/docs/PLUGIN_ARCHITECTURE.md
+++ b/docs/PLUGIN_ARCHITECTURE.md
@@ -72,6 +72,7 @@ registries:
 | `catalog` | Operator catalog name (`redhat` or `certified`). Defaults to `redhat`. |
 | `operators` | List of OLM operators to install. Each entry is passed to `configure_operator.yaml`. When combined with `clusterSelector` and `installOperators: false`, operators are deployed to spoke clusters via ACM OperatorPolicy for version control. |
 | `installOperators` | Set to `false` to deploy operators to fleet via ACM policies instead of installing on hub. Requires `clusterSelector`. Defaults to `true`. |
+| `installOperatorsFleet` | Controls operator policy creation for fleet. Set to `false` to deploy only the catalog source to fleet when `clusterSelector` is set (no operator subscriptions). Defaults to `true`. Requires `clusterSelector`. |
 | `clusterSelector` | Label-matching expressions to identify and select specific managed clusters for deploying the plugin (using ACM policies). When defined with `installOperators: false`, creates ACM policies using OperatorPolicy for version-controlled fleet deployment. |
 | `defaults` | Variables loaded into Ansible scope before tasks run. Alternative to `defaults.yaml` — cannot use both. All top-level property names must be prefixed with the plugin name (e.g. `lvmsDefaults`, not just `Defaults`). DO NOT USE, this property has been deprecated.|
 | `registries` | Registry mirror entries for MCE patching and `registries.conf`. |

--- a/files/plugin-fleet-configuration/10-policy-operators.yaml.j2
+++ b/files/plugin-fleet-configuration/10-policy-operators.yaml.j2
@@ -17,47 +17,44 @@ spec:
   disabled: false
   remediationAction: enforce
   policy-templates:
-  - objectDefinition:
-      apiVersion: policy.open-cluster-management.io/v1
-      kind: ConfigurationPolicy
-      metadata:
-        name: {{ plugin.name }}-operators
-      spec:
-        evaluationInterval:
-          compliant: 2h
-          noncompliant: 45s
-        object-templates:
 {% for operator in plugin.operators | default([]) %}
-        - complianceType: mustonlyhave
-          metadataComplianceType: musthave
-          objectDefinition:
-            apiVersion: v1
-            kind: Namespace
-            metadata:
-                name: {{ operator.namespace }}
-        - complianceType: mustonlyhave
-          metadataComplianceType: musthave
-          objectDefinition:
-            apiVersion: operators.coreos.com/v1
-            kind: OperatorGroup
-            metadata:
-              name: {{ operator.name }}
-              namespace: {{ operator.namespace }}
-            spec:
-              targetNamespaces:
-              - {{ operator.namespace }}
-        - complianceType: mustonlyhave
-          metadataComplianceType: musthave
-          objectDefinition:
-            apiVersion: operators.coreos.com/v1alpha1
-            kind: Subscription
-            metadata:
-              name: {{ operator.name }}
-              namespace: {{ operator.namespace }}
-            spec:
-              channel: {{ operator.channel }}
-              installPlanApproval: Automatic
-              name: {{ operator.name }}
-              source: {{ operator.source | default(catalog_mirror) }}
-              sourceNamespace: openshift-marketplace
+  - objectDefinition:
+      apiVersion: policy.open-cluster-management.io/v1beta1
+      kind: OperatorPolicy
+      metadata:
+        name: {{ operator.name }}
+      spec:
+        # Enforce the operator installation with version control
+        remediationAction: enforce
+        severity: medium
+        complianceType: musthave
+
+        # Automatic upgrades, but only to versions in the allowed list
+        upgradeApproval: Automatic
+
+        # Subscription configuration
+        subscription:
+          name: {{ operator.name }}
+{% if operator.init_version is defined %}
+          # Install initial version
+          startingCSV: {{ operator.csvNames | default([operator.name]) | first }}.v{{ operator.init_version | replace('+', '-') }}
+{% endif %}
+          channel: {{ operator.channel }}
+          source: {{ operator.source | default(catalog_mirror) }}
+          sourceNamespace: openshift-marketplace
+
+        # Version control: only allow specified versions
+        versions:
+          - {{ operator.csvNames | default([operator.name]) | first }}.v{{ operator.version | replace('+', '-') }}
+
+        # Alert when new upgrades are available outside the allowed list
+        complianceConfig:
+          upgradesAvailable: NonCompliant
+
+        # OperatorGroup configuration for namespaced operators
+        operatorGroup:
+          name: {{ operator.name }}
+          namespace: {{ operator.namespace }}
+          targetNamespaces:
+            - {{ operator.namespace }}
 {% endfor %}

--- a/files/plugin-fleet-configuration/10-policy-operators.yaml.j2
+++ b/files/plugin-fleet-configuration/10-policy-operators.yaml.j2
@@ -35,6 +35,7 @@ spec:
         # Subscription configuration
         subscription:
           name: {{ operator.name }}
+          namespace: {{ operator.namespace }}
 {% if operator.init_version is defined %}
           # Install initial version
           startingCSV: {{ operator.csvNames | default([operator.name]) | first }}.v{{ operator.init_version | replace('+', '-') }}


### PR DESCRIPTION
## Summary

Migrate fleet operator deployment from ConfigurationPolicy-based Subscription management to **OperatorPolicy** for precise version control across spoke clusters.

## Problem

The current Subscription-based approach with `installPlanApproval: Automatic` cannot control operator versions on spoke clusters. Any version from the channel is accepted, making fleet-wide version consistency impossible to maintain.

## Solution

Use **OperatorPolicy** (ACM v2.11+ GA feature) which provides:
- Initial version pinning via `startingCSV`
- Allowed version list via `versions` field
- Automatic approval only for specified versions
- Alerts when new versions become available outside the allowed list

Inspired by [AutoShift v2](https://github.com/auto-shift/autoshiftv2), which uses OperatorPolicy as a core pattern for declarative operator lifecycle management.

## Changes

### Modified Files
- **`files/plugin-fleet-configuration/10-policy-operators.yaml.j2`**  
  Replace ConfigurationPolicy with OperatorPolicy for version-controlled deployments

- **`docs/PLUGIN_ARCHITECTURE.md`**  
  Update field descriptions for `operators`, `installOperators`, and `clusterSelector`

### New Files
- **`docs/FLEET_OPERATOR_MANAGEMENT.md`**  
  Comprehensive guide for fleet operator management with OperatorPolicy

## Example: Version Control Workflow

### Plugin Definition
```yaml
operators:
  - name: gpu-operator-certified
    version: 25.10.1
    init_version: 25.10.1
    channel: v25.10
```

### Generated OperatorPolicy
```yaml
spec:
  upgradeApproval: Automatic
  subscription:
    startingCSV: gpu-operator-certified.v25.10.1
  versions:
    - gpu-operator-certified.v25.10.1
  complianceConfig:
    upgradesAvailable: NonCompliant
```

### Controlled Upgrade
1. Update plugin: `version: 25.12.0`
2. Redeploy plugin
3. Fleet auto-upgrades to v25.12.0
4. All other versions remain blocked

## Benefits

✅ **Version Control**: Pin specific versions, control upgrades centrally  
✅ **Fleet Consistency**: All spoke clusters run approved versions  
✅ **Change Tracking**: Upgrades are explicit changes in plugin.yaml  
✅ **Automated Compliance**: Detect and remediate version drift  
✅ **Upgrade Alerts**: Notified when new versions are available  

## References

- [Getting started with OperatorPolicy](https://developers.redhat.com/articles/2024/08/08/getting-started-operatorpolicy)
- [AutoShift v2](https://github.com/auto-shift/autoshiftv2) - Inspiration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Operator deployments to managed spoke clusters now use ACM OperatorPolicy when fleet deployment is configured.
  - Operator policies support automatic upgrades, channel and source selection, optional initial versions, version allowlists, compliance reporting, and namespaced OperatorGroup settings.

- **Documentation**
  - Clarified how `clusterSelector`, `installOperators: false`, and `installOperatorsFleet` configure fleet-based operator deployment instead of hub installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->