### PR TITLE
Load plugin user config for day-2 deployments

### DIFF
--- a/playbooks/tasks/deploy_plugin.yaml
+++ b/playbooks/tasks/deploy_plugin.yaml
@@ -78,6 +78,21 @@
     - not r_plugin_defaults_yaml.stat.exists
   tags: always
 
+# Load user config for this plugin (config/plugins/<name>.yaml) if it exists.
+# The load-vars.yaml only loads config files for plugins in enabled_plugins,
+# but day-2 plugins deployed via deploy-plugin.yaml may not be in that list.
+- name: Stat plugin user config file
+  ansible.builtin.stat:
+    path: "{{ playbook_dir }}/../config/plugins/{{ plugin_name }}.yaml"
+  register: r_plugin_user_config
+  tags: always
+
+- name: Load plugin user config
+  ansible.builtin.include_vars:
+    file: "{{ r_plugin_user_config.stat.path }}"
+  when: r_plugin_user_config.stat.exists
+  tags: always
+
 - name: Validate plugin requirements (vars)
   ansible.builtin.assert:
     that: "item.name in vars"


### PR DESCRIPTION
## Summary

- Add loading of plugin-specific user configuration files (`config/plugins/<name>.yaml`) for day-2 plugin deployments via `deploy-plugin.yaml`
- The existing `load-vars.yaml` task only loads config files for plugins in `enabled_plugins`, but day-2 plugins deployed via `deploy-plugin.yaml` may not be in that list
- This ensures plugin user config is available regardless of deployment method

## Test plan

- [ ] Day-2 plugin deployment with user config file loads successfully
- [ ] Day-2 plugin deployment without user config file continues to work
- [ ] `make -f Makefile.ci validate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)