### PR TITLE
do not auto-deploy addon plugins

### DIFF
--- a/playbooks/05-operators.yaml
+++ b/playbooks/05-operators.yaml
@@ -85,17 +85,3 @@
             apply:
               tags: operators
           tags: operators
-
-        - name: Auto-discover and deploy addon plugins
-          ansible.builtin.include_tasks:
-            file: tasks/deploy_plugins.yaml
-            apply:
-              tags:
-                - addon-plugins
-                - operators
-          vars:
-            plugin_type: addon
-            plugin_mirror: true
-          tags:
-            - addon-plugins
-            - operators


### PR DESCRIPTION
introduced in #357, this functionality is not performing as expected.

this was tested in #474: https://github.com/rh-ecosystem-edge/enclave/actions/runs/27323271783/job/80718919973?pr=474

this is a temporary removal as we want to support this feature.