### PR TITLE
Add connected_auto property for operators to enable automatic approval when not disconnected

### DIFF
--- a/defaults/operators.yaml
+++ b/defaults/operators.yaml
@@ -13,6 +13,7 @@ operators:
     init_version: 2.10.0
     namespace: multicluster-engine
     seed: true
+    connected_auto: true
 
   - name: advanced-cluster-management
     version: 2.15.3

--- a/operators/advanced-cluster-management/configure_mch.yaml
+++ b/operators/advanced-cluster-management/configure_mch.yaml
@@ -13,11 +13,11 @@
 - name: Set MCE subscription spec for connected
   when: not (disconnected | default(true) | bool)
   vars:
-    _mce_operator: "{{ operators | selectattr('name', 'equalto', 'multicluster-engine') | first }}"
+    _mce_operator: "{{ (operators | selectattr('name', 'equalto', 'multicluster-engine') | list)[0] | default({}) }}"
     _mce_use_automatic: "{{ _mce_operator.connected_auto | default(false) | bool }}"
   ansible.builtin.set_fact:
     mce_subscription_spec:
-      installPlanApproval: "{{ 'Automatic' if _mce_use_automatic else 'Manual' }}"
+      installPlanApproval: "{{ 'Automatic' if (_mce_use_automatic | bool) else 'Manual' }}"
 
 - name: Ensure RHACM MultiClusterHub is present with MCE subscription spec
   kubernetes.core.k8s:

--- a/operators/advanced-cluster-management/configure_mch.yaml
+++ b/operators/advanced-cluster-management/configure_mch.yaml
@@ -12,9 +12,12 @@
 
 - name: Set MCE subscription spec for connected
   when: not (disconnected | default(true) | bool)
+  vars:
+    _mce_operator: "{{ operators | selectattr('name', 'equalto', 'multicluster-engine') | first }}"
+    _mce_use_automatic: "{{ _mce_operator.connected_auto | default(false) | bool }}"
   ansible.builtin.set_fact:
     mce_subscription_spec:
-      installPlanApproval: Manual
+      installPlanApproval: "{{ 'Automatic' if _mce_use_automatic else 'Manual' }}"
 
 - name: Ensure RHACM MultiClusterHub is present with MCE subscription spec
   kubernetes.core.k8s:

--- a/playbooks/tasks/configure_operator.yaml
+++ b/playbooks/tasks/configure_operator.yaml
@@ -75,10 +75,14 @@
     namespace: "{{ operator.namespace }}"
   register: r_sub_check
 
+- name: "Determine if operator should use automatic approval (not in disconnected)"
+  ansible.builtin.set_fact:
+    _use_automatic_approval: "{{ operator.connected_auto | default(false) and not (disconnected | default(true) | bool) }}"
+
 - name: "Ensure Subscription exists (Automatic)"
   when:
     - r_sub_check.resources | length == 0
-    - operator.namespace == "openshift-operators"
+    - operator.namespace == "openshift-operators" or _use_automatic_approval
   kubernetes.core.k8s:
     state: present
     definition:
@@ -102,6 +106,7 @@
   when:
     - r_sub_check.resources | length == 0
     - operator.namespace != "openshift-operators"
+    - not _use_automatic_approval
   kubernetes.core.k8s:
     state: present
     definition:

--- a/playbooks/tasks/configure_operator.yaml
+++ b/playbooks/tasks/configure_operator.yaml
@@ -75,14 +75,16 @@
     namespace: "{{ operator.namespace }}"
   register: r_sub_check
 
-- name: "Determine if operator should use automatic approval (not in disconnected)"
+- name: "Determine if operator should use automatic approval"
   ansible.builtin.set_fact:
-    _use_automatic_approval: "{{ operator.connected_auto | default(false) and not (disconnected | default(true) | bool) }}"
+    _use_automatic_approval: >-
+      {{ operator.namespace == "openshift-operators" or
+         (operator.connected_auto | default(false) | bool and not (disconnected | default(true) | bool)) }}
 
 - name: "Ensure Subscription exists (Automatic)"
   when:
     - r_sub_check.resources | length == 0
