### PR TITLE
fix: trust external Quay registry CA for UpdateService

### DIFF
--- a/playbooks/tasks/trust_quay_registry_ca_for_image_config.yaml
+++ b/playbooks/tasks/trust_quay_registry_ca_for_image_config.yaml
@@ -1,5 +1,7 @@
 ---
-# Trust the internal Quay registry TLS cert for image pulls and UpdateService.
+# Trust the Quay registry route TLS cert for image pulls and UpdateService.
+# Routes signed by the ingress router CA use router-ca; externally signed routes
+# (for example ZeroSSL) use the intermediate/root CAs fetched from the live chain.
 # OSUS graph-builder reads updateservice-registry from the image.config additionalTrustedCA
 # ConfigMap; nodes use the registry hostname key.
 

--- a/src/enclave/tools/quay_registry_ca.py
+++ b/src/enclave/tools/quay_registry_ca.py
@@ -110,14 +110,21 @@ def _openssl_verify(ca_pem: str, cert_pem: str) -> bool:
     return result.returncode == 0
 
 
+def _chain_trust_anchor_pem(chain: list[str]) -> str:
+    """Return CA PEM bundle from a fetched TLS chain (all certs except the leaf)."""
+    ca_certs = chain[1:]
+    if not ca_certs:
+        msg = "TLS chain contains only a leaf certificate; cannot determine trust anchor"
+        raise RuntimeError(msg)
+    return "\n".join(ca_certs) + "\n"
+
+
 def resolve_registry_ca_pem(hostname: str, *, oc: str = "oc") -> str:
     """Return PEM for the CA that should trust the registry route certificate."""
     router_ca = get_router_ca_pem(oc=oc).strip()
     chain = pem_blocks(fetch_tls_chain_pem(hostname))
     if not chain:
-        if router_ca:
-            return f"{router_ca}\n"
-        msg = f"unable to resolve registry CA for {hostname}"
+        msg = f"unable to fetch TLS certificate chain for {hostname}"
         raise RuntimeError(msg)
 
     leaf = chain[0]
@@ -125,8 +132,8 @@ def resolve_registry_ca_pem(hostname: str, *, oc: str = "oc") -> str:
         logger.debug("using router-ca to trust %s", hostname)
         return f"{router_ca}\n"
 
-    logger.debug("using TLS chain root to trust %s", hostname)
-    return f"{chain[-1]}\n"
+    logger.debug("using TLS chain CA bundle to trust %s", hostname)
+    return _chain_trust_anchor_pem(chain)
 
 
 def main(hostname: str, *, oc: str = "oc") -> None:

--- a/src/enclave/tools/quay_registry_ca.py
+++ b/src/enclave/tools/quay_registry_ca.py
@@ -114,7 +114,9 @@ def _chain_trust_anchor_pem(chain: list[str]) -> str:
     """Return CA PEM bundle from a fetched TLS chain (all certs except the leaf)."""
     ca_certs = chain[1:]
     if not ca_certs:
-        msg = "TLS chain contains only a leaf certificate; cannot determine trust anchor"
+        msg = (
+            "TLS chain contains only a leaf certificate; cannot determine trust anchor"
+        )
         raise RuntimeError(msg)
     return "\n".join(ca_certs) + "\n"
 

