### PR TITLE
OSAC-955: Address review feedback for OSAC plugin

### DIFF
--- a/docs/OSAC_DEPLOYMENT.md
+++ b/docs/OSAC_DEPLOYMENT.md
@@ -102,7 +102,7 @@ make deploy-plugin PLUGIN=authorino
 # 4. AAP — installs operator only, no config required (provides CRDs for OSAC)
 make deploy-plugin PLUGIN=aap
 
-# 5. (VMaaS only) OpenShift Virtualization — required for VM workloads
+# 5. (VMaaS/development profiles) OpenShift Virtualization — required for VM workloads
 # make deploy-plugin PLUGIN=cnv
 
 # 6. Deploy the OSAC plugin

--- a/plugins/osac/tasks/post-validate.yaml
+++ b/plugins/osac/tasks/post-validate.yaml
@@ -84,7 +84,23 @@
       - __r_ingress_proxy.resources[0].status.availableReplicas | default(0) | int > 0
     fail_msg: "fulfillment-ingress-proxy deployment is not running in osac namespace"
 
-# 6. osac-operator deployment
+# 6. fulfillment-console-proxy deployment
+- name: Check fulfillment-console-proxy deployment
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: fulfillment-console-proxy
+    namespace: osac
+  register: __r_console_proxy
+
+- name: Assert fulfillment-console-proxy is running
+  ansible.builtin.assert:
+    that:
+      - __r_console_proxy.resources | length > 0
+      - __r_console_proxy.resources[0].status.availableReplicas | default(0) | int > 0
+    fail_msg: "fulfillment-console-proxy deployment is not running in osac namespace"
+
+# 7. osac-operator deployment
 - name: Check osac-operator deployment
   kubernetes.core.k8s_info:
     api_version: apps/v1
@@ -100,7 +116,7 @@
       - __r_osac_operator.resources[0].status.availableReplicas | default(0) | int > 0
     fail_msg: "osac-operator deployment is not running in osac namespace"
 
-# 7. AAP instance ready
+# 8. AAP instance ready
 - name: Check AAP instance is ready
   kubernetes.core.k8s_info:
     api_version: aap.ansible.com/v1alpha1
@@ -119,7 +135,7 @@
         | list | length > 0
     fail_msg: "AAP instance {{ osac_aap_name }} is not ready in osac namespace"
 
-# 8. Authorino instance ready
+# 9. Authorino instance ready
 - name: Check Authorino instance in osac namespace
   kubernetes.core.k8s_info:
     api_version: operator.authorino.kuadrant.io/v1beta1
@@ -137,7 +153,7 @@
         | list | length > 0
     fail_msg: "Authorino instance not found or not ready in osac namespace"
 
-# 9. AAP bootstrap job completed
+# 10. AAP bootstrap job completed
 - name: Check AAP bootstrap job completed
   kubernetes.core.k8s_info:
     api_version: batch/v1
@@ -158,6 +174,6 @@
 - name: Log OSAC validation success
   ansible.builtin.debug:
     msg: >-
-      OSAC post-validate passed: all fulfillment deployments running,
+      OSAC post-validate passed: all fulfillment deployments running (including console-proxy),
       OSAC operator running, AAP instance ready, Authorino ready,
       bootstrap job completed{{ ', PostgreSQL running' if not osacBYODatabase | bool else '' }}.

--- a/plugins/osac/tasks/pre-validate.yaml
+++ b/plugins/osac/tasks/pre-validate.yaml
@@ -82,7 +82,9 @@
     name: fulfillment-db
     namespace: osac
   register: __r_byo_db_secret
-  when: osacBYODatabase | bool
+  when:
+    - osacBYODatabase | bool
+    - osacDatabaseUrl is not defined or osacDatabaseUrl | length == 0
 
 - name: Assert fulfillment-db secret exists (BYO database)
   ansible.builtin.assert:


### PR DESCRIPTION
## Summary

Follow-up to #482. Addresses valid findings from code review round 2:

- Add `fulfillment-console-proxy` deployment check to post-validate (was missing from the 10-check health suite)
- Align `when` clause on BYO database secret check task to skip when `osacDatabaseUrl` is provided (matching the assert's condition)
- Fix CNV deployment comment to mention both `vmaas` and `development` profiles (was incorrectly "VMaaS only")

## Skipped findings (already addressed in round 1 or not applicable)

- `deploy_plugin.yaml` include_vars namespacing — addressed in round 1
- `defaults.yaml` validate_certs — addressed in round 1
- `plugin.yaml` latest tags — addressed in round 1
- `deploy.yaml` gateway uniqueness — fixed in round 1
- `deploy.yaml` token parsing/idempotency — addressed in round 1
- `post-operators.yaml` validate_certs — addressed in round 1
- `pre-validate.yaml` Keycloak CRD guard — addressed in round 1
- `schemas/plugin.yaml` extractImages — out of scope
- `schemas/config.yaml` if/then for osacDatabaseUrl — runtime validation in pre-validate.yaml already handles this
- `post-operators.yaml` ingressVIP assertion — `ingressVIP` is an Enclave core variable always defined when `enclave_deployment_mode == 'connected'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OSAC Day-2 deployment documentation to clarify that OpenShift Virtualization is required for both VMaaS and development profiles.

* **Tests**
  * Added health check validation to confirm fulfillment-console-proxy Deployment exists and is available.
  * Refined pre-deployment validation logic for Bring-Your-Own database configuration to account for multiple conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->