### PR TITLE
OSAC-1535: Add OSAC E2E CI job and AAP license handling

### DIFF
--- a/.github/workflows/e2e-deployment.yml
+++ b/.github/workflows/e2e-deployment.yml
@@ -2,12 +2,15 @@ name: E2E Deployment
 
 # Unified end-to-end deployment testing for connected and disconnected modes.
 #
-# Runs two parallel jobs:
-#   - e2e-connected:    Fast deployment pulling from upstream registries
-#   - e2e-disconnected: Full air-gapped deployment with local mirror registry
+# Runs up to three parallel jobs:
+#   - e2e-connected:        Fast deployment pulling from upstream registries
+#   - e2e-disconnected:     Full air-gapped deployment with local mirror registry
+#   - e2e-osac-connected:   OSAC plugin stack (connected mode, lvms storage)
 #
-# Both jobs run on every PR and nightly schedule. Manual dispatch allows
-# selecting which modes to run, skipping cleanup, and sending Slack notifications.
+# The first two jobs run on every PR and nightly schedule. The OSAC job runs only
+# when OSAC-relevant files change or on manual dispatch with run-osac: true.
+# Manual dispatch allows selecting which modes to run, skipping cleanup, and
+# sending Slack notifications.
 
 # Cancel previous runs when a PR is updated
 concurrency:
@@ -44,6 +47,11 @@ on:
         required: false
         type: boolean
         default: false
+      run-osac:
+        description: 'Run OSAC E2E test (connected mode with OSAC plugin stack)'
+        required: false
+        type: boolean
+        default: false
       send-slack-notification:
         description: 'Send Slack notification on completion'
         required: false
@@ -65,6 +73,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       should_run: ${{ steps.decision.outputs.should_run }}
+      run_osac: ${{ steps.decision.outputs.run_osac }}
       storage_plugins: ${{ steps.decision.outputs.storage_plugins }}
       storage_plugins_connected: ${{ steps.decision.outputs.storage_plugins_connected }}
 
@@ -104,6 +113,9 @@ jobs:
               - 'scripts/infrastructure/setup_ceph*'
               - 'scripts/infrastructure/verify_ceph*'
               - 'scripts/lib/odf.sh'
+            osac:
+              - 'plugins/osac/**'
+              - 'playbooks/tasks/helm_deploy.yaml'
 
       - name: Make decision
         id: decision
@@ -120,16 +132,24 @@ jobs:
             else
               echo "storage_plugins_connected=[\"${PLUGIN}\"]" >> $GITHUB_OUTPUT
             fi
+            # OSAC runs when explicitly requested via manual dispatch
+            if [[ "${{ inputs.run-osac }}" == "true" ]]; then
+              echo "run_osac=true" >> $GITHUB_OUTPUT
+            else
+              echo "run_osac=false" >> $GITHUB_OUTPUT
+            fi
             echo "Manual trigger - E2E will run (${PLUGIN})" | tee -a $GITHUB_STEP_SUMMARY
           elif [[ "${{ github.event_name }}" == "schedule" ]]; then
             echo "should_run=true" >> $GITHUB_OUTPUT
             echo "storage_plugins=[\"lvms\"]" >> $GITHUB_OUTPUT
             echo "storage_plugins_connected=[\"lvms\"]" >> $GITHUB_OUTPUT
+            echo "run_osac=false" >> $GITHUB_OUTPUT
             echo "Scheduled trigger - E2E will run" | tee -a $GITHUB_STEP_SUMMARY
           elif [[ "${{ github.event_name }}" == "merge_group" ]]; then
             echo "should_run=true" >> $GITHUB_OUTPUT
             echo "storage_plugins=[\"lvms\"]" >> $GITHUB_OUTPUT
             echo "storage_plugins_connected=[\"lvms\"]" >> $GITHUB_OUTPUT
