### PR TITLE
OSAC-1609: Fix bootstrap job validation in post-validate

### DIFF
--- a/plugins/osac/tasks/post-validate.yaml
+++ b/plugins/osac/tasks/post-validate.yaml
@@ -142,9 +142,8 @@
   kubernetes.core.k8s_info:
     api_version: batch/v1
     kind: Job
+    name: "{{ osac_aap_name }}-bootstrap"
     namespace: osac
-    label_selectors:
-      - "app=osac-aap-bootstrap"
   register: __r_bootstrap_job
 
 - name: Assert AAP bootstrap job completed
@@ -152,7 +151,6 @@
     that:
       - __r_bootstrap_job.resources | length > 0
       - __r_bootstrap_job.resources[0].status.succeeded | default(0) | int >= 1
-      - __r_bootstrap_job.resources[0].status.failed | default(0) | int == 0
     fail_msg: "AAP bootstrap job has not completed successfully in osac namespace"
 
 - name: Log OSAC validation success


### PR DESCRIPTION
## Summary

- The bootstrap job check used label selector `app=osac-aap-bootstrap` which doesn't exist on the job (actual labels are `app.kubernetes.io/name=aap`, `app.kubernetes.io/managed-by=Helm`). Look up by job name instead.
- Removed the `status.failed == 0` assertion — the bootstrap job retries while waiting for the EDA project to sync its git repo, so `failed > 0` is normal for a successful job (e.g. `failed: 5, succeeded: 1`).

## Test plan

- [x] Verified job labels don't include `app=osac-aap-bootstrap`
- [x] Deployed OSAC plugin end-to-end — post-validate passed with `succeeded: 1, failed: 5`
- [x] All assertions passed including bootstrap job check

Fixes: [OSAC-1609](https://redhat.atlassian.net/browse/OSAC-1609)

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted AAP bootstrap job validation criteria to enhance validation accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->