### PR TITLE
OSAC-1381: Fix htpasswd generation failure with special characters in password

### DIFF
--- a/playbooks/tasks/deploy_ironic.yaml
+++ b/playbooks/tasks/deploy_ironic.yaml
@@ -12,13 +12,10 @@
   ansible.builtin.set_fact:
     metal3_ironic_image: "{{ r_ironic_image.stdout }}"
 
-- name: Generate htpasswd hash for Ironic credentials
-  ansible.builtin.command:
-    argv:
-      - /usr/bin/htpasswd
-      - -nbB
-      - "{{ metal3_ironic_username }}"
-      - "{{ metal3_ironic_password }}"
+- name: Generate htpasswd hash for Ironic credentials  # noqa: command-instead-of-shell
+  # shell module required: quote filter produces shell-quoted strings that need shell parsing
+  ansible.builtin.shell:
+    cmd: /usr/bin/htpasswd -nbB {{ metal3_ironic_username | quote }} {{ metal3_ironic_password | quote }}
   register: r_htpasswd
   changed_when: false
   no_log: true


### PR DESCRIPTION
## Summary

Fixes Ironic API authentication failures (401 Unauthorized) caused by incorrect htpasswd generation when passwords contain special characters.

## Problem

Bootstrap deployment fails at the "Check if baremetal node already exists" task when the randomly-generated Metal3 Ironic password contains certain special characters (e.g., `#`, `@`, `\`, `}`, `/`, `~`, `=`).

**Error:**
```
TASK [Check if baremetal node already exists]
fatal: [localhost]: FAILED! =>
    msg: 'Status code was 401 and not [200, 404]: HTTP Error 401: Unauthorized'
    json:
        error:
            code: 401
            message: Incorrect username or password
```

## Root Cause

Commit [0eb46d5](https://github.com/rh-ecosystem-edge/enclave/commit/0eb46d5f8e178c07b12061bf88e8d4c02e763a67) (April 19, 2026) switched from `command` module to `argv` form to fix trailing backslash issues. However, the `argv` form does not properly handle complex special characters, causing htpasswd to receive mangled input and generate an incorrect hash that doesn't match the stored password.

**Timeline:**
- ❌ Not in release 0.1.0 (April 17, 2026) 
- ⚠️ Introduced in commit 0eb46d5 (April 19, 2026)
- ✅ Fixed by this PR

## Solution

Use `shell` module with Ansible's `quote` filter instead of `argv` form. The `quote` filter uses `shlex.quote()` to properly escape ALL special characters:

**Before:**
```yaml
ansible.builtin.command:
  argv:
    - /usr/bin/htpasswd
    - -nbB
    - "{{ metal3_ironic_username }}"
    - "{{ metal3_ironic_password }}"
```

**After:**
```yaml
ansible.builtin.shell:
  cmd: /usr/bin/htpasswd -nbB {{ metal3_ironic_username | quote }} {{ metal3_ironic_password | quote }}
```

This properly handles:
- ✅ Trailing backslashes (the original issue from 0eb46d5)
- ✅ Complex special characters like `#@\#}/~=` (the current issue)
- ✅ Spaces, quotes, and other edge cases

## Testing

Validated that `shlex.quote()` (which backs Ansible's `quote` filter) correctly handles the problematic password from the failing deployment: `#@Ny.MGr76\#}YPvm3W1Y/~=GdjQ0MQV`

## Related Issues

- Jira: [OSAC-1381](https://redhat.atlassian.net/browse/OSAC-1381)
- GoRI: [#915](https://github.com/gori-project/GoRI/issues/915)

## Checklist

- [x] Code follows project conventions
- [x] Commit message includes Jira ticket reference
- [x] Changes are minimal and focused on the fix
- [x] Root cause analysis documented

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the internal deployment process for Ironic credential generation, streamlining the implementation while maintaining the same functionality and security measures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->