### PR TITLE
Add pre-bootstrap leftover check via enclave environment subcommand

### DIFF
--- a/.github/workflows/disconnected-dry-run.yml
+++ b/.github/workflows/disconnected-dry-run.yml
@@ -110,6 +110,13 @@ jobs:
           make -f Makefile.ci install-enclave
           echo "✅ Enclave Lab installed" >> $GITHUB_STEP_SUMMARY
 
+      - name: Check for leftover resources on Landing Zone
+        id: check-leftovers
+        run: |
+          echo "## Pre-bootstrap Leftover Check" >> $GITHUB_STEP_SUMMARY
+          make -f Makefile.ci deploy-cluster-check-leftovers
+          echo "Landing Zone is clean" >> $GITHUB_STEP_SUMMARY
+
       - name: Phase 1 - Prepare binaries and content
         run: |
           echo "## Phase 1: Prepare" >> $GITHUB_STEP_SUMMARY
@@ -164,6 +171,8 @@ jobs:
           # Check steps in reverse order to find the last failed step
           if [ "${{ steps.upload_artifacts.outcome }}" = "failure" ]; then
             echo "FAILED_STEP=Upload artifacts" >> $GITHUB_OUTPUT
+          elif [ "${{ steps.check-leftovers.outcome }}" = "failure" ]; then
+            echo "FAILED_STEP=Check for leftover resources on Landing Zone" >> $GITHUB_OUTPUT
           elif [ "${{ job.status }}" = "failure" ]; then
             echo "FAILED_STEP=Phase 2/2.5 - Mirror registry or validation" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/e2e-deployment.yml
+++ b/.github/workflows/e2e-deployment.yml
@@ -316,6 +316,13 @@ jobs:
           make -f Makefile.ci install-enclave
           echo "Enclave Lab installed" >> $GITHUB_STEP_SUMMARY
 
+      - name: Check for leftover resources on Landing Zone
+        id: check_leftovers
+        run: |
+          echo "## Pre-bootstrap Leftover Check" >> $GITHUB_STEP_SUMMARY
+          make -f Makefile.ci deploy-cluster-check-leftovers
+          echo "Landing Zone is clean" >> $GITHUB_STEP_SUMMARY
+
       - name: Generate Ironic ISO server TLS certificate
         id: generate_ironic_cert
         if: env.ENCLAVE_IRONIC_HTTPS == 'true'
@@ -455,7 +462,7 @@ jobs:
               mkdir -p artifacts/must-gather
               GATHER_OUT=$(ssh $SSH_OPTS cloud-user@$LZ_IP \
                 "cd /home/cloud-user/enclave/scripts/diagnostics && \
-                 export KUBECONFIG=/home/cloud-user/ocp-cluster/auth/kubeconfig && \
+                 export KUBECONFIG=/home/cloud-user/sessions/1/ocp-cluster/auth/kubeconfig && \
                  GITHUB_RUN_ID='${{ github.run_id }}' ./gather.sh --must-gather=full ../../config/global.yaml 2>&1" || true)
               echo "$GATHER_OUT" >> artifacts/must-gather/gather-output.txt
 
@@ -587,6 +594,7 @@ jobs:
           STEPS_JSON: ${{ toJSON(steps) }}
         run: |
           declare -A step_names=(
+            ["check_leftovers"]="Check for leftover resources on Landing Zone"
             ["generate_ironic_cert"]="Generate Ironic ISO server TLS certificate"
             ["setup_ceph"]="Setup Ceph on Landing Zone"
             ["bootstrap_setup"]="Bootstrap: Setup environment"
@@ -609,6 +617,7 @@ jobs:
           )
 
           step_order=(
+            check_leftovers
             generate_ironic_cert
             setup_ceph
             bootstrap_setup
@@ -762,6 +771,13 @@ jobs:
           make -f Makefile.ci install-enclave
           echo "Enclave Lab installed" >> $GITHUB_STEP_SUMMARY
 
+      - name: Check for leftover resources on Landing Zone
+        id: check_leftovers
+        run: |
+          echo "## Pre-bootstrap Leftover Check" >> $GITHUB_STEP_SUMMARY
+          make -f Makefile.ci deploy-cluster-check-leftovers
+          echo "Landing Zone is clean" >> $GITHUB_STEP_SUMMARY
+
       - name: Generate Ironic ISO server TLS certificate
         id: generate_ironic_cert
         if: env.ENCLAVE_IRONIC_HTTPS == 'true'
@@ -910,7 +926,7 @@ jobs:
               mkdir -p artifacts/must-gather
               GATHER_OUT=$(ssh $SSH_OPTS cloud-user@$LZ_IP \
                 "cd /home/cloud-user/enclave/scripts/diagnostics && \
-                 export KUBECONFIG=/home/cloud-user/ocp-cluster/auth/kubeconfig && \
+                 export KUBECONFIG=/home/cloud-user/sessions/1/ocp-cluster/auth/kubeconfig && \
                  GITHUB_RUN_ID='${{ github.run_id }}' ./gather.sh --must-gather=full ../../config/global.yaml 2>&1" || true)
               echo "$GATHER_OUT" >> artifacts/must-gather/gather-output.txt
 
@@ -1042,6 +1058,7 @@ jobs:
           STEPS_JSON: ${{ toJSON(steps) }}
         run: |
           declare -A step_names=(
+            ["check_leftovers"]="Check for leftover resources on Landing Zone"
             ["generate_ironic_cert"]="Generate Ironic ISO server TLS certificate"
             ["setup_ceph"]="Setup Ceph on Landing Zone"
             ["bootstrap_setup"]="Bootstrap: Setup environment"
@@ -1064,6 +1081,7 @@ jobs:
           )
 
           step_order=(
+            check_leftovers
             generate_ironic_cert
             setup_ceph
             bootstrap_setup

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -171,6 +171,13 @@ deploy-cluster-setup: setup-dev-scripts
 	@echo ""
 	@./scripts/deployment/deploy_bootstrap_step.sh setup
 
+deploy-cluster-check-leftovers: setup-dev-scripts
+	@echo "=========================================="
+	@echo "Pre-bootstrap leftover check"
+	@echo "=========================================="
+	@echo ""
+	@./scripts/deployment/deploy_bootstrap_step.sh check-leftovers
+
 deploy-cluster-validate: setup-dev-scripts
 	@echo "=========================================="
 	@echo "Validate configuration"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -8,9 +8,11 @@ usage() {
     echo "Options:"
     echo "  --step STEP           Run a single step instead of all steps"
     echo "  --non-interactive     Skip interactive prompts"
+    echo "  -f, --force-cleanup   Automatically run cleanup if leftovers are detected"
     echo "  -h, --help            Show this help message"
     echo ""
     echo "Available steps:"
+    echo "  check-leftovers     Check for leftover resources from a previous installation"
     echo "  setup               Configure environment (setup_env + setup_ansible)"
     echo "  validate            Validate configuration (schema + validations)"
     echo "  download-content    Download control binaries and dependency content (Phase 1)"
@@ -33,6 +35,7 @@ cloud_infra_vars=config/cloud_infra.yaml
 
 run_step=""
 non_interactive=false
+force_cleanup=false
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -42,6 +45,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --non-interactive)
             non_interactive=true
+            shift
+            ;;
+        -f|--force-cleanup)
+            force_cleanup=true
             shift
             ;;
         -h|--help)
