### PR TITLE
[WIP] OSAC-1384: Fix operator-versions to approve InstallPlans on every poll iteration

### DIFF
--- a/src/enclave/reconcile/operator_versions.py
+++ b/src/enclave/reconcile/operator_versions.py
@@ -1,11 +1,11 @@
 import json
 import logging
+import time
 
 from enclave.utils import (
     log_subprocess_output,
     run_oc_command,
     semver_key,
-    wait_for_resource_status,
 )
 
 logger = logging.getLogger(__name__)
@@ -165,6 +165,66 @@ def approve_install_plans(
             )
 
 
+def approve_and_wait_for_csv(
+    dry_run: bool,
+    namespace: str,
+    op_version_map: dict[str, str],
+    csv_name: str,
+    csv_version: str,
+    *,
+    timeout_minutes: int = 30,
+    sleep_interval: int = 10,
+) -> None:
+    """Approve pending InstallPlans and poll until the target CSV reaches Succeeded.
+
+    Calls approve_install_plans on every iteration so that InstallPlans created
+    by OLM after an intermediate version installs are not missed by a single
+    upfront approval pass.
+    """
+    deadline = time.time() + timeout_minutes * 60
+    logger.info(
+        "Waiting for CSV %s.v%s in namespace %s to reach status.phase=Succeeded.",
+        csv_name,
+        csv_version,
+        namespace,
+    )
+    while True:
+        approve_install_plans(dry_run, namespace, op_version_map)
+        result = run_oc_command([
+            "oc",
+            "get",
+            "clusterserviceversion.operators.coreos.com",
+            f"{csv_name}.v{csv_version}",
+            "-n",
+            namespace,
+            "-o",
+            "jsonpath={.status.phase}",
+        ])
+        if result.returncode != 0:
+            log_subprocess_output(
+                f"oc get clusterserviceversion/{csv_name}.v{csv_version} failed"
+                f" (exit {result.returncode})",
+                result.stderr or "",
+            )
+            phase = ""
+        else:
+            phase = (result.stdout or "").strip()
+        if phase == "Succeeded":
+            logger.info(
+                "CSV %s.v%s in namespace %s reached status.phase=Succeeded.",
+                csv_name,
+                csv_version,
+                namespace,
+            )
+            return
+        if time.time() >= deadline:
+            raise TimeoutError(
+                f"CSV {csv_name}.v{csv_version} did not reach phase=Succeeded"
+                f" within {timeout_minutes} minutes (last observed: {phase!r})"
+            )
+        time.sleep(sleep_interval)
+
+
 def reconcile(
     version: str,
     namespace: str,
@@ -174,32 +234,20 @@ def reconcile(
     """Approve pending InstallPlans and wait for each CSV to reach Succeeded.
 
     Normalises the version string ('+' → '-') to match the format OLM uses
-    in CSV names, then delegates approval to approve_install_plans. For each
-    CSV, waits up to 30 minutes (polling every 10 s) for its phase to become
-    Succeeded. The wait is skipped in dry-run mode.
+    in CSV names, then delegates to approve_and_wait_for_csv per CSV.
+
+    Dry-run limitation: only the initial set of InstallPlans visible at call
+    time is inspected and logged; no approval is issued and the CSV wait is
+    skipped entirely. InstallPlans that OLM would create after each
+    intermediate version installs are therefore invisible in dry-run mode,
+    so the output does not reflect the full sequence of approvals a real run
+    would perform.
     """
     op_version_map = {csv: version.replace("+", "-") for csv in csv_names}
-    approve_install_plans(dry_run, namespace, op_version_map)
+    if dry_run:
+        approve_install_plans(dry_run, namespace, op_version_map)
+        return
     for csv_name, csv_version in op_version_map.items():
-        if not dry_run:
-            logger.info(
-                "Waiting for CSV %s.v%s in namespace %s to reach status.phase=Succeeded.",
-                csv_name,
-                csv_version,
-                namespace,
-            )
-            wait_for_resource_status(
-                "clusterserviceversion.operators.coreos.com",
-                f"{csv_name}.v{csv_version}",
-                "phase",
-                "Succeeded",
-                namespace=namespace,
-                timeout_minutes=30,
-                sleep_interval=10,
-            )
-            logger.info(
-                "CSV %s.v%s in namespace %s reached status.phase=Succeeded.",
-                csv_name,
-                csv_version,
-                namespace,
-            )
+        approve_and_wait_for_csv(
+            dry_run, namespace, op_version_map, csv_name, csv_version
+        )

--- a/src/tests/test_operator_versions.py
+++ b/src/tests/test_operator_versions.py
@@ -3,7 +3,11 @@ import json
 import pytest
 from pytest_mock import MockerFixture
 
-from enclave.reconcile.operator_versions import approve_install_plans, reconcile
+from enclave.reconcile.operator_versions import (
+    approve_and_wait_for_csv,
+    approve_install_plans,
+    reconcile,
+)
 from tests.fixtures import Fixtures, OcResultFactory
 
 fxt = Fixtures("operator_versions")
@@ -206,80 +210,127 @@ def test_approve_fixture_approves_when_at_desired(
 # ---------------------------------------------------------------------------
 
 
-def test_reconcile_calls_approve_and_wait(mocker: MockerFixture) -> None:
-    """reconcile calls approve_install_plans then waits for each CSV to reach Succeeded."""
-    mock_approve = mocker.patch(
-        "enclave.reconcile.operator_versions.approve_install_plans"
-    )
-    mock_wait = mocker.patch(
-        "enclave.reconcile.operator_versions.wait_for_resource_status"
-    )
+def test_reconcile_delegates_to_approve_and_wait_per_csv(mocker: MockerFixture) -> None:
+    """reconcile calls approve_and_wait_for_csv once per CSV with the right arguments."""
+    mock_aw = mocker.patch("enclave.reconcile.operator_versions.approve_and_wait_for_csv")
     dry_run = False
     reconcile("3.15.3", "quay-enterprise", ["quay-operator"], dry_run=dry_run)
-    mock_approve.assert_called_once_with(
+    mock_aw.assert_called_once_with(
         dry_run,
         "quay-enterprise",
         {"quay-operator": "3.15.3"},
-    )
-    mock_wait.assert_called_once_with(
-        "clusterserviceversion.operators.coreos.com",
-        "quay-operator.v3.15.3",
-        "phase",
-        "Succeeded",
-        namespace="quay-enterprise",
-        timeout_minutes=30,
-        sleep_interval=10,
+        "quay-operator",
+        "3.15.3",
     )
 
 
 def test_reconcile_dry_run_skips_wait(mocker: MockerFixture) -> None:
-    """In dry-run mode reconcile calls approve but never waits for CSV status."""
-    mocker.patch("enclave.reconcile.operator_versions.approve_install_plans")
-    mock_wait = mocker.patch(
-        "enclave.reconcile.operator_versions.wait_for_resource_status"
-    )
+    """In dry-run mode reconcile calls approve_install_plans once and skips the wait."""
+    mock_approve = mocker.patch("enclave.reconcile.operator_versions.approve_install_plans")
+    mock_aw = mocker.patch("enclave.reconcile.operator_versions.approve_and_wait_for_csv")
     reconcile("3.15.3", "quay-enterprise", ["quay-operator"], dry_run=True)
-    mock_wait.assert_not_called()
+    mock_approve.assert_called_once()
+    mock_aw.assert_not_called()
 
 
 def test_reconcile_replaces_plus_in_version(mocker: MockerFixture) -> None:
     """'+' in the version string is normalised to '-' before building CSV names."""
-    mock_approve = mocker.patch(
-        "enclave.reconcile.operator_versions.approve_install_plans"
-    )
-    mocker.patch("enclave.reconcile.operator_versions.wait_for_resource_status")
+    mock_aw = mocker.patch("enclave.reconcile.operator_versions.approve_and_wait_for_csv")
     dry_run = False
     reconcile(
         "4.20.0+202602261925", "metallb-system", ["metallb-operator"], dry_run=dry_run
     )
-    mock_approve.assert_called_once_with(
+    mock_aw.assert_called_once_with(
         dry_run,
         "metallb-system",
         {"metallb-operator": "4.20.0-202602261925"},
+        "metallb-operator",
+        "4.20.0-202602261925",
     )
+
+
+def test_approve_and_wait_approves_intermediate_then_target(
+    mocker: MockerFixture, oc_result: OcResultFactory
+) -> None:
+    """When OLM requires stepping through 2.10.2 before 2.10.3, approve_and_wait_for_csv must approve both.
+
+    The 2.10.3 plan is created by OLM only after 2.10.2 installs, so approve_install_plans
+    is called on every poll iteration.
+    """
+    intermediate_plan = _plan(
+        "ip-intermediate", "RequiresApproval", ["my-operator.v2.10.2"]
+    )
+    target_plan = _plan("ip-target", "RequiresApproval", ["my-operator.v2.10.3"])
+    mock_run = mocker.patch(
+        "enclave.reconcile.operator_versions.run_oc_command",
+        side_effect=[
+            oc_result(
+                stdout=json.dumps({"items": [intermediate_plan]})
+            ),  # get plans (iter 1)
+            oc_result(stdout="patched"),  # patch ip-intermediate
+            oc_result(stdout="Installing"),  # get CSV phase → not done
+            oc_result(
+                stdout=json.dumps({"items": [target_plan]})
+            ),  # get plans (iter 2)
+            oc_result(stdout="patched"),  # patch ip-target
+            oc_result(stdout="Succeeded"),  # get CSV phase → done
+        ],
+    )
+    mocker.patch("enclave.reconcile.operator_versions.time.sleep")
+
+    dry_run = False
+    approve_and_wait_for_csv(
+        dry_run, "test-ns", {"my-operator": "2.10.3"}, "my-operator", "2.10.3"
+    )
+
+    def contains(cmd: list[str], *substrings: str) -> bool:
+        return all(any(s in part for part in cmd) for s in substrings)
+
+    cmds = [call.args[0] for call in mock_run.call_args_list]
+    assert contains(cmds[0], "get", "installplan")
+    assert contains(cmds[1], "patch", "ip-intermediate")
+    assert contains(cmds[2], "get", "clusterserviceversion")
+    assert contains(cmds[3], "get", "installplan")
+    assert contains(cmds[4], "patch", "ip-target")
+    assert contains(cmds[5], "get", "clusterserviceversion")
+
+
+def test_approve_and_wait_raises_on_timeout(
+    mocker: MockerFixture, oc_result: OcResultFactory
+) -> None:
+    """approve_and_wait_for_csv raises TimeoutError when CSV never reaches Succeeded."""
+    plan = _plan("ip-abc", "RequiresApproval", ["my-operator.v1.0.0"])
+    mocker.patch(
+        "enclave.reconcile.operator_versions.run_oc_command",
+        side_effect=[
+            oc_result(stdout=json.dumps({"items": [plan]})),
+            oc_result(stdout="patched"),
+            oc_result(stdout="Installing"),
+        ],
+    )
+    mocker.patch("enclave.reconcile.operator_versions.time.sleep")
+    mocker.patch("enclave.reconcile.operator_versions.time.time", side_effect=[0.0, 9999.0])
+
+    dry_run = False
+    with pytest.raises(TimeoutError, match=r"my-operator\.v1\.0\.0"):
+        approve_and_wait_for_csv(
+            dry_run, "test-ns", {"my-operator": "1.0.0"}, "my-operator", "1.0.0"
+        )
 
 
 def test_reconcile_multiple_csv_names(mocker: MockerFixture) -> None:
-    """When multiple CSV names are given, approve is called once and wait is called per CSV."""
-    mock_approve = mocker.patch(
-        "enclave.reconcile.operator_versions.approve_install_plans"
-    )
-    mock_wait = mocker.patch(
-        "enclave.reconcile.operator_versions.wait_for_resource_status"
-    )
-    dry_run = False
+    """When multiple CSV names are given, approve_and_wait_for_csv is called once per CSV."""
+    mock_aw = mocker.patch("enclave.reconcile.operator_versions.approve_and_wait_for_csv")
+    op_version_map = {"update-service-operator": "5.0.3", "another-csv": "5.0.3"}
     reconcile(
         "5.0.3",
         "openshift-update-service",
         ["update-service-operator", "another-csv"],
-        dry_run=dry_run,
+        dry_run=False,
     )
-    mock_approve.assert_called_once_with(
-        dry_run,
-        "openshift-update-service",
-        {"update-service-operator": "5.0.3", "another-csv": "5.0.3"},
-    )
-    assert mock_wait.call_count == 2
-    called_names = [c.args[1] for c in mock_wait.call_args_list]
-    assert "update-service-operator.v5.0.3" in called_names
-    assert "another-csv.v5.0.3" in called_names
+    assert mock_aw.call_count == 2
+    called_csv_names = [c.args[3] for c in mock_aw.call_args_list]
+    assert "update-service-operator" in called_csv_names
+    assert "another-csv" in called_csv_names
+    for call in mock_aw.call_args_list:
+        assert call.args[2] == op_version_map


### PR DESCRIPTION
When upgrading across multiple versions, OLM may not create all InstallPlans upfront — depending on the channel's skips graph, intermediate InstallPlans can appear only after earlier versions finish installing. The previous implementation called approve_install_plans once upfront then blocked in wait_for_resource_status, so any InstallPlan that did not exist at that moment was never approved.

Replace wait_for_resource_status with a new approve_and_wait_for_csv function that calls approve_install_plans on every poll iteration before checking the target CSV phase, ensuring no InstallPlan is missed regardless of when OLM creates it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test coverage for operator version reconciliation, including new assertions for approval workflow and timeout scenarios.

* **Bug Fixes**
  * Enhanced operator approval process with improved handling of install plan approval and timeout detection during status transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->