### PR TITLE
Add version-specific upgrade notes to UPGRADE.md

### DIFF
--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -71,3 +71,27 @@ Each Enclave tarball release includes:
 ---
 
 **Note**: This is a high-level guide. Consult OpenShift and operator-specific documentation for detailed upgrade procedures and troubleshooting.
+
+---
+
+## Version-Specific Upgrade Notes
+
+### Upgrading from 0.1.0 to 0.1.1
+
+This section documents changes, migrations, and operator version updates when upgrading from Enclave 0.1.0 to 0.1.1.
+
+#### What's Changed
+
+**Operator Version Updates:**
+- **Quay**: 3.15.3 → 3.15.5
+- **Multicluster Engine (MCE)**: 2.10.1 → 2.10.3
+- **Advanced Cluster Management (ACM)**: 2.15.1 → 2.15.3
+
+**Architecture Changes:**
+- **Plugin Catalog Source Migration**: Foundation plugins (ODF, LVMS) now use dedicated catalog sources instead of the shared core catalog source
+  - Before: All operators used `cs-redhat-operator-index-v4-20` (or equivalent mirrored catalog)
+  - After: Foundation plugins have plugin-specific catalog sources (e.g., `cs-mirror-redhat-operators-odf-v4-20`)
+  - This change improves plugin isolation and allows independent catalog management per plugin
+- **Per-Plugin Configuration System**: plugins global configuration migrated to per-plugin config files under `config/plugins/`
+- **Operator Source Definitions Removed**: The explicit `source:` field has been removed from most operators in `defaults/operators.yaml` as catalog sources are now derived automatically
+- **MCE Subscription Management**: ACM is prevented from changing the MCE subscription installPlanApproval to Automatic (keeps it as Manual for upgrade control)

--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -95,3 +95,4 @@ This section documents changes, migrations, and operator version updates when up
 - **Per-Plugin Configuration System**: plugins global configuration migrated to per-plugin config files under `config/plugins/`
 - **Operator Source Definitions Removed**: The explicit `source:` field has been removed from most operators in `defaults/operators.yaml` as catalog sources are now derived automatically
 - **MCE Subscription Management**: ACM is prevented from changing the MCE subscription installPlanApproval to Automatic (keeps it as Manual for upgrade control)
+- **clair-import**: Standalone addon plugin for Clair security scanning (migrated from inline integration)


### PR DESCRIPTION
## Summary

Adds a new "Version-Specific Upgrade Notes" section to `docs/UPGRADE.md` documenting the upgrade path from 0.1.0 to 0.1.1.

## What's Included

- **Operator version updates**: Documents version changes for Quay (3.15.3 → 3.15.5), MCE (2.10.1 → 2.10.3), and ACM (2.15.1 → 2.15.3)
- **Architecture changes**: Details the plugin catalog source migration, per-plugin configuration system, operator source definitions removal, and MCE subscription management
- **Clear structure**: Uses a version-specific format that's easy to extend for future releases

## Why This Matters

Users upgrading from 0.1.0 need to understand:
- What content is being upgraded (operator versions, architecture changes)
- What migrations are automatically applied by `upgrade.sh`
- What configuration changes might be required

This documentation provides that clarity without duplicating the procedural steps already documented in the main upgrade guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)