### PR TITLE
OSAC-955: Add OSAC plugin with chart-managed AAP

### DIFF
--- a/config/plugins/osac.example.yaml
+++ b/config/plugins/osac.example.yaml
@@ -1,0 +1,17 @@
+---
+##############################################################################
+# OSAC PLUGIN CONFIGURATION TEMPLATE
+# Instructions: Copy this file to 'config/plugins/osac.yaml' and set values.
+# Required when the osac plugin is enabled.
+##############################################################################
+
+# Required: path to AAP license manifest.zip file on the Landing Zone.
+# Obtain from: https://access.redhat.com/management/subscription_allocations
+# osacAapLicenseFile: "/path/to/aap-license.zip"
+
+# Optional: deployment profile (default: development)
+# osacProfile: development   # Options: development, vmaas, caas
+
+# Optional: bring your own database
+# osacBYODatabase: true
+# osacDatabaseUrl: "postgres://user@host:5432/dbname?sslmode=require"

--- a/docs/OSAC_DEPLOYMENT.md
+++ b/docs/OSAC_DEPLOYMENT.md
@@ -1,0 +1,237 @@
+# OSAC Day-2 Deployment Guide
+
+This guide describes how to deploy the Open Sovereign AI Cloud (OSAC) stack as day-2 addon plugins on an existing Enclave cluster.
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Prerequisites](#prerequisites)
+3. [Configuration](#configuration)
+4. [Deployment](#deployment)
+5. [Verification](#verification)
+6. [BYO Database](#byo-database)
+7. [Profiles](#profiles)
+8. [Post-Install Steps](#post-install-steps)
+9. [Troubleshooting](#troubleshooting)
+
+## Overview
+
+OSAC is deployed as a set of Enclave plugins that are installed sequentially. Each plugin handles its own operator installation, resource creation, and validation.
+
+| Plugin | Order | Purpose |
+|--------|-------|---------|
+| `trust-manager` | 100 | cert-manager ClusterIssuer and CA bundle sync |
+| `rhbk` | 101 | Red Hat Build of Keycloak (identity provider) |
+| `authorino` | 102 | gRPC authorization operator |
+| `aap` | 103 | AAP operator installation (provides CRDs for the OSAC chart) |
+| `cnv` | 104 | OpenShift Virtualization (optional, for VMaaS) |
+| `osac` | 200 | OSAC fulfillment service, operator, chart-managed AAP instance, bootstrap |
+
+The `aap` plugin installs the AAP operator and waits for it to be available (no configuration required). The `osac` plugin then deploys the OSAC Helm chart, which creates its own AAP instance (`osac-aap`) in the `osac` namespace.
+
+### What Gets Deployed
+
+After a successful deployment, the `osac` namespace contains:
+
+- **Fulfillment service**: grpc-server, rest-gateway, controller, ingress-proxy
+- **OSAC operator**: manages tenant, networking, compute, and cluster order controllers
+- **AAP instance** (`osac-aap`): gateway, controller, EDA, Redis, PostgreSQL (AAP internal)
+- **PostgreSQL**: fulfillment database with mTLS (unless BYO database)
+- **Authorino instance**: gRPC authorization for the fulfillment API
+- **Bootstrap job**: configures AAP with execution environments and project templates
+
+## Prerequisites
+
+Before starting, ensure:
+
+- An Enclave cluster is fully deployed (Phases 1-7 complete)
+- SSH access to the Landing Zone
+- An AAP license `manifest.zip` file (obtain from [Red Hat Subscription Allocations](https://access.redhat.com/management/subscription_allocations))
+- For VMaaS deployments: nodes with bare-metal or nested-virt capability
+
+## Configuration
+
+On the Landing Zone, create the OSAC plugin configuration file:
+
+```bash
+cd ~/enclave
+cp config/plugins/osac.example.yaml config/plugins/osac.yaml
+```
+
+> **Note:** The `aap` plugin requires no configuration -- it only installs the AAP operator.
+
+Edit `config/plugins/osac.yaml`:
+
+```yaml
+# Required: path to AAP license file on the Landing Zone
+osacAapLicenseFile: "/home/<user>/aap-license.zip"
+
+# Optional: deployment profile (default: development)
+# osacProfile: development   # Options: development, vmaas, caas
+
+# Optional: bring your own database
+# osacBYODatabase: true
+# osacDatabaseUrl: "postgres://user@host:5432/dbname?sslmode=require"
+```
+
+### OSAC Configuration Reference
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `osacAapLicenseFile` | string | Yes | — | Path to AAP license manifest.zip on the Landing Zone |
+| `osacProfile` | string | No | `development` | Deployment profile: `development`, `vmaas`, or `caas` |
+| `osacBYODatabase` | boolean | No | `false` | Use an external database instead of the built-in dev postgres |
+| `osacDatabaseUrl` | string | No | — | Connection URL for external database (requires `osacBYODatabase: true`) |
+
+## Deployment
+
+Deploy each plugin sequentially. Later plugins depend on resources created by earlier ones.
+
+```bash
+cd ~/enclave
+
+# 1. Trust Manager — cert-manager ClusterIssuer and CA bundle sync
+make deploy-plugin PLUGIN=trust-manager
+
+# 2. Red Hat Build of Keycloak — identity provider
+make deploy-plugin PLUGIN=rhbk
+
+# 3. Authorino — gRPC authorization operator
+make deploy-plugin PLUGIN=authorino
+
+# 4. AAP — installs operator only, no config required (provides CRDs for OSAC)
+make deploy-plugin PLUGIN=aap
+
+# 5. (VMaaS only) OpenShift Virtualization — required for VM workloads
+# make deploy-plugin PLUGIN=cnv
+
+# 6. Deploy the OSAC plugin
+make deploy-plugin PLUGIN=osac
+```
+
+The `make deploy-plugin PLUGIN=osac` command runs the full plugin lifecycle:
+
+1. **pre-validate** — checks Keycloak ready, AAP CRDs registered, license file exists
+2. **mirror** — mirrors images (disconnected environments only)
+3. **post-operators** — creates osac namespace, Keycloak realm/client, PostgreSQL, secrets
+4. **helm deploy** — installs the OSAC Helm chart
+5. **deploy** — waits for AAP, creates access token, patches the OSAC operator
+6. **post-validate** — verifies all components are healthy
+
+> **Note:** AAP takes 30+ minutes to become fully available. The deploy step waits up to 45 minutes for the AAP gateway.
+
+### Experience Bundle
+
+The `osac` experience defines the complete plugin stack:
+
+```bash
+# View the experience definition
+cat experiences/osac/experience.yaml
+```
+
+Each plugin must still be deployed individually via `make deploy-plugin`.
+
+## Verification
+
+After deployment, verify all components:
+
+```bash
+# Check all pods in the osac namespace
+oc get pods -n osac
+
+# Expected pods (all Running/Completed):
+# - fulfillment-grpc-server-*
+# - fulfillment-rest-gateway-*
+# - fulfillment-controller-*
+# - fulfillment-ingress-proxy-*
+# - osac-operator-*
+# - osac-aap-* (multiple pods: web, task, eda, redis, etc.)
+# - postgres-* (unless BYO database)
+# - authorino-* (Authorino instance)
+# - osac-aap-bootstrap-* (Completed)
+
+# Check Helm release
+helm status osac -n osac
+
+# Check AAP instance
+oc get ansibleautomationplatform osac-aap -n osac
+
+# Check fulfillment deployments
+oc get deployments -n osac
+```
+
+## BYO Database
+
+For production environments with an external PostgreSQL database:
+
+1. Set `osacBYODatabase: true` in `config/plugins/osac.yaml`
+
+2. **Option A** — provide the connection URL and let the plugin create the secret:
+   ```yaml
+   osacBYODatabase: true
+   osacDatabaseUrl: "postgres://user@host:5432/dbname?sslmode=require"
+   ```
+
+3. **Option B** — pre-create the secret manually:
+   ```bash
+   oc create namespace osac
+   oc create secret generic fulfillment-db -n osac \
+     --from-literal=url="postgres://user@host:5432/dbname?sslmode=require"
+   ```
+
+4. If the external database requires mTLS, also create the client cert secret:
+   ```bash
+   oc create secret tls postgres-client-cert-service -n osac \
+     --cert=client.crt --key=client.key
+   # Add CA cert
+   oc patch secret postgres-client-cert-service -n osac \
+     --type merge -p '{"data":{"ca.crt":"'$(base64 -w0 ca.crt)'"}}'
+   ```
+
+5. Deploy OSAC normally:
+   ```bash
+   make deploy-plugin PLUGIN=osac
+   ```
+
+When BYO database is enabled:
+- The built-in PostgreSQL Deployment, PVC, ConfigMap, and certificates are skipped
+- The `postgres-client-cert-service` secret entry is omitted from the Helm values `service.database.connection` list
+- Post-validate skips the PostgreSQL health check
+
+## Profiles
+
+The `osacProfile` config value selects which OSAC operator controllers are enabled:
+
+| Profile | Controllers | Extra Prerequisites |
+|---------|------------|---------------------|
+| `development` (default) | clusterOrder, computeInstance, tenant, networking | CNV + MCE |
+| `vmaas` | computeInstance, tenant, networking | CNV |
+| `caas` | clusterOrder, tenant, networking | MCE |
+
+- **MCE** (Multicluster Engine) is part of Enclave core infrastructure (ACM-based platform) and is always available.
+- **CNV** must be deployed separately before OSAC for `vmaas` and `development` profiles: `make deploy-plugin PLUGIN=cnv`
+
+## Post-Install Steps
+
+After deployment, hub registration and tenant creation require manual steps:
+
+```bash
+# These steps will be documented in a follow-up and may be automated in future versions
+# 1. Register hub via osac CLI
+# 2. Create initial tenant
+```
+
+## Troubleshooting
+
+| Issue | Check | Fix |
+|-------|-------|-----|
+| pre-validate fails on ClusterIssuer | `oc get clusterissuer default-ca` | Deploy trust-manager plugin first |
+| pre-validate fails on Keycloak | `oc get keycloak -n keycloak` | Deploy rhbk plugin first |
+| pre-validate fails on AAP CRD | `oc get crd ansibleautomationplatforms.aap.ansible.com` | Deploy aap plugin first |
+| pre-validate fails on HyperConverged CRD | `oc get crd hyperconvergeds.hco.kubevirt.io` | Deploy cnv plugin first (required for vmaas/development profile) |
+| AAP gateway not becoming available | `oc get pods -n osac -l app.kubernetes.io/managed-by=automationgateway` | AAP takes 30+ minutes; check operator logs |
+| Helm chart install fails | `helm status osac -n osac` | Check post-operators secrets exist: `oc get secrets -n osac` |
+| PostgreSQL not starting | `oc logs deployment/postgres -n osac` | Check PVC bound (`oc get pvc -n osac`), cert-manager certs issued (`oc get certificates -n osac`) |
+| Fulfillment pods CrashLoopBackOff | `oc logs deployment/fulfillment-grpc-server -n osac` | Check `fulfillment-db` secret URL, PostgreSQL reachable, client cert valid |
+| Keycloak realm creation fails | Check Keycloak pod logs in `keycloak` namespace | Verify Keycloak route resolves; check `/etc/hosts` in connected mode |
+| Bootstrap job fails | `oc logs job -n osac -l app=osac-aap-bootstrap` | Check `config-as-code-ig` and `config-as-code-manifest-ig` secrets |

--- a/experiences/osac/experience.yaml
+++ b/experiences/osac/experience.yaml
@@ -2,5 +2,9 @@
 name: osac
 description: Open Sovereign AI Cloud experience
 plugins:
-  - name: vast-csi
-  - name: authorino
+  - name: trust-manager    # order 100 -- cert-manager ClusterIssuer + CA bundle
+  - name: rhbk             # order 101 -- Keycloak identity provider
+  - name: authorino        # order 102 -- gRPC authorization operator
+  - name: aap              # order 103 -- AAP operator (CRDs for OSAC chart)
+  # cnv (order 104) is optional -- deploy separately for VMaaS deployments
+  - name: osac             # order 200 -- OSAC fulfillment + chart-managed AAP instance

--- a/playbooks/tasks/deploy_plugin.yaml
+++ b/playbooks/tasks/deploy_plugin.yaml
@@ -78,6 +78,21 @@
     - not r_plugin_defaults_yaml.stat.exists
   tags: always
 
+# Load user config for this plugin (config/plugins/<name>.yaml) if it exists.
+# The load-vars.yaml only loads config files for plugins in enabled_plugins,
+# but day-2 plugins deployed via deploy-plugin.yaml may not be in that list.
+- name: Stat plugin user config file
+  ansible.builtin.stat:
+    path: "{{ playbook_dir }}/../config/plugins/{{ plugin_name }}.yaml"
+  register: r_plugin_user_config
+  tags: always
+
+- name: Load plugin user config
+  ansible.builtin.include_vars:
+    file: "{{ r_plugin_user_config.stat.path }}"
+  when: r_plugin_user_config.stat.exists
+  tags: always
+
 - name: Validate plugin requirements (vars)
   ansible.builtin.assert:
     that: "item.name in vars"

--- a/playbooks/tasks/helm_deploy.yaml
+++ b/playbooks/tasks/helm_deploy.yaml
@@ -4,11 +4,18 @@
 # Required loop_var: helm_chart (from deploy_plugin.yaml loop)
 # Required vars: plugin_dir, plugin_name, workingDir
 #
-# Supports two modes:
+# Supports three modes:
+#   OCI chart:    set helm_chart.chart to an oci:// URL (e.g. oci://ghcr.io/org/chart).
 #   Remote chart: set helm_chart.repo (Helm repo URL) and helm_chart.chart (chart name).
 #   Local chart:  set helm_chart.chart (path relative to plugin dir) or omit for default.
 
-# --- Remote repo setup ---
+# --- Determine chart type ---
+
+- name: "Helm | Determine chart type for {{ helm_chart.release }}"
+  ansible.builtin.set_fact:
+    _helm_is_oci: "{{ helm_chart.chart is defined and helm_chart.chart is match('^oci://') }}"
+
+# --- Remote repo setup (non-OCI only) ---
 
 - name: "Helm | Add repo for {{ helm_chart.release }}"
   ansible.builtin.command:
@@ -16,13 +23,17 @@
       {{ workingDir }}/bin/helm repo add
       {{ helm_chart.release }}-repo
       {{ helm_chart.repo }}
-  when: helm_chart.repo is defined
+  when:
+    - helm_chart.repo is defined
+    - not _helm_is_oci | bool
   changed_when: true
 
 - name: "Helm | Update repo cache"
   ansible.builtin.command:
     cmd: "{{ workingDir }}/bin/helm repo update"
-  when: helm_chart.repo is defined
+  when:
+    - helm_chart.repo is defined
+    - not _helm_is_oci | bool
   changed_when: true
 
 # --- Chart reference ---
@@ -30,21 +41,45 @@
 - name: "Helm | Set chart reference for {{ helm_chart.release }}"
   ansible.builtin.set_fact:
     _helm_chart_ref: >-
-      {{ helm_chart.release ~ '-repo/' ~ helm_chart.chart
-         if helm_chart.repo is defined
-         else plugin_dir ~ '/' ~ (helm_chart.chart | default('charts/' ~ helm_chart.release)) }}
+      {{ helm_chart.chart
+         if (_helm_is_oci | bool)
+         else (helm_chart.release ~ '-repo/' ~ helm_chart.chart
+               if helm_chart.repo is defined
+               else plugin_dir ~ '/' ~ (helm_chart.chart | default('charts/' ~ helm_chart.release))) }}
 
 - name: "Helm | Verify local chart exists"
   ansible.builtin.stat:
     path: "{{ _helm_chart_ref }}"
   register: _r_chart_stat
-  when: helm_chart.repo is not defined
+  when:
+    - helm_chart.repo is not defined
+    - not _helm_is_oci | bool
 
 - name: "Helm | Assert local chart exists"
   ansible.builtin.assert:
     that: _r_chart_stat.stat.exists
     fail_msg: "Helm chart not found: {{ _helm_chart_ref }}"
-  when: helm_chart.repo is not defined
+  when:
+    - helm_chart.repo is not defined
+    - not _helm_is_oci | bool
+
+- name: "Helm | Read Chart.yaml for {{ helm_chart.release }}"
+  ansible.builtin.slurp:
+    src: "{{ _helm_chart_ref }}/Chart.yaml"
+  register: _r_deploy_chart_yaml
+  when:
+    - helm_chart.repo is not defined
+    - not _helm_is_oci | bool
+
+- name: "Helm | Build dependencies for {{ helm_chart.release }}"
+  ansible.builtin.command:
+    cmd: >-
+      {{ workingDir }}/bin/helm dependency build {{ _helm_chart_ref }}
+  when:
+    - helm_chart.repo is not defined
+    - not _helm_is_oci | bool
+    - (_r_deploy_chart_yaml.content | b64decode | from_yaml).dependencies is defined
+  changed_when: true
 
 # --- Values ---
 

--- a/plugins/aap/plugin.yaml
+++ b/plugins/aap/plugin.yaml
@@ -9,5 +9,6 @@ operators:
     channel: stable-2.5-cluster-scoped
     init_version: 2.5.0-0.1777407881
     namespace: ansible-aap
+    global: true
     csvNames:
       - aap-operator

--- a/plugins/osac/defaults.yaml
+++ b/plugins/osac/defaults.yaml
@@ -1,0 +1,42 @@
+---
+# OSAC plugin defaults
+# Note: config/plugins/osac.yaml uses camelCase (osacProfile, osacBYODatabase)
+# which is loaded into Ansible scope as-is. The defaults below use the same
+# camelCase convention to match. Ansible variables from defaults.yaml and
+# config/plugins/osac.yaml are merged into the same scope.
+osacProfile: development    # development | vmaas | caas
+
+# AAP settings (chart manages the instance, these configure it)
+osac_aap_name: osac-aap
+osac_aap_operator_ns: ansible-aap
+osac_aap_api_user: admin      # Used as --user arg to awx-manage create_oauth2_token
+osac_aap_validate_certs: false
+
+# Keycloak integration
+osac_keycloak_ns: keycloak
+osac_keycloak_name: keycloak                  # Keycloak CR name (used for route hostname, admin API)
+osac_keycloak_svc_name: keycloak-service      # RHBK operator creates <cr-name>-service
+osac_keycloak_realm: osac
+osac_keycloak_client_id: osac-controller
+osac_keycloak_service_port: 8443
+
+# Fulfillment database (built-in dev postgres)
+osacBYODatabase: false
+osac_db_name: postgres
+osac_db_image: "quay.io/sclorg/postgresql-15-c9s:latest"
+osac_db_size: 5Gi
+osac_db_user: service
+osac_db_database: service
+
+# AAP bootstrap
+osac_aap_project_git_uri: "https://github.com/osac-project/osac-aap"
+osac_aap_project_git_branch: main
+
+# Container images
+osac_images:
+  operator: "ghcr.io/osac-project/osac-operator"
+  operator_tag: "latest"
+  fulfillment_service: "ghcr.io/osac-project/fulfillment-service:latest"
+  envoy: "docker.io/envoyproxy/envoy:v1.33.0"
+  aap_bootstrap: "ghcr.io/osac-project/osac-aap:latest"
+  cli: "quay.io/openshift/origin-cli:4.20.0"

--- a/plugins/osac/plugin.yaml
+++ b/plugins/osac/plugin.yaml
@@ -1,0 +1,49 @@
+---
+name: osac
+type: addon
+order: 200
+
+# The AAP operator is installed by the 'aap' plugin (order 103).
+# This plugin only deploys the OSAC Helm chart, which creates its own
+# AAP instance in the osac namespace (aap.aap.instance.enabled: true).
+installOperators: false
+
+helm:
+  - release: osac
+    namespace: osac
+    chart: "oci://ghcr.io/osac-project/charts/osac"
+    version: "0.0.1"
+    valuesTemplate: templates/values.yaml.j2
+    createNamespace: true
+    timeout: "45m"
+    wait: false    # AAP takes 30+ minutes; deploy.yaml handles post-install waits
+
+additionalImages:
+  - ghcr.io/osac-project/osac-operator:latest
+  - ghcr.io/osac-project/fulfillment-service:latest
+  - ghcr.io/osac-project/osac-aap:latest
+  - docker.io/envoyproxy/envoy:v1.33.0
+  - quay.io/openshift/origin-cli:4.20.0
+  - quay.io/keycloak/keycloak:26.3
+  - quay.io/sclorg/postgresql-15-c9s:latest
+  - quay.io/prometheus/prometheus:v3.8.1
+  - docker.io/bitnami/kubectl:latest
+
+registries:
+  - location: "ghcr.io/osac-project"
+    mirror: "osac-project"
+  - location: "docker.io/envoyproxy"
+    mirror: "envoyproxy"
+  - location: "docker.io/bitnami"
+    mirror: "bitnami"
+  - location: "quay.io/keycloak"
+    mirror: "keycloak"
+  - location: "quay.io/sclorg"
+    mirror: "sclorg"
+  - location: "quay.io/prometheus"
+    mirror: "prometheus"
+
+requires:
+  files:
+    - path: "../../config/plugins/osac.yaml"
+      description: "OSAC plugin configuration (profile, AAP license path, BYO DB settings)"

--- a/plugins/osac/schemas/config.yaml
+++ b/plugins/osac/schemas/config.yaml
@@ -1,0 +1,21 @@
+---
+type: object
+properties:
+  osacAapLicenseFile:
+    type: string
+    description: "Path to AAP license manifest.zip file on the Landing Zone"
+  osacProfile:
+    type: string
+    enum: [development, vmaas, caas]
+    description: "Deployment profile: development (all controllers), vmaas (VM only), caas (cluster only)"
+  osacBYODatabase:
+    type: boolean
+    description: "Set to true to use an external database instead of the built-in dev postgres"
+  osacDatabaseUrl:
+    type: string
+    description: >-
+      Connection URL for external database. When provided with osacBYODatabase=true,
+      post-operators.yaml creates the fulfillment-db secret from this value.
+      If omitted, the user must pre-create the fulfillment-db secret manually.
+required:
+  - osacAapLicenseFile

--- a/plugins/osac/tasks/deploy.yaml
+++ b/plugins/osac/tasks/deploy.yaml
@@ -1,0 +1,175 @@
+---
+# Post-Helm deployment tasks for OSAC plugin.
+# Runs after the OSAC Helm chart is installed.
+#
+# Responsibilities:
+#   1. Check Helm release status (fail early if chart install failed)
+#   2. Wait for AAP gateway deployment to be available
+#   3. Add AAP route hostname to /etc/hosts (connected mode)
+#   4. Create AAP personal access token via awx-manage
+#   5. Patch OSAC operator deployment with OSAC_AAP_URL env var
+#   6. Wait for OSAC operator rollout
+
+# =====================================================================
+# 1. Check Helm release status
+# =====================================================================
+
+- name: Check OSAC Helm release status
+  ansible.builtin.command:
+    cmd: "{{ workingDir }}/bin/helm status osac --namespace osac"
+  register: __r_helm_status
+  retries: 10
+  delay: 60
+  until: __r_helm_status.rc == 0
+  changed_when: false
+
+- name: Assert OSAC Helm release is deployed
+  ansible.builtin.assert:
+    that: "'deployed' in __r_helm_status.stdout"
+    fail_msg: >-
+      OSAC Helm release is not in 'deployed' state.
+      Check the Helm install log and post-operators secrets.
+
+# =====================================================================
+# 2. Wait for AAP gateway deployment
+# =====================================================================
+
+- name: Wait for AAP gateway deployment available
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    namespace: osac
+    label_selectors:
+      - "app.kubernetes.io/managed-by=automationgateway"
+  register: __r_aap_gateway
+  retries: 90
+  delay: 30
+  until:
+    - __r_aap_gateway.resources | length > 0
+    - __r_aap_gateway.resources[0].status.availableReplicas | default(0) | int > 0
+
+# =====================================================================
+# 3. Add AAP route hostname to /etc/hosts (connected mode)
+# =====================================================================
+
+- name: Get AAP route
+  kubernetes.core.k8s_info:
+    api_version: route.openshift.io/v1
+    kind: Route
+    namespace: osac
+    label_selectors:
+      - "app.kubernetes.io/managed-by=automationgateway"
+  register: __r_aap_route
+
+- name: Assert exactly one AAP route found
+  ansible.builtin.assert:
+    that: __r_aap_route.resources | length == 1
+    fail_msg: >-
+      Expected exactly one AAP gateway route in osac namespace
+      (managed-by=automationgateway), found {{ __r_aap_route.resources | length }}.
+
+- name: Set AAP URL fact
+  ansible.builtin.set_fact:
+    _osac_aap_url: "https://{{ __r_aap_route.resources[0].spec.host }}"
+    _osac_aap_route_host: "{{ __r_aap_route.resources[0].spec.host }}"
+
+# In connected/libvirt deployments, dnsmasq only resolves a fixed set
+# of app hostnames. Dynamically created routes won't resolve by default.
+- name: Add AAP route hostname to /etc/hosts
+  ansible.builtin.lineinfile:
+    path: /etc/hosts
+    line: "{{ ingressVIP }} {{ _osac_aap_route_host }}"
+    regexp: "{{ _osac_aap_route_host | regex_escape() }}"
+    state: present
+  become: true
+  when: enclave_deployment_mode | default('') == 'connected'
+
+# =====================================================================
+# 4. Create AAP personal access token via awx-manage
+# =====================================================================
+# AAP 2.5 gateway does not support Basic auth or expose the OAuth2 token
+# endpoint (/api/o/token/) through the route. Create the token directly
+# via awx-manage inside the controller pod, bypassing the gateway.
+
+- name: Create AAP personal access token via awx-manage
+  ansible.builtin.command:
+    cmd: >-
+      oc exec -n osac
+      deployment/{{ osac_aap_name }}-controller-web
+      -- awx-manage create_oauth2_token
+      --user {{ osac_aap_api_user }}
+  register: __r_aap_token_exec
+  retries: 10
+  delay: 15
+  until: __r_aap_token_exec.rc == 0
+  changed_when: __r_aap_token_exec.rc == 0
+  no_log: true
+
+- name: Set AAP token fact
+  ansible.builtin.set_fact:
+    _osac_aap_token: "{{ __r_aap_token_exec.stdout_lines | last | trim }}"
+  no_log: true
+
+# =====================================================================
+# 5. Store AAP credentials and patch OSAC operator deployment
+# =====================================================================
+
+- name: Create osac-aap-secret with token
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: osac-aap-secret
+        namespace: osac
+      type: Opaque
+      stringData:
+        token: "{{ _osac_aap_token }}"
+  no_log: true
+
+- name: Patch OSAC operator deployment with AAP URL
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: osac-operator
+        namespace: osac
+      spec:
+        template:
+          spec:
+            containers:
+              - name: osac-operator
+                env:
+                  - name: OSAC_AAP_URL
+                    value: "{{ _osac_aap_url }}"
+                  - name: OSAC_AAP_TOKEN
+                    valueFrom:
+                      secretKeyRef:
+                        name: osac-aap-secret
+                        key: token
+
+# =====================================================================
+# 6. Wait for OSAC operator rollout
+# =====================================================================
+
+- name: Wait for OSAC operator rollout
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: osac-operator
+    namespace: osac
+  register: __r_operator_rollout
+  retries: 30
+  delay: 10
+  until:
+    - __r_operator_rollout.resources | length > 0
+    - __r_operator_rollout.resources[0].status.availableReplicas | default(0) | int > 0
+    - __r_operator_rollout.resources[0].status.updatedReplicas | default(0) | int ==
+      __r_operator_rollout.resources[0].spec.replicas | default(1) | int
+
+- name: Log OSAC deploy completion
+  ansible.builtin.debug:
+    msg: "OSAC deploy complete. AAP URL={{ _osac_aap_url }}, operator patched and rolled out."

--- a/plugins/osac/tasks/post-operators.yaml
+++ b/plugins/osac/tasks/post-operators.yaml
@@ -1,0 +1,773 @@
+---
+# Post-operators hook for OSAC plugin.
+# Runs after the AAP operator is installed (CRDs available),
+# before the OSAC Helm chart is deployed.
+#
+# Responsibilities:
+#   1.  Create osac namespace with ca-bundle label
+#   2.  Wait for ca-bundle ConfigMap sync (trust-manager)
+#   3.  Detect Keycloak hostname from cluster ingress config
+#   4.  Add Keycloak route to /etc/hosts (connected mode only)
+#   5.  Get Keycloak admin credentials
+#   6.  Obtain Keycloak admin access token via REST API
+#   7.  Create osac realm (idempotent)
+#   8.  Create osac-controller client (idempotent)
+#   9.  Fetch client UUID + secret, create fulfillment-controller-credentials
+#   10. Deploy PostgreSQL (when not BYO): certs, init secret, config, Deployment, Service, NetworkPolicy
+#   11. Create postgres-client-cert-service Certificate CR (when not BYO)
+#   12. Wait for certificate issuance
+#   13. Create fulfillment-db secret (when not BYO, or BYO with osacDatabaseUrl)
+#   14. Create config-as-code-ig secret
+#   15. Create config-as-code-manifest-ig secret (AAP license)
+
+# =====================================================================
+# 1. Create osac namespace with ca-bundle label
+# =====================================================================
+
+- name: Create osac namespace with ca-bundle label
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: osac
+        labels:
+          enclave/ca-bundle: "true"
+  register: __r_ns
+  retries: 5
+  delay: 5
+  until: __r_ns is success
+
+# =====================================================================
+# 2. Wait for ca-bundle ConfigMap sync
+# =====================================================================
+
+- name: Wait for ca-bundle ConfigMap in osac namespace
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: ConfigMap
+    name: ca-bundle
+    namespace: osac
+  register: __r_ca_bundle
+  retries: 30
+  delay: 10
+  until: __r_ca_bundle.resources | length > 0
+
+# =====================================================================
+# 3. Detect Keycloak hostname from cluster ingress config
+# =====================================================================
+
+- name: Detect cluster ingress domain
+  kubernetes.core.k8s_info:
+    api_version: config.openshift.io/v1
+    kind: Ingress
+    name: cluster
+  register: __r_ingress_config
+
+- name: Set Keycloak hostname
+  ansible.builtin.set_fact:
+    _osac_keycloak_hostname: "{{ osac_keycloak_name }}.{{ __r_ingress_config.resources[0].spec.domain }}"
+
+# =====================================================================
+# 4. Add Keycloak route hostname to /etc/hosts (connected mode only)
+# =====================================================================
+# In connected/libvirt deployments, dnsmasq only resolves a fixed set
+# of app hostnames. Dynamically created routes won't resolve by default,
+# so we add them to /etc/hosts on the Landing Zone.
+
+- name: Add Keycloak route hostname to /etc/hosts
+  ansible.builtin.lineinfile:
+    path: /etc/hosts
+    line: "{{ ingressVIP }} {{ _osac_keycloak_hostname }}"
+    regexp: "{{ _osac_keycloak_hostname | regex_escape() }}"
+    state: present
+  become: true
+  when: enclave_deployment_mode | default('') == 'connected'
+
+# =====================================================================
+# 5. Get Keycloak admin credentials
+# =====================================================================
+
+- name: Get Keycloak admin credentials secret
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    name: "{{ osac_keycloak_name }}-initial-admin"
+    namespace: "{{ osac_keycloak_ns }}"
+  register: __r_keycloak_admin_secret
+  retries: 10
+  delay: 10
+  until: __r_keycloak_admin_secret.resources | length > 0
+  no_log: true
+
+- name: Extract Keycloak admin credentials
+  ansible.builtin.set_fact:
+    _osac_kc_admin_user: "{{ __r_keycloak_admin_secret.resources[0].data.username | b64decode }}"
+    _osac_kc_admin_pass: "{{ __r_keycloak_admin_secret.resources[0].data.password | b64decode }}"
+  no_log: true
+
+# =====================================================================
+# 6. Obtain Keycloak admin access token
+# =====================================================================
+
+- name: Get Keycloak admin access token
+  ansible.builtin.uri:
+    url: "https://{{ _osac_keycloak_hostname }}/realms/master/protocol/openid-connect/token"
+    method: POST
+    body_format: form-urlencoded
+    body:
+      grant_type: password
+      client_id: admin-cli
+      username: "{{ _osac_kc_admin_user }}"
+      password: "{{ _osac_kc_admin_pass }}"
+    validate_certs: false
+    status_code: 200
+  register: __r_kc_token
+  retries: 10
+  delay: 15
+  until: __r_kc_token.status == 200
+  no_log: true
+
+- name: Set Keycloak access token fact
+  ansible.builtin.set_fact:
+    _osac_kc_token: "{{ __r_kc_token.json.access_token }}"
+  no_log: true
+
+# =====================================================================
+# 7. Create osac realm (idempotent)
+# =====================================================================
+
+- name: Check if osac realm exists
+  ansible.builtin.uri:
+    url: "https://{{ _osac_keycloak_hostname }}/admin/realms/{{ osac_keycloak_realm }}"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ _osac_kc_token }}"
+    validate_certs: false
+    status_code: [200, 404]
+  register: __r_realm_check
+  no_log: true
+
+- name: Create osac realm
+  ansible.builtin.uri:
+    url: "https://{{ _osac_keycloak_hostname }}/admin/realms"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ _osac_kc_token }}"
+      Content-Type: application/json
+    body_format: json
+    body:
+      realm: "{{ osac_keycloak_realm }}"
+      enabled: true
+      organizationsEnabled: true
+    validate_certs: false
+    status_code: [201]
+  when: __r_realm_check.status == 404
+  no_log: true
+
+# =====================================================================
+# 8. Create osac-controller client (idempotent)
+# =====================================================================
+
+- name: Check if osac-controller client exists
+  ansible.builtin.uri:
+    url: "https://{{ _osac_keycloak_hostname }}/admin/realms/{{ osac_keycloak_realm }}/clients?clientId={{ osac_keycloak_client_id }}"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ _osac_kc_token }}"
+    validate_certs: false
+    status_code: 200
+  register: __r_client_check
+  no_log: true
+
+- name: Create osac-controller client
+  ansible.builtin.uri:
+    url: "https://{{ _osac_keycloak_hostname }}/admin/realms/{{ osac_keycloak_realm }}/clients"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ _osac_kc_token }}"
+      Content-Type: application/json
+    body_format: json
+    body:
+      clientId: "{{ osac_keycloak_client_id }}"
+      enabled: true
+      publicClient: false
+      serviceAccountsEnabled: true
+      clientAuthenticatorType: client-secret
+      protocol: openid-connect
+    validate_certs: false
+    status_code: [201]
+  when: __r_client_check.json | length == 0
+  no_log: true
+
+# =====================================================================
+# 8a. Configure client protocol mapper and service account roles
+# =====================================================================
+
+- name: Fetch osac-controller client UUID for configuration
+  ansible.builtin.uri:
+    url: "https://{{ _osac_keycloak_hostname }}/admin/realms/{{ osac_keycloak_realm }}/clients?clientId={{ osac_keycloak_client_id }}"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ _osac_kc_token }}"
+    validate_certs: false
+    status_code: 200
+  register: __r_client_for_config
+  no_log: true
+
+- name: Set client UUID for configuration
+  ansible.builtin.set_fact:
+    _osac_client_uuid_config: "{{ __r_client_for_config.json[0].id }}"
+  no_log: true
+
+# The OPA policy in the AuthConfig references input.auth.identity.username,
+# but Keycloak JWTs use preferred_username. Add a protocol mapper that
+# copies the username user attribute into a "username" token claim.
+- name: Check if username protocol mapper exists
+  ansible.builtin.uri:
+    url: "https://{{ _osac_keycloak_hostname }}/admin/realms/{{ osac_keycloak_realm }}/clients/{{ _osac_client_uuid_config }}/protocol-mappers/models"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ _osac_kc_token }}"
+    validate_certs: false
+    status_code: 200
+  register: __r_mappers
+  no_log: true
+
+- name: Add username protocol mapper to client
+  ansible.builtin.uri:
+    url: "https://{{ _osac_keycloak_hostname }}/admin/realms/{{ osac_keycloak_realm }}/clients/{{ _osac_client_uuid_config }}/protocol-mappers/models"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ _osac_kc_token }}"
+      Content-Type: application/json
+    body_format: json
+    body:
+      name: username
+      protocol: openid-connect
+      protocolMapper: oidc-usermodel-attribute-mapper
+      config:
+        user.attribute: username
+        claim.name: username
+        jsonType.label: String
+        id.token.claim: "true"
+        access.token.claim: "true"
+        userinfo.token.claim: "true"
+        multivalued: "false"
+        aggregate.attrs: "false"
+    validate_certs: false
+    status_code: [201]
+  when: __r_mappers.json | selectattr('name', 'equalto', 'username') | list | length == 0
+  no_log: true
+
+# Assign realm-admin client role from the realm-management client to the
+# service account so the controller can manage Keycloak organizations.
+- name: Fetch service account user for osac-controller
+  ansible.builtin.uri:
+    url: "https://{{ _osac_keycloak_hostname }}/admin/realms/{{ osac_keycloak_realm }}/clients/{{ _osac_client_uuid_config }}/service-account-user"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ _osac_kc_token }}"
+    validate_certs: false
+    status_code: 200
+  register: __r_sa_user
+  no_log: true
+
+- name: Fetch realm-management client UUID
+  ansible.builtin.uri:
+    url: "https://{{ _osac_keycloak_hostname }}/admin/realms/{{ osac_keycloak_realm }}/clients?clientId=realm-management"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ _osac_kc_token }}"
+    validate_certs: false
+    status_code: 200
+  register: __r_realm_mgmt
+  no_log: true
+
+- name: Fetch realm-admin role from realm-management client
+  ansible.builtin.uri:
+    url: "https://{{ _osac_keycloak_hostname }}/admin/realms/{{ osac_keycloak_realm }}/clients/{{ __r_realm_mgmt.json[0].id }}/roles/realm-admin"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ _osac_kc_token }}"
+    validate_certs: false
+    status_code: 200
+  register: __r_realm_admin_role
+  no_log: true
+
+- name: Check current realm-management role mappings for service account
+  ansible.builtin.uri:
+    url: "https://{{ _osac_keycloak_hostname }}/admin/realms/{{ osac_keycloak_realm }}/users/{{ __r_sa_user.json.id }}/role-mappings/clients/{{ __r_realm_mgmt.json[0].id }}"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ _osac_kc_token }}"
+    validate_certs: false
+    status_code: 200
+  register: __r_sa_client_roles
+  no_log: true
+
+- name: Assign realm-admin role to service account
+  ansible.builtin.uri:
+    url: "https://{{ _osac_keycloak_hostname }}/admin/realms/{{ osac_keycloak_realm }}/users/{{ __r_sa_user.json.id }}/role-mappings/clients/{{ __r_realm_mgmt.json[0].id }}"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ _osac_kc_token }}"
+      Content-Type: application/json
+    body_format: json
+    body:
+      - "{{ __r_realm_admin_role.json }}"
+    validate_certs: false
+    status_code: [204]
+  when: __r_sa_client_roles.json | selectattr('name', 'equalto', 'realm-admin') | list | length == 0
+  no_log: true
+
+# =====================================================================
+# 9. Fetch client UUID + secret, create fulfillment-controller-credentials
+# =====================================================================
+
+- name: Fetch osac-controller client details
+  ansible.builtin.uri:
+    url: "https://{{ _osac_keycloak_hostname }}/admin/realms/{{ osac_keycloak_realm }}/clients?clientId={{ osac_keycloak_client_id }}"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ _osac_kc_token }}"
+    validate_certs: false
+    status_code: 200
+  register: __r_client_details
+  no_log: true
+
+- name: Set client UUID fact
+  ansible.builtin.set_fact:
+    _osac_client_uuid: "{{ __r_client_details.json[0].id }}"
+  no_log: true
+
+# Use the secret from the client representation if available.
+# For newly created clients Keycloak may not populate the secret field
+# until it is explicitly generated via POST.
+- name: Set client secret from client representation
+  ansible.builtin.set_fact:
+    _osac_client_secret: "{{ __r_client_details.json[0].secret }}"
+  when: __r_client_details.json[0].secret | default('') | length > 0
+  no_log: true
+
+- name: Fetch client secret if not in representation
+  ansible.builtin.uri:
+    url: "https://{{ _osac_keycloak_hostname }}/admin/realms/{{ osac_keycloak_realm }}/clients/{{ _osac_client_uuid }}/client-secret"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ _osac_kc_token }}"
+    validate_certs: false
+    status_code: 200
+  register: __r_fetched_secret
+  when: _osac_client_secret is not defined
+  no_log: true
+
+- name: Set client secret from fetched value
+  ansible.builtin.set_fact:
+    _osac_client_secret: "{{ __r_fetched_secret.json.value }}"
+  when:
+    - _osac_client_secret is not defined
+    - __r_fetched_secret.json.value | default('') | length > 0
+  no_log: true
+
+- name: Generate client secret as last resort
+  ansible.builtin.uri:
+    url: "https://{{ _osac_keycloak_hostname }}/admin/realms/{{ osac_keycloak_realm }}/clients/{{ _osac_client_uuid }}/client-secret"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ _osac_kc_token }}"
+    validate_certs: false
+    status_code: 200
+  register: __r_generated_secret
+  when: _osac_client_secret is not defined
+  no_log: true
+
+- name: Set client secret from generated value
+  ansible.builtin.set_fact:
+    _osac_client_secret: "{{ __r_generated_secret.json.value }}"
+  when: _osac_client_secret is not defined
+  no_log: true
+
+- name: Create fulfillment-controller-credentials secret
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: fulfillment-controller-credentials
+        namespace: osac
+      type: Opaque
+      stringData:
+        client-id: "{{ osac_keycloak_client_id }}"
+        client-secret: "{{ _osac_client_secret }}"
+  no_log: true
+
+# =====================================================================
+# 10. Deploy PostgreSQL (when not BYO database)
+# =====================================================================
+
+# --- Server certificate ---
+
+- name: Create postgres-server-cert Certificate
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: cert-manager.io/v1
+      kind: Certificate
+      metadata:
+        name: postgres-server-cert
+        namespace: osac
+      spec:
+        secretName: postgres-server-cert
+        issuerRef:
+          kind: ClusterIssuer
+          name: default-ca
+        commonName: "{{ osac_db_name }}"
+        dnsNames:
+          - "{{ osac_db_name }}"
+          - "{{ osac_db_name }}.osac"
+          - "{{ osac_db_name }}.osac.svc"
+          - "{{ osac_db_name }}.osac.svc.cluster.local"
+        usages:
+          - server auth
+        privateKey:
+          rotationPolicy: Always
+  when: not osacBYODatabase | bool
+
+# --- PostgreSQL server config ---
+
+- name: Create postgres-config ConfigMap
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: postgres-config
+        namespace: osac
+      data:
+        server.conf: |
+          listen_addresses = '*'
+          ssl = on
+          ssl_cert_file = '/etc/postgres-certs/tls.crt'
+          ssl_key_file = '/etc/postgres-certs/tls.key'
+          ssl_ca_file = '/etc/postgres-certs/ca.crt'
+          hba_file = '/etc/postgres-config/access.conf'
+        access.conf: |
+          # TYPE  DATABASE  USER        ADDRESS      METHOD
+          local   all       all                      trust
+          host    all       all         127.0.0.1/32 trust
+          host    all       all         ::1/128      trust
+          hostssl all       all         all          cert clientcert=verify-full
+  when: not osacBYODatabase | bool
+
+# --- PostgreSQL Service ---
+
+- name: Deploy PostgreSQL Service
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: "{{ osac_db_name }}"
+        namespace: osac
+      spec:
+        selector:
+          app: "{{ osac_db_name }}"
+        ports:
+          - name: postgres
+            port: 5432
+            targetPort: 5432
+  when: not osacBYODatabase | bool
+
+# --- PostgreSQL NetworkPolicy ---
+
+- name: Restrict PostgreSQL ingress to osac namespace pods
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      metadata:
+        name: allow-osac-to-db
+        namespace: osac
+      spec:
+        podSelector:
+          matchLabels:
+            app: "{{ osac_db_name }}"
+        ingress:
+          - from:
+              - podSelector: {}
+            ports:
+              - protocol: TCP
+                port: 5432
+        policyTypes:
+          - Ingress
+  when: not osacBYODatabase | bool
+
+# --- PostgreSQL PVC ---
+
+- name: Create PostgreSQL PVC
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: "{{ osac_db_name }}-data"
+        namespace: osac
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "{{ osac_db_size }}"
+  when: not osacBYODatabase | bool
+
+# --- PostgreSQL Deployment ---
+
+- name: Deploy PostgreSQL Deployment
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: "{{ osac_db_name }}"
+        namespace: osac
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app: "{{ osac_db_name }}"
+        template:
+          metadata:
+            labels:
+              app: "{{ osac_db_name }}"
+          spec:
+            automountServiceAccountToken: false
+            containers:
+              - name: postgresql
+                image: "{{ osac_db_image }}"
+                ports:
+                  - containerPort: 5432
+                args:
+                  - run-postgresql
+                  - -c
+                  - config_file=/etc/postgres-config/server.conf
+                env:
+                  - name: POSTGRESQL_USER
+                    value: "{{ osac_db_user }}"
+                  - name: POSTGRESQL_PASSWORD
+                    value: "{{ osac_db_user }}"
+                  - name: POSTGRESQL_DATABASE
+                    value: "{{ osac_db_database }}"
+                securityContext:
+                  runAsNonRoot: true
+                  readOnlyRootFilesystem: true
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                      - ALL
+                resources:
+                  requests:
+                    cpu: 100m
+                    memory: 256Mi
+                  limits:
+                    cpu: 500m
+                    memory: 512Mi
+                volumeMounts:
+                  - name: data
+                    mountPath: /var/lib/pgsql
+                  - name: tmp
+                    mountPath: /tmp
+                  - name: run-postgresql
+                    mountPath: /var/run/postgresql
+                  - name: server-certs
+                    mountPath: /etc/postgres-certs
+                    readOnly: true
+                  - name: config
+                    mountPath: /etc/postgres-config
+                    readOnly: true
+                readinessProbe:
+                  exec:
+                    command:
+                      - /usr/libexec/check-container
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                livenessProbe:
+                  exec:
+                    command:
+                      - /usr/libexec/check-container
+                      - --live
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+            volumes:
+              - name: data
+                persistentVolumeClaim:
+                  claimName: "{{ osac_db_name }}-data"
+              - name: tmp
+                emptyDir: {}
+              - name: run-postgresql
+                emptyDir: {}
+              - name: server-certs
+                secret:
+                  secretName: postgres-server-cert
+                  defaultMode: 288
+              - name: config
+                configMap:
+                  name: postgres-config
+  when: not osacBYODatabase | bool
+
+# --- Wait for PostgreSQL ready ---
+
+- name: Wait for PostgreSQL ready
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: "{{ osac_db_name }}"
+    namespace: osac
+  register: __r_db_ready
+  retries: 30
+  delay: 10
+  until:
+    - __r_db_ready.resources | length > 0
+    - __r_db_ready.resources[0].status.availableReplicas | default(0) | int > 0
+  when: not osacBYODatabase | bool
+
+# =====================================================================
+# 11. Create postgres-client-cert-service Certificate CR (when not BYO)
+# =====================================================================
+
+- name: Create postgres-client-cert-service Certificate
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: cert-manager.io/v1
+      kind: Certificate
+      metadata:
+        name: postgres-client-cert-service
+        namespace: osac
+      spec:
+        secretName: postgres-client-cert-service
+        issuerRef:
+          kind: ClusterIssuer
+          name: default-ca
+        commonName: "{{ osac_db_user }}"
+        usages:
+          - client auth
+        privateKey:
+          rotationPolicy: Always
+  when: not osacBYODatabase | bool
+
+# =====================================================================
+# 12. Wait for certificate issuance
+# =====================================================================
+
+- name: Wait for postgres-client-cert-service certificate ready
+  kubernetes.core.k8s_info:
+    api_version: cert-manager.io/v1
+    kind: Certificate
+    name: postgres-client-cert-service
+    namespace: osac
+  register: __r_client_cert
+  retries: 30
+  delay: 5
+  until:
+    - __r_client_cert.resources | length > 0
+    - __r_client_cert.resources[0].status.conditions | default([])
+      | selectattr('type', 'equalto', 'Ready')
+      | selectattr('status', 'equalto', 'True')
+      | list | length > 0
+  when: not osacBYODatabase | bool
+
+# =====================================================================
+# 13. Create fulfillment-db secret
+# =====================================================================
+
+- name: Build fulfillment database connection URL
+  ansible.builtin.set_fact:
+    _osac_db_url: >-
+      postgres://{{ osac_db_user }}@{{ osac_db_name }}:5432/{{ osac_db_database
+      }}?sslmode=verify-full&sslrootcert=/etc/fulfillment-grpc-server/db/sslrootcert&sslcert=/etc/fulfillment-grpc-server/db/sslcert&sslkey=/etc/fulfillment-grpc-server/db/sslkey
+  when: not osacBYODatabase | bool
+
+- name: Create fulfillment-db secret (built-in PostgreSQL with mTLS)
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: fulfillment-db
+        namespace: osac
+      type: Opaque
+      stringData:
+        url: "{{ _osac_db_url }}"
+  when: not osacBYODatabase | bool
+  no_log: true
+
+- name: Create fulfillment-db secret (BYO database with provided URL)
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: fulfillment-db
+        namespace: osac
+      type: Opaque
+      stringData:
+        url: "{{ osacDatabaseUrl }}"
+  when:
+    - osacBYODatabase | bool
+    - osacDatabaseUrl is defined
+    - osacDatabaseUrl | length > 0
+  no_log: true
+
+# =====================================================================
+# 14. Create config-as-code-ig secret
+# =====================================================================
+
+- name: Create config-as-code-ig secret for bootstrap
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: config-as-code-ig
+        namespace: osac
+      type: Opaque
+      stringData:
+        AAP_EE_IMAGE: "{{ osac_images.aap_bootstrap }}"
+        AAP_PROJECT_GIT_URI: "{{ osac_aap_project_git_uri }}"
+        AAP_PROJECT_GIT_BRANCH: "{{ osac_aap_project_git_branch }}"
+
+# =====================================================================
+# 15. Create config-as-code-manifest-ig secret (AAP license)
+# =====================================================================
+
+- name: Create config-as-code-manifest-ig secret
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: config-as-code-manifest-ig
+        namespace: osac
+      type: Opaque
+      data:
+        license.zip: "{{ lookup('ansible.builtin.file', osacAapLicenseFile) | b64encode }}"
+  no_log: true
+
+- name: Log OSAC post-operators completion
+  ansible.builtin.debug:
+    msg: >-
+      OSAC post-operators complete. Namespace osac created, Keycloak
+      realm/client configured, PostgreSQL {{ 'skipped (BYO)' if osacBYODatabase | bool else 'deployed' }},
+      secrets created.

