### PR TITLE
Document OpenShift version update in upgrade notes

### DIFF
--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -82,6 +82,9 @@ This section documents changes, migrations, and operator version updates when up
 
 #### What's Changed
 
+**Management Cluster Version Update:**
+- **OpenShift**: 4.20.8 → 4.20.21
+
 **Operator Version Updates:**
 - **Quay**: 3.15.3 → 3.15.5
 - **Multicluster Engine (MCE)**: 2.10.1 → 2.10.3


### PR DESCRIPTION
## Summary

Addresses review feedback on PR #492 to include the OpenShift management cluster version update in the 0.1.0 to 0.1.1 upgrade notes.

## Changes

- Added **Management Cluster Version Update** section documenting OpenShift 4.20.8 → 4.20.21
- Properly categorizes OpenShift as a management cluster version rather than an operator

Fixes: https://github.com/rh-ecosystem-edge/enclave/pull/492#discussion_r3414156322

## Test plan

- [x] Documentation change only - no functional testing required
- [x] Verified version information against `defaults/platforms.yaml` history

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated upgrade notes for version 0.1.0 → 0.1.1 with management cluster version information. Added OpenShift version change details, documenting the update from 4.20.8 to 4.20.21, to guide users through the upgrade process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->