### PR TITLE
Fix race condition in addon plugin mirroring to Quay Enterprise

### DIFF
--- a/operators/quay-operator/quay_disconnected_finish.yaml
+++ b/operators/quay-operator/quay_disconnected_finish.yaml
@@ -27,3 +27,6 @@
       | bool
     )
     and not (mirror_dry_run | default(false) | bool)
+
+- name: Wait for Quay to stabilize before addon plugin mirroring
+  ansible.builtin.include_tasks: wait_quay_app_ready.yaml

--- a/operators/quay-operator/wait_quay_app_ready.yaml
+++ b/operators/quay-operator/wait_quay_app_ready.yaml
@@ -1,0 +1,50 @@
+---
+# Wait for quay-app Deployment to be fully ready and stable.
+# This task ensures all quay-app replicas are updated, ready, and available
+# before proceeding with operations that depend on Quay being responsive.
+#
+# Context: After heavy mirroring operations, Quay may need time to stabilize.
+# This wait prevents race conditions where subsequent oc-mirror operations
+# fail with 503 or authentication errors.
+#
+# Called from:
+# - quay_disconnected_finish.yaml (ensures Quay is stable before addon plugin mirroring)
+
+- name: Wait for quay-app Deployment to be ready
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: registry-quay-app
+    namespace: quay-enterprise
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  register: r_quay_app_deployment
+  retries: 60
+  delay: 10
+  until:
+    - r_quay_app_deployment.resources is defined
+    - r_quay_app_deployment.resources | length > 0
+    - r_quay_app_deployment.resources[0].status is defined
+    - r_quay_app_deployment.resources[0].status.observedGeneration is defined
+    - r_quay_app_deployment.resources[0].status.observedGeneration == r_quay_app_deployment.resources[0].metadata.generation
+    - r_quay_app_deployment.resources[0].status.updatedReplicas | default(0) == r_quay_app_deployment.resources[0].status.replicas | default(0)
+    - r_quay_app_deployment.resources[0].status.readyReplicas | default(0) == r_quay_app_deployment.resources[0].status.replicas | default(0)
+    - r_quay_app_deployment.resources[0].status.availableReplicas | default(0) == r_quay_app_deployment.resources[0].status.replicas | default(0)
+    - r_quay_app_deployment.resources[0].status.unavailableReplicas | default(0) == 0
+
+- name: Verify Quay API health endpoint responds
+  ansible.builtin.uri:
+    url: "https://registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/health/instance"
+    method: GET
+    validate_certs: false
+    return_content: yes
+    status_code:
+      - 200
+  register: r_quay_health
+  retries: 12
+  delay: 5
+  until: r_quay_health.status == 200
+
+- name: Display Quay readiness status
+  ansible.builtin.debug:
+    msg: "Quay Enterprise is ready - {{ r_quay_app_deployment.resources[0].status.readyReplicas }}/{{ r_quay_app_deployment.resources[0].status.replicas }} replicas ready, API responding"


### PR DESCRIPTION
## Problem

During `bootstrap.sh` execution, addon plugins (especially openshift-ai) fail to mirror images to Quay Enterprise with errors:
- `503 Service Unavailable`
- `unable to retrieve auth token: invalid username/password`

This occurs when addon plugin mirroring starts immediately after core operator mirroring completes, while Quay is still under load or experiencing pod restarts.

## Root Cause

The `quay_disconnected_finish.yaml` task waits for the async core operator mirroring to complete, but does not verify that Quay is actually ready to handle additional mirroring workloads. The QuayRegistry "Available" status only confirms the CR is deployed, not that the API is stable and responsive.

## Solution

Added a comprehensive Quay readiness check at the end of `quay_disconnected_finish.yaml`:

### Files Changed

**1. `operators/quay-operator/wait_quay_app_ready.yaml`** (NEW)
- Reusable task that waits for Quay to be fully ready
- Checks:
  - quay-app Deployment: all replicas updated, ready, available, no unavailable replicas
  - Quay API `/health/instance` endpoint returns 200 OK

**2. `operators/quay-operator/quay_disconnected_finish.yaml`** (MODIFIED)
- Added call to `wait_quay_app_ready.yaml` at the end of the finish phase
- Ensures Quay is stable before addon plugins start mirroring

## Impact

This ensures Quay is stable before addon plugin mirroring begins, eliminating the race condition that causes intermittent failures.

## Testing

Should be tested with:
```yaml
enabled_plugins: ['odf', 'openshift-ai', 'nvidia-gpu']
```

Verify that bootstrap completes without 503 or authentication errors during addon plugin mirroring.

## Related

- Fixes https://github.com/gori-project/GoRI/issues/911
- Component: Enclave
- Type: Bug Fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Quay application stabilization by adding a wait mechanism that ensures the Quay service is fully ready and health-checked before proceeding with subsequent operations in disconnected environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->