--- a/plugins/osac/tasks/post-validate.yaml
+++ b/plugins/osac/tasks/post-validate.yaml
@@ -1,0 +1,163 @@
+---
+# Post-deployment validation for OSAC plugin.
+# Verifies all components are healthy after deployment.
+
+# 1. PostgreSQL running (when not BYO database)
+- name: Check PostgreSQL deployment is running
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: "{{ osac_db_name }}"
+    namespace: osac
+  register: __r_postgres
+  when: not osacBYODatabase | bool
+
+- name: Assert PostgreSQL is running
+  ansible.builtin.assert:
+    that:
+      - __r_postgres.resources | length > 0
+      - __r_postgres.resources[0].status.availableReplicas | default(0) | int > 0
+    fail_msg: "PostgreSQL deployment is not running in osac namespace"
+  when: not osacBYODatabase | bool
+
+# 2. fulfillment-grpc-server deployment
+- name: Check fulfillment-grpc-server deployment
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: fulfillment-grpc-server
+    namespace: osac
+  register: __r_grpc_server
+
+- name: Assert fulfillment-grpc-server is running
+  ansible.builtin.assert:
+    that:
+      - __r_grpc_server.resources | length > 0
+      - __r_grpc_server.resources[0].status.availableReplicas | default(0) | int > 0
+    fail_msg: "fulfillment-grpc-server deployment is not running in osac namespace"
+
+# 3. fulfillment-rest-gateway deployment
+- name: Check fulfillment-rest-gateway deployment
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: fulfillment-rest-gateway
+    namespace: osac
+  register: __r_rest_gateway
+
+- name: Assert fulfillment-rest-gateway is running
+  ansible.builtin.assert:
+    that:
+      - __r_rest_gateway.resources | length > 0
+      - __r_rest_gateway.resources[0].status.availableReplicas | default(0) | int > 0
+    fail_msg: "fulfillment-rest-gateway deployment is not running in osac namespace"
+
+# 4. fulfillment-controller deployment
+- name: Check fulfillment-controller deployment
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: fulfillment-controller
+    namespace: osac
+  register: __r_controller
+
+- name: Assert fulfillment-controller is running
+  ansible.builtin.assert:
+    that:
+      - __r_controller.resources | length > 0
+      - __r_controller.resources[0].status.availableReplicas | default(0) | int > 0
+    fail_msg: "fulfillment-controller deployment is not running in osac namespace"
+
+# 5. fulfillment-ingress-proxy deployment
+- name: Check fulfillment-ingress-proxy deployment
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: fulfillment-ingress-proxy
+    namespace: osac
+  register: __r_ingress_proxy
+
+- name: Assert fulfillment-ingress-proxy is running
+  ansible.builtin.assert:
+    that:
+      - __r_ingress_proxy.resources | length > 0
+      - __r_ingress_proxy.resources[0].status.availableReplicas | default(0) | int > 0
+    fail_msg: "fulfillment-ingress-proxy deployment is not running in osac namespace"
+
+# 6. osac-operator deployment
+- name: Check osac-operator deployment
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: osac-operator
+    namespace: osac
+  register: __r_osac_operator
+
+- name: Assert osac-operator is running
+  ansible.builtin.assert:
+    that:
+      - __r_osac_operator.resources | length > 0
+      - __r_osac_operator.resources[0].status.availableReplicas | default(0) | int > 0
+    fail_msg: "osac-operator deployment is not running in osac namespace"
+
+# 7. AAP instance ready
+- name: Check AAP instance is ready
+  kubernetes.core.k8s_info:
+    api_version: aap.ansible.com/v1alpha1
+    kind: AnsibleAutomationPlatform
+    name: "{{ osac_aap_name }}"
+    namespace: osac
+  register: __r_aap_instance
+
+- name: Assert AAP instance is ready
+  ansible.builtin.assert:
+    that:
+      - __r_aap_instance.resources | length > 0
+      - __r_aap_instance.resources[0].status.conditions | default([])
+        | selectattr('type', 'equalto', 'Successful')
+        | selectattr('status', 'equalto', 'True')
+        | list | length > 0
+    fail_msg: "AAP instance {{ osac_aap_name }} is not ready in osac namespace"
+
+# 8. Authorino instance ready
+- name: Check Authorino instance in osac namespace
+  kubernetes.core.k8s_info:
+    api_version: operator.authorino.kuadrant.io/v1beta1
+    kind: Authorino
+    namespace: osac
+  register: __r_authorino
+
+- name: Assert Authorino instance is ready
+  ansible.builtin.assert:
+    that:
+      - __r_authorino.resources | length > 0
+      - __r_authorino.resources[0].status.conditions | default([])
+        | selectattr('type', 'equalto', 'Ready')
+        | selectattr('status', 'in', ['True', 'true'])
+        | list | length > 0
+    fail_msg: "Authorino instance not found or not ready in osac namespace"
+
+# 9. AAP bootstrap job completed
+- name: Check AAP bootstrap job completed
+  kubernetes.core.k8s_info:
+    api_version: batch/v1
+    kind: Job
+    namespace: osac
+    label_selectors:
+      - "app=osac-aap-bootstrap"
+  register: __r_bootstrap_job
+
+- name: Assert AAP bootstrap job completed
+  ansible.builtin.assert:
+    that:
+      - __r_bootstrap_job.resources | length > 0
+      - __r_bootstrap_job.resources[0].status.succeeded | default(0) | int >= 1
+      - __r_bootstrap_job.resources[0].status.failed | default(0) | int == 0
+    fail_msg: "AAP bootstrap job has not completed successfully in osac namespace"
+
+- name: Log OSAC validation success
+  ansible.builtin.debug:
+    msg: >-
+      OSAC post-validate passed: all fulfillment deployments running,
+      OSAC operator running, AAP instance ready, Authorino ready,
+      bootstrap job completed{{ ', PostgreSQL running' if not osacBYODatabase | bool else '' }}.

