### PR TITLE
OSAC-1594: Auto-resolve KUBECONFIG for enclave CLI commands

### DIFF
--- a/playbooks/03-deploy.yaml
+++ b/playbooks/03-deploy.yaml
@@ -78,6 +78,10 @@
               tags: pre-install-validate
           tags: pre-install-validate
 
+        - name: Set up enclave kubeconfig symlink
+          ansible.builtin.include_tasks:
+            file: tasks/setup_enclave_kubeconfig_symlink.yaml
+
         - name: Wait for deployment
           ansible.builtin.include_tasks:
             file: tasks/wait_for_deployment.yaml

--- a/playbooks/tasks/migrations.yaml
+++ b/playbooks/tasks/migrations.yaml
@@ -23,3 +23,7 @@
   when:
     - sslCACertificate is defined
     - sslCACertificate | length > 0
+
+- name: Enclave kubeconfig symlink migration
+  ansible.builtin.include_tasks:
+    file: migrations/setup_enclave_kubeconfig_symlink.yaml

--- a/playbooks/tasks/migrations/setup_enclave_kubeconfig_symlink.yaml
+++ b/playbooks/tasks/migrations/setup_enclave_kubeconfig_symlink.yaml
@@ -1,0 +1,11 @@
+---
+# Enclave Kubeconfig Symlink Migration
+#
+# Creates ~/.config/enclave/kubeconfig as a symlink to the cluster kubeconfig
+# so that enclave CLI commands (enclave reconcile, enclave tools) can locate
+# the kubeconfig automatically when KUBECONFIG is not set in the environment.
+#
+# Required for clusters deployed before this symlink was created during install.
+
+- name: Set up enclave kubeconfig symlink
+  ansible.builtin.include_tasks: ../setup_enclave_kubeconfig_symlink.yaml

--- a/playbooks/tasks/setup_enclave_kubeconfig_symlink.yaml
+++ b/playbooks/tasks/setup_enclave_kubeconfig_symlink.yaml
@@ -1,0 +1,12 @@
+---
+- name: Ensure enclave config dir exists
+  ansible.builtin.file:
+    path: "{{ lookup('env','HOME') }}/.config/enclave"
+    state: directory
+  register: _enclave_config_dir
+
+- name: Create symlink for kubeconfig in user's home
+  ansible.builtin.file:
+    src: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+    dest: "{{ _enclave_config_dir.path }}/kubeconfig"
+    state: link

--- a/src/enclave/reconcile/cli.py
+++ b/src/enclave/reconcile/cli.py
@@ -9,7 +9,11 @@ from enclave.reconcile.cluster_upgrade import (
     reconcile as cluster_upgrade_reconcile,
 )
 from enclave.reconcile.operator_versions import reconcile as operator_versions_reconcile
-from enclave.utils import LOG_LEVELS, configure_logging
+from enclave.utils import (
+    LOG_LEVELS,
+    KubeconfigGroup,
+    configure_logging,
+)
 
 
 def defaults_path(filename: str) -> Path:
@@ -22,7 +26,7 @@ def defaults_path(filename: str) -> Path:
     return path
 
 
