### PR TITLE
fix: route logging to stderr to protect stdout tool output

### DIFF
--- a/playbooks/tasks/configure_operator.yaml
+++ b/playbooks/tasks/configure_operator.yaml
@@ -151,12 +151,12 @@
       --no-dry-run
   register: operator_update_result
 
-- name: Print the output
+- name: Print Install Plan approval output ({{ operator.name }})
   when:
     - r_sub_check.resources | length == 0
     - operator.namespace != "openshift-operators"
   ansible.builtin.debug:
-    var: operator_update_result.stdout_lines
+    var: operator_update_result.stderr_lines
 
 - name: "Get Installed CSV ({{ operator.name }})"
   when:

--- a/src/enclave/tools/node_image_digests.py
+++ b/src/enclave/tools/node_image_digests.py
@@ -252,8 +252,8 @@ def emit_collection_output(
             output_path = Path(raw_output_file)
             output_path.parent.mkdir(parents=True, exist_ok=True)
             output_path.write_text(result.raw_output, encoding="utf-8")
-            sys.stderr.write(
-                f"No digest refs were collected; raw output saved to {output_path}\n"
+            logger.info(
+                "No digest refs were collected; raw output saved to %s", output_path
             )
         else:
             sys.stderr.write(result.raw_output)

--- a/src/enclave/utils.py
+++ b/src/enclave/utils.py
@@ -21,7 +21,7 @@ def configure_logging(log_level: str) -> None:
             level=getattr(logging, log_level.upper()),
             format="%(asctime)s %(levelname)-8s %(message)s",
             datefmt="%Y-%m-%dT%H:%M:%S",
-            stream=sys.stdout,
+            stream=sys.stderr,
         )
 
 

--- a/src/tests/test_node_image_digests.py
+++ b/src/tests/test_node_image_digests.py
@@ -171,6 +171,7 @@ def test_reconcile_emits_raw_on_empty_refs(
 def test_reconcile_writes_raw_output_file_on_empty_refs(
     mocker: MockerFixture,
     capsys: pytest.CaptureFixture,
+    caplog: pytest.LogCaptureFixture,
     tmp_path: Path,
 ) -> None:
     mocker.patch(
@@ -179,10 +180,12 @@ def test_reconcile_writes_raw_output_file_on_empty_refs(
     )
     raw_output_file = tmp_path / "collect" / "node-0.log"
 
-    main("node-0", raw_output_file=str(raw_output_file))
+    with caplog.at_level("INFO"):
+        main("node-0", raw_output_file=str(raw_output_file))
 
     captured = capsys.readouterr()
     assert captured.out == ""
-    assert "No digest refs were collected; raw output saved to" in captured.err
-    assert str(raw_output_file) in captured.err
+    assert captured.err == ""
+    assert "No digest refs were collected; raw output saved to" in caplog.text
+    assert str(raw_output_file) in caplog.text
     assert raw_output_file.read_text(encoding="utf-8") == "crictl failed"


### PR DESCRIPTION
Python logging was configured to write to sys.stdout, which corrupts the machine-readable output of tools that write digest refs and PEM certificates to stdout for shell script consumption.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated logging output handling to use the logging system instead of direct stderr writes for diagnostic messages.
  * Adjusted Ansible task output to reference error logs instead of standard output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->