### PR TITLE
Apply catalog sources and signatures after oc-mirror on day-2 sync

### DIFF
--- a/playbooks/tasks/mirror_registry.yaml
+++ b/playbooks/tasks/mirror_registry.yaml
@@ -144,3 +144,10 @@
           {{ _oc_mirror_tail.stdout | default('Unable to read oc-mirror log tail.') }}
 
           Full log: {{ _oc_mirror_log }}
+
+- name: Apply cluster resources from oc-mirror workspace
+  ansible.builtin.include_tasks:
+    file: mirror_registry_cluster_resources.yaml
+  when:
+    - r_oc_mirror is success
+    - not (fresh | default(true) | bool)

--- a/playbooks/tasks/mirror_registry_cluster_resources.yaml
+++ b/playbooks/tasks/mirror_registry_cluster_resources.yaml
@@ -1,0 +1,47 @@
+---
+- name: Find catalog sources and signatures from workspace
+  ansible.builtin.find:
+    paths: "{{ workingDir }}/config/oc-mirror-workspace/working-dir/cluster-resources/"
+    patterns:
+      - "cs-*.yaml"
+      - "signature-configmap.yaml"
+    recurse: false
+  register: r_catalog_manifests
+
+- name: Set applied catalog source names
+  ansible.builtin.set_fact:
+    _applied_cs_names: "{{ r_catalog_manifests.files
+      | map(attribute='path')
+      | map('basename')
+      | reject('equalto', 'signature-configmap.yaml')
+      | map('regex_replace', '\\.ya?ml$', '')
+      | list }}"
+
+- name: Apply catalog sources and signatures to cluster
+  ansible.builtin.shell: |
+    {{ workingDir }}/bin/oc apply --server-side --force-conflicts -f {{ item }}
+  loop: "{{ r_catalog_manifests.files | map(attribute='path') | list }}"
+  loop_control:
+    label: "{{ item | basename }}"
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  register: r_catalog_apply
+  changed_when: "'configured' in r_catalog_apply.stdout or 'created' in r_catalog_apply.stdout"
+
+- name: Wait for catalog sources to be ready
+  kubernetes.core.k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: CatalogSource
+    namespace: openshift-marketplace
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  register: r_catalog_sources
+  retries: 24
+  delay: 10
+  until: >-
+    r_catalog_sources.resources | default([])
+    | selectattr('metadata.name', 'in', _applied_cs_names)
+    | selectattr('status', 'defined')
+    | selectattr('status.connectionState', 'defined')
+    | selectattr('status.connectionState.lastObservedState', 'equalto', 'READY')
+    | list | length == (_applied_cs_names | length)


### PR DESCRIPTION
After oc-mirror runs during sync.sh (fresh=false), find and apply cs-*.yaml catalog sources and signature-configmap.yaml from the oc-mirror workspace cluster-resources to the cluster, then wait for all catalog sources to be READY. Skipped during bootstrap (fresh=true) where configure_ocp_abi.yaml handles the same resources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Enhanced registry mirroring now applies additional cluster resources produced by the mirroring process to support day 2 operations.
- Automatically discovers and deploys catalog manifests from the mirroring workspace.
- Waits for selected CatalogSource objects to report **READY** before completing, improving reliability.
- This runs only when the mirroring step succeeds and the deployment isn’t marked as already fresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->