### PR TITLE
Use default_operator_source to configure MultiClusterHub

### DIFF
--- a/operators/advanced-cluster-management/configure_mch.yaml
+++ b/operators/advanced-cluster-management/configure_mch.yaml
@@ -8,7 +8,7 @@
   ansible.builtin.set_fact:
     mce_subscription_spec:
       installPlanApproval: Manual
-      source: cs-mirror-redhat-operators-v4-20
+      source: "{{ default_operator_source }}"
 
 - name: Set MCE subscription spec for connected
   when: not (disconnected | default(true) | bool)


### PR DESCRIPTION
## Summary
Replace hardcoded catalog source name with the `default_operator_source` variable in MCE subscription configuration.

## Context
Follow-up to #488 (Extract MultiClusterHub configuration to reusable task).

## Changes
- Changed MCE subscription source from hardcoded `cs-mirror-redhat-operators-v4-20` to `{{ default_operator_source }}`

## Benefits
- Consistent with other operator configurations that use `default_operator_source`
- Avoids hardcoding version-specific catalog source names (the `-v4-20` suffix)
- Makes the configuration more flexible across different OpenShift versions

## Testing
- Verified the variable reference is correct
- Consistent with existing operator configuration patterns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved operator source configuration for disconnected environments by enabling dynamic defaults instead of hardcoded values, providing greater deployment flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->