-    - operator.namespace == "openshift-operators" or _use_automatic_approval
+    - _use_automatic_approval | bool
   kubernetes.core.k8s:
     state: present
     definition:
@@ -105,8 +107,7 @@
 - name: "Ensure Subscription exists (Manual)"
   when:
     - r_sub_check.resources | length == 0
-    - operator.namespace != "openshift-operators"
-    - not _use_automatic_approval
+    - not (_use_automatic_approval | bool)
   kubernetes.core.k8s:
     state: present
     definition:
@@ -130,7 +131,7 @@
 - name: "Wait for Install Plan ({{ operator.name }})"
   when:
     - r_sub_check.resources | length == 0
-    - operator.namespace != "openshift-operators"
+    - not (_use_automatic_approval | bool)
   kubernetes.core.k8s_info:
     api_version: operators.coreos.com/v1alpha1
     kind: Subscription
@@ -146,7 +147,7 @@
 - name: "Approve Install Plan ({{ operator.name }})"
   when:
     - r_sub_check.resources | length == 0
-    - operator.namespace != "openshift-operators"
+    - not (_use_automatic_approval | bool)
   ansible.builtin.shell: |
     enclave reconcile operator-versions \
       --name "{{ operator.name }}" \
@@ -159,14 +160,14 @@
 - name: Print Install Plan approval output ({{ operator.name }})
   when:
     - r_sub_check.resources | length == 0
-    - operator.namespace != "openshift-operators"
+    - not (_use_automatic_approval | bool)
   ansible.builtin.debug:
     var: operator_update_result.stderr_lines
 
 - name: "Get Installed CSV ({{ operator.name }})"
   when:
     - r_sub_check.resources | length == 0
-    - operator.namespace == "openshift-operators"
+    - _use_automatic_approval | bool
   kubernetes.core.k8s_info:
     api_version: operators.coreos.com/v1alpha1
     kind: Subscription
@@ -182,7 +183,7 @@
 - name: "Wait until CSV is installed"
   when:
     - r_sub_check.resources | length == 0
-    - operator.namespace == "openshift-operators"
+    - _use_automatic_approval | bool
   kubernetes.core.k8s_info:
     api_version: operators.coreos.com/v1alpha1
     kind: ClusterServiceVersion

--- a/schemas/operators.yaml
+++ b/schemas/operators.yaml
@@ -44,6 +44,9 @@ definitions:
       seed:
         type: boolean
         description: Seed operators are deployed before anything else.
+      connected_auto:
+        type: boolean
+        description: Use automatic install plan approval when not disconnected.
     dependencies:
       csvMirror:
       - csvNames


### PR DESCRIPTION
## Summary
This change introduces a new `connected_auto` property for operators that enables automatic install plan approval when the environment is not disconnected.

## Changes
- Added `connected_auto: true` to multicluster-engine operator in `defaults/operators.yaml`
- Updated `schemas/operators.yaml` to include the new boolean property with validation
- Modified `playbooks/tasks/configure_operator.yaml` to:
  - Extract approval logic to `_use_automatic_approval` variable
  - Use Automatic approval when operator has `connected_auto: true` and not disconnected
  - Maintain Manual approval for all other cases

## How it works
- When `disconnected: false` and operator has `connected_auto: true`, the operator subscription uses `installPlanApproval: Automatic`
- Otherwise, operators in custom namespaces use `installPlanApproval: Manual` (existing behavior)
- Operators in `openshift-operators` namespace always use `Automatic` (existing behavior)

## Extensibility
This approach is extensible - any operator can set `connected_auto: true` in the future to get automatic approval when connected, while maintaining the current Manual behavior in disconnected environments.

## Note
This is a workaround proposal to replace PR #467. We should pursue a bug with the ACM team for a proper fix, but this provides a flexible solution in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)