### PR TITLE
Skip dev-scripts release image lookup in CI

### DIFF
--- a/scripts/setup/configure_devscripts.sh
+++ b/scripts/setup/configure_devscripts.sh
@@ -229,6 +229,9 @@ export MIRROR_IMAGES="false"
 # Libvirt firmware (UEFI)
 export LIBVIRT_FIRMWARE="uefi"
 
+# Skip dev-scripts release image lookup (enclave uses its own install flow)
+export OPENSHIFT_RELEASE_IMAGE="unused"
+
 # =============================================================================
 # Environment Info
 # =============================================================================


### PR DESCRIPTION
## Summary

- Set `OPENSHIFT_RELEASE_IMAGE="unused"` in the generated dev-scripts config to skip the nightly release image lookup
- Dev-scripts' `common.sh` recently bumped its default `OPENSHIFT_RELEASE_STREAM` from `4.22` to `5.0`, and the 5.0 nightly image is intermittently unavailable, breaking CI at the `make infra_only` step
- Enclave only uses dev-scripts for VM and network provisioning (`make infra_only`) — OCP installation is handled by enclave's own deployment flow, so the release image is never consumed

## Test plan

- [ ] CI E2E jobs pass without the nightly image lookup


Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment configuration to include the `OPENSHIFT_RELEASE_IMAGE` environment variable in the dev-scripts setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->