### PR TITLE
Install defaults YAML files under enclave/ package in wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ only-include = ["src/enclave", "defaults/operators.yaml", "defaults/platforms.ya
 
 [tool.hatch.build.targets.wheel.sources]
 "src" = ""
+"defaults" = "enclave/defaults"
 
 [tool.ruff]
 line-length = 88

--- a/src/enclave/reconcile/cli.py
+++ b/src/enclave/reconcile/cli.py
@@ -13,12 +13,12 @@ from enclave.utils import LOG_LEVELS, configure_logging
 
 
 def defaults_path(filename: str) -> Path:
-    # Non-editable install: cli.py → site-packages/enclave/reconcile/ → site-packages/enclave/ → site-packages/ → defaults/
-    # Editable src layout:  cli.py → src/enclave/reconcile/ → src/enclave/ → src/ → (not found) → repo root → defaults/
-    pkg_root = Path(__file__).resolve().parent.parent.parent
-    path = pkg_root / "defaults" / filename
+    # Installed: site-packages/enclave/reconcile/cli.py → site-packages/enclave/ → enclave/defaults/
+    # Editable:  src/enclave/reconcile/cli.py → src/enclave/ (no defaults/) → repo_root/defaults/
+    enclave_pkg = Path(__file__).resolve().parent.parent
+    path = enclave_pkg / "defaults" / filename
     if not path.exists():
-        path = pkg_root.parent / "defaults" / filename
+        path = enclave_pkg.parent.parent / "defaults" / filename
     return path
 
 


### PR DESCRIPTION
Map defaults/operators.yaml and defaults/platforms.yaml to enclave/defaults/ via hatchling wheel source mapping, so they install under the enclave package tree instead of at the site-packages root.

Update defaults_path() accordingly: walk two levels up to the enclave package directory (instead of three) and fall back to repo_root/defaults/ for editable installs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to properly package and locate default files across different installation environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->