--- a/plugins/osac/tasks/pre-validate.yaml
+++ b/plugins/osac/tasks/pre-validate.yaml
@@ -1,0 +1,115 @@
+---
+# Pre-deployment validation for OSAC plugin.
+# Verifies cluster prerequisites before mirroring/operators run.
+
+# 1. cert-manager ClusterIssuer default-ca exists
+- name: Check ClusterIssuer default-ca exists
+  kubernetes.core.k8s_info:
+    api_version: cert-manager.io/v1
+    kind: ClusterIssuer
+    name: default-ca
+  register: __r_ca_issuer
+  failed_when: false
+
+- name: Assert ClusterIssuer default-ca is ready
+  ansible.builtin.fail:
+    msg: >-
+      ClusterIssuer default-ca not found or not ready.
+      Deploy the trust-manager plugin (order 100) before OSAC.
+  when: >
+    __r_ca_issuer.failed | default(false) or
+    __r_ca_issuer.resources | default([]) | length == 0 or
+    (__r_ca_issuer.resources[0].status.conditions | default([])
+    | selectattr('type', 'equalto', 'Ready')
+    | selectattr('status', 'equalto', 'True')
+    | list | length == 0)
+
+# 2. Keycloak CR is ready
+- name: Check Keycloak CR is ready
+  kubernetes.core.k8s_info:
+    api_version: k8s.keycloak.org/v2beta1
+    kind: Keycloak
+    name: "{{ osac_keycloak_name }}"
+    namespace: "{{ osac_keycloak_ns }}"
+  register: __r_keycloak
+  retries: 5
+  delay: 10
+  until:
+    - __r_keycloak.resources | default([]) | length > 0
+    - __r_keycloak.resources[0].status.conditions | default([])
+      | selectattr('type', 'equalto', 'Ready')
+      | selectattr('status', 'equalto', 'True')
+      | list | length > 0
+
+# 3. AnsibleAutomationPlatform CRD is registered
+- name: Check AnsibleAutomationPlatform CRD exists
+  kubernetes.core.k8s_info:
+    api_version: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    name: ansibleautomationplatforms.aap.ansible.com
+  register: __r_aap_crd
+
+- name: Assert AnsibleAutomationPlatform CRD is registered
+  ansible.builtin.fail:
+    msg: >-
+      AnsibleAutomationPlatform CRD not found. Deploy the aap plugin
+      (order 103) before OSAC: make deploy-plugin PLUGIN=aap
+  when: __r_aap_crd.resources | default([]) | length == 0
+
+# 4. AAP license file exists
+- name: Check AAP license file exists
+  ansible.builtin.stat:
+    path: "{{ osacAapLicenseFile }}"
+  register: __r_aap_license
+
+- name: Assert AAP license file is present
+  ansible.builtin.assert:
+    that:
+      - __r_aap_license.stat.exists
+      - __r_aap_license.stat.isreg
+      - __r_aap_license.stat.readable
+    fail_msg: >-
+      AAP license file not found or not a readable regular file at
+      '{{ osacAapLicenseFile }}'. Set osacAapLicenseFile in
+      config/plugins/osac.yaml to the path of the AAP license
+      manifest.zip on the Landing Zone.
+
+# 5. BYO database: verify fulfillment-db secret exists
+- name: Check fulfillment-db secret exists (BYO database)
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    name: fulfillment-db
+    namespace: osac
+  register: __r_byo_db_secret
+  when: osacBYODatabase | bool
+
+- name: Assert fulfillment-db secret exists (BYO database)
+  ansible.builtin.assert:
+    that: __r_byo_db_secret.resources | length > 0
+    fail_msg: >-
+      BYO database is enabled (osacBYODatabase=true) but the fulfillment-db
+      secret was not found in the osac namespace. Either set osacDatabaseUrl
+      in config/plugins/osac.yaml or pre-create the secret manually.
+  when:
+    - osacBYODatabase | bool
+    - osacDatabaseUrl is not defined or osacDatabaseUrl | length == 0
+
+# 6. VMaaS/development profile: HyperConverged CRD exists (CNV installed)
+- name: Check HyperConverged CRD exists (VMaaS prerequisite)
+  kubernetes.core.k8s_info:
+    api_version: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    name: hyperconvergeds.hco.kubevirt.io
+  register: __r_hco_crd
+  when: osacProfile in ['vmaas', 'development']
+
+- name: Assert HyperConverged CRD exists (VMaaS prerequisite)
+  ansible.builtin.fail:
+    msg: >-
+      HyperConverged CRD not found. The {{ osacProfile }} profile requires
+      OpenShift Virtualization (CNV). Deploy the cnv plugin (order 104)
+      before OSAC: make deploy-plugin PLUGIN=cnv
+  when:
+    - osacProfile in ['vmaas', 'development']
+    - __r_hco_crd.resources | default([]) | length == 0