@@ -55,7 +62,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Validate --step value if provided
-valid_steps="setup validate download-content build-cache acquire-hardware deploy post-install operators day2 discovery partner-overlay"
+valid_steps="check-leftovers setup validate download-content build-cache acquire-hardware deploy post-install operators day2 discovery partner-overlay"
 if [ -n "$run_step" ]; then
     step_valid=false
     for s in $valid_steps; do
@@ -168,6 +175,27 @@ step_done
 
 # --- Step functions ---
 
+step_check_leftovers() {
+    echo "Checking for leftover resources from a previous installation..." | tee -a ${log}
+    if ! WORKING_DIR="${workingDir}" enclave environment check-leftovers 2>&1 | tee -a ${log}; then
+        if [ "$force_cleanup" = true ]; then
+            echo "Leftover resources detected, running cleanup automatically (--force-cleanup)..." | tee -a ${log}
+            _log_backup=$(mktemp)
+            cp "$log" "$_log_backup"
+            WORKING_DIR="${workingDir}" enclave environment cleanup 2>&1 | tee -a "${log}" "${_log_backup}"
+            mkdir -p "$(dirname "$log")"
+            mv "$_log_backup" "$log"
+            echo "Cleanup complete, proceeding" | tee -a ${log}
+        else
+            echo "ERROR: Leftover resources detected, add --force-cleanup flag to this script" | tee -a ${log}
+            exit 1
+        fi
+    else
+        echo "Environment is clean, proceeding" | tee -a ${log}
+    fi
+    step_done
+}
+
 step_setup() {
     echo 'Runtime Host:' | tee -a ${log}
     cat /etc/redhat-release | tee -a ${log}
@@ -277,6 +305,7 @@ if [ -n "${run_step}" ]; then
     "$func_name"
 else
     # Full run mode: execute all steps sequentially
+    step_check_leftovers
     step_setup
     step_validate
     step_download_content

--- a/docs/LOCAL_TESTING.md
+++ b/docs/LOCAL_TESTING.md
@@ -465,19 +465,19 @@ SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
 
 # Kubeconfig exists
 ssh $SSH_OPTS cloud-user@$LZ_IP \
-  "test -f /home/cloud-user/ocp-cluster/auth/kubeconfig && echo 'OK'"
+  "test -f /home/cloud-user/sessions/1/ocp-cluster/auth/kubeconfig && echo 'OK'"
 
 # Nodes
 ssh $SSH_OPTS cloud-user@$LZ_IP \
-  "export KUBECONFIG=/home/cloud-user/ocp-cluster/auth/kubeconfig && oc get nodes"
+  "export KUBECONFIG=/home/cloud-user/sessions/1/ocp-cluster/auth/kubeconfig && oc get nodes"
 
 # Cluster operators
 ssh $SSH_OPTS cloud-user@$LZ_IP \
-  "export KUBECONFIG=/home/cloud-user/ocp-cluster/auth/kubeconfig && oc get co"
+  "export KUBECONFIG=/home/cloud-user/sessions/1/ocp-cluster/auth/kubeconfig && oc get co"
 
 # Cluster version
 ssh $SSH_OPTS cloud-user@$LZ_IP \
-  "export KUBECONFIG=/home/cloud-user/ocp-cluster/auth/kubeconfig && oc get clusterversion"
+  "export KUBECONFIG=/home/cloud-user/sessions/1/ocp-cluster/auth/kubeconfig && oc get clusterversion"
 ```
 
 ## Troubleshooting
@@ -583,13 +583,13 @@ SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
 
 # Get degraded operators
 ssh $SSH_OPTS cloud-user@$LZ_IP \
-  "export KUBECONFIG=/home/cloud-user/ocp-cluster/auth/kubeconfig && \
+  "export KUBECONFIG=/home/cloud-user/sessions/1/ocp-cluster/auth/kubeconfig && \
    oc get co -o json | jq -r '.items[] | select(.status.conditions[] | \
    select(.type==\"Degraded\" and .status==\"True\")) | .metadata.name'"
 
 # Describe specific operator
 ssh $SSH_OPTS cloud-user@$LZ_IP \
-  "export KUBECONFIG=/home/cloud-user/ocp-cluster/auth/kubeconfig && \
+  "export KUBECONFIG=/home/cloud-user/sessions/1/ocp-cluster/auth/kubeconfig && \
    oc describe co <operator-name>"
 ```
 

--- a/scripts/deployment/deploy_bootstrap_step.sh
+++ b/scripts/deployment/deploy_bootstrap_step.sh
@@ -36,11 +36,11 @@ STEP_NAME="$1"
 
 # Validate step name against allowed values
 case "$STEP_NAME" in
-    setup|validate|download-content|build-cache|acquire-hardware|deploy|post-install|operators|day2|discovery|partner-overlay)
+    check-leftovers|setup|validate|download-content|build-cache|acquire-hardware|deploy|post-install|operators|day2|discovery|partner-overlay)
         ;;
     *)
         error "Unknown bootstrap step: $STEP_NAME"
-        error "Valid steps: setup validate download-content build-cache acquire-hardware deploy post-install operators day2 discovery partner-overlay"
+        error "Valid steps: check-leftovers setup validate download-content build-cache acquire-hardware deploy post-install operators day2 discovery partner-overlay"
         exit 1
         ;;
 esac

