### PR TITLE
Validate UpdateService deployment pods are ready before completing install

### DIFF
--- a/operators/cincinnati-operator/tasks.yaml
+++ b/operators/cincinnati-operator/tasks.yaml
@@ -22,7 +22,7 @@
       spec:
         graphDataImage: registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/openshift/graph-image
         releases: registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/openshift/release-images
-        replicas: "{{ updateservice_replicas }}"
+        replicas: "{{ updateservice_replicas | int }}"
   register: r_update_service
   retries: "{{ k8s_retries }}"
   delay: "{{ k8s_delay }}"

--- a/operators/cincinnati-operator/tasks.yaml
+++ b/operators/cincinnati-operator/tasks.yaml
@@ -1,4 +1,8 @@
 ---
+- name: Set UpdateService replicas
+  ansible.builtin.set_fact:
+    updateservice_replicas: 3
+
 # UpdateService requires image.config additionalTrustedCA with updateservice-registry
 # before graph-builder can scrape the mirrored release repository over TLS.
 - name: Trust Quay registry CA in image.config for UpdateService
@@ -18,7 +22,7 @@
       spec:
         graphDataImage: registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/openshift/graph-image
         releases: registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/openshift/release-images
-        replicas: 3
+        replicas: "{{ updateservice_replicas }}"
   register: r_update_service
   retries: "{{ k8s_retries }}"
   delay: "{{ k8s_delay }}"
@@ -43,6 +47,24 @@
       | selectattr('status', 'equalto', 'True')
       | list | length > 0
     )
+
+- name: Wait for UpdateService deployment pods to be ready
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: service
+    namespace: openshift-update-service
+  register: r_update_service_deployment
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: >-
+    r_update_service_deployment.resources | default([]) | length > 0
+    and r_update_service_deployment.resources[0].status.replicas | default(0) == updateservice_replicas
+    and r_update_service_deployment.resources[0].status.readyReplicas | default(0) == updateservice_replicas
+    and r_update_service_deployment.resources[0].status.updatedReplicas | default(0) == updateservice_replicas
+    and r_update_service_deployment.resources[0].status.availableReplicas | default(0) == updateservice_replicas
 
 - name: Create ACM Policy for Update Service
   environment:


### PR DESCRIPTION
## Summary

Adds validation that all UpdateService deployment pods are running and healthy before Enclave install completes. This ensures a functional UpdateService is handed over to partner overlays or day-2 operations.

## Problem

IBM reported in https://github.com/gori-project/GoRI/issues/924 that UpdateService pods were crash-looping during their partner overlay deployment, which caused MachineConfigPool updates to hang when trying to drain nodes.

Investigation revealed that partner overlays apply certificate changes (e.g., ZeroSSL) after Enclave bootstrap completes. When these changes occur, the UpdateService pods may need to be restarted to pick up the new CA trust configuration.

However, if Enclave hands over a system where UpdateService pods are already unhealthy or crash-looping, the partner overlay has no baseline to work from.

## Changes

- Set `updateservice_replicas` fact to 3 for parameterization
- Use the variable in UpdateService CR spec instead of hardcoded value
- Add validation task that waits for the deployment to have all 3 replicas:
  - `replicas` == 3
  - `readyReplicas` == 3
  - `updatedReplicas` == 3
  - `availableReplicas` == 3

## Impact

This ensures that before Enclave install completes, the UpdateService pods are actually running and healthy, not just that the CR was created and the `RegistryCACertFound` condition is True.

If pods are crash-looping during install, the task will fail with a clear error rather than silently handing over a broken system.

## Testing

- [ ] Verify install completes successfully when UpdateService pods are healthy
- [ ] Verify install fails with clear error if UpdateService pods are crash-looping

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced configurable replica count parameter for the update service deployment, replacing hard-coded values for improved flexibility.
  * Added automated verification to monitor service replica readiness, ensuring all desired replicas are ready before marking deployment as complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->