### PR TITLE
Apply release signatures on day-2 LZ to Quay Enterprise sync

### DIFF
--- a/operators/quay-operator/quay_apply_release_signatures.yaml
+++ b/operators/quay-operator/quay_apply_release_signatures.yaml
@@ -1,0 +1,16 @@
+---
+- name: Stat release signature ConfigMap from Quay oc-mirror workspace
+  ansible.builtin.stat:
+    path: "{{ workingDir }}/config/oc-mirror-workspace-quay/working-dir/cluster-resources/signature-configmap.yaml"
+  register: quay_signature_configmap_stat
+
+- name: Apply release signature ConfigMap to cluster
+  ansible.builtin.command:
+    argv:
+      - "{{ workingDir }}/bin/oc"
+      - apply
+      - -f
+      - "{{ workingDir }}/config/oc-mirror-workspace-quay/working-dir/cluster-resources/signature-configmap.yaml"
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  when: quay_signature_configmap_stat.stat.exists

--- a/operators/quay-operator/quay_apply_release_signatures.yaml
+++ b/operators/quay-operator/quay_apply_release_signatures.yaml
@@ -11,6 +11,10 @@
       - apply
       - -f
       - "{{ workingDir }}/config/oc-mirror-workspace-quay/working-dir/cluster-resources/signature-configmap.yaml"
+  register: quay_signature_apply_result
+  changed_when: >
+    'created' in (quay_signature_apply_result.stdout | lower) or
+    'configured' in (quay_signature_apply_result.stdout | lower)
   environment:
     KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
   when: quay_signature_configmap_stat.stat.exists

--- a/operators/quay-operator/quay_disconnected_finish.yaml
+++ b/operators/quay-operator/quay_disconnected_finish.yaml
@@ -18,6 +18,12 @@
 - name: Apply Quay mirrors and trust registry CA for image pulls
   ansible.builtin.include_tasks: quay_disconnected_mirrors.yaml
 
+# We only want to apply these in day-2 operations. In bootstrap, the release signatures are
+# added as part of the OCP ABI configuration, see playbooks/tasks/configure_ocp_abi.yaml
+- name: Apply release signature ConfigMap from Quay mirror
+  ansible.builtin.include_tasks: quay_apply_release_signatures.yaml
+  tags: quay-disconnected
+
 - name: Generate and apply master PinnedImageSet from images on master nodes
   ansible.builtin.include_tasks: quay_pinnedimageset.yaml
   when: >-


### PR DESCRIPTION
oc-mirror generates a signature-configmap.yaml in the Quay workspace during the LZ-to-Quay-Enterprise mirror. This ConfigMap is required by the ClusterVersion operator to verify release image signatures before upgrading. Without it, upgrades fail with:
```
  unable to verify sha256:... against keyrings: verifier-public-key-redhat
```
Add quay_apply_release_signatures.yaml called from quay_disconnected_finish.yaml under the quay-disconnected tag so it only runs in day-2 sync and not during bootstrap, where signatures are already applied by configure_ocp_abi.yaml.


Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for applying release signatures to the cluster during offline/disconnected Quay operator deployments, enabling signature validation in air-gapped environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->