-@click.group()
+@click.group(cls=KubeconfigGroup)
 @click.option(
     "--log-level",
     default="INFO",

--- a/src/enclave/reconcile/cli.py
+++ b/src/enclave/reconcile/cli.py
@@ -39,7 +39,7 @@ def cli(log_level: str) -> None:
     configure_logging(log_level)
 
 
-@cli.command()
+@cli.command(no_args_is_help=True)
 @click.option("--name", help="Operator package name")
 @click.option("--version", help="Operator version")
 @click.option("--namespace", help="Operator namespace")
@@ -102,7 +102,7 @@ def operator_versions(
         )
 
 
-@cli.command()
+@cli.command(no_args_is_help=True)
 @click.option(
     "--version", "version", default=None, help="OpenShift version to upgrade to"
 )

--- a/src/enclave/tools/cli.py
+++ b/src/enclave/tools/cli.py
@@ -10,7 +10,7 @@ def cli() -> None:
     """Enclave tools CLI."""
 
 
-@cli.command("resolve-quay-registry-ca")
+@cli.command("resolve-quay-registry-ca", no_args_is_help=True)
 @click.option("--hostname", required=True, help="Quay registry route hostname.")
 @click.option(
     "--oc",
@@ -26,7 +26,7 @@ def resolve_quay_registry_ca(hostname: str, oc: str) -> None:
         raise click.ClickException(str(exc)) from exc
 
 
-@cli.command("collect-node-image-digests")
+@cli.command("collect-node-image-digests", no_args_is_help=True)
 @click.option("--node", required=True, help="Node name.")
 @click.option(
     "--oc",

--- a/src/enclave/tools/cli.py
+++ b/src/enclave/tools/cli.py
@@ -2,9 +2,10 @@ import click
 
 from enclave.tools.node_image_digests import main as collect_node_image_digests_main
 from enclave.tools.quay_registry_ca import main as quay_registry_ca_main
+from enclave.utils import KubeconfigGroup
 
 
-@click.group()
+@click.group(cls=KubeconfigGroup)
 def cli() -> None:
     """Enclave tools CLI."""
 

--- a/src/enclave/utils.py
+++ b/src/enclave/utils.py
@@ -1,8 +1,12 @@
 import logging
+import os
 import re
 import subprocess
 import sys
 import time
+from pathlib import Path
+
+import click
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +27,45 @@ def configure_logging(log_level: str) -> None:
             datefmt="%Y-%m-%dT%H:%M:%S",
             stream=sys.stderr,
         )
+
+
+class KubeconfigNotFoundError(RuntimeError):
+    pass
+
+
+def setup_kubeconfig() -> None:
+    """Ensure KUBECONFIG is set before running cluster commands.
+
+    If KUBECONFIG is already set, nothing happens. Otherwise tries
+    ~/.config/enclave/kubeconfig (symlinked by the deploy playbook).
+    Raises KubeconfigNotFoundError with a helpful message if neither is available.
+    """
+    if os.environ.get("KUBECONFIG"):
+        return
+
+    fallback = Path.home() / ".config" / "enclave" / "kubeconfig"
+    if fallback.exists():
+        os.environ["KUBECONFIG"] = str(fallback)
+        logger.debug("KUBECONFIG not set; using %s", fallback)
+        return
+
+    raise KubeconfigNotFoundError(
+        "KUBECONFIG is not set and ~/.config/enclave/kubeconfig does not exist.\n"
+        "Set KUBECONFIG to your kubeconfig file, for example:\n"
+        "  export KUBECONFIG=<enclave-workingDir>/ocp-cluster/auth/kubeconfig"
+    )
+
+
+class KubeconfigGroup(click.Group):
+    def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
+        if not ctx.resilient_parsing:  # do nor fire during shell-completion parsing
+            help_flags = set(ctx.help_option_names or ["--help", "-h"])
+            if not any(f in args for f in help_flags):
+                try:
+                    setup_kubeconfig()
+                except KubeconfigNotFoundError as exc:
+                    raise click.ClickException(str(exc)) from exc
+        return super().parse_args(ctx, args)
 
 
 def parse_jsonpath_value(raw: str) -> str:

--- a/src/enclave/utils.py
+++ b/src/enclave/utils.py
@@ -58,14 +58,19 @@ def setup_kubeconfig() -> None:
 
 class KubeconfigGroup(click.Group):
     def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
-        if not ctx.resilient_parsing:  # do nor fire during shell-completion parsing
+        remaining = super().parse_args(ctx, args)
+        # ctx.args holds the subcommand's own args (empty when no subcommand was given, or
+        # when a bare subcommand name was given with no further args). Only check kubeconfig
+        # when there are actual subcommand args — otherwise Click will show help and kubeconfig
+        # is irrelevant. Also skip during shell-completion parsing and for --help.
+        if not ctx.resilient_parsing and ctx.args:
             help_flags = set(ctx.help_option_names or ["--help", "-h"])
-            if not any(f in args for f in help_flags):
+            if not any(f in ctx.args for f in help_flags):
                 try:
                     setup_kubeconfig()
                 except KubeconfigNotFoundError as exc:
                     raise click.ClickException(str(exc)) from exc
-        return super().parse_args(ctx, args)
+        return remaining
 
 
 def parse_jsonpath_value(raw: str) -> str:

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -4,6 +4,8 @@ from pytest_mock import MockerFixture
 
 from enclave.reconcile.cli import cli, defaults_path
 
+_KC = {"KUBECONFIG": "/fake/kubeconfig"}
+
 
 def test_cli_help() -> None:
     result = CliRunner().invoke(cli, ["--help"])
@@ -14,7 +16,7 @@ def test_cli_help() -> None:
 
 
 def test_operator_versions_help() -> None:
-    result = CliRunner().invoke(cli, ["operator-versions", "--help"])
+    result = CliRunner().invoke(cli, ["operator-versions", "--help"], env=_KC)
     assert result.exit_code == 0
     assert "--name" in result.output
     assert "--version" in result.output
@@ -26,7 +28,7 @@ def test_operator_versions_help() -> None:
 
 
 def test_mgmt_cluster_version_help() -> None:
-    result = CliRunner().invoke(cli, ["mgmt-cluster-version", "--help"])
+    result = CliRunner().invoke(cli, ["mgmt-cluster-version", "--help"], env=_KC)
     assert result.exit_code == 0
     assert "--version" in result.output
     assert "--use-defaults" in result.output
@@ -59,6 +61,7 @@ def test_operator_versions_csv_name_defaults_to_name(mocker: MockerFixture) -> N
             "quay-enterprise",
             "--dry-run",
         ],
+        env=_KC,
     )
     assert result.exit_code == 0
     mock_reconcile.assert_called_once_with(
@@ -85,6 +88,7 @@ def test_operator_versions_multiple_csv_names(mocker: MockerFixture) -> None:
             "metallb-operator-bundle",
             "--dry-run",
         ],
