### PR TITLE
move Mirrored catalogsource configuration ACM policy to operators

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -266,8 +266,7 @@ step_operators() {
 }
 
 step_day2() {
-    echo "Catalog source ACM policy .." | tee -a ${log}
-    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/06-day2.yaml $EXTRA_VARS --tags acm-policy-catalogsources
+    echo "Day2 operations .." | tee -a ${log}
     step_done
 }
 

--- a/playbooks/05-operators.yaml
+++ b/playbooks/05-operators.yaml
@@ -8,6 +8,7 @@
 #   Storage plugins (LVMS/ODF) run here, BEFORE core operators,
 #   so that Quay can rely on the storage backend being present.
 # - Install general operators from defaults/operators.yaml
+# - ACM policies for mirrored catalogsources (disconnected only)
 # - Auto-discover and deploy addon plugins (type: addon)
 #   Addon plugins (nvidia-gpu, openshift-ai, etc.) run AFTER core
 #   operators and Quay mirroring are complete.
@@ -76,6 +77,22 @@
               tags: operators
           vars:
             target_operators: "{{ operators | rejectattr('seed', 'sameas', true) | list }}"
+          tags: operators
+
+        - name: Mirrored catalogsource configuration ACM policy
+          when: disconnected | default(true)
+          vars:
+            short_version_dot: "{{ openshift_version.version.split('.')[:2] | join('.') }}"
+            short_version_dash: "{{ openshift_version.version.split('.')[:2] | join('-') }}"
+          ansible.builtin.include_tasks:
+            file: tasks/catalogsource.yaml
+            apply:
+              tags: operators
+              environment:
+                KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+          loop: "{{ openshift_versions }}"
+          loop_control:
+            loop_var: openshift_version
           tags: operators
 
         - name: Finish quay mirroring task while disconnected

--- a/playbooks/06-day2.yaml
+++ b/playbooks/06-day2.yaml
@@ -4,11 +4,9 @@
 #
 # Performs:
 # - Clair configuration for disconnected Quay (disconnected only)
-# - ACM policies for mirrored catalogsources (disconnected only)
 #
 # Usage:
 #   ansible-playbook playbooks/06-day2.yaml [-e disconnected=false]
-#   ansible-playbook playbooks/06-day2.yaml --tags acm-policy-catalogsources
 
 - name: Phase 6 - Day-2 operations
   hosts: localhost
@@ -57,22 +55,6 @@
               environment:
                 KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
           tags: acm-cis
-
-        - name: Mirrored catalogsource configuration ACM policy
-          when: disconnected | default(true)
-          vars:
-            short_version_dot: "{{ openshift_version.version.split('.')[:2] | join('.') }}"
-            short_version_dash: "{{ openshift_version.version.split('.')[:2] | join('-') }}"
-          ansible.builtin.include_tasks:
-            file: tasks/catalogsource.yaml
-            apply:
-              tags: acm-policy-catalogsources
-              environment:
-                KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
-          loop: "{{ openshift_versions }}"
-          loop_control:
-            loop_var: openshift_version
-          tags: acm-policy-catalogsources
 
         - name: Finish Quay configuration in disconnected environments
           when: disconnected | default(true)

--- a/scripts/verification/validate.sh
+++ b/scripts/verification/validate.sh
@@ -133,7 +133,7 @@ validate_tags() {
         "playbooks/04-post-install.yaml:post-install-config:Post-install configurations"
         "playbooks/05-operators.yaml:operators:Configure seed operators"
         "playbooks/05-operators.yaml:operators:Configure remaining operators"
-        "playbooks/06-day2.yaml:acm-policy-catalogsources:Mirrored catalogsource configuration ACM policy"
+        "playbooks/05-operators.yaml:operators:Mirrored catalogsource configuration ACM policy"
         "playbooks/validation/validate-schema.yaml:test-fixtures:Include defaults schema validation tasks"
         "playbooks/validation/validate-schema.yaml:validate-config:Include config schema validation tasks"
         "playbooks/validation/validate-mirror.yaml:mirror-validation:Include mirror validation tasks"


### PR DESCRIPTION
this step is currently executed as part of day 2 operations, but without it - core operators can not be installed on spoke clusters. moving it to be installed after operators.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized installation workflow to apply ACM catalog source policies during post-install phase rather than day-2 operations, simplifying the day-2 workflow to focus on Clair disconnected configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->