### PR TITLE
Add custom CA trust migration for 0.1.0 upgrades

### DIFF
--- a/playbooks/tasks/migrations.yaml
+++ b/playbooks/tasks/migrations.yaml
@@ -16,3 +16,10 @@
   ansible.builtin.include_tasks:
     file: migrations/foundation_plugin_fleet_catalogs.yaml
   when: disconnected | default(true) | bool
+
+- name: Trust custom CA migration
+  ansible.builtin.include_tasks:
+    file: migrations/trust_custom_ca.yaml
+  when:
+    - sslCACertificate is defined
+    - sslCACertificate | length > 0

--- a/playbooks/tasks/migrations/trust_custom_ca.yaml
+++ b/playbooks/tasks/migrations/trust_custom_ca.yaml
@@ -1,0 +1,35 @@
+---
+# Custom CA Trust Migration
+#
+# Ensures the cluster Proxy trusts the custom Root CA certificate for clusters
+# installed with Enclave 0.1.0, where trust_custom_ca was not part of the
+# install flow.
+#
+# Without this migration, the ClusterVersion operator cannot verify the TLS
+# certificate presented by the Update Service route (signed by the custom CA),
+# leaving availableUpdates empty. The UpdateService deployment is restarted
+# after the proxy trust is applied so the graph-builder reloads the updated
+# CA bundle.
+#
+# Only applies when sslCACertificate is configured.
+
+- name: Trust custom Root CA certificate
+  ansible.builtin.include_tasks: ../trust_custom_ca.yaml
+
+- name: Restart UpdateService deployment to reload custom CA trust
+  ansible.builtin.command:
+    argv:
+      - "{{ workingDir }}/bin/oc"
+      - rollout
+      - restart
+      - deployment/service
+      - -n
+      - openshift-update-service
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  register: r_updateservice_rollout_restart
+  when: not ca_already_trusted
+  changed_when: r_updateservice_rollout_restart.rc == 0
+  failed_when:
+    - r_updateservice_rollout_restart.rc != 0
+    - '"not found" not in r_updateservice_rollout_restart.stderr | lower'


### PR DESCRIPTION
Clusters installed with Enclave 0.1.0 with an API cert signed by a custom CA cannot retrieve available updates after install because the cluster Proxy does not trust the custom CA. The ClusterVersion operator fails to reach the Update Service route with:
```
  tls: failed to verify certificate: x509: certificate signed by unknown authority
```
trust_custom_ca was promoted to the standard install flow in #287, after the 0.1.0 release. This migration backfills that step for existing clusters and restarts the UpdateService deployment so the graph-builder reloads the updated CA bundle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a custom root CA trust migration that runs only when an SSL CA certificate is provided, then restarts the update service to ensure the newly trusted CA bundle is loaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->