### PR TITLE
Fix spoke cluster catalog source name for 0.1.0 compatibility

### DIFF
--- a/files/catalogsource-configuration/10-policy.yaml.j2
+++ b/files/catalogsource-configuration/10-policy.yaml.j2
@@ -32,13 +32,15 @@ spec:
             spec:
               disableAllDefaultSources: true
 
+        # Hardcoded catalog source name for backwards compatibility with 0.1.0
+        # See: https://github.com/rh-ecosystem-edge/enclave/blob/0.1.0/defaults/catalogs.yaml#L6
         - complianceType: mustonlyhave
           metadataComplianceType: musthave
           objectDefinition:
             apiVersion: operators.coreos.com/v1alpha1
             kind: CatalogSource
             metadata:
-              name: {{ mirror_rh_operator_catalog }}
+              name: mirror-redhat-operators
               namespace: openshift-marketplace
             spec:
               image: registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/redhat/{{ mirror_rh_operator_catalog }}:v{{ short_version_dot }}


### PR DESCRIPTION
## Summary

Fixes spoke cluster catalog source naming to maintain backward compatibility with 0.1.0, addressing the issue raised in https://github.com/rh-ecosystem-edge/enclave/pull/509#issuecomment-4741784946

## Problem

PR #509 changed `mirror_rh_operator_catalog` from `"mirror-redhat-operators"` to `"redhat-operator-index"` which fixed management cluster compatibility but **broke spoke cluster upgrades from 0.1.0**.

In 0.1.0, spoke clusters had a CatalogSource named `mirror-redhat-operators` (see [defaults/catalogs.yaml#L6](https://github.com/rh-ecosystem-edge/enclave/blob/0.1.0/defaults/catalogs.yaml#L6)). After the change in #509:
- **New catalog source name**: `redhat-operator-index` 
- **Existing subscriptions**: Still reference `mirror-redhat-operators`
- **Result**: Operator installation failures on spoke clusters upgrading from 0.1.0

## Solution

Hardcode the spoke cluster catalog source name to `mirror-redhat-operators` in `files/catalogsource-configuration/10-policy.yaml.j2` while keeping the image path dynamic (`{{ mirror_rh_operator_catalog }}`).

This:
- ✅ Maintains compatibility with 0.1.0 spoke clusters (catalog name unchanged)
- ✅ Preserves management cluster fix from #509 (uses current variable value for image path)
- ✅ Avoids dual catalog sources on spoke clusters during upgrades

## Changes

- `files/catalogsource-configuration/10-policy.yaml.j2`: Hardcode catalog source name to `mirror-redhat-operators` with explanatory comment

## Impact

Spoke clusters upgrading from 0.1.0 will continue using their existing `mirror-redhat-operators` catalog source without breaking operator subscriptions.

## Test Plan

- [ ] Deploy spoke cluster on 0.1.0
- [ ] Verify catalog source is named `mirror-redhat-operators`
- [ ] Upgrade to current main with this fix
- [ ] Verify catalog source name remains `mirror-redhat-operators`
- [ ] Verify operator subscriptions continue working

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated policy enforcement mechanism to utilize a hardcoded catalog source identifier instead of dynamic template references, providing consistent and reliable operations across all environments and deployment scenarios.

* **Documentation**
  * Added backwards-compatibility notes within the policy configuration to document version 0.1.0 compatibility intent, enabling smoother transitions for users with existing deployments and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->