### PR TITLE
bump quay to 3.15.5

### DIFF
--- a/defaults/operators.yaml
+++ b/defaults/operators.yaml
@@ -2,7 +2,7 @@
 operators:
 
   - name: quay-operator
-    version: 3.15.3
+    version: 3.15.5
     channel: stable-3.15
     init_version: 3.15.0
     namespace: quay-enterprise

--- a/operators/quay-operator/clair_validations.yaml
+++ b/operators/quay-operator/clair_validations.yaml
@@ -1,0 +1,45 @@
+---
+- name: Get the name of the first Clair pod
+  kubernetes.core.k8s_info:
+    kind: Pod
+    namespace: quay-enterprise
+    label_selectors:
+      - quay-component=clair-app
+  register: clair_pods
+
+- name: Set clair pod name fact
+  ansible.builtin.set_fact:
+    clair_pod_name: "{{ clair_pods.resources[0].metadata.name }}"
+
+- name: Check for repository-to-cpe.json in the pod
+  kubernetes.core.k8s_exec:
+    namespace: quay-enterprise
+    pod: "{{ clair_pod_name }}"
+    command: ls /data/repository-to-cpe.json
+  register: cpe_file_check
+
+- name: Check for container-name-repos-map.json in the pod
+  kubernetes.core.k8s_exec:
+    namespace: quay-enterprise
+    pod: "{{ clair_pod_name }}"
+    command: ls /data/container-name-repos-map.json
+  register: repo_map_check
+
+- name: Fail if files are missing
+  fail:
+    msg: "Required CPE mapping files are missing from /data in pod {{ clair_pod_name }}"
+  when: cpe_file_check.rc != 0 or repo_map_check.rc != 0
+
+- name: Validate that Clair postgres config Secret exists
+  kubernetes.core.k8s_info:
+    kind: Secret
+    name: clairpostgres-config-secret
+    namespace: quay-enterprise
+  register: clair_postgres_config_secret
+
+- name: Fail if Secret is missing
+  ansible.builtin.assert:
+    that:
+      - clair_postgres_config_secret.resources | length > 0
+    fail_msg: "Validation Failed: Secret clairpostgres-config-secret was not found in namespace quay-enterprise."
+    success_msg: "Validation Passed: Secret clairpostgres-config-secret is present in namespace quay-enterprise."

--- a/operators/quay-operator/clair_validations.yaml
+++ b/operators/quay-operator/clair_validations.yaml
@@ -29,17 +29,3 @@
   fail:
     msg: "Required CPE mapping files are missing from /data in pod {{ clair_pod_name }}"
   when: cpe_file_check.rc != 0 or repo_map_check.rc != 0
-
-- name: Validate that Clair postgres config Secret exists
-  kubernetes.core.k8s_info:
-    kind: Secret
-    name: clairpostgres-config-secret
-    namespace: quay-enterprise
-  register: clair_postgres_config_secret
-
-- name: Fail if Secret is missing
-  ansible.builtin.assert:
-    that:
-      - clair_postgres_config_secret.resources | length > 0
-    fail_msg: "Validation Failed: Secret clairpostgres-config-secret was not found in namespace quay-enterprise."
-    success_msg: "Validation Passed: Secret clairpostgres-config-secret is present in namespace quay-enterprise."

--- a/operators/quay-operator/tasks.yaml
+++ b/operators/quay-operator/tasks.yaml
@@ -173,3 +173,7 @@
   when: disconnected | default(true)
   ansible.builtin.include_tasks:
     file: quay_disconnected_start.yaml
+
+- name: Clair validations
+  ansible.builtin.include_tasks:
+    file: clair_validations.yaml


### PR DESCRIPTION
we need a quay version that includes:
1. CPE files
```
$ podman run -it --entrypoint /bin/ls registry.redhat.io/quay/clair-rhel9:v3.17.1 -lah /data
total 2.9M
drwxr-xr-x. 1 root root  102 Apr  6 14:34 .
dr-xr-xr-x. 1 root root   24 Apr  9 08:56 ..
-rw-r--r--. 1 root root 101K Apr  6 14:31 container-name-repos-map.json
-rw-r--r--. 1 root root 2.8M Apr  6 14:31 repository-to-cpe.json
```
2. clair postgres config secret.

both should be included in 3.15.5 and missing from 3.15.3 (current version).

this PR also includes validations for both issues.