### PR TITLE
Document upgrade.sh execution in upgrade guide

### DIFF
--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -46,17 +46,17 @@ Each Enclave tarball release includes:
     ```sh
     ./sync.sh
     ```
-7. **Upgrade management cluster** - Update OpenShift to the version in the tarball:
+7. **Execute upgrade script** - Run the upgrade automation to apply configuration migrations and updates. Currently executes the `playbooks/upgrade.yaml` playbook. Future versions will also automate steps 8 and 9 (cluster and operator upgrades):
+    ```sh
+    ./upgrade.sh
+    ```
+8. **Upgrade management cluster** - Update OpenShift to the version in the tarball:
     ```sh
     enclave reconcile mgmt-cluster-version --use-defaults
     ```
-8. **Upgrade operators** - Update operators to the versions in the tarball:
+9. **Upgrade operators** - Update operators to the versions in the tarball:
     ```sh
     enclave reconcile operator-versions --use-defaults
-    ```
-9. **Execute upgrade script** - Run the upgrade automation to apply configuration migrations and updates. Currently executes the `playbooks/upgrade.yaml` playbook. Future versions will also automate steps 7 and 8 (cluster and operator upgrades):
-    ```sh
-    ./upgrade.sh
     ```
 
 ---

--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -43,6 +43,9 @@ Each Enclave tarball release includes:
 4. **Restore configurations** - Copy your `config/*.yaml` files back (or merge if needed)
 5. **Validate configuration** - Ensure your configs are compatible with new release
 6. **Sync content** - Run sync process to mirror new versions (disconnected mode)
+    ```sh
+    ./sync.sh
+    ```
 7. **Upgrade management cluster** - Update OpenShift to the version in the tarball:
     ```sh
     enclave reconcile mgmt-cluster-version --use-defaults
@@ -50,6 +53,10 @@ Each Enclave tarball release includes:
 8. **Upgrade operators** - Update operators to the versions in the tarball:
     ```sh
     enclave reconcile operator-versions --use-defaults
+    ```
+9. **Execute upgrade script** - Run the upgrade automation to apply configuration migrations and updates. Currently executes the `playbooks/upgrade.yaml` playbook. Future versions will also automate steps 7 and 8 (cluster and operator upgrades):
+    ```sh
+    ./upgrade.sh
     ```
 
 ---


### PR DESCRIPTION
## Summary

- Add step 9 to document `upgrade.sh` script execution in the upgrade process
- Explain that the script currently runs `playbooks/upgrade.yaml` for configuration migrations
- Note that future versions will automate cluster and operator upgrades (steps 7 and 8)
- Add missing code block for `sync.sh` step for consistency

## Test plan

- [x] Documentation changes reviewed for clarity and accuracy
- [x] Consistent formatting with existing upgrade guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced upgrade process documentation with explicit instructions for executing sync and upgrade scripts in the correct sequence during disconnected-mode operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->