### PR TITLE
call oc adm release info with registry config for machine-os-images

### DIFF
--- a/playbooks/tasks/download_content_single_version.yaml
+++ b/playbooks/tasks/download_content_single_version.yaml
@@ -11,6 +11,7 @@
       ansible.builtin.command:
         cmd: >
           {{ workingDir }}/bin/oc adm release info
+          --registry-config={{ pullSecretPath }}
           --image-for=machine-os-images
           quay.io/openshift-release-dev/ocp-release:{{ version_item.version }}-x86_64
       register: machine_os_image


### PR DESCRIPTION
need to use to avoid permission denied issues.
from `oc adm release info --help`:
```
    -a, --registry-config='':
	Path to your registry credentials. Alternatively REGISTRY_AUTH_FILE
	env variable can be also specified. Defaults to
	${XDG_RUNTIME_DIR}/containers/auth.json,
	/run/containers/${UID}/auth.json,
	${XDG_CONFIG_HOME}/containers/auth.json, ${DOCKER_CONFIG},
	~/.docker/config.json, ~/.dockercfg. The order can be changed via the
	REGISTRY_AUTH_PREFERENCE env variable (deprecated) to a "docker" value
	to prioritizes Docker credentials over Podman's.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed registry credential handling during content download operations to ensure proper authentication when fetching image information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->