### PR TITLE
OSAC-1427: Add Netris config passthrough to OSAC plugin

### DIFF
--- a/config/plugins/osac.example.yaml
+++ b/config/plugins/osac.example.yaml
@@ -27,3 +27,47 @@
 #   envoy: "docker.io/envoyproxy/envoy:v1.33.0"
 #   aap_bootstrap: "ghcr.io/osac-project/osac-aap:v0.0.4"
 #   cli: "quay.io/openshift/origin-cli:4.20.0"
+
+# --- Netris Network Backend ---
+# Enable Netris integration for cluster and network fulfillment.
+# Requires a pre-deployed Netris controller (see Netris + OSAC Prerequisites Guide).
+# osacNetrisEnabled: true
+
+# Required when osacNetrisEnabled is true:
+# osacNetrisControllerUrl: "https://ctl.netris.io"
+# osacNetrisUsername: "netris"
+# osacNetrisPassword: "changeme"
+# osacNetrisSiteId: "1"
+# osacNetrisTenantId: "1"
+# osacNetrisTenantName: "Admin"
+
+# Optional Netris config:
+# osacNetrisStepsCollection: "netris.steps"
+# osacNetrisMgmtVpcId: "4"
+# osacNetrisMgmtVpcName: "RH-Infra"
+# osacNetrisResourceClassMap: '{"fc430": {"server_cluster_template_id": 89, "mgmt_interface": "ens4", "vpc_interfaces": ["ens13"]}}'
+# osacNetrisSshBastionHost: "bastion.example.com"
+# osacNetrisSshBastionUser: "ubuntu"
+# osacNetrisSshUser: "core"
+# osacNetrisMgmtRouteDestination: "10.8.0.0/30"
+# osacNetrisMgmtRouteGateway: "192.168.16.1"
+# osacNetrisExternalAccessBaseDomain: "example.com"
+# osacNetrisExternalAccessSupportedBaseDomains: "example.com"
+# osacNetrisExternalAccessApiInternalNetwork: "hypershift"
+# osacNetrisHostedClusterBaseDomain: "example.com"
+# osacNetrisHostedClusterControllerAvailabilityPolicy: "HighlyAvailable"
+# osacNetrisHostedClusterInfrastructureAvailabilityPolicy: "HighlyAvailable"
+
+# AWS Route53 credentials for DNS record management:
+# osacNetrisAwsAccessKeyId: "AKIA..."
+# osacNetrisAwsSecretAccessKey: ""
+
+# SSH keys for server management (multiline, use YAML literal block):
+# osacNetrisSshKey: |
+#   -----BEGIN OPENSSH PRIVATE KEY-----
+#   ...
+#   -----END OPENSSH PRIVATE KEY-----
+# osacNetrisSshBastionKey: |
+#   -----BEGIN OPENSSH PRIVATE KEY-----
+#   ...
+#   -----END OPENSSH PRIVATE KEY-----

--- a/plugins/osac/defaults.yaml
+++ b/plugins/osac/defaults.yaml
@@ -1,12 +1,15 @@
 ---
 # OSAC plugin defaults
-# Note: config/plugins/osac.yaml uses camelCase (osacProfilesList, osacBYODatabase)
+# Note: config/plugins/osac.yaml uses camelCase (osacProfilesList, osacBYODatabase, osacNetrisEnabled)
 # which is loaded into Ansible scope as-is. The defaults below use the same
 # camelCase convention to match. Ansible variables from defaults.yaml and
 # config/plugins/osac.yaml are merged into the same scope.
 osacProfilesList:
   - caas
   - vmaas
+
+# Netris network backend
+osacNetrisEnabled: false
 
 # AAP settings (chart manages the instance, these configure it)
 osac_aap_name: osac-aap

--- a/plugins/osac/schemas/config.yaml
+++ b/plugins/osac/schemas/config.yaml
@@ -45,5 +45,104 @@ properties:
     description: >-
       Optional container image overrides. When unset, the Helm chart's
       built-in image references are used.
