### PR TITLE
Add collections/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ __pycache__/
 .ruff_cache/
 .coverage
 
+# Ansible Galaxy collections
+collections/
+
 # IDE folders
 .vscode/
 .idea/


### PR DESCRIPTION
## Summary
- Add `collections/` directory to `.gitignore`
- This directory is generated by `ansible-galaxy collection install` at runtime and should not be tracked

## Test plan
- [x] Verify `collections/` no longer shows in `git status` after running Ansible Galaxy installs

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version control configuration to exclude build artifacts from tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->