### PR TITLE
Restart catalog pods after sync to detect new operator versions

### DIFF
--- a/operators/quay-operator/quay_disconnected_finish.yaml
+++ b/operators/quay-operator/quay_disconnected_finish.yaml
@@ -27,3 +27,6 @@
       | bool
     )
     and not (mirror_dry_run | default(false) | bool)
+
+- name: Restart catalog source pods to pick up new operator versions
+  ansible.builtin.include_tasks: ../../playbooks/tasks/restart_catalog_pods.yaml

--- a/operators/quay-operator/quay_disconnected_finish.yaml
+++ b/operators/quay-operator/quay_disconnected_finish.yaml
@@ -27,10 +27,3 @@
       | bool
     )
     and not (mirror_dry_run | default(false) | bool)
-
-- name: Restart catalog source pods to pick up new operator versions
-  ansible.builtin.include_tasks:
-    file: ../../playbooks/tasks/restart_catalog_pods.yaml
-    apply:
-      environment:
-        KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"

--- a/operators/quay-operator/quay_disconnected_finish.yaml
+++ b/operators/quay-operator/quay_disconnected_finish.yaml
@@ -29,4 +29,8 @@
     and not (mirror_dry_run | default(false) | bool)
 
 - name: Restart catalog source pods to pick up new operator versions
-  ansible.builtin.include_tasks: ../../playbooks/tasks/restart_catalog_pods.yaml
+  ansible.builtin.include_tasks:
+    file: ../../playbooks/tasks/restart_catalog_pods.yaml
+    apply:
+      environment:
+        KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"

--- a/playbooks/06-day2.yaml
+++ b/playbooks/06-day2.yaml
@@ -74,3 +74,13 @@
               environment:
                 KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
           tags: quay-disconnected
+
+        - name: Restart catalog source pods to pick up new operator versions
+          when: disconnected | default(true)
+          ansible.builtin.include_tasks:
+            file: tasks/restart_catalog_pods.yaml
+            apply:
+              tags: restart-catalog-pods
+              environment:
+                KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+          tags: restart-catalog-pods

--- a/playbooks/tasks/restart_catalog_pods.yaml
+++ b/playbooks/tasks/restart_catalog_pods.yaml
@@ -1,0 +1,42 @@
+---
+# Restart catalog source pods to pick up new operator versions after mirroring.
+# This forces OLM to recreate the pods and detect newly mirrored operator versions.
+
+- name: Get catalog source pods in openshift-marketplace
+  kubernetes.core.k8s_info:
+    kind: Pod
+    namespace: openshift-marketplace
+    label_selectors:
+      - "olm.catalogSource"
+  register: r_catalog_pods
+
+- name: Delete catalog source pods to trigger refresh
+  kubernetes.core.k8s:
+    state: absent
+    api_version: v1
+    kind: Pod
+    name: "{{ item.metadata.name }}"
+    namespace: openshift-marketplace
+  loop: "{{ r_catalog_pods.resources }}"
+  when: r_catalog_pods.resources | length > 0
+  register: r_delete_catalog_pods
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_delete_catalog_pods is success
+
+- name: Wait for catalog source pods to be recreated
+  kubernetes.core.k8s_info:
+    kind: Pod
+    namespace: openshift-marketplace
+    label_selectors:
+      - "olm.catalogSource={{ item.metadata.labels['olm.catalogSource'] }}"
+    field_selectors:
+      - "status.phase=Running"
+  loop: "{{ r_catalog_pods.resources }}"
+  when: r_catalog_pods.resources | length > 0
+  register: r_catalog_pods_running
+  retries: 30
+  delay: 10
+  until:
+    - r_catalog_pods_running.resources is defined
+    - r_catalog_pods_running.resources | length > 0

--- a/sync.sh
+++ b/sync.sh
@@ -92,3 +92,7 @@ step_done
 echo "ACM ClusterImageSets .." | tee -a ${log}
     ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/06-day2.yaml -e fresh=false --tags acm-cis
 step_done
+
+echo "Restart catalog pods .." | tee -a ${log}
+    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/06-day2.yaml -e fresh=false --tags restart-catalog-pods
+step_done


### PR DESCRIPTION
## Summary

- Adds `playbooks/tasks/restart_catalog_pods.yaml` to restart OLM catalog pods
- Calls this task at the end of `quay_disconnected_finish.yaml`
- Ensures catalog pods pick up newly mirrored operator versions after sync.sh

## Problem

After running `sync.sh` to mirror new operator versions to Quay, the OLM catalog source pods in `openshift-marketplace` do not automatically detect the new content. This requires manual deletion of the catalog pods to force OLM to recreate them and discover the newly available operator versions.

From testing (see Slack thread):
```bash
# After sync.sh, no new install plans appeared
$ oc get installplans -n multicluster-engine
NAME            CSV                           APPROVAL   APPROVED
install-rhkt9   multicluster-engine.v2.10.1   Manual     true

# Manual pod deletion was required
$ oc delete pods -n openshift-marketplace cs-mirror-redhat-operators-v4-20-dxr2s

# Then new install plans appeared
$ oc get installplans -n multicluster-engine
NAME            CSV                           APPROVAL    APPROVED
install-7jsks   multicluster-engine.v2.10.3   Automatic   true
install-rhkt9   multicluster-engine.v2.10.1   Manual      true
```

See Slack thread: https://redhat-internal.slack.com/archives/C0B7CM99EH5/p1781260765092579

## Solution

Automatically restart catalog source pods after mirroring completes in `quay_disconnected_finish.yaml`. The new task:
1. Gets all catalog source pods in `openshift-marketplace`
2. Deletes them (OLM immediately recreates them)
3. Waits for them to reach `Running` state

This eliminates the manual workaround and ensures `sync.sh` fully prepares the environment for operator upgrades.

## Test plan

- [ ] Run sync.sh with operator version changes in defaults
- [ ] Verify catalog pods are automatically restarted after mirroring
- [ ] Verify new install plans appear without manual intervention
- [ ] Test with both MCE and Quay operator version upgrades

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic restart of catalog source components following operator image updates, ensuring newly applied operator versions are properly refreshed and available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->