### PR TITLE
Fix migration task path

### DIFF
--- a/playbooks/tasks/migrations/foundation_plugin_catalog_sources.yaml
+++ b/playbooks/tasks/migrations/foundation_plugin_catalog_sources.yaml
@@ -41,7 +41,7 @@
 
 - name: Migrate foundation plugin operator subscriptions
   ansible.builtin.include_tasks:
-    file: migrations/operator_catalog_source.yaml
+    file: operator_catalog_source.yaml
   vars:
     plugin: "{{ plugin_operator.0 }}"
     operator: "{{ plugin_operator.1 }}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the file path reference in the foundation plugin operator subscriptions migration task, ensuring migrations execute properly and subscriptions are accurately processed during platform updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->