### PR TITLE
Fix storage plugin config not loaded due to ordering in load-vars

### DIFF
--- a/playbooks/common/load-vars.yaml
+++ b/playbooks/common/load-vars.yaml
@@ -47,6 +47,10 @@
   loop_control:
     loop_var: config_file
 
+- name: Ensure storage plugin is in enabled_plugins
+  ansible.builtin.set_fact:
+    enabled_plugins: "{{ enabled_plugins | union([storage_plugin]) }}"
+
 - name: Find plugin directories
   ansible.builtin.find:
     paths: "{{ playbook_dir }}/../plugins"
@@ -71,10 +75,6 @@
   loop: "{{ r_plugin_config_stats.results | selectattr('stat.exists') | list }}"
   loop_control:
     label: "{{ item.stat.path | basename }}"
-
-- name: Ensure storage plugin is in enabled_plugins
-  ansible.builtin.set_fact:
-    enabled_plugins: "{{ enabled_plugins | union([storage_plugin]) }}"
 
 - name: Set Management cluster OpenShift version from default
   ansible.builtin.set_fact:


### PR DESCRIPTION
## Summary
- Move `storage_plugin` union into `enabled_plugins` **before** plugin config loading in `load-vars.yaml`
- Previously, `config/plugins/odf.yaml` was never loaded when `odf` was set via `storage_plugin` but not explicitly listed in `enabled_plugins`, leaving `odfExternalConfig` undefined
- The ODF deploy task silently skipped StorageCluster creation due to the undefined variable
- Users should not need to add the storage plugin to `enabled_plugins` — setting `storage_plugin` should be sufficient

## Root Cause
In `load-vars.yaml`, the plugin config loading filtered by `enabled_plugins`, but the `storage_plugin` union happened **after** that block. When `odf` was only set via `storage_plugin` and not in `enabled_plugins`, its config file was never read.

## Test plan
- [ ] Deploy with `storage_plugin: odf` and `odf` **not** in `enabled_plugins` — verify StorageCluster is created
- [ ] Deploy with `odf` explicitly in `enabled_plugins` — verify no regression
- [ ] Deploy with LVMS as `storage_plugin` — verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)