+  osacNetrisEnabled:
+    type: boolean
+    description: "Enable Netris network backend for cluster/network fulfillment"
+  osacNetrisControllerUrl:
+    type: string
+    description: "Netris controller API URL (e.g. https://ctl.netris.io)"
+  osacNetrisUsername:
+    type: string
+    description: "Netris API username"
+  osacNetrisPassword:
+    type: string
+    description: "Netris API password"
+  osacNetrisSiteId:
+    type: string
+    description: "Netris site ID (integer as string)"
+  osacNetrisTenantId:
+    type: string
+    description: "Netris tenant ID (integer as string)"
+  osacNetrisTenantName:
+    type: string
+    description: "Netris tenant name"
+  osacNetrisStepsCollection:
+    type: string
+    description: "Ansible steps collection for Netris (default: netris.steps)"
+  osacNetrisMgmtVpcId:
+    type: string
+    description: "Management VPC ID in Netris"
+  osacNetrisMgmtVpcName:
+    type: string
+    description: "Management VPC name in Netris"
+  osacNetrisResourceClassMap:
+    type: string
+    description: "JSON dict mapping resource classes to Netris server cluster templates"
+  osacNetrisSshBastionHost:
+    type: string
+    description: "SSH bastion hostname/IP for server management access"
+  osacNetrisSshBastionUser:
+    type: string
+    description: "SSH bastion username"
+  osacNetrisSshUser:
+    type: string
+    description: "SSH username for bare-metal servers (typically 'core')"
+  osacNetrisMgmtRouteDestination:
+    type: string
+    description: "Management route CIDR (e.g. 10.8.0.0/30)"
+  osacNetrisMgmtRouteGateway:
+    type: string
+    description: "Management route gateway IP"
+  osacNetrisExternalAccessBaseDomain:
+    type: string
+    description: "DNS domain for cluster endpoints"
+  osacNetrisExternalAccessSupportedBaseDomains:
+    type: string
+    description: "Comma-separated list of allowed base domains"
+  osacNetrisExternalAccessApiInternalNetwork:
+    type: string
+    description: "Internal network type for API access (e.g. 'hypershift')"
+  osacNetrisHostedClusterBaseDomain:
+    type: string
+    description: "Base domain for hosted clusters"
+  osacNetrisHostedClusterControllerAvailabilityPolicy:
+    type: string
+    enum: [SingleReplica, HighlyAvailable]
+    description: "Controller availability policy for hosted clusters"
+  osacNetrisHostedClusterInfrastructureAvailabilityPolicy:
+    type: string
+    enum: [SingleReplica, HighlyAvailable]
+    description: "Infrastructure availability policy for hosted clusters"
+  osacNetrisAwsAccessKeyId:
+    type: string
+    description: "AWS access key for Route53 DNS management"
+  osacNetrisAwsSecretAccessKey:
+    type: string
+    description: "AWS secret key for Route53 DNS management"
+  osacNetrisSshKey:
+    type: string
+    description: "SSH private key for bare-metal server access"
+  osacNetrisSshBastionKey:
+    type: string
+    description: "SSH private key for bastion host access"
 required:
   - osacAapLicenseFile
+dependencies:
+  osacNetrisAwsAccessKeyId:
+    - osacNetrisAwsSecretAccessKey
+  osacNetrisAwsSecretAccessKey:
+    - osacNetrisAwsAccessKeyId
+if:
+  required:
+    - osacNetrisEnabled
+  properties:
+    osacNetrisEnabled:
+      const: true
+then:
+  required:
+    - osacNetrisControllerUrl
+    - osacNetrisUsername
+    - osacNetrisPassword
+    - osacNetrisSiteId
+    - osacNetrisTenantId
+    - osacNetrisTenantName

--- a/plugins/osac/templates/values.yaml.j2
+++ b/plugins/osac/templates/values.yaml.j2
@@ -124,3 +124,83 @@ dbMigrate:
 
 validation:
   enabled: true
