### PR TITLE
Download clairctl as part of clair-import plugin

### DIFF
--- a/defaults/control_binaries.yaml
+++ b/defaults/control_binaries.yaml
@@ -12,6 +12,3 @@ control_binaries:
   oc_mirror:
     url: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.20.15/oc-mirror.tar.gz"
     checksum: "sha256:59791d2e6b84ee380bc6a180e4e5e2006590ca1e0f146b0176819386e11e26d1"
-  clairctl:
-    url: "https://github.com/quay/clair/releases/download/v4.8.0/clairctl-linux-amd64"
-    checksum: "sha256:eec1311f5e68165b49c8b4d024c83fc46285bdca2f37e756becf21d534551434"

--- a/playbooks/tasks/download_control_binaries.yaml
+++ b/playbooks/tasks/download_control_binaries.yaml
@@ -66,10 +66,3 @@
   ansible.builtin.file:
     path: "{{ workingDir }}/bin/oc-mirror"
     mode: "0755"
-
-- name: Download clairctl
-  ansible.builtin.get_url:
-    url: "{{ control_binaries.clairctl.url }}"
-    dest: "{{ workingDir }}/bin/clairctl"
-    checksum: "{{ control_binaries.clairctl.checksum }}"
-    mode: "0750"

--- a/plugins/clair-import/defaults.yaml
+++ b/plugins/clair-import/defaults.yaml
@@ -1,0 +1,3 @@
+---
+clairImportClairctlUrl: "https://github.com/quay/clair/releases/download/v4.8.0/clairctl-linux-amd64"
+clairImportClairctlChecksum: "sha256:eec1311f5e68165b49c8b4d024c83fc46285bdca2f37e756becf21d534551434"

--- a/plugins/clair-import/schemas/defaults.yaml
+++ b/plugins/clair-import/schemas/defaults.yaml
@@ -1,0 +1,15 @@
+---
+"$schema": "http://json-schema.org/draft-07/schema"
+type: object
+additionalProperties: false
+properties:
+  clairImportClairctlUrl:
+    "$ref": "#/definitions/httpUrl"
+    description: URL to download the clairctl binary.
+  clairImportClairctlChecksum:
+    type: string
+    pattern: "^sha256:[0-9a-f]{64}$"
+    description: SHA256 checksum for the clairctl binary.
+required:
+  - clairImportClairctlUrl
+  - clairImportClairctlChecksum

--- a/plugins/clair-import/tasks/pre-validate.yaml
+++ b/plugins/clair-import/tasks/pre-validate.yaml
@@ -1,3 +1,15 @@
+- name: Ensure {{ workingDir }}/bin/ exists
+  ansible.builtin.file:
+    path: "{{ workingDir }}/bin/"
+    state: directory
+
+- name: Download clairctl
+  ansible.builtin.get_url:
+    url: "{{ clairImportClairctlUrl }}"
+    dest: "{{ workingDir }}/bin/clairctl"
+    checksum: "{{ clairImportClairctlChecksum }}"
+    mode: "0750"
+
 - name: Verify clairctl binary is present
   ansible.builtin.stat:
     path: "{{ workingDir }}/bin/clairctl"

--- a/plugins/clair-import/test-fixtures/schemas/defaults/invalid/unknown-property.yaml
+++ b/plugins/clair-import/test-fixtures/schemas/defaults/invalid/unknown-property.yaml
@@ -1,0 +1,6 @@
+---
+# Fixture: unknown top-level property
+# Expected failure: additionalProperties is false
+clairImportClairctlUrl: "https://github.com/quay/clair/releases/download/v4.8.0/clairctl-linux-amd64"
+clairImportClairctlChecksum: "sha256:eec1311f5e68165b49c8b4d024c83fc46285bdca2f37e756becf21d534551434"
+unknownField: this-should-fail

--- a/plugins/clair-import/test-fixtures/schemas/defaults/valid/base.yaml
+++ b/plugins/clair-import/test-fixtures/schemas/defaults/valid/base.yaml
@@ -1,0 +1,3 @@
+---
+clairImportClairctlUrl: "https://github.com/quay/clair/releases/download/v4.8.0/clairctl-linux-amd64"
+clairImportClairctlChecksum: "sha256:eec1311f5e68165b49c8b4d024c83fc46285bdca2f37e756becf21d534551434"

--- a/schemas/control_binaries.yaml
+++ b/schemas/control_binaries.yaml
@@ -65,20 +65,6 @@ properties:
         - url
         - checksum
         additionalProperties: false
-      clairctl:
-        type: object
-        properties:
-          url:
-            type: string
-            description: URL to download clairctl binary.
-          checksum:
-            type: string
-            description: SHA256 checksum for the binary.
-            pattern: "^sha256:[0-9a-f]{64}$"
-        required:
-        - url
-        - checksum
-        additionalProperties: false
     additionalProperties: false
 required:
 - control_binaries


### PR DESCRIPTION
It's actually the only place where it is needed, so no need to download it always.

OSAC-1355

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Updates**
  * Reorganized clairctl binary configuration from global control binaries to plugin-specific management
  * Clairctl download URL and checksum now configurable per deployment

* **Tests**
  * Added validation test fixtures for clair-import plugin defaults
<!-- end of auto-generated comment: release notes by coderabbit.ai -->