### PR TITLE
Always reinstall enclave python code

### DIFF
--- a/setup_ansible.sh
+++ b/setup_ansible.sh
@@ -13,7 +13,9 @@ curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" -o "$UV_INSTALLER"
 UV_UNMANAGED_INSTALL="$UV_PREFIX/bin" sh "$UV_INSTALLER"
 rm -f "$UV_INSTALLER"
 
-"$UV_PREFIX/bin/uv" tool install . --with-executables-from ansible-core
+"$UV_PREFIX/bin/uv" tool install . \
+    --with-executables-from ansible-core \
+    --reinstall-package enclave
 
 # Download Ansible Collections to check the checksum
 # Check if the 'collections' directory exists and has files in it


### PR DESCRIPTION
Or we would need to maintain the version in pyproject.toml to make sure uv always installs the last thing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved setup script to ensure proper package installation and reinstallation during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->