### PR TITLE
Fix foundation plugin catalog availability on spoke clusters

### DIFF
--- a/files/plugin-fleet-configuration/30-placementbinding.yaml.j2
+++ b/files/plugin-fleet-configuration/30-placementbinding.yaml.j2
@@ -11,6 +11,8 @@ subjects:
 - apiGroup: policy.open-cluster-management.io
   kind: Policy
   name: {{ plugin.name }}-catalogsource
+{% if plugin.installOperatorsFleet | default(true) | bool %}
 - apiGroup: policy.open-cluster-management.io
   kind: Policy
   name: {{ plugin.name }}-operators
+{% endif %}

--- a/playbooks/tasks/configure_operators_fleet.yaml
+++ b/playbooks/tasks/configure_operators_fleet.yaml
@@ -53,7 +53,7 @@
   kubernetes.core.k8s:
     state: present
     namespace: openshift-acm-policies
-    definition: "{{ lookup('ansible.builtin.template', 'files/plugin-fleet-configuration/30-placementbinding.yaml.j2') | from_yaml }}"
+    definition: "{{ lookup('ansible.builtin.template', '{{ playbook_dir }}/../files/plugin-fleet-configuration/30-placementbinding.yaml.j2') | from_yaml }}"
   register: r_acm_placementbinding
   retries: "{{ k8s_retries }}"
   delay: "{{ k8s_delay }}"

--- a/playbooks/tasks/configure_operators_fleet.yaml
+++ b/playbooks/tasks/configure_operators_fleet.yaml
@@ -32,6 +32,8 @@
   retries: "{{ k8s_retries }}"
   delay: "{{ k8s_delay }}"
   until: r_acm_policy_operators is success
+  when:
+    - plugin.installOperatorsFleet | default(true) | bool
 
 - name: Create ACM PlacementRule for Plugin
   environment:

--- a/playbooks/tasks/configure_operators_fleet.yaml
+++ b/playbooks/tasks/configure_operators_fleet.yaml
@@ -3,7 +3,7 @@
     KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
   kubernetes.core.k8s:
     state: present
-    definition: "{{ lookup('ansible.builtin.file', 'files/plugin-fleet-configuration/00-namespace.yaml') | from_yaml }}"
+    definition: "{{ lookup('ansible.builtin.file', '{{ playbook_dir }}/../files/plugin-fleet-configuration/00-namespace.yaml') | from_yaml }}"
   register: r_acm_policy_ns
   retries: "{{ k8s_retries }}"
   delay: "{{ k8s_delay }}"
@@ -15,7 +15,7 @@
   kubernetes.core.k8s:
     state: present
     namespace: openshift-acm-policies
-    definition: "{{ lookup('ansible.builtin.template', 'files/plugin-fleet-configuration/09-policy-catalogsource.yaml.j2') | from_yaml }}"
+    definition: "{{ lookup('ansible.builtin.template', '{{ playbook_dir }}/../files/plugin-fleet-configuration/09-policy-catalogsource.yaml.j2') | from_yaml }}"
   register: r_acm_policy_cs
   retries: "{{ k8s_retries }}"
   delay: "{{ k8s_delay }}"
@@ -27,7 +27,7 @@
   kubernetes.core.k8s:
     state: present
     namespace: openshift-acm-policies
-    definition: "{{ lookup('ansible.builtin.template', 'files/plugin-fleet-configuration/10-policy-operators.yaml.j2') | from_yaml }}"
+    definition: "{{ lookup('ansible.builtin.template', '{{ playbook_dir }}/../files/plugin-fleet-configuration/10-policy-operators.yaml.j2') | from_yaml }}"
   register: r_acm_policy_operators
   retries: "{{ k8s_retries }}"
   delay: "{{ k8s_delay }}"
@@ -41,7 +41,7 @@
   kubernetes.core.k8s:
     state: present
     namespace: openshift-acm-policies
-    definition: "{{ lookup('ansible.builtin.template', 'files/plugin-fleet-configuration/20-placementrule.yaml.j2') | from_yaml }}"
+    definition: "{{ lookup('ansible.builtin.template', '{{ playbook_dir }}/../files/plugin-fleet-configuration/20-placementrule.yaml.j2') | from_yaml }}"
   register: r_acm_placementrule
   retries: "{{ k8s_retries }}"
   delay: "{{ k8s_delay }}"

--- a/playbooks/tasks/migrations.yaml
+++ b/playbooks/tasks/migrations.yaml
@@ -11,3 +11,8 @@
   ansible.builtin.include_tasks:
     file: migrations/foundation_plugin_catalog_sources.yaml
   when: disconnected | default(true) | bool
+
+- name: Foundation plugin fleet catalog migration
+  ansible.builtin.include_tasks:
+    file: migrations/foundation_plugin_fleet_catalogs.yaml
+  when: disconnected | default(true) | bool

