### PR TITLE
OSAC-1597: Use JSON patch to configure OSAC operator with AAP URL and token

### DIFF
--- a/plugins/osac/tasks/deploy.yaml
+++ b/plugins/osac/tasks/deploy.yaml
@@ -128,49 +128,26 @@
         token: "{{ _osac_aap_token }}"
   no_log: true
 
-- name: Get current OSAC operator deployment
-  kubernetes.core.k8s_info:
-    api_version: apps/v1
-    kind: Deployment
-    name: osac-operator
-    namespace: osac
-  register: __r_osac_operator_deployment
-
-- name: Assert osac-operator has a single container
-  ansible.builtin.assert:
-    that:
-      - __r_osac_operator_deployment.resources[0].spec.template.spec.containers | length == 1
-    fail_msg: "osac-operator deployment has multiple containers — review env patch target"
-
-- name: Set OSAC operator env var names
-  ansible.builtin.set_fact:
-    _osac_operator_env_names: >-
-      {{ __r_osac_operator_deployment.resources[0].spec.template.spec.containers[0].env
-         | default([]) | map(attribute='name') | list }}
-
 - name: Patch OSAC operator deployment with AAP URL and AAP token
-  kubernetes.core.k8s_json_patch:
-    api_version: apps/v1
+  kubernetes.core.k8s:
+    state: patched
     kind: Deployment
     name: osac-operator
     namespace: osac
-    patch:
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
-          name: OSAC_AAP_URL
-          value: "{{ _osac_aap_url }}"
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
-          name: OSAC_AAP_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: osac-aap-secret
-              key: token
-  when:
-    - "'OSAC_AAP_URL' not in _osac_operator_env_names"
-    - "'OSAC_AAP_TOKEN' not in _osac_operator_env_names"
+    definition:
+      spec:
+        template:
+          spec:
+            containers:
+              - name: manager
+                env:
+                  - name: OSAC_AAP_URL
+                    value: "{{ _osac_aap_url }}"
+                  - name: OSAC_AAP_TOKEN
+                    valueFrom:
+                      secretKeyRef:
+                        name: osac-aap-secret
+                        key: token
 
 # =====================================================================
 # 6. Wait for OSAC operator rollout

--- a/plugins/osac/tasks/deploy.yaml
+++ b/plugins/osac/tasks/deploy.yaml
@@ -128,28 +128,26 @@
         token: "{{ _osac_aap_token }}"
   no_log: true
 
-- name: Patch OSAC operator deployment with AAP URL
-  kubernetes.core.k8s:
-    state: present
-    definition:
-      apiVersion: apps/v1
-      kind: Deployment
-      metadata:
-        name: osac-operator
-        namespace: osac
-      spec:
-        template:
-          spec:
-            containers:
-              - name: osac-operator
-                env:
-                  - name: OSAC_AAP_URL
-                    value: "{{ _osac_aap_url }}"
-                  - name: OSAC_AAP_TOKEN
-                    valueFrom:
-                      secretKeyRef:
-                        name: osac-aap-secret
-                        key: token
+- name: Patch OSAC operator deployment with AAP URL and AAP token
+  kubernetes.core.k8s_json_patch:
+    api_version: apps/v1
+    kind: Deployment
+    name: osac-operator
+    namespace: osac
+    patch:
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: OSAC_AAP_URL
+          value: "{{ _osac_aap_url }}"
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: OSAC_AAP_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: osac-aap-secret
+              key: token
 
 # =====================================================================
 # 6. Wait for OSAC operator rollout

--- a/plugins/osac/tasks/deploy.yaml
+++ b/plugins/osac/tasks/deploy.yaml
@@ -128,6 +128,26 @@
         token: "{{ _osac_aap_token }}"
   no_log: true
 
+- name: Get current OSAC operator deployment
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: osac-operator
+    namespace: osac
+  register: __r_osac_operator_deployment
+
+- name: Assert osac-operator has a single container
+  ansible.builtin.assert:
+    that:
+      - __r_osac_operator_deployment.resources[0].spec.template.spec.containers | length == 1
+    fail_msg: "osac-operator deployment has multiple containers — review env patch target"
+
+- name: Set OSAC operator env var names
+  ansible.builtin.set_fact:
+    _osac_operator_env_names: >-
+      {{ __r_osac_operator_deployment.resources[0].spec.template.spec.containers[0].env
+         | default([]) | map(attribute='name') | list }}
+
 - name: Patch OSAC operator deployment with AAP URL and AAP token
   kubernetes.core.k8s_json_patch:
     api_version: apps/v1
@@ -148,6 +168,9 @@
             secretKeyRef:
               name: osac-aap-secret
               key: token
+  when:
+    - "'OSAC_AAP_URL' not in _osac_operator_env_names"
+    - "'OSAC_AAP_TOKEN' not in _osac_operator_env_names"
 
 # =====================================================================
 # 6. Wait for OSAC operator rollout
@@ -170,4 +193,4 @@
 
 - name: Log OSAC deploy completion
   ansible.builtin.debug:
-    msg: "OSAC deploy complete. AAP URL={{ _osac_aap_url }}, operator patched and rolled out."
+    msg: "OSAC deploy complete. Operator patched and rolled out."


### PR DESCRIPTION
## Summary

- `kubernetes.core.k8s` with `state: present` fails when patching the osac-operator deployment because the container spec omits the required `image` field
- Strategic merge patch (`--type=strategic`) also fails with the same validation error
- Replaced with `kubernetes.core.k8s_json_patch` using RFC 6902 `add` operations to append env vars without touching other container fields
- Also renamed the task to reflect both AAP URL and token being configured

## Test plan

- [x] Reproduced the failure with `oc apply` (missing image error)
- [x] Confirmed `oc patch --type=json` works
- [x] Deployed OSAC plugin end-to-end with this fix — operator patched and rolled out successfully
- [x] All post-validate checks passed (PostgreSQL, fulfillment services, operator, AAP, Authorino)

Fixes: [OSAC-1597](https://redhat.atlassian.net/browse/OSAC-1597)

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the OSAC post-Helm deployment workflow to patch the OSAC operator Deployment in-place (instead of replacing the full Deployment specification).
  * The operator now receives OSAC AAP connection settings via environment variables, including a new OSAC AAP token sourced from the cluster secret.
  * OSAC deploy completion output was adjusted to reflect the new patch-and-rollout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->