### PR TITLE
Require config/plugins/vast-csi.yaml to be present for VAST CSI plugin

### DIFF
--- a/plugins/vast-csi/plugin.yaml
+++ b/plugins/vast-csi/plugin.yaml
@@ -19,6 +19,8 @@ requires:
       description: "VAST Quay storage configuration"
     - path: "tasks/create_tenant_manager.yaml"
       description: "VAST tenant manager creation tasks"
+    - path: "../../config/plugins/vast-csi.yaml"
+      description: "VAST CSI user configuration"
 
 clusterSelector:
   matchLabels:


### PR DESCRIPTION
Without this, the pipeline would silently skip validating the user config file that holds the required vastCSI credentials and VIP pool config.

related to OSAC-922