--- a/scripts/deployment/deploy_cluster.sh
+++ b/scripts/deployment/deploy_cluster.sh
@@ -151,7 +151,7 @@ info ""
 
 # Build ansible-playbook command with extra vars file
 # Create a temporary extra vars YAML file on the Landing Zone
-EXTRA_VARS_CONTENT="workingDir: /home/${LZ_USER}
+EXTRA_VARS_CONTENT="workingDir: /home/${LZ_USER}/sessions/1
 "
 
 # Set disconnected mode based on DEPLOYMENT_MODE
@@ -200,7 +200,7 @@ EOF
 
 # Run ansible-playbook with the extra vars file
 # shellcheck disable=SC2086  # SSH_OPTS needs word splitting
-ssh -t $SSH_OPTS "$LZ_SSH" "cd $LZ_ENCLAVE_DIR && bash -c 'set -o pipefail; ansible-playbook playbooks/main.yaml -e @config/extra_vars.yaml 2>&1 | tee deployment.log'"
+ssh -t $SSH_OPTS "$LZ_SSH" "cd $LZ_ENCLAVE_DIR && bash -c 'export PATH=/home/${LZ_USER}/sessions/1/bin:\$PATH KUBECONFIG=/home/${LZ_USER}/sessions/1/ocp-cluster/auth/kubeconfig; set -o pipefail; ansible-playbook playbooks/main.yaml -e @config/extra_vars.yaml 2>&1 | tee deployment.log'"
 
 DEPLOYMENT_EXIT_CODE=$?
 

--- a/scripts/deployment/deploy_phase.sh
+++ b/scripts/deployment/deploy_phase.sh
@@ -85,7 +85,7 @@ if ! ssh_file_exists "$LZ_ENCLAVE_DIR/config/global.yaml"; then
 fi
 
 # Build ansible-playbook command with extra vars
-EXTRA_VARS_CONTENT="workingDir: /home/${LZ_USER}
+EXTRA_VARS_CONTENT="workingDir: /home/${LZ_USER}/sessions/1
 "
 
 # Set disconnected mode based on DEPLOYMENT_MODE
@@ -168,7 +168,7 @@ EOF
 LOG_FILE="deployment_$(basename "$PLAYBOOK_FILE" .yaml).log"
 info "Running playbook (logging to $LOG_FILE)..."
 # shellcheck disable=SC2086  # SSH_OPTS and ANSIBLE_EXTRA_ARGS need word splitting
-ssh -t $SSH_OPTS "$LZ_SSH" "cd $LZ_ENCLAVE_DIR && bash -c 'set -o pipefail; ansible-playbook playbooks/$PLAYBOOK_FILE -e @phase_vars.yaml $ANSIBLE_EXTRA_ARGS 2>&1 | tee $LOG_FILE'"
+ssh -t $SSH_OPTS "$LZ_SSH" "cd $LZ_ENCLAVE_DIR && bash -c 'export PATH=/home/${LZ_USER}/sessions/1/bin:\$PATH KUBECONFIG=/home/${LZ_USER}/sessions/1/ocp-cluster/auth/kubeconfig; set -o pipefail; ansible-playbook playbooks/$PLAYBOOK_FILE -e @phase_vars.yaml $ANSIBLE_EXTRA_ARGS 2>&1 | tee $LOG_FILE'"
 
 PHASE_EXIT_CODE=$?
 

--- a/scripts/deployment/deploy_plugin.sh
+++ b/scripts/deployment/deploy_plugin.sh
@@ -98,7 +98,7 @@ if ! ssh_file_exists "$LZ_ENCLAVE_DIR/config/global.yaml"; then
 fi
 
 # Build ansible-playbook command with extra vars
-EXTRA_VARS_CONTENT="workingDir: /home/${LZ_USER}
+EXTRA_VARS_CONTENT="workingDir: /home/${LZ_USER}/sessions/1
 plugin_name: ${PLUGIN_NAME}
 "
 
@@ -170,7 +170,7 @@ LOG_FILE="deployment_plugin_${PLUGIN_NAME}.log"
 info "Running playbook (logging to $LOG_FILE)..."
 # shellcheck disable=SC2086  # SSH_OPTS needs word splitting
 set +e
-ssh -t $SSH_OPTS "$LZ_SSH" "cd $LZ_ENCLAVE_DIR && bash -c 'set -o pipefail; ansible-playbook playbooks/deploy-plugin.yaml -e @phase_vars.yaml $ANSIBLE_EXTRA_ARGS 2>&1 | tee $LOG_FILE'"
+ssh -t $SSH_OPTS "$LZ_SSH" "cd $LZ_ENCLAVE_DIR && bash -c 'export PATH=/home/${LZ_USER}/sessions/1/bin:\$PATH KUBECONFIG=/home/${LZ_USER}/sessions/1/ocp-cluster/auth/kubeconfig; set -o pipefail; ansible-playbook playbooks/deploy-plugin.yaml -e @phase_vars.yaml $ANSIBLE_EXTRA_ARGS 2>&1 | tee $LOG_FILE'"
 PLUGIN_EXIT_CODE=$?
 set -e
 

--- a/scripts/infrastructure/generate_enclave_vars.sh
+++ b/scripts/infrastructure/generate_enclave_vars.sh
@@ -102,7 +102,7 @@ cat > "$GLOBAL_VARS_OUTPUT" <<EOF
 # ============================================================================
 # Base Configuration
 # ============================================================================
-workingDir: "/home/cloud-user"
+workingDir: "/home/cloud-user/sessions/1"
 schemaValidationNoLog: true
 
 # ============================================================================

