### PR TITLE
Prevent ACM from changing MCE subscription to Automatic

### DIFF
--- a/operators/advanced-cluster-management/tasks.yaml
+++ b/operators/advanced-cluster-management/tasks.yaml
@@ -1,12 +1,12 @@
 - name: Set MCE subscription spec for disconnected
-  when: disconnected | default(true)
+  when: disconnected | default(true) | bool
   ansible.builtin.set_fact:
     mce_subscription_spec:
       installPlanApproval: Manual
       source: cs-mirror-redhat-operators-v4-20
 
 - name: Set MCE subscription spec for connected
-  when: not (disconnected | default(true))
+  when: not (disconnected | default(true) | bool)
   ansible.builtin.set_fact:
     mce_subscription_spec:
       installPlanApproval: Manual

--- a/operators/advanced-cluster-management/tasks.yaml
+++ b/operators/advanced-cluster-management/tasks.yaml
@@ -1,3 +1,16 @@
+- name: Set MCE subscription spec for disconnected
+  when: disconnected | default(true)
+  ansible.builtin.set_fact:
+    mce_subscription_spec:
+      installPlanApproval: Manual
+      source: cs-mirror-redhat-operators-v4-20
+
+- name: Set MCE subscription spec for connected
+  when: not (disconnected | default(true))
+  ansible.builtin.set_fact:
+    mce_subscription_spec:
+      installPlanApproval: Manual
+
 - name: Ensure RHACM MultiClusterHub is present
   kubernetes.core.k8s:
     state: present
@@ -7,6 +20,8 @@
       metadata:
         name: multiclusterhub
         namespace: open-cluster-management
+        annotations:
+          installer.open-cluster-management.io/mce-subscription-spec: "{{ mce_subscription_spec | to_json }}"
       spec: {}
   retries: 60
   delay: 10


### PR DESCRIPTION
## Summary

- Adds `installer.open-cluster-management.io/mce-subscription-spec` annotation to MultiClusterHub
- Ensures MCE subscription remains with `installPlanApproval: Manual`
- For disconnected mode, also specifies the mirrored catalog source

## Problem

ACM's MultiClusterHub operator automatically changes the multicluster-engine subscription's `installPlanApproval` from `Manual` to `Automatic`, breaking the manual approval workflow required for disconnected environments. This was discovered during operator upgrade testing where MCE install plans were auto-approved, bypassing the `enclave reconcile` step.

See Slack thread: https://redhat-internal.slack.com/archives/C0B7CM99EH5/p1781260765092579

## Solution

Use the `installer.open-cluster-management.io/mce-subscription-spec` annotation ([docs](https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.15/html/install/installing)) on the MultiClusterHub resource to instruct ACM to:
1. Keep `installPlanApproval: Manual` for MCE subscription
2. Use the mirrored catalog source (`cs-mirror-redhat-operators-v4-20`) in disconnected environments

## Test plan

- [ ] Verify MultiClusterHub is created with the annotation
- [ ] Verify MCE subscription remains `Manual` after ACM installation
- [ ] Test operator upgrade workflow with `enclave reconcile` for MCE
- [ ] Verify behavior in both connected and disconnected modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Enhanced advanced cluster management to properly handle disconnected environment setups.
  * Improved subscription specification configuration for multi-cluster deployments.
  * Automatic installation plan approval management based on environment connectivity.
  * Refined cluster hub resource metadata annotations for advanced deployment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->