--- a/plugins/osac/templates/values.yaml.j2
+++ b/plugins/osac/templates/values.yaml.j2
@@ -1,0 +1,102 @@
+# Rendered by Enclave from Ansible variables.
+# Chart-managed AAP architecture: the OSAC Helm chart deploys its own
+# AAP instance. deploy.yaml handles post-install AAP token creation
+# and operator patching.
+
+operator:
+  image:
+    pullPolicy: Always
+    repository: "{{ osac_images.operator }}"
+    tag: "{{ osac_images.operator_tag }}"
+  aap:
+    insecureSkipVerify: "true"
+    statusPollInterval: 30s
+    templatePrefix: osac
+    url: ""               # Set post-install by deploy.yaml
+  controllers:
+{% if osacProfile in ['development', 'caas'] %}
+    clusterOrder: true
+{% else %}
+    clusterOrder: false
+{% endif %}
+{% if osacProfile in ['development', 'vmaas'] %}
+    computeInstance: true
+{% else %}
+    computeInstance: false
+{% endif %}
+    networking: true
+    tenant: true
+  fulfillment:
+    serverAddress: fulfillment-api:8000
+    tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+  provisioning:
+    provider: aap
+
+service:
+  variant: openshift
+  images:
+    service: "{{ osac_images.fulfillment_service }}"
+    envoy: "{{ osac_images.envoy }}"
+  certs:
+    caBundle:
+      configMap: ca-bundle
+    issuerRef:
+      kind: ClusterIssuer
+      name: default-ca
+  auth:
+    issuerUrl: "https://{{ _osac_keycloak_hostname }}/realms/{{ osac_keycloak_realm }}"
+    controllerCredentials:
+      - secret:
+          name: fulfillment-controller-credentials
+          items:
+            - key: client-id
+              param: client-id
+            - key: client-secret
+              param: client-secret
+  idp:
+    provider: keycloak
+    url: "https://{{ _osac_keycloak_hostname }}"
+    credentials:
+      - secret:
+          name: fulfillment-controller-credentials
+          items:
+            - key: client-id
+              param: client-id
+            - key: client-secret
+              param: client-secret
+  database:
+    connection:
+      - secret:
+          name: fulfillment-db
+          items:
+            - key: url
+              param: url
+{% if not osacBYODatabase %}
+      - secret:
+          name: postgres-client-cert-service
+          items:
+            - key: tls.crt
+              param: sslcert
+            - key: tls.key
+              param: sslkey
+            - key: ca.crt
+              param: sslrootcert
+{% endif %}
+
+# Chart manages the AAP instance
+aap:
+  aap:
+    instance:
+      enabled: true
+      name: "{{ osac_aap_name }}"
+  bootstrap:
+    backoffLimit: 15
+    cliImage: "{{ osac_images.cli }}"
+    enabled: true
+    image: "{{ osac_images.aap_bootstrap }}"
+
+dbMigrate:
+  enabled: false
+
+validation:
+  enabled: true