--- a/playbooks/tasks/migrations/foundation_plugin_fleet_catalogs.yaml
+++ b/playbooks/tasks/migrations/foundation_plugin_fleet_catalogs.yaml
@@ -1,0 +1,58 @@
+---
+# Foundation Plugin Fleet Catalog Migration
+#
+# Creates ACM policies to deploy foundation plugin catalog sources to spoke clusters.
+#
+# Background: After the May 2026 catalog separation, foundation plugins (ODF, LVMS)
+# moved from the core catalog to plugin-specific catalogs. However, these plugin-specific
+# catalogs were not being deployed to spoke clusters, breaking operator availability.
+#
+# This migration creates ACM policies to push plugin-specific catalog sources
+# (e.g., cs-mirror-redhat-operators-odf-v4-20) to spoke clusters in disconnected environments.
+#
+# Only applies to disconnected deployments and enabled foundation plugins with clusterSelector.
+
+- name: Find plugin descriptors
+  ansible.builtin.find:
+    paths: "{{ playbook_dir }}/../plugins"
+    patterns: "plugin.yaml"
+    recurse: true
+    depth: 2
+  register: r_fleet_find
+
+- name: Read plugin descriptors
+  ansible.builtin.slurp:
+    src: "{{ plugin_path }}"
+  loop: "{{ r_fleet_find.files | default([]) | map(attribute='path') | list }}"
+  register: r_fleet_slurp
+  loop_control:
+    loop_var: plugin_path
+
+- name: Filter foundation plugins with clusterSelector
+  ansible.builtin.set_fact:
+    _foundation_fleet_plugins: >-
+      {{ r_fleet_slurp.results | default([])
+         | map(attribute='content')
+         | map('b64decode')
+         | map('from_yaml')
+         | selectattr('type', 'equalto', 'foundation')
+         | selectattr('name', 'in', enabled_plugins | default([]))
+         | selectattr('clusterSelector', 'defined')
+         | list }}
+
+- name: Create ACM policies for foundation plugin fleet catalogs
+  ansible.builtin.include_tasks:
+    file: tasks/configure_operators_fleet.yaml
+    apply:
+      environment:
+        KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  vars:
+    plugin: "{{ fleet_plugin }}"
+    catalog_image: "{{ (fleet_plugin.catalog | default('redhat')) == 'certified' | ternary(certified_operator_catalog, rh_operator_catalog) }}"
+    catalog_mirror: "{{ (fleet_plugin.catalog | default('redhat')) == 'certified' | ternary(mirror_certified_rh_operator_catalog, mirror_rh_operator_catalog) }}-{{ fleet_plugin.name }}"
+    catalog_version: "{{ (fleet_plugin.catalog | default('redhat')) == 'certified' | ternary(certified_operator_catalog_version, rh_operator_catalog_version) }}"
+  loop: "{{ _foundation_fleet_plugins }}"
+  loop_control:
+    loop_var: fleet_plugin
+    label: "{{ fleet_plugin.name }}"
+  when: _foundation_fleet_plugins | length > 0

--- a/plugins/lvms/plugin.yaml
+++ b/plugins/lvms/plugin.yaml
@@ -3,6 +3,23 @@ name: lvms
 type: foundation
 order: 10
 
+# Deploy LVMS catalog source to all managed clusters (excludes management cluster)
+# This makes LVMS operators available on spoke clusters in disconnected environments.
+# Operators are installed manually on spoke clusters as needed (not auto-deployed).
+clusterSelector:
+  matchExpressions:
+    - key: local-cluster
+      operator: NotIn
+      values:
+        - "true"
+
+# Install operators on management cluster
+installOperators: true
+
+# Only deploy catalog source to fleet (not operator subscriptions)
+# Spoke clusters get LVMS operators available, but not auto-installed
+installOperatorsFleet: false
+
 operators:
   - name: lvms-operator
     version: 4.20.0

--- a/plugins/odf/plugin.yaml
+++ b/plugins/odf/plugin.yaml
@@ -3,6 +3,23 @@ name: odf
 type: foundation
 order: 10
 
+# Deploy ODF catalog source to all managed clusters (excludes management cluster)
+# This makes ODF operators available on spoke clusters in disconnected environments.
+# Operators are installed manually on spoke clusters as needed (not auto-deployed).
+clusterSelector:
+  matchExpressions:
+    - key: local-cluster
+      operator: NotIn
+      values:
+        - "true"
+
+# Install operators on management cluster
+installOperators: true
+
+# Only deploy catalog source to fleet (not operator subscriptions)
+# Spoke clusters get ODF operators available, but not auto-installed
+installOperatorsFleet: false
+
 operators:
   - name: odf-operator
     version: 4.20.7-rhodf

--- a/schemas/plugin.yaml
+++ b/schemas/plugin.yaml
@@ -238,6 +238,13 @@ properties:
   installOperators:
     type: boolean
     decsription: Install operators.