+            echo "run_osac=false" >> $GITHUB_OUTPUT
             echo "Merge queue - E2E will run" | tee -a $GITHUB_STEP_SUMMARY
           elif [[ "${{ steps.filter.outputs.e2e }}" == "true" ]]; then
             echo "should_run=true" >> $GITHUB_OUTPUT
@@ -141,10 +161,18 @@ jobs:
               echo "storage_plugins=[\"lvms\"]" >> $GITHUB_OUTPUT
               echo "E2E-relevant files changed - E2E will run" | tee -a $GITHUB_STEP_SUMMARY
             fi
+            # OSAC runs when OSAC-relevant files change
+            if [[ "${{ steps.filter.outputs.osac }}" == "true" ]]; then
+              echo "run_osac=true" >> $GITHUB_OUTPUT
+              echo "OSAC-relevant files changed - OSAC E2E will run" | tee -a $GITHUB_STEP_SUMMARY
+            else
+              echo "run_osac=false" >> $GITHUB_OUTPUT
+            fi
           else
             echo "should_run=false" >> $GITHUB_OUTPUT
             echo "storage_plugins=[\"lvms\"]" >> $GITHUB_OUTPUT
             echo "storage_plugins_connected=[\"lvms\"]" >> $GITHUB_OUTPUT
+            echo "run_osac=false" >> $GITHUB_OUTPUT
             echo "Only documentation/config files changed - E2E will be skipped" | tee -a $GITHUB_STEP_SUMMARY
             echo "To run E2E anyway, use manual workflow_dispatch" | tee -a $GITHUB_STEP_SUMMARY
           fi
@@ -966,6 +994,434 @@ jobs:
         with:
           status: ${{ job.status }}
           workflow-name: E2E Deployment - Disconnected
