### PR TITLE
Require config/plugins/aap.yaml to be present for AAP plugin

### DIFF
--- a/plugins/aap/plugin.yaml
+++ b/plugins/aap/plugin.yaml
@@ -11,3 +11,8 @@ operators:
     namespace: ansible-aap
     csvNames:
       - aap-operator
+
+requires:
+  files:
+    - path: "../../config/plugins/aap.yaml"
+      description: "AAP user configuration"


### PR DESCRIPTION
Without this, the pipeline would silently skip validating the user config file that holds the required aapLicenseFile.

OSAC-922

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin configuration to include a required dependency declaration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->