### PR TITLE
Extract MultiClusterHub configuration to reusable task for upgrades

### DIFF
--- a/operators/advanced-cluster-management/configure_mch.yaml
+++ b/operators/advanced-cluster-management/configure_mch.yaml
@@ -1,0 +1,51 @@
+---
+# Configure MultiClusterHub with MCE subscription spec annotation.
+# This ensures ACM respects Manual installPlanApproval for MCE subscription.
+# Can be used for both initial creation and patching existing MCH during upgrades.
+
+- name: Set MCE subscription spec for disconnected
+  when: disconnected | default(true) | bool
+  ansible.builtin.set_fact:
+    mce_subscription_spec:
+      installPlanApproval: Manual
+      source: cs-mirror-redhat-operators-v4-20
+
+- name: Set MCE subscription spec for connected
+  when: not (disconnected | default(true) | bool)
+  ansible.builtin.set_fact:
+    mce_subscription_spec:
+      installPlanApproval: Manual
+
+- name: Ensure RHACM MultiClusterHub is present with MCE subscription spec
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: operator.open-cluster-management.io/v1
+      kind: MultiClusterHub
+      metadata:
+        name: multiclusterhub
+        namespace: open-cluster-management
+        annotations:
+          installer.open-cluster-management.io/mce-subscription-spec: "{{ mce_subscription_spec | to_json }}"
+      spec: {}
+  retries: 60
+  delay: 10
+  register: r_mch
+  until: r_mch is succeeded
+
+- name: Wait until RHACM MultiClusterHub is ready
+  kubernetes.core.k8s_info:
+    api_version: operator.open-cluster-management.io/v1
+    kind: MultiClusterHub
+    name: multiclusterhub
+    namespace: open-cluster-management
+  register: r_mch_status
+  retries: 120
+  delay: 30
+  until:
+    - r_mch_status is defined
+    - r_mch_status.resources is defined
+    - r_mch_status.resources | length > 0
+    - r_mch_status.resources[0].status is defined
+    - r_mch_status.resources[0].status.phase is defined
+    - r_mch_status.resources[0].status.phase == "Running"

--- a/operators/advanced-cluster-management/tasks.yaml
+++ b/operators/advanced-cluster-management/tasks.yaml
@@ -1,49 +1,6 @@
-- name: Set MCE subscription spec for disconnected
-  when: disconnected | default(true) | bool
-  ansible.builtin.set_fact:
-    mce_subscription_spec:
-      installPlanApproval: Manual
-      source: cs-mirror-redhat-operators-v4-20
-
-- name: Set MCE subscription spec for connected
-  when: not (disconnected | default(true) | bool)
-  ansible.builtin.set_fact:
-    mce_subscription_spec:
-      installPlanApproval: Manual
-
-- name: Ensure RHACM MultiClusterHub is present
-  kubernetes.core.k8s:
-    state: present
-    definition:
-      apiVersion: operator.open-cluster-management.io/v1
-      kind: MultiClusterHub
-      metadata:
-        name: multiclusterhub
-        namespace: open-cluster-management
-        annotations:
-          installer.open-cluster-management.io/mce-subscription-spec: "{{ mce_subscription_spec | to_json }}"
-      spec: {}
-  retries: 60
-  delay: 10
-  register: r_mhc
-  until: r_mhc is succeeded
-
-- name: Wait until RHACM MultiClusterHub is ready
-  kubernetes.core.k8s_info:
-    api_version: operator.open-cluster-management.io/v1
-    kind: MultiClusterHub
-    name: multiclusterhub
-    namespace: open-cluster-management
-  register: rhacm_multiclusterhub
-  retries: 120
-  delay: 30
-  until:
-  - rhacm_multiclusterhub is defined
-  - rhacm_multiclusterhub.resources is defined
-  - rhacm_multiclusterhub.resources | length > 0
-  - rhacm_multiclusterhub.resources[0].status is defined
-  - rhacm_multiclusterhub.resources[0].status.phase is defined
-  - rhacm_multiclusterhub.resources[0].status.phase == "Running"
+- name: Configure MultiClusterHub
+  ansible.builtin.include_tasks:
+    file: configure_mch.yaml
 
 - name: Create Namespace for policies
   kubernetes.core.k8s:

--- a/playbooks/06-day2.yaml
+++ b/playbooks/06-day2.yaml
@@ -30,6 +30,15 @@
             msg: "Running day-2 operations in {{ 'disconnected' if (disconnected | default(true)) else 'connected' }} mode"
           tags: always
 
+        - name: Configure MultiClusterHub MCE subscription spec
+          ansible.builtin.include_tasks:
+            file: ../operators/advanced-cluster-management/configure_mch.yaml
+            apply:
+              tags: acm-mch
+              environment:
+                KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+          tags: acm-mch
+
         - name: Configure Quay in disconnected environments
           when: disconnected | default(true)
           ansible.builtin.include_tasks:

--- a/sync.sh
+++ b/sync.sh
@@ -85,6 +85,10 @@ echo "Building local cache .. " | tee -a ${log}
     ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/02-mirror.yaml -e fresh=false --tags mirror-registry
 step_done
 
+echo "Configure MultiClusterHub .." | tee -a ${log}
+    ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/06-day2.yaml -e fresh=false --tags acm-mch
+step_done
+
 echo "Quay disconnected .." | tee -a ${log}
     ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/06-day2.yaml -e fresh=false --tags quay-disconnected
 step_done


### PR DESCRIPTION
## Summary

- Created `operators/advanced-cluster-management/configure_mch.yaml` with MCE subscription spec logic and MCH creation/waiting
- Updated `operators/advanced-cluster-management/tasks.yaml` to use the extracted task
- Added `acm-mch` tag to `playbooks/06-day2.yaml` as the first day-2 step
- Added MCH configuration step to `sync.sh` before mirroring

## Problem

When upgrading from an older enclave version, existing MultiClusterHub resources don't have the `installer.open-cluster-management.io/mce-subscription-spec` annotation. This means ACM will continue to change the MCE subscription's `installPlanApproval` to `Automatic`, bypassing manual approval workflows.

Related to the Slack thread discussion: https://redhat-internal.slack.com/archives/C0B7CM99EH5/p1781260765092579

## Solution

Extract the MCH configuration (including MCE subscription spec annotation) into a reusable task that:
- Sets the MCE subscription spec based on connected/disconnected mode
- Uses `state: present` which creates the resource if it doesn't exist, or patches it if it does
- Waits for MCH to reach `Running` state

The task is now called:
1. During initial ACM operator deployment (from `operators/advanced-cluster-management/tasks.yaml`)
2. As the first step of day-2 operations (from `playbooks/06-day2.yaml` with `acm-mch` tag)
3. During `sync.sh` execution (before mirroring starts)

This ensures both fresh installs and upgrades get the annotation, preventing ACM from changing MCE to Automatic.

## Test plan

- [ ] Fresh install: verify MCH created with annotation
- [ ] Upgrade scenario: run sync.sh on existing deployment without annotation, verify it gets patched
- [ ] Verify MCE subscription remains `Manual` after patching
- [ ] Test in both connected and disconnected modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)