### PR TITLE
Make quayPinnedImageSetEnabled opt-in instead of opt-out

### DIFF
--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -322,23 +322,6 @@ defaultNtpServers:
 - Only needed when cluster nodes cannot reach the default public NTP pool
 - Useful in air-gapped or firewalled environments
 
-#### `quayPinnedImageSetEnabled`
-
-**Description**: Controls whether the post-mirror master `PinnedImageSet` is generated and applied after Quay image mirroring.
-
-**Type**: Boolean (optional)
-
-**Default**: `true`
-
-**Example**:
-```yaml
-quayPinnedImageSetEnabled: false
-```
-
-**Notes**:
-- Set to `false` when you want to skip post-mirror prefetch pinning.
-- This setting is ignored when `mirror_dry_run` is enabled.
-
 ### Hardware Configuration
 
 #### `agent_hosts`
@@ -758,6 +741,23 @@ quayBackendLocalStorageConfiguration:
 ```
 
 **Note**: If omitted, Quay uses `storage_path: /datastorage/registry` from `defaults/quay_operator.yaml`.
+
+##### `quayPinnedImageSetEnabled`
+
+**Description**: Controls whether the post-mirror master `PinnedImageSet` is generated and applied after Quay image mirroring.
+
+**Type**: Boolean (optional)
+
+**Default**: `false`
+
+**Example**:
+```yaml
+quayPinnedImageSetEnabled: true
+```
+
+**Notes**:
+- Set to `true` to enable post-mirror prefetch pinning.
+- This setting is ignored when `mirror_dry_run` is enabled.
 
 #### Pull Secrets
 

--- a/operators/quay-operator/quay_disconnected_finish.yaml
+++ b/operators/quay-operator/quay_disconnected_finish.yaml
@@ -21,9 +21,5 @@
 - name: Generate and apply master PinnedImageSet from images on master nodes
   ansible.builtin.include_tasks: quay_pinnedimageset.yaml
   when: >-
-    (
-      quayPinnedImageSetEnabled
-      | default(quay_pinnedimageset_enabled | default(true))
-      | bool
-    )
+    (quayPinnedImageSetEnabled | default(false) | bool)
     and not (mirror_dry_run | default(false) | bool)

--- a/schemas/global.yaml
+++ b/schemas/global.yaml
@@ -71,7 +71,7 @@ properties:
     "$ref": "#/definitions/ocMirrorLogLevel"
   quayPinnedImageSetEnabled:
     type: boolean
-    default: true
+    default: false
     description: >-
       Whether to apply a master PinnedImageSet after Quay mirror sync.
       Set to false to skip post-mirror image prefetch pinning.


### PR DESCRIPTION
## Summary
Changes the `quayPinnedImageSetEnabled` feature from opt-out (enabled by default) to opt-in (disabled by default).

## Context
Per Slack discussion, this feature should be opt-in to avoid blocking users who encounter issues with it. Users can explicitly enable it when needed.

## Changes
- Set default to `false` in `schemas/global.yaml`
- Simplified conditional logic in `operators/quay-operator/quay_disconnected_finish.yaml`
- Removed backward compatibility variable `quay_pinnedimageset_enabled`
- Updated documentation in `CONFIGURATION_REFERENCE.md` to reflect opt-in behavior

## Testing
- Verified schema default is now `false`
- Verified playbook conditional properly uses the new default
- Documentation accurately describes the opt-in behavior

## Related Issues
- Addresses feedback from GoRI issue #921