### PR TITLE
OSAC-1578: Replace undefined enclave_deployment_mode with disconnected var

### DIFF
--- a/plugins/osac/tasks/deploy.yaml
+++ b/plugins/osac/tasks/deploy.yaml
@@ -82,7 +82,7 @@
     regexp: "{{ _osac_aap_route_host | regex_escape() }}"
     state: present
   become: true
-  when: enclave_deployment_mode | default('') == 'connected'
+  when: not disconnected | default(true) | bool
 
 # =====================================================================
 # 4. Create AAP personal access token via awx-manage

--- a/plugins/osac/tasks/post-operators.yaml
+++ b/plugins/osac/tasks/post-operators.yaml
@@ -83,7 +83,7 @@
     regexp: "{{ _osac_keycloak_hostname | regex_escape() }}"
     state: present
   become: true
-  when: enclave_deployment_mode | default('') == 'connected'
+  when: not disconnected | default(true) | bool
 
 # =====================================================================
 # 5. Get Keycloak admin credentials


### PR DESCRIPTION
## Summary

- The OSAC plugin tasks for adding Keycloak and AAP route hostnames to `/etc/hosts` checked `enclave_deployment_mode`, an Ansible variable that is never set
- The deploy scripts (`deploy_plugin.sh`, `deploy_phase.sh`) translate the shell env var `ENCLAVE_DEPLOYMENT_MODE` into the Ansible variable `disconnected` (true/false), but never pass `enclave_deployment_mode`
- Replaced the condition in both `plugins/osac/tasks/post-operators.yaml` and `plugins/osac/tasks/deploy.yaml` to use `not disconnected | default(true) | bool`

## Test plan

- [x] Deploy OSAC plugin in connected mode and verify `/etc/hosts` entries are created for Keycloak and AAP routes
- [ ] Deploy OSAC plugin in disconnected mode and verify `/etc/hosts` tasks are skipped

Fixes: [OSAC-1578](https://redhat.atlassian.net/browse/OSAC-1578)

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment task configuration to improve consistency in route hostname setup across deployment modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->