### PR TITLE
Harden Ironic password generation and always regenerate htpasswd

### DIFF
--- a/playbooks/tasks/deploy_ironic.yaml
+++ b/playbooks/tasks/deploy_ironic.yaml
@@ -31,7 +31,7 @@
     name: metal3-ironic-htpasswd
     data: "{{ metal3_ironic_htpasswd }}"
     state: present
-    force: false
+    force: true
   no_log: true
 
 - name: Check if SSL certificates are configured

--- a/playbooks/tasks/deploy_metal3_common.yaml
+++ b/playbooks/tasks/deploy_metal3_common.yaml
@@ -25,7 +25,7 @@
 
 - name: Generate random ironic password if secret doesn't exist
   ansible.builtin.set_fact:
-    metal3_ironic_password: "{{ lookup('password', '/dev/null chars=ascii_letters,digits,punctuation length=32') }}"
+    metal3_ironic_password: "{{ lookup('password', '/dev/null chars=ascii_letters,digits length=48') }}"
   when: r_password_secret_check.rc != 0
   no_log: true
 


### PR DESCRIPTION
Users report Ironic 401 errors caused by a mismatch between the stored password and its htpasswd hash. The randomly generated password uses punctuation characters ($, !, \, ', etc.) that are fragile across Ansible module boundaries — the command module's expand_argument_vars and shell quoting can silently mangle these characters during htpasswd generation, producing a hash that doesn't match the original password.

Remove the risk entirely by restricting the password charset to ascii_letters and digits, increasing length from 32 to 48 to compensate (~285 bits entropy, well above the ~198 bits from 32 mixed chars). Existing passwords are unaffected since generation only runs when the secret doesn't already exist.

Additionally, change the htpasswd secret from force: false to force: true. The htpasswd hash is derived data — not a source of truth like the password itself — so it should always be regenerated from the current credentials. With force: false, a broken hash from a prior run would persist across code updates and re-runs, preventing self-healing.