### PR TITLE
docs/upgrade: add KUBECONFIG instructions to encalve reconcile

### DIFF
--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -52,10 +52,14 @@ Each Enclave tarball release includes:
     ```
 8. **Upgrade management cluster** - Update OpenShift to the version in the tarball:
     ```sh
+    WORKING_DIR=<your global.yaml workingDir variable>
+    export KUBECONFIG=$WORKING_DIR/ocp-cluster/auth/kubeconfig
     enclave reconcile mgmt-cluster-version --use-defaults
     ```
 9. **Upgrade operators** - Update operators to the versions in the tarball:
     ```sh
+    WORKING_DIR=<your global.yaml workingDir variable>
+    export KUBECONFIG=$WORKING_DIR/ocp-cluster/auth/kubeconfig
     enclave reconcile operator-versions --use-defaults
     ```
 


### PR DESCRIPTION
enclave cli needs KUBECONFIG set. The problem is that once installed, the enclave cli loses track of where the installation is, so we cannot track the $workingDir/ocp/auth/kubeconfig.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated upgrade documentation with expanded instructions for management cluster and operator upgrade procedures, including required environment variable setup steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->