### PR TITLE
Deprecate plugins.defaults property

### DIFF
--- a/docs/PLUGIN_ARCHITECTURE.md
+++ b/docs/PLUGIN_ARCHITECTURE.md
@@ -11,7 +11,7 @@ A plugin is a directory under `plugins/` with a single descriptor and optional t
 ```
 plugins/lvms/
   plugin.yaml              <- the descriptor (required)
-  defaults.yaml            <- plugin defaults (optional; alternative to defaults: in plugin.yaml)
+  defaults.yaml            <- plugin defaults (optional)
   schemas/
     defaults.yaml          <- JSON Schema validating defaults.yaml (optional)
     config.yaml            <- JSON Schema validating config/plugins/lvms.yaml (optional)
@@ -73,7 +73,7 @@ registries:
 | `operators` | List of OLM operators to install. Each entry is passed to `configure_operator.yaml`. |
 | `installOperators` | Set to `false` to skip operator installation (mirror-only plugins). Defaults to `true`. |
 | `clusterSelector` | Label-matching expressions to identify and select specific managed clusters for deploying the plugin (using ACM policies). |
-| `defaults` | Variables loaded into Ansible scope before tasks run. Alternative to `defaults.yaml` — cannot use both. All top-level property names must be prefixed with the plugin name (e.g. `lvmsDefaults`, not just `Defaults`). |
+| `defaults` | Variables loaded into Ansible scope before tasks run. Alternative to `defaults.yaml` — cannot use both. All top-level property names must be prefixed with the plugin name (e.g. `lvmsDefaults`, not just `Defaults`). DO NOT USE, this property has been deprecated.|
 | `registries` | Registry mirror entries for MCE patching and `registries.conf`. |
 | `additionalImages` | Extra images to include in the plugin's oc-mirror image set. |
 | `blockedImages` | Images to exclude from mirroring (by tag, digest, or pattern). |
@@ -147,7 +147,7 @@ registries:
 
 ### `defaults.yaml`
 
-Plugin defaults live in `defaults.yaml` (alternative to the `defaults:` field in `plugin.yaml` — cannot use both):
+Plugin defaults live in `defaults.yaml`:
 
 ```yaml
 lvmsConfigDefaults:
@@ -190,7 +190,7 @@ These variables get loaded into Ansible scope before tasks run. The naming conve
       spec: "{{ _spec | from_yaml }}"
 ```
 
-After the operator is installed, this creates the LVMCluster CR using variables from `defaults`.
+After the operator is installed, this creates the LVMCluster CR using variables from `defaults.yaml`.
 
 ### `tasks/quay.yaml`
 
@@ -378,7 +378,7 @@ requires:
 
 1. Create `plugins/your-plugin/plugin.yaml` with `name` (must match the directory name) and `type`
 1. Add `operators` list if you need OLM operators
-1. Add `defaults.yaml` with your configurable parameters (or a `defaults:` field in `plugin.yaml` — not both). Prefix all top-level variable names with the plugin name (e.g. `yourPluginDefaults`, not just `defaults`).
+1. Add `defaults.yaml` with your configurable parameters. Prefix all top-level variable names with the plugin name (e.g. `yourPluginDefaults`, not just `defaults`).
 1. If your plugin needs user-provided deployment configuration, document the expected properties and provide `plugins/your-plugin/schemas/config.yaml`. Users put their values in `config/plugins/your-plugin.yaml`.
 1. Optionally add `plugins/your-plugin/schemas/defaults.yaml` to validate your defaults, with test fixtures under `plugins/your-plugin/test-fixtures/schemas/`.
 1. Add `registries` if disconnected mirroring is needed

--- a/plugins/example/defaults.yaml
+++ b/plugins/example/defaults.yaml
@@ -1,0 +1,2 @@
+---
+example_message: "Hello from example plugin"

--- a/plugins/example/plugin.yaml
+++ b/plugins/example/plugin.yaml
@@ -2,6 +2,3 @@
 name: example
 type: addon
 order: 999
-
-defaults:
-  example_message: "Hello from example plugin"

--- a/plugins/example/schemas/defaults.yaml
+++ b/plugins/example/schemas/defaults.yaml
@@ -1,0 +1,8 @@
+---
+"$schema": "http://json-schema.org/draft-07/schema"
+type: object
+additionalProperties: false
+properties:
+  example_message:
+    type: string
+    description: Message displayed by the example plugin deploy task.

--- a/plugins/example/test-fixtures/schemas/defaults/invalid/unknown-property.yaml
+++ b/plugins/example/test-fixtures/schemas/defaults/invalid/unknown-property.yaml
@@ -1,0 +1,5 @@
+---
+# Fixture: unknown top-level property
+# Expected failure: additionalProperties is false
+example_message: "Hello from example plugin"
+unknownField: this-should-fail

--- a/plugins/example/test-fixtures/schemas/defaults/valid/base.yaml
+++ b/plugins/example/test-fixtures/schemas/defaults/valid/base.yaml
@@ -1,0 +1,2 @@
+---
+example_message: "Hello from example plugin"

--- a/schemas/plugin.yaml
+++ b/schemas/plugin.yaml
@@ -247,7 +247,10 @@ properties:
       $ref: "#/definitions/helm_chart"
   defaults:
     type: object
-    description: Default variables loaded into Ansible scope before plugin tasks run.
+    description: |
+      Default variables loaded into Ansible scope before plugin tasks run.
+      This property has been DEPRECATED in favor of plugin defaults.yaml, and will
+      be removed from enclave in a future release.
   registries:
     type: array
     description: Registry mirror entries for MCE custom-registries patching.


### PR DESCRIPTION
It's been replaced by defaults.yaml file inside plugin.

related to OSAC-922

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated plugin architecture guide to standardize plugin default configuration practices.

* **Chores**
  * Reorganized example plugin to align with standardized defaults configuration and added schema validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->