### PR TITLE
[RFC] Multi-cluster support: Enable plugins to declare cluster requirements

### DIFF
--- a/plugins/aap/plugin.yaml
+++ b/plugins/aap/plugin.yaml
@@ -3,6 +3,10 @@ name: aap
 type: addon
 order: 103
 
+clusters:
+  - name: enclave-managed-aap
+    version: 4.20.21
+
 operators:
   - name: ansible-automation-platform-operator
     version: 2.5.0-0.1777407881


### PR DESCRIPTION
## Overview

This RFC proposes extending Enclave's architecture from managing a single management cluster to orchestrating multiple spoke clusters via ACM. This addresses the user journey gap identified in [this Slack discussion](https://redhat-internal.slack.com/archives/C0B7CM99EH5/p1780931313879079).

## Current State

Enclave today:
- Provisions a single management cluster (ACM + Quay + local services)
- Installs ACM policies that apply to **separately-provisioned** spoke clusters
- Leaves cluster creation as a manual day2 operation

This creates friction:
- Users must read documentation and manually provision clusters via ACM
- No unified experience from "install Enclave" to "use VMaaS/AI inference/etc."
- Questions the value proposition of the wizard (see Rom's feedback in thread)

## Proposed Change

Allow plugin descriptors to declare cluster requirements:

```yaml
# plugins/aap/plugin.yaml
clusters:
  - name: enclave-managed-aap
    version: 4.20.21

operators:
  - name: ansible-automation-platform-operator
    version: 2.5.0-0.1777407881
```

Enclave would:
1. **Provision** the cluster via ACM APIs (using ACM's lifecycle management)
2. **Apply** operators and policies to the cluster
3. **Manage** upgrades and scaling through ACM (not custom logic)

## Why This Matters

### 1. Complete User Journey
Instead of "I validated your hardware, you could install VMaaS, good luck!" the wizard delivers a working environment.

### 2. Scalability Architecture
As discussed in the thread, "one cluster will only scale so much." Workload-specific clusters enable:
- Dedicated compute for AI inference
- Isolated virtualization infrastructure  
- Independent scaling and upgrade windows
- Hub-of-hubs architecture for large deployments

### 3. Alignment with "Experience" Model
The openshift-ai plugin already uses ACM policies on labeled clusters. This extends that pattern to include the cluster provisioning step.

## Implementation Scope

### Schema Changes
- Update `schemas/plugin.yaml` to support optional `clusters` field
- Validate cluster declarations (name, version, sizing hints?)

### Provisioning Logic
- Generate ACM `ManagedCluster` and `ClusterDeployment` CRs from plugin declarations
- Orchestrate cluster creation before operator installation (respect `order` field)
- Handle cluster readiness checks

### Documentation
- Multi-cluster architecture guide
- Decision tree: when to use multiple clusters vs. single management cluster
- Migration path for existing single-cluster deployments

## Open Questions

1. **Sizing**: Should plugins declare cluster size (worker count, instance types)?
2. **Networking**: How do cross-cluster services discover each other?
3. **Management cluster**: Do operators with no `clusters` field still apply to the management cluster?
4. **Order semantics**: Does `order` now control cluster provisioning order AND operator installation order?
5. **Validation**: Should we validate that enough hardware exists for all declared clusters during early-validate phase?

## Alternatives Considered

### Alternative 1: Keep Enclave Focused on Management Cluster Only
**Pro**: Clear separation of concerns, simpler scope  
**Con**: Doesn't solve the user journey problem, manual cluster provisioning remains

### Alternative 2: Generate ACM CRs for Download
**Pro**: Gives users automation without Enclave "doing management"  
**Con**: Still manual, doesn't enable autonomous operation in disconnected environments

### Alternative 3: Separate Tool for Spoke Provisioning
**Pro**: Could layer OSAC or other UI on top  
**Con**: Introduces another tool, increases cognitive load

## Timeline

This is an **RFC for discussion**, not ready for merge. Next steps:

1. Gather feedback from stakeholders (Michael Hrivnak, Nick Carboni, Riccardo Piccoli, Rom Freiman)
2. Validate against M1 requirements (Liat's concern about VMaaS needing Virt cluster)
3. Prototype schema validation and ACM CR generation
4. Design validation phase for hardware capacity checks

## Related Work

- Plugin infrastructure refactor (#420, #448, #456, #457)
- OpenShift AI experience bundle (uses ACM policies on labeled clusters)
- AutoShift hub-of-hubs discussion (referenced in thread)

---

**This PR is intended for discussion only.** Please comment on:
- Architecture direction (should Enclave manage multiple clusters?)
- Implementation feasibility (can we deliver this for M1?)
- Alternative approaches we should consider

cc @mhrivnak @ncarboni @rpiccoli @rfreiman