### PR TITLE
Add validation to detect persistent Metal3 from previous deployments

### DIFF
--- a/playbooks/tasks/configure_hardware_ironic_setup.yaml
+++ b/playbooks/tasks/configure_hardware_ironic_setup.yaml
@@ -1,6 +1,9 @@
 ---
 # Set up Ironic for hardware configuration
 
+- name: Validate no persistent Metal3 from previous deployment
+  ansible.builtin.include_tasks: validate_no_persistent_metal3.yaml
+
 - name: Deploy Metal3 common resources
   ansible.builtin.include_tasks: deploy_metal3_common.yaml
 

--- a/playbooks/tasks/validate_no_persistent_metal3.yaml
+++ b/playbooks/tasks/validate_no_persistent_metal3.yaml
@@ -1,0 +1,89 @@
+---
+# Validate that no persistent Metal3 stack is running from a previous deployment
+# This prevents confusing 401 errors when old root-level Ironic containers
+# conflict with new user-level deployments
+
+- name: Check for running root-level Metal3 pod
+  become: true
+  ansible.builtin.command: podman pod ps --format {% raw %}'{{.Name}}'{% endraw %} --filter name=metal3-ironic
+  register: root_metal3_pods
+  changed_when: false
+  failed_when: false
+
+- name: Check for Metal3 systemd services
+  become: true
+  ansible.builtin.systemd:
+    name: "{{ item }}"
+  register: metal3_services
+  loop:
+    - metal3-ironic-pod.service
+    - metal3-ironic-api.service
+    - metal3-bmo.service
+    - metal3-httpd.service
+  failed_when: false
+  changed_when: false
+
+- name: Check for Metal3 quadlet unit files
+  become: true
+  ansible.builtin.stat:
+    path: "/etc/containers/systemd/{{ item }}"
+  register: quadlet_units
+  loop:
+    - metal3-ironic.pod
+    - metal3-ironic-api.container
+    - metal3-bmo.container
+    - metal3-httpd.container
+  failed_when: false
+
+- name: Fail if persistent Metal3 is detected
+  when: >
+    (root_metal3_pods.stdout | length > 0) or
+    (metal3_services.results | selectattr('status.LoadState', 'defined') | selectattr('status.LoadState', 'equalto', 'loaded') | list | length > 0) or
+    (quadlet_units.results | selectattr('stat.exists', 'equalto', true) | list | length > 0)
+  ansible.builtin.fail:
+    msg: |
+      ==========================================
+      ERROR: Persistent Metal3 from previous deployment detected
+      ==========================================
+
+      Found leftover Metal3 components running as root from a previous deployment.
+      This will cause authentication failures (401 Unauthorized) because the old
+      Ironic instance has different credentials than the new deployment.
+
+      Detected components:
+      {% if root_metal3_pods.stdout | length > 0 %}
+        - Root-level Metal3 pods: {{ root_metal3_pods.stdout }}
+      {% endif %}
+      {% for service in metal3_services.results | selectattr('status.LoadState', 'defined') | selectattr('status.LoadState', 'equalto', 'loaded') %}
+        - Systemd service: {{ service.item }}
+      {% endfor %}
+      {% for unit in quadlet_units.results | selectattr('stat.exists', 'equalto', true) %}
+        - Quadlet unit file: {{ unit.item }}
+      {% endfor %}
+
+      REQUIRED ACTION:
+      Run the following cleanup commands before redeploying:
+
+        # Stop and disable all metal3 quadlet services
+        sudo systemctl stop metal3-bmo.service metal3-ironic-api.service metal3-httpd.service metal3-ironic-pod.service
+        sudo systemctl disable metal3-bmo.service metal3-ironic-api.service metal3-httpd.service metal3-ironic-pod.service
+
+        # Remove quadlet unit files
+        sudo rm -f /etc/containers/systemd/metal3-bmo.container
+        sudo rm -f /etc/containers/systemd/metal3-ironic-api.container
+        sudo rm -f /etc/containers/systemd/metal3-httpd.container
+        sudo rm -f /etc/containers/systemd/metal3-ironic.pod
+
+        # Reload systemd
+        sudo systemctl daemon-reload
+
+        # Remove root's pod, containers, secrets, and volumes
+        sudo podman pod rm -f metal3-ironic 2>/dev/null || true
+        sudo podman rm -f baremetal-operator 2>/dev/null || true
+        sudo podman secret rm metal3-ironic-htpasswd metal3-ironic-username metal3-ironic-password metal3-ca-bundle ironic-vmedia-cert ironic-vmedia-key metal3-kubeconfig 2>/dev/null || true
+        sudo podman volume rm metal3-ironic-conf metal3-ironic-data metal3-ironic-shared 2>/dev/null || true
+
+      Then retry the deployment.
+
+      Reference: https://github.com/gori-project/GoRI/issues/915
+      ==========================================


### PR DESCRIPTION
## Summary

Adds early validation to prevent confusing 401 Unauthorized errors when persistent Metal3 components from a previous deployment are still running.

## Problem

The real root cause of GoRI issue #915 was **not** the htpasswd generation, but leftover Metal3 infrastructure from a previous deployment:

1. Previous deployment used `metal3_persistent: true` → creates systemd quadlet services running as **root**
2. Cleanup script only removed **user-level** podman resources
3. New deployment generates new credentials in user secret store
4. New user-level Ironic container fails to start (port already bound by root Ironic)
5. API calls hit the **old root-level Ironic** with old credentials → 401 Unauthorized

This caused hours of debugging because:
- Password verification showed credentials were correct ✓
- Container saw correct hash ✓
- But authentication failed ✗ (hitting wrong Ironic instance)

## Solution

Added `validate_no_persistent_metal3.yaml` that runs before Metal3 deployment and checks for:
- Root-level Metal3 pods (`sudo podman pod ps`)
- Metal3 systemd services (quadlets)
- Quadlet unit files in `/etc/containers/systemd/`

**Fails fast** with clear error message including:
- Explanation of the problem
- List of what was detected
- Complete cleanup commands (from Nick's solution)
- Reference to the GitHub issue

## Changes

1. **New file**: `playbooks/tasks/validate_no_persistent_metal3.yaml`
   - Validation task that checks for persistent Metal3
   - Comprehensive error message with cleanup instructions

2. **Modified**: `playbooks/tasks/configure_hardware_ironic_setup.yaml`
   - Added validation as first step before deploying Metal3

## Testing

Validation will detect the conditions that caused the issue on Cluster 10 and Cluster 17, failing early with actionable instructions instead of later with confusing 401 errors.

## Related Issues

- GoRI: [#915](https://github.com/gori-project/GoRI/issues/915)
- Root cause identified by @carbonin in [this comment](https://github.com/gori-project/GoRI/issues/915#issuecomment-4695481122)

## Checklist

- [x] Validation runs before Metal3 deployment
- [x] Error message includes complete cleanup commands
- [x] References the GitHub issue for context
- [x] Commit includes Assisted-by trailer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment reliability by adding validation checks to detect and prevent conflicts from previous Metal3 installations. When legacy artifacts are detected, the deployment process now fails with clear error messages and specific cleanup instructions, ensuring successful redeployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->