--- a/src/tests/test_quay_registry_ca.py
+++ b/src/tests/test_quay_registry_ca.py
@@ -4,6 +4,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from enclave.tools.quay_registry_ca import (
+    _chain_trust_anchor_pem,
     _openssl_verify,
     fetch_tls_chain_pem,
     get_router_ca_pem,
@@ -13,6 +14,9 @@ from enclave.tools.quay_registry_ca import (
 
 _LEAF = """-----BEGIN CERTIFICATE-----
 leaf
+-----END CERTIFICATE-----"""
+_INTERMEDIATE = """-----BEGIN CERTIFICATE-----
+intermediate
 -----END CERTIFICATE-----"""
 _ROOT = """-----BEGIN CERTIFICATE-----
 root
@@ -98,7 +102,17 @@ def test_resolve_registry_ca_pem_uses_router_ca_when_it_verifies(
     assert resolve_registry_ca_pem("registry.example.com") == f"{_ROUTER_CA.strip()}\n"
 
 
-def test_resolve_registry_ca_pem_falls_back_to_chain_root(
+def test_chain_trust_anchor_pem_returns_all_non_leaf_certs() -> None:
+    chain = pem_blocks(f"{_LEAF}\n{_INTERMEDIATE}\n{_ROOT}\n")
+    assert _chain_trust_anchor_pem(chain) == f"{_INTERMEDIATE}\n{_ROOT}\n"
+
+
+def test_chain_trust_anchor_pem_leaf_only_raises() -> None:
+    with pytest.raises(RuntimeError, match="only a leaf certificate"):
+        _chain_trust_anchor_pem([_LEAF])
+
+
+def test_resolve_registry_ca_pem_falls_back_to_chain_ca_bundle(
     mocker: MockerFixture,
 ) -> None:
     mocker.patch(
@@ -106,26 +120,35 @@ def test_resolve_registry_ca_pem_falls_back_to_chain_root(
     )
     mocker.patch(
         "enclave.tools.quay_registry_ca.fetch_tls_chain_pem",
-        return_value=f"{_LEAF}\n{_ROOT}\n",
+        return_value=f"{_LEAF}\n{_INTERMEDIATE}\n{_ROOT}\n",
     )
     mocker.patch("enclave.tools.quay_registry_ca._openssl_verify", return_value=False)
-    assert resolve_registry_ca_pem("registry.example.com") == f"{_ROOT.strip()}\n"
+    assert resolve_registry_ca_pem("registry.example.com") == (
+        f"{_INTERMEDIATE}\n{_ROOT}\n"
+    )
 
 
-def test_resolve_registry_ca_pem_empty_chain_uses_router_ca_fallback(
+def test_resolve_registry_ca_pem_empty_chain_raises(
     mocker: MockerFixture,
 ) -> None:
     mocker.patch(
         "enclave.tools.quay_registry_ca.get_router_ca_pem", return_value=_ROUTER_CA
     )
     mocker.patch("enclave.tools.quay_registry_ca.fetch_tls_chain_pem", return_value="")
-    assert resolve_registry_ca_pem("registry.example.com") == f"{_ROUTER_CA.strip()}\n"
+    with pytest.raises(RuntimeError, match="unable to fetch TLS certificate chain"):
+        resolve_registry_ca_pem("registry.example.com")
 
 
-def test_resolve_registry_ca_pem_empty_chain_without_router_ca_raises(
+def test_resolve_registry_ca_pem_leaf_only_chain_raises(
     mocker: MockerFixture,
 ) -> None:
-    mocker.patch("enclave.tools.quay_registry_ca.get_router_ca_pem", return_value="")
-    mocker.patch("enclave.tools.quay_registry_ca.fetch_tls_chain_pem", return_value="")
-    with pytest.raises(RuntimeError, match="unable to resolve registry CA"):
+    mocker.patch(
+        "enclave.tools.quay_registry_ca.get_router_ca_pem", return_value=_ROUTER_CA
+    )
+    mocker.patch(
+        "enclave.tools.quay_registry_ca.fetch_tls_chain_pem",
+        return_value=f"{_LEAF}\n",
+    )
+    mocker.patch("enclave.tools.quay_registry_ca._openssl_verify", return_value=False)
+    with pytest.raises(RuntimeError, match="only a leaf certificate"):
         resolve_registry_ca_pem("registry.example.com")


### PR DESCRIPTION
When a Quay route is signed by an external CA (for example ZeroSSL), UpdateService failed with "unable to get local issuer certificate" because resolve-quay-registry-ca could fall back to the ingress router-ca even though that CA does not sign the live route cert.

Keep router-ca for default ingress-signed routes, but for all other chains store the intermediate and root CAs fetched from the registry. Fail loudly when the TLS chain cannot be fetched instead of writing a misleading router-ca entry into image.config additionalTrustedCA.

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Quay registry certificate handling to distinguish between ingress-router-signed and externally-signed certificate paths.

* **Bug Fixes**
  * Improved registry CA certificate validation to require valid TLS chain data and extract proper certificate bundles for trust verification.

* **Tests**
  * Expanded test coverage for certificate chain handling and updated validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->