### PR TITLE
update openshift-ai plugin policy to install cert-manager from mirror-redhat-operators

### DIFF
--- a/plugins/openshift-ai/files/10-policy-operators.yaml.j2
+++ b/plugins/openshift-ai/files/10-policy-operators.yaml.j2
@@ -212,7 +212,7 @@ spec:
               channel: stable-v1
               installPlanApproval: Automatic
               name: openshift-cert-manager-operator
-              source: {{ mirror_rh_operator_catalog }}
+              source: mirror-redhat-operators
               sourceNamespace: openshift-marketplace
         # Install Service Mesh Operator
         - complianceType: mustonlyhave


### PR DESCRIPTION
follow up on #523

without this, cert-manager installations in spoke clusters installed with the openshift-ai plugin will not find the catalog source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated operator sourcing configuration for the cert-manager Operator to reference a specific catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->