### PR TITLE
Fix UpdateService PDB deadlock by increasing replicas to 3

### DIFF
--- a/operators/cincinnati-operator/tasks.yaml
+++ b/operators/cincinnati-operator/tasks.yaml
@@ -18,7 +18,7 @@
       spec:
         graphDataImage: registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/openshift/graph-image
         releases: registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/openshift/release-images
-        replicas: 2
+        replicas: 3
   register: r_update_service
   retries: "{{ k8s_retries }}"
   delay: "{{ k8s_delay }}"


### PR DESCRIPTION
## Problem

IBM test clusters have been experiencing deadlocks during MachineConfigPool updates after upgrading to Enclave commit `bd1a90b1b41b370fef334bacb862e14cccec1b00`. Node draining fails with:

```
error when evicting pods/"service-9c9fc5b97-b6rtn" -n "openshift-update-service" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
```

## Root Cause

The OpenShift Update Service (cincinnati-operator) is configured with:
- **2 replicas**
- A default PodDisruptionBudget requiring **minAvailable=1**

This creates a deadlock scenario when draining nodes:
1. With 2 pods running, evicting one pod leaves 1 running (satisfies PDB)
2. When attempting to drain the second node, evicting that pod would leave 0 running (violates PDB)
3. The operation blocks indefinitely

The workaround has been to manually scale down the operator, delete the PDB, complete the MCP update, then scale back up.

## Solution

Increase UpdateService replicas from **2 to 3**.

With 3 replicas and minAvailable=1:
- Up to 2 pods can be evicted while maintaining 1 available
- Node draining proceeds safely during MCP updates
- Better high availability for the update service

## Testing

IBM should verify that MCP updates complete successfully without manual intervention after this change is deployed.

Fixes https://github.com/gori-project/GoRI/issues/924