### PR TITLE
Remove redundant odfExternalConfig guard from ODF deploy

### DIFF
--- a/plugins/odf/tasks/deploy.yaml
+++ b/plugins/odf/tasks/deploy.yaml
@@ -1,67 +1,59 @@
-- name: Skip ODF external storage configuration when odfExternalConfig is not set
-  ansible.builtin.debug:
-    msg: "odfExternalConfig is not defined — skipping external StorageCluster creation"
-  when: odfExternalConfig is not defined
+- name: Ensure Secret is present
+  no_log: true
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: rook-ceph-external-cluster-details
+        namespace: openshift-storage
+      data:
+        external_cluster_details: "{{ odfExternalConfig | b64encode }}"
+      type: Opaque
+  register: r_odf_secret
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_odf_secret is success
 
-- name: Configure ODF external StorageCluster
-  when: odfExternalConfig is defined
-  block:
-    - name: Ensure Secret is present
-      no_log: true
-      kubernetes.core.k8s:
-        state: present
-        definition:
-          apiVersion: v1
-          kind: Secret
-          metadata:
-            name: rook-ceph-external-cluster-details
-            namespace: openshift-storage
-          data:
-            external_cluster_details: "{{ odfExternalConfig | b64encode }}"
-          type: Opaque
-      register: r_odf_secret
-      retries: "{{ k8s_retries }}"
-      delay: "{{ k8s_delay }}"
-      until: r_odf_secret is success
-
-    - name: Ensure StorageCluster is present
-      kubernetes.core.k8s:
-        state: present
-        definition:
-          apiVersion: ocs.openshift.io/v1
-          kind: StorageCluster
-          metadata:
-            name: ocs-external-storagecluster
-            namespace: openshift-storage
-          spec:
-            encryption: {}
-            externalStorage:
-              enable: true
-            labelSelector: {}
-            managedResources:
-              cephBlockPools:
-                defaultStorageClass: "{{ odfDefaults.defaultStorageClass }}"
-              cephFilesystems: {}
-              cephObjectStoreUsers:
-                reconcileStrategy: ignore
-              cephObjectStores:
-                reconcileStrategy: ignore
-      retries: "{{ k8s_retries }}"
-      delay: "{{ k8s_delay }}"
-      register: r_storagecluster
-      until: r_storagecluster is succeeded
-
-    - name: Wait for StorageCluster to be available
-      kubernetes.core.k8s_info:
-        api_version: ocs.openshift.io/v1
-        kind: StorageCluster
+- name: Ensure StorageCluster is present
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: ocs.openshift.io/v1
+      kind: StorageCluster
+      metadata:
         name: ocs-external-storagecluster
         namespace: openshift-storage
-        wait: true
-        wait_sleep: 10
-        wait_timeout: 600
-        wait_condition:
-          reason: ReconcileCompleted
-          status: "True"
-          type: Available
-      register: r_storage_cluster_info
+      spec:
+        encryption: {}
+        externalStorage:
+          enable: true
+        labelSelector: {}
+        managedResources:
+          cephBlockPools:
+            defaultStorageClass: "{{ odfDefaults.defaultStorageClass }}"
+          cephFilesystems: {}
+          cephObjectStoreUsers:
+            reconcileStrategy: ignore
+          cephObjectStores:
+            reconcileStrategy: ignore
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  register: r_storagecluster
+  until: r_storagecluster is succeeded
+
+- name: Wait for StorageCluster to be available
+  kubernetes.core.k8s_info:
+    api_version: ocs.openshift.io/v1
+    kind: StorageCluster
+    name: ocs-external-storagecluster
+    namespace: openshift-storage
+    wait: true
+    wait_sleep: 10
+    wait_timeout: 600
+    wait_condition:
+      reason: ReconcileCompleted
+      status: "True"
+      type: Available
+  register: r_storage_cluster_info


### PR DESCRIPTION
## Summary
- Remove the `when: odfExternalConfig is defined` conditional guard from ODF `tasks/deploy.yaml`
- `odfExternalConfig` is already validated as required by `plugins/odf/schemas/config.yaml` and the config file is enforced by `requires.files` in `plugin.yaml`
- The guard silently skipped StorageCluster creation when the variable was missing instead of failing loudly, making misconfigurations hard to diagnose

## Test plan
- [x] Deploy with `storage_plugin: odf` and valid `config/plugins/odf.yaml` — verify StorageCluster is created
- [x] Deploy with `storage_plugin: odf` and missing `config/plugins/odf.yaml` — verify plugin validation fails before reaching deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified ODF deployment configuration to always apply external cluster settings and storage resources without conditional skipping, ensuring consistent initialization of required components and improved status monitoring during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->