### PR TITLE
Use FQCN for set_fact in deploy_plugin.yaml

### DIFF
--- a/playbooks/tasks/deploy_plugin.yaml
+++ b/playbooks/tasks/deploy_plugin.yaml
@@ -147,14 +147,14 @@
   tags: mirror
 
 - name: Set catalog image and mirror defaults
-  set_fact:
+  ansible.builtin.set_fact:
     catalog_image: "{{ rh_operator_catalog }}"
     catalog_mirror: "{{ mirror_rh_operator_catalog }}-{{ plugin.name }}"
     catalog_version: "{{ rh_operator_catalog_version }}"
   tags: always
 
 - name: Override variables for certified catalog
-  set_fact:
+  ansible.builtin.set_fact:
     catalog_image: "{{ certified_operator_catalog }}"
     catalog_mirror: "{{ mirror_certified_rh_operator_catalog }}-{{ plugin.name }}"
     catalog_version: "{{ certified_operator_catalog_version }}"


### PR DESCRIPTION
## Summary

Use `ansible.builtin.set_fact` instead of `set_fact` to comply with Ansible best practices and ansible-lint requirements for fully qualified collection names (FQCN).

## Changes

- `playbooks/tasks/deploy_plugin.yaml`: Replace `set_fact` with `ansible.builtin.set_fact` (2 occurrences)

## Impact

- No functional changes
- Improves ansible-lint compliance
- Follows Ansible best practices for FQCN usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `installOperatorsFleet` configuration option to control operator installation on fleet-managed clusters.

* **Configuration Updates**
  * Updated LVMS and ODF plugins with cluster targeting and selective operator installation controls.
  * Operators can now be independently managed on management and fleet clusters based on configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->