--- a/schemas/plugin.yaml
+++ b/schemas/plugin.yaml
@@ -168,7 +168,8 @@ definitions:
       chart:
         type: string
         description: >-
-          Chart name (when repo is set) or path relative to the plugin
+          Chart name (when repo is set), OCI reference starting with oci://
+          (e.g. oci://ghcr.io/org/chart), or path relative to the plugin
           directory (local chart). Default for local: charts/<release>.
       repo:
         type: string
@@ -204,7 +205,8 @@ definitions:
         description: >-
           Extract container image references from the chart's default values
           via helm template and merge into additionalImages for mirroring.
-          Only works for local charts (repo must not be set). Default: false.
+          Only works for local charts (repo and oci:// must not be set).
+          Default: false.
     required:
       - release
       - namespace


### PR DESCRIPTION
Replaces #415

## Summary

- Add the OSAC plugin deploying the full stack via OCI Helm chart
  (`oci://ghcr.io/osac-project/charts/osac`) with chart-managed AAP
  instance lifecycle
- Plugin lifecycle tasks: pre-validate, post-operators (Keycloak
  realm/client/OIDC, PostgreSQL with mTLS, AAP bootstrap secrets),
  Helm deploy, post-deploy (AAP readiness, token, operator patching),
  post-validate (health checks for all components)
- Add OCI chart support to `helm_deploy.yaml`
- Set AAP operator to global scope (`AllNamespaces` OperatorGroup) so
  the operator can reconcile the AAP CR in the `osac` namespace
- Remove AAP platform instance lifecycle from the `aap` plugin
  (OSAC-1405) — the OSAC chart now owns it
- Add OSAC experience bundle: trust-manager, rhbk, authorino, osac

## Test plan

- [x] Full deployment on live cluster (rdu-infra-edge-04)
- [x] All fulfillment pods healthy (controller, grpc-server, rest-gateway,
  console-proxy, ingress-proxy, operator)
- [x] Authorino OIDC discovery and authorization working
- [x] AAP instance deployed and reconciled (gateway, controller, EDA)
- [x] AAP bootstrap job completed (license, organizations, schedules)
- [x] PostgreSQL with mTLS operational
- [x] Keycloak client_credentials flow verified
- [ ] `make -f Makefile.ci validate-plugins` passes
- [ ] Disconnected deployment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added Open Sovereign AI Cloud (OSAC) plugin with day-2 templates, defaults, and automated deployment workflow.
  * Introduced OSAC-specific pre-deploy, post-deploy, and post-validate checks, including optional bring-your-own database.

* **Documentation**
  * Added an OSAC deployment guide with configuration reference and troubleshooting.

* **Enhancements**
  * Added OCI Helm chart support to the deployment flow.
  * Enabled loading per-plugin user configuration overrides when present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->