+        env=_KC,
     )
     assert result.exit_code == 0
     mock_reconcile.assert_called_once_with(
@@ -102,7 +106,7 @@ def test_use_defaults_calls_reconcile_per_operator(mocker: MockerFixture) -> Non
         operators = yaml.safe_load(fh)["operators"]
     dry_run = True
     result = CliRunner().invoke(
-        cli, ["operator-versions", "--use-defaults", "--dry-run"]
+        cli, ["operator-versions", "--use-defaults", "--dry-run"], env=_KC
     )
     assert result.exit_code == 0, result.output
     assert mock_reconcile.call_count == len(operators)
@@ -117,7 +121,7 @@ def test_use_defaults_calls_reconcile_per_operator(mocker: MockerFixture) -> Non
 
 def test_use_defaults_mutual_exclusive_name() -> None:
     result = CliRunner().invoke(
-        cli, ["operator-versions", "--use-defaults", "--name", "foo"]
+        cli, ["operator-versions", "--use-defaults", "--name", "foo"], env=_KC
     )
     assert result.exit_code != 0
     assert "mutually exclusive" in result.output
@@ -125,7 +129,7 @@ def test_use_defaults_mutual_exclusive_name() -> None:
 
 def test_use_defaults_mutual_exclusive_version() -> None:
     result = CliRunner().invoke(
-        cli, ["operator-versions", "--use-defaults", "--version", "1.0.0"]
+        cli, ["operator-versions", "--use-defaults", "--version", "1.0.0"], env=_KC
     )
     assert result.exit_code != 0
     assert "mutually exclusive" in result.output
@@ -133,14 +137,14 @@ def test_use_defaults_mutual_exclusive_version() -> None:
 
 def test_use_defaults_mutual_exclusive_csv_name() -> None:
     result = CliRunner().invoke(
-        cli, ["operator-versions", "--use-defaults", "--csv-name", "foo"]
+        cli, ["operator-versions", "--use-defaults", "--csv-name", "foo"], env=_KC
     )
     assert result.exit_code != 0
     assert "mutually exclusive" in result.output
 
 
 def test_operator_versions_missing_required_without_defaults() -> None:
-    result = CliRunner().invoke(cli, ["operator-versions", "--name", "foo"])
+    result = CliRunner().invoke(cli, ["operator-versions", "--name", "foo"], env=_KC)
     assert result.exit_code != 0
     assert "Missing option" in result.output
 
@@ -149,7 +153,7 @@ def test_mgmt_cluster_version_with_version(mocker: MockerFixture) -> None:
     mock_reconcile = mocker.patch("enclave.reconcile.cli.cluster_upgrade_reconcile")
     dry_run = True
     result = CliRunner().invoke(
-        cli, ["mgmt-cluster-version", "--version", "4.20.21", "--dry-run"]
+        cli, ["mgmt-cluster-version", "--version", "4.20.21", "--dry-run"], env=_KC
     )
     assert result.exit_code == 0, result.output
     mock_reconcile.assert_called_once_with("4.20.21", dry_run, 180, 60)
@@ -159,7 +163,7 @@ def test_mgmt_cluster_version_use_defaults(mocker: MockerFixture) -> None:
     mock_reconcile = mocker.patch("enclave.reconcile.cli.cluster_upgrade_reconcile")
     dry_run = True
     result = CliRunner().invoke(
-        cli, ["mgmt-cluster-version", "--use-defaults", "--dry-run"]
+        cli, ["mgmt-cluster-version", "--use-defaults", "--dry-run"], env=_KC
     )
     assert result.exit_code == 0, result.output
     mock_reconcile.assert_called_once_with("4.20.21", dry_run, 180, 60)
@@ -167,13 +171,20 @@ def test_mgmt_cluster_version_use_defaults(mocker: MockerFixture) -> None:
 
 def test_mgmt_cluster_version_use_defaults_mutual_exclusive_version() -> None:
     result = CliRunner().invoke(
-        cli, ["mgmt-cluster-version", "--use-defaults", "--version", "4.20.8"]
+        cli, ["mgmt-cluster-version", "--use-defaults", "--version", "4.20.8"], env=_KC
     )
     assert result.exit_code != 0
     assert "mutually exclusive" in result.output
 
 
 def test_mgmt_cluster_version_neither_version_nor_defaults() -> None:
-    result = CliRunner().invoke(cli, ["mgmt-cluster-version"])
+    result = CliRunner().invoke(cli, ["mgmt-cluster-version"], env=_KC)
     assert result.exit_code != 0
     assert "Either --version or --use-defaults" in result.output
+
+
+def test_kubeconfig_missing_fails(mocker: MockerFixture) -> None:
+    mocker.patch("enclave.utils.Path.exists", return_value=False)
+    result = CliRunner().invoke(cli, ["mgmt-cluster-version"], env={"KUBECONFIG": ""})
+    assert result.exit_code != 0
+    assert "KUBECONFIG" in result.output

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -177,14 +177,23 @@ def test_mgmt_cluster_version_use_defaults_mutual_exclusive_version() -> None:
     assert "mutually exclusive" in result.output
 
 
-def test_mgmt_cluster_version_neither_version_nor_defaults() -> None:
-    result = CliRunner().invoke(cli, ["mgmt-cluster-version"], env=_KC)
-    assert result.exit_code != 0
-    assert "Either --version or --use-defaults" in result.output
+def test_mgmt_cluster_version_no_args_shows_help() -> None:
+    result = CliRunner().invoke(cli, ["mgmt-cluster-version"])
+    assert result.exit_code == 2
+    assert "--version" in result.output
+    assert "--use-defaults" in result.output
+
+
+def test_reconcile_no_args_shows_help() -> None:
+    result = CliRunner().invoke(cli, [])
+    assert result.exit_code == 2
+    assert "Reconcile CLI" in result.output
 
 
 def test_kubeconfig_missing_fails(mocker: MockerFixture) -> None:
     mocker.patch("enclave.utils.Path.exists", return_value=False)
-    result = CliRunner().invoke(cli, ["mgmt-cluster-version"], env={"KUBECONFIG": ""})
+    result = CliRunner().invoke(
+        cli, ["mgmt-cluster-version", "--version", "4.14"], env={"KUBECONFIG": ""}
+    )
     assert result.exit_code != 0
     assert "KUBECONFIG" in result.output

--- a/src/tests/test_tools_cli.py
+++ b/src/tests/test_tools_cli.py
@@ -5,6 +5,8 @@ from pytest_mock import MockerFixture
 
 from enclave.tools.cli import cli
 
+_KC = {"KUBECONFIG": "/fake/kubeconfig"}
+
 
 def test_tools_cli_help() -> None:
     result = CliRunner().invoke(cli, ["--help"])
@@ -13,7 +15,7 @@ def test_tools_cli_help() -> None:
 
 
 def test_resolve_quay_registry_ca_help() -> None:
-    result = CliRunner().invoke(cli, ["resolve-quay-registry-ca", "--help"])
+    result = CliRunner().invoke(cli, ["resolve-quay-registry-ca", "--help"], env=_KC)
     assert result.exit_code == 0
     assert "--hostname" in result.output
 
@@ -29,6 +31,7 @@ def test_resolve_quay_registry_ca_forwards_args(mocker: MockerFixture) -> None:
             "--oc",
             "/usr/bin/oc",
         ],