+          cluster-name: ${{ env.ENCLAVE_CLUSTER_NAME }}
+          slack-webhook-urls: ${{ secrets.SLACK_WEBHOOK_URLS }}
+          workflow-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          branch-name: ${{ github.ref_name }}
+          commit-sha: ${{ github.sha }}
+          failed-step: ${{ steps.failed_step.outputs.FAILED_STEP }}
+          artifact-url: ${{ steps.artifact_url.outputs.ARTIFACT_URL }}
+
+  # ---------------------------------------------------------------------------
+  # OSAC Connected mode E2E deployment
+  # ---------------------------------------------------------------------------
+  e2e-osac-connected:
+    name: E2E OSAC Connected (lvms)
+    needs: check-e2e-needed
+    if: >-
+      needs.check-e2e-needed.outputs.run_osac == 'true'
+    runs-on: [self-hosted, enclave-large]
+    timeout-minutes: 360
+
+    concurrency:
+      group: enclave-ci-osac-connected-${{ github.run_id }}
+      cancel-in-progress: false
+
+    env:
+      BASE_WORKING_DIR: ${{ vars.BASE_WORKING_DIR }}
+      PULL_SECRET: ${{ secrets.PULL_SECRET }}
+      ENCLAVE_DEPLOYMENT_MODE: connected
+      ENCLAVE_IRONIC_HTTPS: 'true'
+      CLEANUP_AFTER: 'true'
+      STORAGE_PLUGIN: lvms
+      ENABLED_PLUGINS: lvms,trust-manager,rhbk,authorino,aap,osac
+      OPENSHIFT_CI: "true"
+      ENCLAVE_ENABLE_GPU_PASSTHROUGH: "false"
+      LZ_OS_VARIANT: ${{ vars.LZ_OS_VARIANT }}
+      AAP_LICENSE_FILE: /etc/enclave-ci/aap-license.zip
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Verify AAP license file exists
+        run: |
+          if [ ! -f "$AAP_LICENSE_FILE" ]; then
+            echo "::error::AAP license file not found at $AAP_LICENSE_FILE"
+            echo "The AAP license file must be pre-staged on the CI runner." >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
+          echo "AAP license file found at $AAP_LICENSE_FILE" >> $GITHUB_STEP_SUMMARY
+
+      - name: Generate unique cluster name
+        uses: ./.github/actions/setup-cluster-name
+        with:
+          naming-strategy: hash
+          prefix: ${{ github.event_name == 'schedule' && 'no' || 'eco' }}
+          run-id: ${{ github.run_id }}
+
+      - name: Setup cluster-specific working directory
+        run: |
+          make -f Makefile.ci setup-working-dir
+          echo "WORKING_DIR=$(cat /tmp/working_dir)" >> $GITHUB_ENV
+
+      - name: Workflow information
+        run: |
+          echo "## E2E Deployment - OSAC Connected Mode" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Started at**: $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_STEP_SUMMARY
+          echo "**Cluster name**: $ENCLAVE_CLUSTER_NAME" >> $GITHUB_STEP_SUMMARY
+          echo "**Trigger**: ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Plugins**: $ENABLED_PLUGINS" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+      - name: Pre-flight checks
+        uses: ./.github/actions/preflight-checks
+        with:
+          title: E2E Deployment - OSAC Connected Mode
+          check-pull-secret: 'true'
+          check-system-resources: 'true'
+          check-libvirt: 'true'
+
+      - name: Allocate unique subnet for cluster
+        uses: ./.github/actions/allocate-subnet
+
+      - name: Create infrastructure
+        env:
+          WORKING_DIR: ${{ env.WORKING_DIR }}
+        run: |
+          echo "## Creating Infrastructure" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Creating VMs, networks, and BMC emulation..." >> $GITHUB_STEP_SUMMARY
+          echo "Using subnet: ${ENCLAVE_SUBNET_ID:-not-set}" >> $GITHUB_STEP_SUMMARY
+          echo "BMC Network: ${ENCLAVE_BMC_NETWORK:-not-set}" >> $GITHUB_STEP_SUMMARY
+          echo "Cluster Network: ${ENCLAVE_CLUSTER_NETWORK:-not-set}" >> $GITHUB_STEP_SUMMARY
+          echo "Working Directory: ${WORKING_DIR:-not-set}" >> $GITHUB_STEP_SUMMARY
+
+          make -f Makefile.ci environment
+          echo "Infrastructure created" >> $GITHUB_STEP_SUMMARY
+
+      - name: Provision Landing Zone
+        env:
+          LZ_CLOUD_IMAGE_URL: ${{ vars.LZ_CLOUD_IMAGE_URL }}
+          LZ_CLOUD_IMAGE_NAME: ${{ vars.LZ_CLOUD_IMAGE_NAME }}
+          LZ_RHSM_ORG: ${{ secrets.LZ_RHSM_ORG }}
+          LZ_RHSM_ACTIVATION_KEY: ${{ secrets.LZ_RHSM_ACTIVATION_KEY }}
+        run: |
+          echo "## Provisioning Landing Zone" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Installing ${LZ_OS_VARIANT:-centos-stream10} on Landing Zone VM..." >> $GITHUB_STEP_SUMMARY
+          make -f Makefile.ci provision-landing-zone
+          echo "Landing Zone provisioned" >> $GITHUB_STEP_SUMMARY
+
+      - name: Install Enclave Lab
+        run: |
+          echo "## Installing Enclave Lab" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Installing dev-scripts and required packages on Landing Zone..." >> $GITHUB_STEP_SUMMARY
+          make -f Makefile.ci install-enclave
+          echo "Enclave Lab installed" >> $GITHUB_STEP_SUMMARY
+
+      - name: Generate Ironic ISO server TLS certificate
+        id: generate_ironic_cert
+        if: env.ENCLAVE_IRONIC_HTTPS == 'true'
+        run: make -f Makefile.ci generate-ironic-cert
+
+      - name: Bootstrap - Validate configuration
+        id: bootstrap_validate
+        run: |
+          echo "## Bootstrap: Validate" >> $GITHUB_STEP_SUMMARY
+          make -f Makefile.ci deploy-cluster-validate
+          echo "Validation complete" >> $GITHUB_STEP_SUMMARY
+
+      - name: Bootstrap - Download content
+        id: bootstrap_download_content
+        run: |
+          echo "## Bootstrap: Download Content" >> $GITHUB_STEP_SUMMARY
+          make -f Makefile.ci deploy-cluster-prepare
+          echo "Download complete" >> $GITHUB_STEP_SUMMARY
+
+      - name: Bootstrap - Build local cache
+        id: bootstrap_build_cache
+        run: |
+          echo "## Bootstrap: Build Cache" >> $GITHUB_STEP_SUMMARY
+          make -f Makefile.ci deploy-cluster-mirror
+          echo "Cache build complete" >> $GITHUB_STEP_SUMMARY
+
+      - name: Bootstrap - Acquire hardware
+        id: bootstrap_acquire_hardware
+        run: |
+          echo "## Bootstrap: Acquire Hardware" >> $GITHUB_STEP_SUMMARY
+          make -f Makefile.ci deploy-cluster-acquire-hardware
+          echo "Hardware acquired" >> $GITHUB_STEP_SUMMARY
+
+      - name: Bootstrap - Deploy cluster
+        id: bootstrap_deploy
+        run: |
+          echo "## Bootstrap: Deploy Cluster" >> $GITHUB_STEP_SUMMARY
+          make -f Makefile.ci deploy-cluster-install
+          echo "Cluster deployed" >> $GITHUB_STEP_SUMMARY
+
+      - name: Bootstrap - Post-install
+        id: bootstrap_post_install
+        run: |
+          echo "## Bootstrap: Post-Install" >> $GITHUB_STEP_SUMMARY
+          make -f Makefile.ci deploy-cluster-post-install
+          echo "Post-install complete" >> $GITHUB_STEP_SUMMARY
+
+      - name: Bootstrap - Operators
+        id: bootstrap_operators
+        run: |
+          echo "## Bootstrap: Operators" >> $GITHUB_STEP_SUMMARY
+          make -f Makefile.ci deploy-cluster-operators
+          echo "Operators installed" >> $GITHUB_STEP_SUMMARY
+
+      - name: Bootstrap - Day-2
+        id: bootstrap_day2
+        run: |
+          echo "## Bootstrap: Day-2" >> $GITHUB_STEP_SUMMARY
+          make -f Makefile.ci deploy-cluster-day2
+          echo "Day-2 complete" >> $GITHUB_STEP_SUMMARY
+
+      - name: Bootstrap - Discovery
+        id: bootstrap_discovery
+        run: |
+          echo "## Bootstrap: Discovery" >> $GITHUB_STEP_SUMMARY
+          make -f Makefile.ci deploy-cluster-discovery
+          echo "Discovery complete" >> $GITHUB_STEP_SUMMARY
+
+      - name: Deploy trust-manager plugin
+        id: deploy_trust_manager
+        run: make -f Makefile.ci deploy-plugin PLUGIN=trust-manager
+
+      - name: Deploy rhbk plugin
+        id: deploy_rhbk
+        run: make -f Makefile.ci deploy-plugin PLUGIN=rhbk
+
+      - name: Deploy authorino plugin
+        id: deploy_authorino
+        run: make -f Makefile.ci deploy-plugin PLUGIN=authorino
+
+      - name: Deploy aap plugin
+        id: deploy_aap
+        run: make -f Makefile.ci deploy-plugin PLUGIN=aap
+
+      - name: Deploy osac plugin
+        id: deploy_osac
+        run: make -f Makefile.ci deploy-plugin PLUGIN=osac
+
+      - name: Verify cluster deployment
+        if: success()
+        id: verify_cluster
+        run: make -f Makefile.ci verify-cluster
+
+      - name: Collect artifacts
+        if: always()
+        uses: ./.github/actions/collect-artifacts
+        with:
+          artifact-type: deployment
+          output-directory: artifacts
+
+      - name: Collect full diagnostics on failure
+        if: failure()
+        run: |
+          echo "## Collecting Full Diagnostics (failure)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if ! ./scripts/verification/collect_ci_artifacts.sh full artifacts 2>&1 | tee artifact-collection-full.log; then
+            echo "Full artifact collection failed; continuing with must-gather" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          LZ_IP=$(./scripts/utils/get_landing_zone_ip.sh)
+          if [ -n "$LZ_IP" ]; then
+            SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10"
+
+            if ssh $SSH_OPTS cloud-user@$LZ_IP "test -f /home/cloud-user/enclave/scripts/diagnostics/gather.sh" 2>/dev/null; then
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "### Running must-gather..." >> $GITHUB_STEP_SUMMARY
+
+              mkdir -p artifacts/must-gather
+              GATHER_OUT=$(ssh $SSH_OPTS cloud-user@$LZ_IP \
+                "cd /home/cloud-user/enclave/scripts/diagnostics && \
+                 export KUBECONFIG=/home/cloud-user/ocp-cluster/auth/kubeconfig && \
+                 GITHUB_RUN_ID='${{ github.run_id }}' ./gather.sh --must-gather=full ../../config/global.yaml 2>&1" || true)
+              echo "$GATHER_OUT" >> artifacts/must-gather/gather-output.txt
+
+              scp $SSH_OPTS "cloud-user@${LZ_IP}:/home/cloud-user/enclave/scripts/diagnostics/lz-logs-*.tar.gz" artifacts/must-gather/ 2>/dev/null || true
+              scp $SSH_OPTS "cloud-user@${LZ_IP}:/home/cloud-user/enclave/scripts/diagnostics/cluster-logs-*.tar.gz" artifacts/must-gather/ 2>/dev/null || true
+
+              if ls artifacts/must-gather/*-logs-*.tar.gz 1>/dev/null 2>&1; then
+                echo "Collected must-gather archives" >> $GITHUB_STEP_SUMMARY
+              else
+                echo "Must-gather failed (see must-gather/gather-output.txt)" >> $GITHUB_STEP_SUMMARY
+              fi
+            fi
+          fi
+
+      - name: Upload artifacts
+        if: always()
+        id: upload_artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-osac-connected-${{ env.ENCLAVE_CLUSTER_NAME }}-${{ github.run_id }}
+          path: artifacts/
+          retention-days: 7
+          if-no-files-found: warn
+
+      - name: Get artifact download URL
+        if: always()
+        id: artifact_url
+        run: |
+          ARTIFACT_ID=""
+          for attempt in 1 2 3 4 5; do
+            sleep $((attempt * 2))
+            ARTIFACT_ID=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts \
+              --jq '[.artifacts[] | select(.name == "e2e-osac-connected-${{ env.ENCLAVE_CLUSTER_NAME }}-${{ github.run_id }}")] | sort_by(.created_at) | last // empty | .id')
+            if [ -n "$ARTIFACT_ID" ]; then
+              break
+            fi
+          done
+
+          if [ -n "$ARTIFACT_ID" ]; then
+            ARTIFACT_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${ARTIFACT_ID}"
+            echo "ARTIFACT_URL=${ARTIFACT_URL}" >> $GITHUB_OUTPUT
+          else
+            echo "ARTIFACT_URL=" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Cleanup infrastructure
+        if: always() && (github.event_name != 'workflow_dispatch' || inputs.skip-cleanup != true)
+        run: |
+          echo "## Cleanup Infrastructure" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Removing infrastructure for cluster: $ENCLAVE_CLUSTER_NAME" >> $GITHUB_STEP_SUMMARY
+
+          mkdir -p cleanup-logs
+
+          set +e
+          make -f Makefile.ci clean 2>&1 | tee cleanup-logs/cleanup.log
+          CLEANUP_EXIT_CODE=$?
+          set -e
+
+          if grep -q "WARNING:" cleanup-logs/cleanup.log; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Cleanup completed with warnings:" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            grep "WARNING:" cleanup-logs/cleanup.log >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          elif [ $CLEANUP_EXIT_CODE -eq 0 ]; then
+            echo "Infrastructure cleaned up successfully" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "Cleanup completed with errors (exit code: $CLEANUP_EXIT_CODE)" >> $GITHUB_STEP_SUMMARY
+            echo "Check cleanup-logs/cleanup.log for details" >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Cleanup skipped notice
+        if: always() && github.event_name == 'workflow_dispatch' && inputs.skip-cleanup == true
+        run: |
+          echo "## Cleanup Skipped" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Infrastructure cleanup was skipped as requested." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**IMPORTANT**: Remember to manually clean up the infrastructure:" >> $GITHUB_STEP_SUMMARY
+          echo '```bash' >> $GITHUB_STEP_SUMMARY
+          echo "make clean" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Cluster name**: $ENCLAVE_CLUSTER_NAME" >> $GITHUB_STEP_SUMMARY
+
+      - name: Collect post-cleanup state
+        if: always()
+        run: |
+          mkdir -p cleanup-state/libvirt cleanup-state/system
+
+          sudo virsh pool-list --all --details > cleanup-state/libvirt/storage-pools.txt 2>&1 || true
+          sudo virsh net-list --all > cleanup-state/libvirt/networks.txt 2>&1 || true
+          sudo virsh list --all > cleanup-state/libvirt/vms.txt 2>&1 || true
+          df -h > cleanup-state/system/disk-usage.txt 2>&1 || true
+
+      - name: Upload post-cleanup artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: post-cleanup-osac-connected-${{ github.run_id }}
+          path: |
+            cleanup-logs/
+            cleanup-state/
+          retention-days: 7
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "---" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "## Deployment Summary" >> $GITHUB_STEP_SUMMARY
+          echo "- **Mode**: OSAC Connected" >> $GITHUB_STEP_SUMMARY
+          echo "- **Storage Plugin**: lvms" >> $GITHUB_STEP_SUMMARY
+          echo "- **Plugins**: $ENABLED_PLUGINS" >> $GITHUB_STEP_SUMMARY
+          echo "- **Cluster**: $ENCLAVE_CLUSTER_NAME" >> $GITHUB_STEP_SUMMARY
+          echo "- **Branch**: ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Commit**: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Triggered by**: @${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Completed at**: $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_STEP_SUMMARY
+          echo "- **Status**: ${{ job.status }}" >> $GITHUB_STEP_SUMMARY
+
+      - name: Determine failed step
+        if: failure()
+        id: failed_step
+        env:
+          STEPS_JSON: ${{ toJSON(steps) }}
+        run: |
+          declare -A step_names=(
+            ["generate_ironic_cert"]="Generate Ironic ISO server TLS certificate"
+            ["bootstrap_validate"]="Bootstrap: Validate configuration"
+            ["bootstrap_download_content"]="Bootstrap: Download content"
+            ["bootstrap_build_cache"]="Bootstrap: Build local cache"
+            ["bootstrap_acquire_hardware"]="Bootstrap: Acquire hardware"
+            ["bootstrap_deploy"]="Bootstrap: Deploy cluster"
+            ["bootstrap_post_install"]="Bootstrap: Post-install"
+            ["bootstrap_operators"]="Bootstrap: Operators"
+            ["bootstrap_day2"]="Bootstrap: Day-2"
+            ["bootstrap_discovery"]="Bootstrap: Discovery"
+            ["deploy_trust_manager"]="Deploy trust-manager plugin"
+            ["deploy_rhbk"]="Deploy rhbk plugin"
+            ["deploy_authorino"]="Deploy authorino plugin"
+            ["deploy_aap"]="Deploy aap plugin"
+            ["deploy_osac"]="Deploy osac plugin"
+            ["verify_cluster"]="Verify cluster deployment"
+          )
+
+          step_order=(
+            generate_ironic_cert
+            bootstrap_validate
+            bootstrap_download_content
+            bootstrap_build_cache
+            bootstrap_acquire_hardware
+            bootstrap_deploy
+            bootstrap_post_install
+            bootstrap_operators
+            bootstrap_day2
+            bootstrap_discovery
+            deploy_trust_manager
+            deploy_rhbk
+            deploy_authorino
+            deploy_aap
+            deploy_osac
+            verify_cluster
+          )
+
+          FAILED_STEP=""
+          for step_id in "${step_order[@]}"; do
+            outcome=$(printf '%s' "$STEPS_JSON" | jq -r --arg id "$step_id" '.[$id].outcome // "skipped"')
+            if [ "$outcome" == "failure" ]; then
+              FAILED_STEP="${step_names[$step_id]}"
+              break
+            fi
+          done
+
+          if [ -n "$FAILED_STEP" ]; then
+            echo "FAILED_STEP=$FAILED_STEP" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Notify Slack
+        if: always() && (github.event_name == 'schedule' || inputs.send-slack-notification == true)
+        uses: ./.github/actions/notify-slack
+        with:
+          status: ${{ job.status }}
+          workflow-name: E2E Deployment - OSAC Connected
           cluster-name: ${{ env.ENCLAVE_CLUSTER_NAME }}
           slack-webhook-urls: ${{ secrets.SLACK_WEBHOOK_URLS }}
           workflow-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/e2e-deployment.yml
+++ b/.github/workflows/e2e-deployment.yml
@@ -1024,7 +1024,7 @@ jobs:
       ENCLAVE_IRONIC_HTTPS: 'true'
       CLEANUP_AFTER: 'true'
       STORAGE_PLUGIN: lvms
-      ENABLED_PLUGINS: lvms,trust-manager,rhbk,authorino,aap,osac
+      ENABLED_PLUGINS: lvms,trust-manager,rhbk,authorino,aap,cnv,osac
       OPENSHIFT_CI: "true"
       ENCLAVE_ENABLE_GPU_PASSTHROUGH: "false"
       LZ_OS_VARIANT: ${{ vars.LZ_OS_VARIANT }}
@@ -1195,6 +1195,10 @@ jobs:
       - name: Deploy aap plugin
         id: deploy_aap
         run: make -f Makefile.ci deploy-plugin PLUGIN=aap
+
+      - name: Deploy cnv plugin
+        id: deploy_cnv
+        run: make -f Makefile.ci deploy-plugin PLUGIN=cnv
 
       - name: Deploy osac plugin
         id: deploy_osac
@@ -1380,6 +1384,7 @@ jobs:
             ["deploy_rhbk"]="Deploy rhbk plugin"
             ["deploy_authorino"]="Deploy authorino plugin"
             ["deploy_aap"]="Deploy aap plugin"
+            ["deploy_cnv"]="Deploy cnv plugin"
             ["deploy_osac"]="Deploy osac plugin"
             ["verify_cluster"]="Verify cluster deployment"
           )
@@ -1399,6 +1404,7 @@ jobs:
             deploy_rhbk
             deploy_authorino
             deploy_aap
+            deploy_cnv
             deploy_osac
             verify_cluster
           )

--- a/scripts/deployment/deploy_plugin.sh
+++ b/scripts/deployment/deploy_plugin.sh
@@ -131,6 +131,20 @@ if [ -n "${ENABLED_PLUGINS:-}" ]; then
     info "Enabled plugins: $ENABLED_PLUGINS"
 fi
 
+# Copy AAP license file to Landing Zone if AAP_LICENSE_FILE is set
+if [ -n "${AAP_LICENSE_FILE:-}" ]; then
+    if [ ! -f "$AAP_LICENSE_FILE" ]; then
+        error "AAP license file not found: $AAP_LICENSE_FILE"
+        exit 1
+    fi
+    LZ_AAP_LICENSE="${LZ_HOME}/aap-license.zip"
+    info "Copying AAP license file to Landing Zone: $LZ_AAP_LICENSE"
+    # shellcheck disable=SC2086  # SSH_OPTS needs word splitting
+    scp $SSH_OPTS "$AAP_LICENSE_FILE" "${LZ_SSH}:${LZ_AAP_LICENSE}"
+    EXTRA_VARS_CONTENT="${EXTRA_VARS_CONTENT}osacAapLicenseFile: ${LZ_AAP_LICENSE}
+"
+fi
+
 # Create the extra vars file on Landing Zone
 # shellcheck disable=SC2087,SC2086  # We want client-side expansion of $EXTRA_VARS_CONTENT
 ssh $SSH_OPTS "$LZ_SSH" "cat > $LZ_ENCLAVE_DIR/phase_vars.yaml" <<EOF

--- a/scripts/deployment/deploy_plugin.sh
+++ b/scripts/deployment/deploy_plugin.sh
@@ -143,6 +143,16 @@ if [ -n "${AAP_LICENSE_FILE:-}" ]; then
     scp $SSH_OPTS "$AAP_LICENSE_FILE" "${LZ_SSH}:${LZ_AAP_LICENSE}"
     EXTRA_VARS_CONTENT="${EXTRA_VARS_CONTENT}osacAapLicenseFile: ${LZ_AAP_LICENSE}
 "
+    # Generate OSAC plugin config on LZ if it doesn't exist (CI environments)
+    # shellcheck disable=SC2086  # SSH_OPTS needs word splitting
+    if ! ssh $SSH_OPTS "$LZ_SSH" "test -f $LZ_ENCLAVE_DIR/config/plugins/osac.yaml"; then
+        info "Generating config/plugins/osac.yaml on Landing Zone"
+        # shellcheck disable=SC2086,SC2087  # SSH_OPTS needs word splitting, we want client-side expansion
+        ssh $SSH_OPTS "$LZ_SSH" "mkdir -p $LZ_ENCLAVE_DIR/config/plugins && cat > $LZ_ENCLAVE_DIR/config/plugins/osac.yaml" <<OSAC_EOF
+---
+osacAapLicenseFile: "${LZ_AAP_LICENSE}"
+OSAC_EOF
+    fi
 fi
 
 # Create the extra vars file on Landing Zone


### PR DESCRIPTION
## Summary

- Add `e2e-osac-connected` job to the E2E deployment workflow that deploys the full OSAC plugin stack (trust-manager → rhbk → authorino → aap → osac) in connected mode with lvms storage
- Add `run-osac` manual dispatch input and `osac` paths-filter for automatic triggering on OSAC file changes
- Add AAP license file handling to `deploy_plugin.sh` — SCP to Landing Zone and inject `osacAapLicenseFile` extra var

## Test plan

- [ ] `make -f Makefile.ci validate-shell` passes (shellcheck)
- [ ] `yamllint` on workflow file shows no new warnings
- [ ] Manual dispatch with `run-osac: true` triggers the OSAC job
- [ ] OSAC file changes in a PR trigger the OSAC job automatically
- [ ] AAP license file is transferred to LZ and injected into `phase_vars.yaml`

Jira: https://redhat.atlassian.net/browse/OSAC-1535

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an OSAC-connected E2E deployment mode that can be triggered manually or automatically when OSAC-related content changes.
  * The deployment now provisions an AAP license when provided, including landing-zone upload and passing the license path to the installer.
  * Automatically ensures OSAC configuration is present before deployment, and reports detailed diagnostics and results (including an OSAC-specific notification).


<!-- end of auto-generated comment: release notes by coderabbit.ai -->