+
+{% if osacNetrisEnabled | default(false) | bool %}
+clusterFulfillment:
+  enabled: true
+  config:
+    NETWORK_CLASS: "netris"
+    NETWORK_STEPS_COLLECTION: "{{ osacNetrisStepsCollection | default('netris.steps') }}"
+    NETRIS_CONTROLLER_URL: "{{ osacNetrisControllerUrl }}"
+    NETRIS_USERNAME: "{{ osacNetrisUsername }}"
+    NETRIS_SITE_ID: "{{ osacNetrisSiteId }}"
+    NETRIS_TENANT_ID: "{{ osacNetrisTenantId }}"
+    NETRIS_TENANT_NAME: "{{ osacNetrisTenantName }}"
+{% if osacNetrisMgmtVpcId is defined %}
+    NETRIS_MGMT_VPC_ID: "{{ osacNetrisMgmtVpcId }}"
+{% endif %}
+{% if osacNetrisMgmtVpcName is defined %}
+    NETRIS_MGMT_VPC_NAME: "{{ osacNetrisMgmtVpcName }}"
+{% endif %}
+{% if osacNetrisResourceClassMap is defined %}
+    NETRIS_RESOURCE_CLASS_MAP: '{{ osacNetrisResourceClassMap }}'
+{% endif %}
+{% if osacNetrisSshBastionHost is defined %}
+    SERVER_SSH_BASTION_HOST: "{{ osacNetrisSshBastionHost }}"
+{% endif %}
+{% if osacNetrisSshBastionUser is defined %}
+    SERVER_SSH_BASTION_USER: "{{ osacNetrisSshBastionUser }}"
+{% endif %}
+{% if osacNetrisSshUser is defined %}
+    SERVER_SSH_USER: "{{ osacNetrisSshUser }}"
+{% endif %}
+{% if osacNetrisMgmtRouteDestination is defined %}
+    SERVER_MGMT_ROUTE_DESTINATION: "{{ osacNetrisMgmtRouteDestination }}"
+{% endif %}
+{% if osacNetrisMgmtRouteGateway is defined %}
+    SERVER_MGMT_ROUTE_GATEWAY: "{{ osacNetrisMgmtRouteGateway }}"
+{% endif %}
+{% if osacNetrisExternalAccessBaseDomain is defined %}
+    EXTERNAL_ACCESS_BASE_DOMAIN: "{{ osacNetrisExternalAccessBaseDomain }}"
+{% endif %}
+{% if osacNetrisExternalAccessSupportedBaseDomains is defined %}
+    EXTERNAL_ACCESS_SUPPORTED_BASE_DOMAINS: "{{ osacNetrisExternalAccessSupportedBaseDomains }}"
+{% endif %}
+{% if osacNetrisExternalAccessApiInternalNetwork is defined %}
+    EXTERNAL_ACCESS_API_INTERNAL_NETWORK: "{{ osacNetrisExternalAccessApiInternalNetwork }}"
+{% endif %}
+{% if osacNetrisHostedClusterBaseDomain is defined %}
+    HOSTED_CLUSTER_BASE_DOMAIN: "{{ osacNetrisHostedClusterBaseDomain }}"
+{% endif %}
+{% if osacNetrisHostedClusterControllerAvailabilityPolicy is defined %}
+    HOSTED_CLUSTER_CONTROLLER_AVAILABILITY_POLICY: "{{ osacNetrisHostedClusterControllerAvailabilityPolicy }}"
+{% endif %}
+{% if osacNetrisHostedClusterInfrastructureAvailabilityPolicy is defined %}
+    HOSTED_CLUSTER_INFRASTRUCTURE_AVAILABILITY_POLICY: "{{ osacNetrisHostedClusterInfrastructureAvailabilityPolicy }}"
+{% endif %}
+  secret:
+    NETRIS_PASSWORD: "{{ osacNetrisPassword }}"
+{% if osacNetrisAwsAccessKeyId is defined %}
+    AWS_ACCESS_KEY_ID: "{{ osacNetrisAwsAccessKeyId }}"
+{% endif %}
+{% if osacNetrisAwsSecretAccessKey is defined %}
+    AWS_SECRET_ACCESS_KEY: "{{ osacNetrisAwsSecretAccessKey }}"
+{% endif %}
+{% if osacNetrisSshKey is defined %}
+    SERVER_SSH_KEY: "{{ osacNetrisSshKey }}"
+{% endif %}
+{% if osacNetrisSshBastionKey is defined %}
+    SERVER_SSH_BASTION_KEY: "{{ osacNetrisSshBastionKey }}"
+{% endif %}
+
+networkFulfillment:
+  enabled: true
+  config:
+    NETRIS_CONTROLLER_URL: "{{ osacNetrisControllerUrl }}"
+    NETRIS_USERNAME: "{{ osacNetrisUsername }}"
+    NETRIS_SITE_ID: "{{ osacNetrisSiteId }}"
+    NETRIS_TENANT_ID: "{{ osacNetrisTenantId }}"
+    NETRIS_TENANT_NAME: "{{ osacNetrisTenantName }}"
+  secret:
+    NETRIS_PASSWORD: "{{ osacNetrisPassword }}"
+{% endif %}


### PR DESCRIPTION
## Summary

- Add `clusterFulfillment` and `networkFulfillment` sections to the OSAC Helm values template, conditionally rendered when `osacNetrisEnabled: true`
- Add 26 Netris-related fields to the plugin config schema with conditional `if/then` validation requiring core fields when enabled
- Add commented-out example config and `osacNetrisEnabled: false` default

## Test plan

- [x] `make -f Makefile.ci validate-plugins` passes
- [x] `make -f Makefile.ci validate-yaml` passes
- [x] `make -f Makefile.ci validate-ansible` passes
- [ ] Manual: render values template with Netris vars set, verify fulfillment sections appear
- [ ] Manual: render without `osacNetrisEnabled`, verify fulfillment sections are absent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional NETRIS network/backend support to the OSAC plugin, including conditional Helm values for controller identity, steps collection, networking, routing, DNS/external access, and SSH/bastion connectivity.
  * Added a commented NETRIS configuration template example and introduced a new enablement flag in OSAC defaults.
* **Bug Fixes**
  * Extended OSAC configuration validation to require NETRIS controller/auth and tenant/site details when NETRIS is enabled, including mutual checks for AWS key/secret pairs.
* **Chores**
  * NETRIS remains disabled by default unless explicitly enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->