+        env=_KC,
     )
     assert result.exit_code == 0
     mock_reconcile.assert_called_once_with("registry.example.com", oc="/usr/bin/oc")
@@ -44,13 +47,14 @@ def test_resolve_quay_registry_ca_runtime_error(mocker: MockerFixture) -> None:
     result = CliRunner().invoke(
         cli,
         ["resolve-quay-registry-ca", "--hostname", "registry.example.com"],
+        env=_KC,
     )
     assert result.exit_code != 0
     assert "unable to resolve registry CA for registry.example.com" in result.output
 
 
 def test_collect_node_image_digests_help() -> None:
-    result = CliRunner().invoke(cli, ["collect-node-image-digests", "--help"])
+    result = CliRunner().invoke(cli, ["collect-node-image-digests", "--help"], env=_KC)
     assert result.exit_code == 0
     assert "--node" in result.output
     assert "--exclude-contains" in result.output
@@ -73,6 +77,7 @@ def test_collect_node_image_digests_forwards_args(
             "--raw-output-file",
             str(raw_output_file),
         ],
+        env=_KC,
     )
     assert result.exit_code == 0
     mock_main.assert_called_once_with(
@@ -81,3 +86,14 @@ def test_collect_node_image_digests_forwards_args(
         exclude_contains_raw=None,
         raw_output_file=str(raw_output_file),
     )
+
+
+def test_kubeconfig_missing_fails(mocker: MockerFixture) -> None:
+    mocker.patch("enclave.utils.Path.exists", return_value=False)
+    result = CliRunner().invoke(
+        cli,
+        ["resolve-quay-registry-ca", "--hostname", "reg.example.com"],
+        env={"KUBECONFIG": ""},
+    )
+    assert result.exit_code != 0
+    assert "KUBECONFIG" in result.output

--- a/src/tests/test_utils.py
+++ b/src/tests/test_utils.py
@@ -1,3 +1,4 @@
+import os
 from subprocess import TimeoutExpired
 from unittest.mock import MagicMock
 
@@ -5,9 +6,11 @@ import pytest
 from pytest_mock import MockerFixture
 
 from enclave.utils import (
+    KubeconfigNotFoundError,
     parse_jsonpath_value,
     run_oc_command,
     semver_key,
+    setup_kubeconfig,
     wait_for_resource_status,
 )
 from tests.fixtures import OcResultFactory
@@ -226,3 +229,49 @@ def test_wait_without_namespace_omits_n_flag(
     wait_for_resource_status("cv", "version", "history[0].state", "Completed")
     args = mock_run.call_args.args[0]
     assert "-n" not in args
+
+
+# ---------------------------------------------------------------------------
+# setup_kubeconfig
+# ---------------------------------------------------------------------------
+
+
+def test_setup_kubeconfig_noop_when_already_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Does nothing when KUBECONFIG is already set in the environment."""
+    monkeypatch.setenv("KUBECONFIG", "/existing/kubeconfig")
+    before = os.environ["KUBECONFIG"]
+    setup_kubeconfig()
+    assert os.environ["KUBECONFIG"] == before
+
+
+def test_setup_kubeconfig_uses_fallback(
+    monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
+) -> None:
+    """Sets KUBECONFIG from the fallback path when it exists and KUBECONFIG is unset."""
+    monkeypatch.delenv("KUBECONFIG", raising=False)
+    mocker.patch("enclave.utils.Path.exists", return_value=True)
+    setup_kubeconfig()
+    assert "KUBECONFIG" in os.environ
+    assert os.environ["KUBECONFIG"].endswith("kubeconfig")
+
+
+def test_setup_kubeconfig_raises_when_neither_set(
+    monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
+) -> None:
+    """Raises KubeconfigNotFoundError with a helpful message when nothing is available."""
+    monkeypatch.delenv("KUBECONFIG", raising=False)
+    mocker.patch("enclave.utils.Path.exists", return_value=False)
+    with pytest.raises(KubeconfigNotFoundError, match="KUBECONFIG"):
+        setup_kubeconfig()
+
+
+def test_setup_kubeconfig_empty_string_treated_as_unset(
+    monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
+) -> None:
+    """An empty KUBECONFIG string falls through to the fallback path."""
+    monkeypatch.setenv("KUBECONFIG", "")
+    mocker.patch("enclave.utils.Path.exists", return_value=False)
+    with pytest.raises(KubeconfigNotFoundError):
+        setup_kubeconfig()


### PR DESCRIPTION
When KUBECONFIG is not set, enclave reconcile and enclave tools now try ~/.config/enclave/kubeconfig (a symlink created by the deploy playbook) before failing with a clear error message.

The check is implemented via KubeconfigGroup(click.Group), overriding parse_args() so --help and shell-completion are not affected.

The deploy playbook creates the symlink at install time:
  ~/.config/enclave/kubeconfig -> <workingDir>/ocp-cluster/auth/kubeconfig

Added a migration so that 0.1.0 will also have the symlink

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic kubeconfig setup so CLI tools can run without manual environment configuration when a fallback config is available.
  * Included support for creating the needed kubeconfig link during deployment and migration steps.

* **Bug Fixes**
  * Improved CLI startup behavior when kubeconfig is missing or unset, with clearer user-facing errors.
  * Updated command behavior to work more reliably in help and validation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->