### PR TITLE
Force-destroy leftover VMs in cleanup script

### DIFF
--- a/scripts/cleanup/cleanup.sh
+++ b/scripts/cleanup/cleanup.sh
@@ -408,11 +408,20 @@ success "=========================================="
 info ""
 info "Verifying cleanup..."
 
-# Check for leftover VMs
-LEFTOVER_VMS=$(sudo virsh list --all 2>/dev/null | grep -E "${CLUSTER_NAME}" || true)
+# Check for leftover VMs — force-destroy if found (safety net for failed dev-scripts cleanup)
+LEFTOVER_VMS=$(sudo virsh list --all --name 2>/dev/null | grep -E "^${CLUSTER_NAME}" || true)
 if [ -n "$LEFTOVER_VMS" ]; then
-    warning "Found leftover VMs for cluster ${CLUSTER_NAME}:"
-    echo "$LEFTOVER_VMS"
+    warning "Found leftover VMs after cleanup — force-destroying..."
+    "${SCRIPT_DIR}/../utils/with_libvirt_lock.sh" bash -c "
+        while IFS= read -r vm; do
+            [ -z \"\$vm\" ] && continue
+            echo \"  Destroying: \$vm\"
+            sudo virsh destroy \"\$vm\" 2>/dev/null || true
+            sudo virsh undefine \"\$vm\" --nvram --remove-all-storage 2>/dev/null \\
+                || sudo virsh undefine \"\$vm\" --remove-all-storage 2>/dev/null \\
+                || echo \"  Failed to undefine \$vm\"
+        done <<< \"${LEFTOVER_VMS}\"
+    "
 else
     success "No leftover VMs found"
 fi


### PR DESCRIPTION
## Summary

- When dev-scripts `make clean` fails during CI cleanup, leftover VMs were detected but only logged as warnings — they were never destroyed
- This caused orphaned VMs to run indefinitely, eventually OOM-killing CI runners on enclave-2 and enclave-3
- Replace the warn-only verification check with force-destroy logic (`virsh destroy` + `virsh undefine --remove-all-storage`), wrapped in the libvirt lock for parallel safety

**Root cause**: Run [27392181064](https://github.com/rh-ecosystem-edge/enclave/actions/runs/27392181064) (`OSAC-955-osac-plugin`) had `ocp_cleanup.sh` fail with Error 1. The cleanup script logged `WARNING: Found leftover VMs` but continued without destroying them. Four VMs (~112 GB) ran for 3+ days on enclave-2, causing OOM at 2026-06-15 03:21 CDT that killed runners 01/02/03. Same pattern on enclave-3.

## Test plan

- [ ] Clean up orphaned VMs on enclave-3 and restart runners
- [ ] Trigger an E2E run, cancel it mid-deployment to leave orphaned VMs
- [ ] Run cleanup script manually — verify leftover VMs are force-destroyed instead of just warned about
- [ ] Verify `make -f Makefile.ci validate-shell` passes (shellcheck)


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced cleanup process to automatically detect and remove leftover virtual machines that were previously left behind, preventing orphaned instances from accumulating and improving resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->