+  installOperatorsFleet:
+    type: boolean
+    description: >-
+      Install operators on fleet managed clusters via ACM policies.
+      Only applicable when clusterSelector is defined.
+      Set to false to deploy only the catalog source to fleet (not operator subscriptions).
+      Defaults to true.
   clusterSelector:
     $ref: "#/definitions/selector"
   helm:
@@ -283,6 +290,9 @@ properties:
         description: Files that must exist within the plugin directory.
         items:
           $ref: "#/definitions/requirement_file"
+dependencies:
+  installOperatorsFleet:
+    - clusterSelector
 required:
   - name
   - type

--- a/scripts/verification/validate_plugins.sh
+++ b/scripts/verification/validate_plugins.sh
@@ -87,7 +87,7 @@ filepath = sys.argv[1]
 dir_name = sys.argv[2]
 required_fields = ['name', 'type']
 valid_fields = ['name', 'type', 'order', 'catalog', 'operators', 'defaults',
-                'installOperators', 'registries', 'additionalImages', 'blockedImages',
+                'installOperators', 'installOperatorsFleet', 'registries', 'additionalImages', 'blockedImages',
                 'requires', 'helm', 'clusterSelector']
 
 try:


### PR DESCRIPTION
## Summary

Fixes foundation plugin (ODF, LVMS) catalog source availability on spoke clusters in disconnected environments. This is a regression from the May 2026 catalog separation where foundation plugins moved to dedicated catalogs but these were not being deployed to spoke clusters.

**Fixes**: https://github.com/gori-project/GoRI/issues/922 (Sev 1 stop-ship bug)

## Problem

After the May 2026 catalog separation (commits 761e628, b44e490), foundation plugins got plugin-specific catalog sources (e.g., `cs-mirror-redhat-operators-odf-v4-20`) instead of being part of the core catalog. However, these plugin-specific catalogs were not being deployed to spoke clusters via ACM policies, breaking operator availability.

**Before**: Foundation plugins mirrored in core catalog → core catalog pushed to all clusters → operators available everywhere

**After catalog separation**: Foundation plugins in dedicated catalogs → only deployed to management cluster → operators unavailable on spoke clusters

## Solution

1. **Add `clusterSelector`** to ODF and LVMS plugins to target all managed clusters (excluding management cluster)

2. **Introduce `installOperatorsFleet` field** to control whether operator subscriptions are deployed to fleet via ACM policies
   - Defaults to `true` for backward compatibility
   - Set to `false` for ODF/LVMS (catalog-only deployment)

3. **Enhance fleet deployment logic** to conditionally create operator policies based on `installOperatorsFleet`

4. **Add schema dependency**: `installOperatorsFleet` requires `clusterSelector`

5. **Add migration** for existing deployments (runs during `upgrade.sh`)

## Changes

### Plugin Configuration

**`plugins/odf/plugin.yaml`** and **`plugins/lvms/plugin.yaml`**:
```yaml
clusterSelector:
  matchExpressions:
    - key: local-cluster
      operator: NotIn
      values:
        - "true"

installOperators: true           # Install on management cluster
installOperatorsFleet: false     # Catalog only on spoke clusters
```

### Core Infrastructure

- **`playbooks/tasks/configure_operators_fleet.yaml`**: Conditional operator policy creation
- **`files/plugin-fleet-configuration/30-placementbinding.yaml.j2`**: Conditional subject binding (catalogsource only vs catalogsource + operators)
- **`schemas/plugin.yaml`**: Add `installOperatorsFleet` field with `clusterSelector` dependency
- **`scripts/verification/validate_plugins.sh`**: Add to valid fields

### Migration

- **`playbooks/tasks/migrations/foundation_plugin_fleet_catalogs.yaml`**: Creates ACM policies for existing deployments
- **`playbooks/tasks/migrations.yaml`**: Register the migration

## Migration Note for Existing Deployments

This change restores catalog source availability on spoke clusters but does **NOT** migrate existing operator Subscriptions on spoke clusters. If you have ODF/LVMS operators already installed on spoke clusters with Subscriptions pointing to the old core catalog (`cs-mirror-redhat-operators-v4-20`), you will need to migrate those Subscriptions to the new plugin-specific catalog sources (`cs-mirror-redhat-operators-odf-v4-20` or `cs-mirror-redhat-operators-lvms-v4-20`). Enclave consumers should handle this migration in their own upgrade processes. See `playbooks/tasks/migrations/foundation_plugin_catalog_sources.yaml` for the migration pattern used on the management cluster.

## Testing

- ✅ Schema validation passes for all plugins
- ✅ ODF plugin validates with new fields
- ✅ LVMS plugin validates with new fields
- ✅ Migration is self-contained and reuses existing infrastructure

## Result

ODF and LVMS catalog sources are now available on spoke clusters in disconnected environments, restoring pre-separation behavior while maintaining the benefits of per-plugin catalog isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)