### PR TITLE
OSAC-1592: Fix AAP gateway label selectors in deploy tasks and docs

### DIFF
--- a/docs/OSAC_DEPLOYMENT.md
+++ b/docs/OSAC_DEPLOYMENT.md
@@ -229,7 +229,7 @@ After deployment, hub registration and tenant creation require manual steps:
 | pre-validate fails on Keycloak | `oc get keycloak -n keycloak` | Deploy rhbk plugin first |
 | pre-validate fails on AAP CRD | `oc get crd ansibleautomationplatforms.aap.ansible.com` | Deploy aap plugin first |
 | pre-validate fails on HyperConverged CRD | `oc get crd hyperconvergeds.hco.kubevirt.io` | Deploy cnv plugin first (required for vmaas/development profile) |
-| AAP gateway not becoming available | `oc get pods -n osac -l app.kubernetes.io/managed-by=automationgateway` | AAP takes 30+ minutes; check operator logs |
+| AAP gateway not becoming available | `oc get pods -n osac -l app.kubernetes.io/component=aap-gateway` | AAP takes 30+ minutes; check operator logs |
 | Helm chart install fails | `helm status osac -n osac` | Check post-operators secrets exist: `oc get secrets -n osac` |
 | PostgreSQL not starting | `oc logs deployment/postgres -n osac` | Check PVC bound (`oc get pvc -n osac`), cert-manager certs issued (`oc get certificates -n osac`) |
 | Fulfillment pods CrashLoopBackOff | `oc logs deployment/fulfillment-grpc-server -n osac` | Check `fulfillment-db` secret URL, PostgreSQL reachable, client cert valid |

--- a/plugins/osac/tasks/deploy.yaml
+++ b/plugins/osac/tasks/deploy.yaml
@@ -40,7 +40,7 @@
     kind: Deployment
     namespace: osac
     label_selectors:
-      - "app.kubernetes.io/managed-by=automationgateway"
+      - "app.kubernetes.io/component=aap-gateway"
   register: __r_aap_gateway
   retries: 90
   delay: 30
@@ -58,7 +58,7 @@
     kind: Route
     namespace: osac
     label_selectors:
-      - "app.kubernetes.io/managed-by=automationgateway"
+      - "app.kubernetes.io/managed-by=aap-operator"
   register: __r_aap_route
 
 - name: Assert exactly one AAP route found
@@ -66,7 +66,7 @@
     that: __r_aap_route.resources | length == 1
     fail_msg: >-
       Expected exactly one AAP gateway route in osac namespace
-      (managed-by=automationgateway), found {{ __r_aap_route.resources | length }}.
+      (managed-by=aap-operator), found {{ __r_aap_route.resources | length }}.
 
 - name: Set AAP URL fact
   ansible.builtin.set_fact:


### PR DESCRIPTION
## Summary

- The OSAC plugin `deploy.yaml` used `app.kubernetes.io/managed-by=automationgateway` to find the AAP gateway deployment and route, but the AAP operator uses different labels
- Updated deployment selector to `app.kubernetes.io/component=aap-gateway`
- Updated route selector to `app.kubernetes.io/managed-by=aap-operator`
- Updated troubleshooting command in `docs/OSAC_DEPLOYMENT.md`

## Test plan

- [x] Deploy OSAC plugin and verify the deploy tasks find the AAP gateway deployment without hanging
- [x] Verify the AAP route is correctly located and /etc/hosts entry is created (connected mode)
- [x] Verify AAP token creation succeeds

Fixes: [OSAC-1592](https://redhat.atlassian.net/browse/OSAC-1592)

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Kubernetes label selectors used to identify AAP gateway Deployments and route resources during OSAC post-Helm deployment, improving reliability of resource discovery during deployment initialization and validation.

* **Documentation**
  * Updated OSAC Day-2 deployment troubleshooting documentation with corrected label-based resource selection criteria for AAP gateway identification, including updated guidance and error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->