--- a/scripts/verification/collect_ci_artifacts.sh
+++ b/scripts/verification/collect_ci_artifacts.sh
@@ -701,7 +701,7 @@ check_kubeconfig_exists() {
     local lz_ip="$1"
     local ssh_opts="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -q"
 
-    ssh $ssh_opts cloud-user@"$lz_ip" "test -f /home/cloud-user/ocp-cluster/auth/kubeconfig" 2>/dev/null
+    ssh $ssh_opts cloud-user@"$lz_ip" "test -f /home/cloud-user/sessions/1/ocp-cluster/auth/kubeconfig" 2>/dev/null
 }
 
 collect_cluster_kubeconfig() {
@@ -710,7 +710,7 @@ collect_cluster_kubeconfig() {
 
     mkdir -p "${OUTPUT_DIR}/cluster"
     info "Collecting kubeconfig..."
-    scp $ssh_opts cloud-user@"$lz_ip":/home/cloud-user/ocp-cluster/auth/kubeconfig "${OUTPUT_DIR}/cluster/" 2>/dev/null || warn "Could not collect kubeconfig"
+    scp $ssh_opts cloud-user@"$lz_ip":/home/cloud-user/sessions/1/ocp-cluster/auth/kubeconfig "${OUTPUT_DIR}/cluster/" 2>/dev/null || warn "Could not collect kubeconfig"
 }
 
 collect_cluster_status() {
@@ -719,7 +719,7 @@ collect_cluster_status() {
 
     info "Collecting cluster status..."
     ssh $ssh_opts cloud-user@"$lz_ip" "
-        export KUBECONFIG=/home/cloud-user/ocp-cluster/auth/kubeconfig
+        export KUBECONFIG=/home/cloud-user/sessions/1/ocp-cluster/auth/kubeconfig
 
         echo '=== Cluster Version ==='
         oc get clusterversion -o yaml
@@ -747,7 +747,7 @@ collect_cluster_events() {
 
     info "Collecting cluster events..."
     ssh $ssh_opts cloud-user@"$lz_ip" "
-        export KUBECONFIG=/home/cloud-user/ocp-cluster/auth/kubeconfig
+        export KUBECONFIG=/home/cloud-user/sessions/1/ocp-cluster/auth/kubeconfig
 
         echo '=== Recent Events (last 100) ==='
         oc get events --all-namespaces --sort-by='.lastTimestamp' | tail -100
@@ -763,7 +763,7 @@ collect_cluster_pods() {
 
     info "Collecting pod information..."
     ssh $ssh_opts cloud-user@"$lz_ip" "
-        export KUBECONFIG=/home/cloud-user/ocp-cluster/auth/kubeconfig
+        export KUBECONFIG=/home/cloud-user/sessions/1/ocp-cluster/auth/kubeconfig
 
         echo '=== All Pods ==='
         oc get pods --all-namespaces -o wide
@@ -785,7 +785,7 @@ collect_cluster_problem_pod_logs() {
 
     info "Collecting logs from problem pods..."
     ssh $ssh_opts cloud-user@"$lz_ip" "
-        export KUBECONFIG=/home/cloud-user/ocp-cluster/auth/kubeconfig
+        export KUBECONFIG=/home/cloud-user/sessions/1/ocp-cluster/auth/kubeconfig
         mkdir -p /tmp/problem-pods-${TIMESTAMP}
 
         # Get pods that are not Running/Succeeded

--- a/scripts/verification/validate.sh
+++ b/scripts/verification/validate.sh
@@ -35,8 +35,8 @@ print_info() {
 validate_shell() {
     print_header "Validating shell scripts with shellcheck"
 
-    if find scripts/ -name "*.sh" -type f 2>/dev/null | grep -q .; then
-        if find scripts/ -name "*.sh" -type f -print0 | xargs -0 shellcheck -x -S warning; then
+    if find scripts/ src/ -name "*.sh" -type f 2>/dev/null | grep -q .; then
+        if find scripts/ src/ -name "*.sh" -type f -print0 | xargs -0 shellcheck -x -S warning; then
             print_success "Shell script validation passed"
             return 0
         else

--- a/scripts/verification/verify_cluster.sh
+++ b/scripts/verification/verify_cluster.sh
@@ -61,11 +61,15 @@ output "✅ Landing Zone IP: $LZ_IP"
 
 SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10"
 
+LZ_SESSION_DIR="/home/cloud-user/sessions/1"
+# Evaluated on the LZ: \$PATH expands to the remote PATH at runtime
+LZ_OC_ENV="export PATH=${LZ_SESSION_DIR}/bin:\$PATH KUBECONFIG=${LZ_SESSION_DIR}/ocp-cluster/auth/kubeconfig"
+
 # Check if kubeconfig exists
-if ! ssh $SSH_OPTS cloud-user@$LZ_IP "test -f /home/cloud-user/ocp-cluster/auth/kubeconfig" 2>&1; then
+if ! ssh $SSH_OPTS cloud-user@$LZ_IP "test -f ${LZ_SESSION_DIR}/ocp-cluster/auth/kubeconfig" 2>&1; then
     output "❌ Kubeconfig not found on Landing Zone"
-    echo -e "${RED}ERROR:${NC} Kubeconfig not found at /home/cloud-user/ocp-cluster/auth/kubeconfig" >&2
-    ssh $SSH_OPTS cloud-user@$LZ_IP "ls -la /home/cloud-user/ocp-cluster/auth/ 2>&1 || echo 'ocp-cluster/auth directory not found'"
+    echo -e "${RED}ERROR:${NC} Kubeconfig not found at ${LZ_SESSION_DIR}/ocp-cluster/auth/kubeconfig" >&2
+    ssh $SSH_OPTS cloud-user@$LZ_IP "ls -la ${LZ_SESSION_DIR}/ocp-cluster/auth/ 2>&1 || echo 'ocp-cluster/auth directory not found'"
     exit 1
 fi
 output "✅ Kubeconfig found"
@@ -74,7 +78,7 @@ output "✅ Kubeconfig found"
 output ""
 output "### Cluster Nodes"
 NODES_FILE=$(mktemp)
-if ! ssh $SSH_OPTS cloud-user@$LZ_IP "export KUBECONFIG=/home/cloud-user/ocp-cluster/auth/kubeconfig && oc get nodes" 2>&1 | tee "$NODES_FILE"; then
+if ! ssh $SSH_OPTS cloud-user@$LZ_IP "${LZ_OC_ENV} && oc get nodes" 2>&1 | tee "$NODES_FILE"; then
     output "❌ Failed to get cluster nodes"
     echo -e "${RED}ERROR:${NC} Failed to run 'oc get nodes'" >&2
     echo "Command output:" >&2
@@ -93,7 +97,7 @@ fi
 rm -f "$NODES_FILE"
 
 # Count ready nodes
-READY_NODES=$(ssh $SSH_OPTS cloud-user@$LZ_IP "export KUBECONFIG=/home/cloud-user/ocp-cluster/auth/kubeconfig && oc get nodes --no-headers 2>/dev/null | grep -c Ready" || echo "0")
+READY_NODES=$(ssh $SSH_OPTS cloud-user@$LZ_IP "${LZ_OC_ENV} && oc get nodes --no-headers 2>/dev/null | grep -c Ready" || echo "0")
 output ""
 output "✅ Ready nodes: $READY_NODES"
 
@@ -101,7 +105,7 @@ output "✅ Ready nodes: $READY_NODES"
 output ""
 output "### Cluster Operators"
 OPERATORS_FILE=$(mktemp)
-if ! ssh $SSH_OPTS cloud-user@$LZ_IP "export KUBECONFIG=/home/cloud-user/ocp-cluster/auth/kubeconfig && oc get co" 2>&1 | tee "$OPERATORS_FILE"; then
+if ! ssh $SSH_OPTS cloud-user@$LZ_IP "${LZ_OC_ENV} && oc get co" 2>&1 | tee "$OPERATORS_FILE"; then
     output "❌ Failed to get cluster operators"
     echo -e "${RED}ERROR:${NC} Failed to run 'oc get co'" >&2
     echo "Command output:" >&2
@@ -118,7 +122,7 @@ rm -f "$OPERATORS_FILE"
 
 # Check for degraded operators
 output ""
-DEGRADED=$(ssh $SSH_OPTS cloud-user@$LZ_IP "export KUBECONFIG=/home/cloud-user/ocp-cluster/auth/kubeconfig && oc get co -o json 2>/dev/null | jq -r '.items[] | select(.status.conditions[] | select(.type==\"Degraded\" and .status==\"True\")) | .metadata.name'" || echo "")
+DEGRADED=$(ssh $SSH_OPTS cloud-user@$LZ_IP "${LZ_OC_ENV} && oc get co -o json 2>/dev/null | jq -r '.items[] | select(.status.conditions[] | select(.type==\"Degraded\" and .status==\"True\")) | .metadata.name'" || echo "")
 
 if [ -n "$DEGRADED" ]; then
     output "⚠️ Warning: Some cluster operators are degraded:"
@@ -134,7 +138,7 @@ fi
 output ""
 output "### Cluster Version"
 CLUSTERVERSION_FILE=$(mktemp)
-if ! ssh $SSH_OPTS cloud-user@$LZ_IP "export KUBECONFIG=/home/cloud-user/ocp-cluster/auth/kubeconfig && oc get clusterversion" > "$CLUSTERVERSION_FILE" 2>&1; then
+if ! ssh $SSH_OPTS cloud-user@$LZ_IP "${LZ_OC_ENV} && oc get clusterversion" > "$CLUSTERVERSION_FILE" 2>&1; then
     output "⚠️ Could not get cluster version"
 else
     if [ "$USE_GITHUB" = true ]; then

--- a/src/enclave/cli.py
+++ b/src/enclave/cli.py
@@ -1,5 +1,6 @@
 import click
 
+from enclave.environment.cli import cli as environment_cli
 from enclave.reconcile.cli import cli as reconcile_cli
 from enclave.tools.cli import cli as tools_cli
 from enclave.utils import LOG_LEVELS, configure_logging
@@ -18,6 +19,7 @@ def cli(log_level: str) -> None:
 
 
 # Add existing command groups as subcommands
+cli.add_command(environment_cli, name="environment")
 cli.add_command(reconcile_cli, name="reconcile")
 cli.add_command(tools_cli, name="tools")
 

--- a/src/enclave/environment/check_leftovers.py
+++ b/src/enclave/environment/check_leftovers.py
@@ -1,0 +1,163 @@
+"""Check for leftover resources from a previous installation."""
+
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_METAL3_QUAY = re.compile(r"metal3|quay")
+_METAL3_CONTAINERS = re.compile(r"metal3|ironic|httpd|baremetal-operator")
+
+
+class LeftoverCheckError(Exception):
+    """Raised when a leftover-check command exits with a non-zero status."""
+
+    def __init__(
+        self, returncode: int, cmd: list[str], stdout: str, stderr: str
+    ) -> None:
+        super().__init__(f"Command failed (exit {returncode}): {' '.join(cmd)}")
+        self.returncode = returncode
+        self.cmd = cmd
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _run(cmd: list[str]) -> list[str]:
+    """Run a command and return its non-empty output lines, raising on failure."""
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        logger.info(
+            "Command failed (exit %d): %s\nstdout: %s\nstderr: %s",
+            result.returncode,
+            " ".join(cmd),
+            (result.stdout or "").strip(),
+            (result.stderr or "").strip(),
+        )
+        raise LeftoverCheckError(
+            result.returncode, cmd, result.stdout or "", result.stderr or ""
+        )
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+def check_systemd() -> bool:
+    """Return True if any metal3 systemd unit files are present on the host."""
+    try:
+        lines = _run([
+            "systemctl",
+            "list-unit-files",
+            "metal3-*.service",
+            "--no-legend",
+        ])
+    except LeftoverCheckError as exc:
+        if not exc.stdout.strip() and not exc.stderr.strip():
+            logger.info(
+                "systemctl exited %d with no output — treating as no metal3 units",
+                exc.returncode,
+            )
+            return False
+        raise
+
+    if lines:
+        logger.warning("Metal3 systemd units detected: %s", lines)
+        return True
+    logger.info("No metal3 systemd units found")
+
+    return False
+
+
+def check_podman(*, sudo: bool) -> bool:
+    """Return True if any metal3/quay-related podman pods, containers, or volumes exist.
+
+    Pass ``sudo=True`` to inspect the root podman context, ``sudo=False`` for the
+    current user context.
+    """
+    prefix = ["sudo"] if sudo else []
+    label = "Root" if sudo else "User"
+    found = False
+
+    pods = _run([*prefix, "podman", "pod", "ls", "--format", "{{.Name}}"])
+    matching_pods = [n for n in pods if _METAL3_QUAY.search(n)]
+    if matching_pods:
+        logger.warning(
+            "%s podman pods with metal3/quay detected: %s", label, matching_pods
+        )
+        found = True
+    else:
+        logger.info("%s podman pods: %d total, none matching", label, len(pods))
+
+    containers = _run([*prefix, "podman", "ps", "-a", "--format", "{{.Names}}"])
+    matching_containers = [n for n in containers if _METAL3_CONTAINERS.search(n)]
+    if matching_containers:
+        logger.warning(
+            "%s podman containers with metal3 components detected: %s",
+            label,
+            matching_containers,
+        )
+        found = True
+    else:
+        logger.info(
+            "%s podman containers: %d total, none matching", label, len(containers)
+        )
+
+    volumes = _run([*prefix, "podman", "volume", "ls", "--format", "{{.Name}}"])
+    matching_volumes = [n for n in volumes if _METAL3_QUAY.search(n)]
+    if matching_volumes:
+        logger.warning(
+            "%s podman volumes with metal3/quay detected: %s", label, matching_volumes
+        )
+        found = True
+    else:
+        logger.info("%s podman volumes: %d total, none matching", label, len(volumes))
+
+    return found
+
+
+def check_working_dir(working_dir: str | None) -> bool:
+    """Return True if the bootstrap working directory exists and contains unexpected files.
+
+    The ``logs/`` subdirectory is excluded from the check because bootstrap.sh
+    creates it on every run, even for a simple check.
+    """
+    if not working_dir:
+        return False
+    path = Path(working_dir)
+    if not path.is_dir():
+        logger.info("Working directory %s does not exist", working_dir)
+        return False
+
+    # logs/ is created every time bootstrap.sh is run, even for a check, its
+    # existence is not a sign of a complete bootstrap.sh run, so we will
+    # return false even if it exists.
+    items = [child for child in path.iterdir() if child.name != "logs"]
+    if items:
+        logger.warning(
+            "Working directory %s is non-empty (%d items): %s",
+            working_dir,
+            len(items),
+            [str(i.name) for i in items[:10]],
+        )
+        return True
+
+    logger.info("Working directory %s is empty or contains only logs/", working_dir)
+    return False
+
+
+def main(working_dir: str | None = None) -> bool:
+    """Return True if cleanup is needed, False if the environment is clean."""
+    checks = [
+        check_systemd(),
+        check_podman(sudo=True),
+        check_podman(sudo=False),
+        check_working_dir(working_dir),
+    ]
+    cleanup_needed = any(checks)
+    if cleanup_needed:
+        logger.info("Cleanup is needed")
+    else:
+        logger.info("Environment is clean, no cleanup needed")
+
+    return cleanup_needed

--- a/src/enclave/environment/cleanup.sh
+++ b/src/enclave/environment/cleanup.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Pre-bootstrap cleanup: removes Metal3 and Quay resources from a previous installation.
+#
+# Designed to be idempotent — commands that fail because a resource no longer exists are ignored.
+# WORKING_DIR must be set in the environment (handled by the enclave environment cleanup command).
+
+set -u
+
+_ts() { date +'%Y-%m-%dT%H:%M:%S'; }
+info()    { echo "$(_ts) INFO     $1"; }
+warning() { echo "$(_ts) WARNING  $1"; }
+error()   { echo "$(_ts) ERROR    $1"; }
+
+workingDir="${WORKING_DIR:?WORKING_DIR must be set}"
+
+info "Starting pre-bootstrap cleanup (working dir: ${workingDir})"
+
+# Stop and disable metal3 systemd services
+info "Stopping metal3 systemd services..."
+sudo systemctl stop metal3-bmo.service metal3-ironic-api.service metal3-httpd.service metal3-ironic-pod.service
+sudo systemctl reset-failed metal3-bmo.service metal3-ironic-api.service metal3-httpd.service metal3-ironic-pod.service
+sudo systemctl disable metal3-bmo.service metal3-ironic-api.service metal3-httpd.service metal3-ironic-pod.service
+info "Metal3 services stopped and disabled"
+
+# Remove quadlet unit files and reload systemd
+info "Removing metal3 quadlet unit files..."
+sudo rm -f /etc/containers/systemd/metal3-bmo.container
+sudo rm -f /etc/containers/systemd/metal3-ironic-api.container
+sudo rm -f /etc/containers/systemd/metal3-httpd.container
+sudo rm -f /etc/containers/systemd/metal3-ironic.pod
+sudo systemctl daemon-reload
+info "Quadlet files removed"
+
+# Remove root podman resources
+info "Removing root podman resources..."
+sudo podman pod rm -f metal3-ironic
+sudo podman rm -f ironic httpd baremetal-operator
+sudo podman volume rm -f metal3-ironic-conf metal3-ironic-data metal3-ironic-shared
+sudo podman secret rm -i metal3-ironic-htpasswd metal3-ironic-password metal3-kubeconfig metal3-ironic-username metal3-ca-bundle
+info "Root podman resources removed"
+
+# Remove user podman resources
+info "Removing user podman resources..."
+podman pod rm -f metal3-ironic
+podman rm -f baremetal-operator
+podman volume rm -f metal3-ironic-conf metal3-ironic-data metal3-ironic-shared quay-storage
+podman secret rm --ignore metal3-ironic-htpasswd metal3-ironic-username metal3-ca-bundle metal3-ironic-password
+info "User podman resources removed"
+
+# Remove Quay registry
+info "Removing Quay registry..."
+if [ -x "${workingDir}/bin/mirror-registry" ]; then
+    "${workingDir}/bin/mirror-registry" uninstall --quayRoot "${workingDir}/data" --autoApprove -v
+fi
+podman pod rm -f quay-pod
+podman secret rm -i pgdb_pass redis_pass
+info "Quay registry removed"
+
+info "Wiping kubeconfig symlink ~/.config/enclave/kubeconfig..."
+rm -f ~/.config/enclave/kubeconfig
+info "kubeconfig symlink wiped"
+
+# Remove discovery cron job (legacy: previously installed by older deployments)
+info "Removing discovery cron job..."
+crontab -l 2>/dev/null | grep -v "07-configure-discovery" | crontab -
+info "Discovery cron job removed"
+#
+# Wipe working directory contents
+info "Wiping working directory ${workingDir}..."
+resolvedWorkingDir="$(readlink -f -- "${workingDir}")"
+if [ -z "${resolvedWorkingDir}" ] || [ ! -d "${resolvedWorkingDir}" ]; then
+    if [ -e "${resolvedWorkingDir}" ]; then
+        error "Invalid WORKING_DIR (not a directory): ${workingDir}"
+        exit 1
+    fi
+    warning "Working directory does not exist, skipping wipe: ${workingDir}"
+    info "Pre-bootstrap cleanup complete"
+    exit 0
+fi
+
+case "${resolvedWorkingDir}" in
+    /|/etc|/usr|/bin|/sbin|/lib|/lib64|/boot|/proc|/sys|/dev|/var|/home|/root|/tmp)
+        error "Refusing to wipe critical system path: ${resolvedWorkingDir}"
+        exit 1
+        ;;
+esac
+shopt -s dotglob nullglob
+rm -fr -- "${resolvedWorkingDir:?}/"*
+shopt -u dotglob
+info "Working directory wiped"
+
+
+info "Pre-bootstrap cleanup complete"

--- a/src/enclave/environment/cli.py
+++ b/src/enclave/environment/cli.py
@@ -1,0 +1,93 @@
+"""CLI for environment management commands."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import click
+import yaml
+
+from enclave.environment.check_leftovers import (
+    LeftoverCheckError,
+    main as check_leftovers_main,
+)
+
+
+@click.group()
+def cli() -> None:
+    """Enclave environment CLI."""
+
+
+@cli.command("check-leftovers")
+@click.option(
+    "--working-dir",
+    envvar="WORKING_DIR",
+    default=None,
+    help="Working directory path to check for leftover content.",
+)
+def check_leftovers_cmd(working_dir: str | None) -> None:
+    """Check for leftover resources from a previous installation.
+
+    Exits 1 if cleanup is needed, 0 if the environment is clean.
+    """
+    try:
+        cleanup_needed = check_leftovers_main(working_dir=working_dir)
+    except LeftoverCheckError as exc:
+        cmd_str = " ".join(str(a) for a in exc.cmd)
+        stdout = exc.stdout.strip()
+        stderr = exc.stderr.strip()
+        details = "\n".join(
+            part
+            for part in [
+                f"stdout: {stdout}" if stdout else "",
+                f"stderr: {stderr}" if stderr else "",
+            ]
+            if part
+        )
+        msg = f"Check command failed (exit {exc.returncode}): {cmd_str}"
+        raise click.ClickException(f"{msg}\n{details}" if details else msg) from exc
+    sys.exit(1 if cleanup_needed else 0)
+
+
+@cli.command("cleanup")
+@click.option(
+    "--working-dir",
+    envvar="WORKING_DIR",
+    default=None,
+    help="Working directory to wipe. Defaults to reading workingDir from config/global.yaml.",
+)
+def cleanup_cmd(working_dir: str | None) -> None:
+    """Remove leftover resources from a previous installation."""
+    resolved = working_dir or _read_working_dir_from_config()
+    if resolved is None:
+        raise click.ClickException(
+            "Working directory not specified. Use --working-dir, set WORKING_DIR, "
+            "or run from the enclave repo root where config/global.yaml is present."
+        )
+    script_path = Path(__file__).parent / "cleanup.sh"
+    env = {**os.environ, "WORKING_DIR": resolved}
+    try:
+        result = subprocess.run(
+            ["bash", str(script_path)], env=env, check=False, timeout=600
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise click.ClickException(
+            "Cleanup script timed out after 600 seconds"
+        ) from exc
+    raise SystemExit(result.returncode)
+
+
+def _read_working_dir_from_config() -> str | None:
+    config_path = Path("config/global.yaml")
+    if not config_path.is_file():
+        return None
+    try:
+        with config_path.open(encoding="utf-8") as f:
+            config: dict[str, object] = yaml.safe_load(f) or {}
+        value = config.get("workingDir")
+        return str(value) if value is not None else None
+    except (OSError, yaml.YAMLError):
+        return None

--- a/src/tests/test_check_leftovers.py
+++ b/src/tests/test_check_leftovers.py
@@ -1,0 +1,219 @@
+from pathlib import Path
+from subprocess import CompletedProcess
+
+import pytest
+from pytest_mock import MockerFixture
+
+from enclave.environment.check_leftovers import (
+    LeftoverCheckError,
+    check_podman,
+    check_systemd,
+    check_working_dir,
+    main,
+)
+
+
+def _proc(
+    stdout: str = "", returncode: int = 0, stderr: str = ""
+) -> CompletedProcess[str]:
+    return CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+# --- _run ---
+
+
+def test_run_raises_on_command_failure(mocker: MockerFixture) -> None:
+    mocker.patch(
+        "enclave.environment.check_leftovers.subprocess.run",
+        return_value=_proc("", returncode=1, stderr="Failed to connect to bus"),
+    )
+    with pytest.raises(LeftoverCheckError):
+        check_systemd()
+
+
+# --- check_systemd ---
+
+
+def testcheck_systemd_detects_units(mocker: MockerFixture) -> None:
+    mocker.patch(
+        "enclave.environment.check_leftovers.subprocess.run",
+        return_value=_proc("metal3-bmo.service enabled"),
+    )
+    assert check_systemd() is True
+
+
+def testcheck_systemd_no_units(mocker: MockerFixture) -> None:
+    mocker.patch(
+        "enclave.environment.check_leftovers.subprocess.run",
+        return_value=_proc(""),
+    )
+    assert check_systemd() is False
+
+
+def test_check_systemd_exit1_no_output_treated_as_clean(mocker: MockerFixture) -> None:
+    mocker.patch(
+        "enclave.environment.check_leftovers.subprocess.run",
+        return_value=_proc("", returncode=1),
+    )
+    assert check_systemd() is False
+
+
+# --- check_podman ---
+
+
+def _podman_clean() -> list[CompletedProcess[str]]:
+    return [_proc(""), _proc(""), _proc("")]
+
+
+def testcheck_podman_detects_metal3_pod(mocker: MockerFixture) -> None:
+    mocker.patch(
+        "enclave.environment.check_leftovers.subprocess.run",
+        side_effect=[_proc("metal3-ironic"), _proc(""), _proc("")],
+    )
+    assert check_podman(sudo=False) is True
+
+
+def testcheck_podman_detects_quay_pod(mocker: MockerFixture) -> None:
+    mocker.patch(
+        "enclave.environment.check_leftovers.subprocess.run",
+        side_effect=[_proc("quay-pod"), _proc(""), _proc("")],
+    )
+    assert check_podman(sudo=True) is True
+
+
+def testcheck_podman_detects_ironic_container(mocker: MockerFixture) -> None:
+    mocker.patch(
+        "enclave.environment.check_leftovers.subprocess.run",
+        side_effect=[_proc(""), _proc("ironic"), _proc("")],
+    )
+    assert check_podman(sudo=False) is True
+
+
+def testcheck_podman_detects_metal3_volume(mocker: MockerFixture) -> None:
+    mocker.patch(
+        "enclave.environment.check_leftovers.subprocess.run",
+        side_effect=[_proc(""), _proc(""), _proc("metal3-ironic-data")],
+    )
+    assert check_podman(sudo=False) is True
+
+
+def testcheck_podman_clean(mocker: MockerFixture) -> None:
+    mocker.patch(
+        "enclave.environment.check_leftovers.subprocess.run",
+        side_effect=_podman_clean(),
+    )
+    assert check_podman(sudo=False) is False
+
+
+def testcheck_podman_sudo_prefixes_commands(mocker: MockerFixture) -> None:
+    run_mock = mocker.patch(
+        "enclave.environment.check_leftovers.subprocess.run",
+        side_effect=_podman_clean(),
+    )
+    check_podman(sudo=True)
+    for call in run_mock.call_args_list:
+        assert call.args[0][0] == "sudo"
+
+
+# --- check_working_dir ---
+
+
+def testcheck_working_dir_none_returns_false() -> None:
+    assert check_working_dir(None) is False
+
+
+def testcheck_working_dir_empty_string_returns_false() -> None:
+    assert check_working_dir("") is False
+
+
+def testcheck_working_dir_not_a_dir() -> None:
+    assert check_working_dir("/nonexistent/path/xyz") is False
+
+
+def testcheck_working_dir_empty_dir(tmp_path: Path) -> None:
+    assert check_working_dir(str(tmp_path)) is False
+
+
+def testcheck_working_dir_non_empty(tmp_path: Path) -> None:
+    (tmp_path / "some_file").write_text("data")
+    assert check_working_dir(str(tmp_path)) is True
+
+
+def testcheck_working_dir_logs_only_is_clean(tmp_path: Path) -> None:
+    (tmp_path / "logs").mkdir()
+    assert check_working_dir(str(tmp_path)) is False
+
+
+def testcheck_working_dir_logs_plus_other_is_dirty(tmp_path: Path) -> None:
+    (tmp_path / "logs").mkdir()
+    (tmp_path / "bin").mkdir()
+    assert check_working_dir(str(tmp_path)) is True
+
+
+# --- main ---
+
+
+def test_main_returns_false_when_clean(mocker: MockerFixture) -> None:
+    mocker.patch(
+        "enclave.environment.check_leftovers.check_systemd", return_value=False
+    )
+    mocker.patch("enclave.environment.check_leftovers.check_podman", return_value=False)
+    mocker.patch(
+        "enclave.environment.check_leftovers.check_working_dir", return_value=False
+    )
+    assert main() is False
+
+
+def test_main_returns_true_when_systemd_leftovers(mocker: MockerFixture) -> None:
+    mocker.patch("enclave.environment.check_leftovers.check_systemd", return_value=True)
+    mocker.patch("enclave.environment.check_leftovers.check_podman", return_value=False)
+    mocker.patch(
+        "enclave.environment.check_leftovers.check_working_dir", return_value=False
+    )
+    assert main() is True
+
+
+def test_main_returns_true_when_podman_leftovers(mocker: MockerFixture) -> None:
+    mocker.patch(
+        "enclave.environment.check_leftovers.check_systemd", return_value=False
+    )
+    mocker.patch(
+        "enclave.environment.check_leftovers.check_podman",
+        side_effect=[True, False],
+    )
+    mocker.patch(
+        "enclave.environment.check_leftovers.check_working_dir", return_value=False
+    )
+    assert main() is True
+
+
+def test_main_returns_true_when_working_dir_non_empty(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    mocker.patch(
+        "enclave.environment.check_leftovers.check_systemd", return_value=False
+    )
+    mocker.patch("enclave.environment.check_leftovers.check_podman", return_value=False)
+    mocker.patch(
+        "enclave.environment.check_leftovers.check_working_dir", return_value=True
+    )
+    assert main(working_dir=str(tmp_path)) is True
+
+
+def test_main_runs_all_checks_even_if_first_returns_true(mocker: MockerFixture) -> None:
+    systemd_mock = mocker.patch(
+        "enclave.environment.check_leftovers.check_systemd", return_value=True
+    )
+    podman_mock = mocker.patch(
+        "enclave.environment.check_leftovers.check_podman", return_value=False
+    )
+    wd_mock = mocker.patch(
+        "enclave.environment.check_leftovers.check_working_dir", return_value=False
+    )
+    result = main()
+    assert result is True
+    systemd_mock.assert_called_once()
+    assert podman_mock.call_count == 2  # called for sudo=True and sudo=False
+    wd_mock.assert_called_once()


### PR DESCRIPTION
Introduces `enclave environment check-leftovers` and `enclave environment cleanup` commands so users can detect and remove Metal3/Quay residue before re-running bootstrap. The logic lives in the Python package (included in the tarball) rather than scripts/ (which is excluded).

- Add src/enclave/environment/ with check_leftovers.py, cli.py, cleanup.sh
- Register `enclave environment` subcommand in src/enclave/cli.py
- Add step_check_leftovers() to bootstrap.sh and the option to
  do a --force-cleanup
- Extend shellcheck coverage to src/ in scripts/verification/validate.sh
- Add deploy-cluster-check-leftovers Makefile.ci target
- Add flag to bootstrap.sh to force cleanup
- Run leftover check in e2e-deployment and disconnected-dry-run GH Actions
  workflows after installing Enclave Lab. Changed workingDir so that it
  is not a standard non-empty directory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `enclave environment` command group with `check-leftovers` (detect stale Metal3/Quay resources) and `cleanup` (remediate and reset the environment).
  * Introduced a pre-bootstrap leftover check for e2e connected/disconnected flows with step summary output.
* **Bug Fixes**
  * Improved failure reporting to correctly attribute failures to the leftover-check step.
* **Tests**
  * Added coverage for leftover detection, command exit-code behavior, and cleanup handling.
* **Chores**
  * Added CI/deployment make target and a bootstrap step for the leftover check; expanded shell linting to cover `src/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->