### PR TITLE
Fix cert-manager configuration race condition

### DIFF
--- a/operators/openshift-cert-manager-operator/tasks.yaml
+++ b/operators/openshift-cert-manager-operator/tasks.yaml
@@ -1,4 +1,29 @@
 ---
+- name: Wait for cert-manager operator to complete initial reconciliation
+  kubernetes.core.k8s_info:
+    api_version: operator.openshift.io/v1alpha1
+    kind: CertManager
+    name: cluster
+  register: r_certmanager_init
+  retries: 60
+  delay: 10
+  until:
+    - r_certmanager_init.resources is defined
+    - r_certmanager_init.resources | length > 0
+    - r_certmanager_init.resources[0].status.conditions is defined
+    - >-
+      r_certmanager_init.resources[0].status.conditions
+      | selectattr('type', 'equalto', 'cert-manager-controller-deploymentAvailable')
+      | selectattr('status', 'equalto', 'True') | list | length > 0
+    - >-
+      r_certmanager_init.resources[0].status.conditions
+      | selectattr('type', 'equalto', 'cert-manager-cainjector-deploymentAvailable')
+      | selectattr('status', 'equalto', 'True') | list | length > 0
+    - >-
+      r_certmanager_init.resources[0].status.conditions
+      | selectattr('type', 'equalto', 'cert-manager-webhook-deploymentAvailable')
+      | selectattr('status', 'equalto', 'True') | list | length > 0
+
 - name: Configure and validate cert-manager
   vars:
     cert_manager_cainjector_replicas: 2


### PR DESCRIPTION
## Summary
- Wait for cert-manager operator to complete initial reconciliation before patching the CertManager CR
- Without this wait, the operator's initial reconciliation can reset the spec, wiping replica and resource overrides
- The subsequent verification assert then fails intermittently with "CertManager operator did not accept controllerConfig.overrideReplicas"

## Root Cause
`configure_operator.yaml` waits for the CSV to reach `Succeeded`, then immediately includes the operator's `tasks.yaml`. The CSV being ready means the operator pod is running, but it hasn't finished reconciling the CertManager CR yet. When the patch is applied during this window, the operator's reconciliation loop resets the spec to defaults.

## Fix
Added a wait task before the configuration block that polls the CertManager CR status conditions until all three deployments report `Available=True`:
- `cert-manager-controller-deploymentAvailable`
- `cert-manager-cainjector-deploymentAvailable`
- `cert-manager-webhook-deploymentAvailable`

Retries up to 60 times with 10s delay (10 min max).

## Test plan
- [x] Deploy Enclave cluster and verify cert-manager operator tasks pass consistently
- [x] Verify CertManager CR retains replica and resource overrides after patching

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced cert-manager operator initialization with an additional readiness check that ensures all core components are fully available and healthy before proceeding with configuration. This improves reliability during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->