### PR TITLE
OSAC-1535: Add OSAC connected CI job

### DIFF
--- a/.github/workflows/e2e-deployment.yml
+++ b/.github/workflows/e2e-deployment.yml
@@ -392,6 +392,36 @@ jobs:
           make -f Makefile.ci deploy-cluster-discovery
           echo "Discovery complete" >> $GITHUB_STEP_SUMMARY
 
+      - name: Deploy trust-manager plugin
+        if: contains(env.ENABLED_PLUGINS, 'trust-manager')
+        id: deploy_trust_manager
+        run: make -f Makefile.ci deploy-plugin PLUGIN=trust-manager
+
+      - name: Deploy rhbk plugin
+        if: contains(env.ENABLED_PLUGINS, 'rhbk')
+        id: deploy_rhbk
+        run: make -f Makefile.ci deploy-plugin PLUGIN=rhbk
+
+      - name: Deploy authorino plugin
+        if: contains(env.ENABLED_PLUGINS, 'authorino')
+        id: deploy_authorino
+        run: make -f Makefile.ci deploy-plugin PLUGIN=authorino
+
+      - name: Deploy aap plugin
+        if: contains(env.ENABLED_PLUGINS, 'aap')
+        id: deploy_aap
+        run: make -f Makefile.ci deploy-plugin PLUGIN=aap
+
+      - name: Deploy cnv plugin
+        if: contains(env.ENABLED_PLUGINS, 'cnv')
+        id: deploy_cnv
+        run: make -f Makefile.ci deploy-plugin PLUGIN=cnv
+
+      - name: Deploy osac plugin
+        if: contains(env.ENABLED_PLUGINS, 'osac')
+        id: deploy_osac
+        run: make -f Makefile.ci deploy-plugin PLUGIN=osac
+
       - name: Verify cluster deployment
         if: success()
         id: verify_cluster
@@ -569,6 +599,12 @@ jobs:
             ["bootstrap_operators"]="Bootstrap: Operators"
             ["bootstrap_day2"]="Bootstrap: Day-2"
             ["bootstrap_discovery"]="Bootstrap: Discovery"
+            ["deploy_trust_manager"]="Deploy trust-manager plugin"
+            ["deploy_rhbk"]="Deploy rhbk plugin"
+            ["deploy_authorino"]="Deploy authorino plugin"
+            ["deploy_aap"]="Deploy aap plugin"
+            ["deploy_cnv"]="Deploy cnv plugin"
+            ["deploy_osac"]="Deploy osac plugin"
             ["verify_cluster"]="Verify cluster deployment"
           )
 
@@ -585,6 +621,12 @@ jobs:
             bootstrap_operators
             bootstrap_day2
             bootstrap_discovery
+            deploy_trust_manager
+            deploy_rhbk
+            deploy_authorino
+            deploy_aap
+            deploy_cnv
+            deploy_osac
             verify_cluster
           )
 
@@ -796,12 +838,35 @@ jobs:
           make -f Makefile.ci deploy-cluster-discovery
           echo "Discovery complete" >> $GITHUB_STEP_SUMMARY
 
-      - name: Deploy - Addon Plugin (example)
-        id: deploy_addon_plugin
-        run: |
-          echo "## Deploy: Addon Plugin" >> $GITHUB_STEP_SUMMARY
-          make -f Makefile.ci deploy-plugin PLUGIN=example
-          echo "Deploy Addon Plugin complete" >> $GITHUB_STEP_SUMMARY
+      - name: Deploy trust-manager plugin
+        if: contains(env.ENABLED_PLUGINS, 'trust-manager')
+        id: deploy_trust_manager
+        run: make -f Makefile.ci deploy-plugin PLUGIN=trust-manager
+
+      - name: Deploy rhbk plugin
+        if: contains(env.ENABLED_PLUGINS, 'rhbk')
+        id: deploy_rhbk
+        run: make -f Makefile.ci deploy-plugin PLUGIN=rhbk
+
+      - name: Deploy authorino plugin
+        if: contains(env.ENABLED_PLUGINS, 'authorino')
+        id: deploy_authorino
+        run: make -f Makefile.ci deploy-plugin PLUGIN=authorino
+
+      - name: Deploy aap plugin
+        if: contains(env.ENABLED_PLUGINS, 'aap')
+        id: deploy_aap
+        run: make -f Makefile.ci deploy-plugin PLUGIN=aap
+
+      - name: Deploy cnv plugin
+        if: contains(env.ENABLED_PLUGINS, 'cnv')
+        id: deploy_cnv
+        run: make -f Makefile.ci deploy-plugin PLUGIN=cnv
+
+      - name: Deploy osac plugin
+        if: contains(env.ENABLED_PLUGINS, 'osac')
+        id: deploy_osac
+        run: make -f Makefile.ci deploy-plugin PLUGIN=osac
 
       - name: Verify cluster deployment
         if: success()
@@ -989,7 +1054,12 @@ jobs:
             ["bootstrap_operators"]="Bootstrap: Operators"
             ["bootstrap_day2"]="Bootstrap: Day-2"
             ["bootstrap_discovery"]="Bootstrap: Discovery"
-            ["deploy_addon_plugin"]="Deploy - Addon Plugin (example)"
+            ["deploy_trust_manager"]="Deploy trust-manager plugin"
+            ["deploy_rhbk"]="Deploy rhbk plugin"
+            ["deploy_authorino"]="Deploy authorino plugin"
+            ["deploy_aap"]="Deploy aap plugin"
+            ["deploy_cnv"]="Deploy cnv plugin"
+            ["deploy_osac"]="Deploy osac plugin"
             ["verify_cluster"]="Verify cluster deployment"
           )
 
@@ -1006,7 +1076,12 @@ jobs:
             bootstrap_operators
             bootstrap_day2
             bootstrap_discovery
-            deploy_addon_plugin
+            deploy_trust_manager
+            deploy_rhbk
+            deploy_authorino
+            deploy_aap
+            deploy_cnv
+            deploy_osac
             verify_cluster
           )
 

--- a/.github/workflows/e2e-deployment.yml
+++ b/.github/workflows/e2e-deployment.yml
@@ -393,32 +393,32 @@ jobs:
           echo "Discovery complete" >> $GITHUB_STEP_SUMMARY
 
       - name: Deploy trust-manager plugin
-        if: contains(env.ENABLED_PLUGINS, 'trust-manager')
+        if: contains(format(',{0},', env.ENABLED_PLUGINS), ',trust-manager,')
         id: deploy_trust_manager
         run: make -f Makefile.ci deploy-plugin PLUGIN=trust-manager
 
       - name: Deploy rhbk plugin
-        if: contains(env.ENABLED_PLUGINS, 'rhbk')
+        if: contains(format(',{0},', env.ENABLED_PLUGINS), ',rhbk,')
         id: deploy_rhbk
         run: make -f Makefile.ci deploy-plugin PLUGIN=rhbk
 
       - name: Deploy authorino plugin
-        if: contains(env.ENABLED_PLUGINS, 'authorino')
+        if: contains(format(',{0},', env.ENABLED_PLUGINS), ',authorino,')
         id: deploy_authorino
         run: make -f Makefile.ci deploy-plugin PLUGIN=authorino
 
       - name: Deploy aap plugin
-        if: contains(env.ENABLED_PLUGINS, 'aap')
+        if: contains(format(',{0},', env.ENABLED_PLUGINS), ',aap,')
         id: deploy_aap
         run: make -f Makefile.ci deploy-plugin PLUGIN=aap
 
       - name: Deploy cnv plugin
-        if: contains(env.ENABLED_PLUGINS, 'cnv')
+        if: contains(format(',{0},', env.ENABLED_PLUGINS), ',cnv,')
         id: deploy_cnv
         run: make -f Makefile.ci deploy-plugin PLUGIN=cnv
 
       - name: Deploy osac plugin
-        if: contains(env.ENABLED_PLUGINS, 'osac')
+        if: contains(format(',{0},', env.ENABLED_PLUGINS), ',osac,')
         id: deploy_osac
         run: make -f Makefile.ci deploy-plugin PLUGIN=osac
 
@@ -839,32 +839,32 @@ jobs:
           echo "Discovery complete" >> $GITHUB_STEP_SUMMARY
 
       - name: Deploy trust-manager plugin
-        if: contains(env.ENABLED_PLUGINS, 'trust-manager')
+        if: contains(format(',{0},', env.ENABLED_PLUGINS), ',trust-manager,')
         id: deploy_trust_manager
         run: make -f Makefile.ci deploy-plugin PLUGIN=trust-manager
 
       - name: Deploy rhbk plugin
-        if: contains(env.ENABLED_PLUGINS, 'rhbk')
+        if: contains(format(',{0},', env.ENABLED_PLUGINS), ',rhbk,')
         id: deploy_rhbk
         run: make -f Makefile.ci deploy-plugin PLUGIN=rhbk
 
       - name: Deploy authorino plugin
-        if: contains(env.ENABLED_PLUGINS, 'authorino')
+        if: contains(format(',{0},', env.ENABLED_PLUGINS), ',authorino,')
         id: deploy_authorino
         run: make -f Makefile.ci deploy-plugin PLUGIN=authorino
 
       - name: Deploy aap plugin
-        if: contains(env.ENABLED_PLUGINS, 'aap')
+        if: contains(format(',{0},', env.ENABLED_PLUGINS), ',aap,')
         id: deploy_aap
         run: make -f Makefile.ci deploy-plugin PLUGIN=aap
 
       - name: Deploy cnv plugin
-        if: contains(env.ENABLED_PLUGINS, 'cnv')
+        if: contains(format(',{0},', env.ENABLED_PLUGINS), ',cnv,')
         id: deploy_cnv
         run: make -f Makefile.ci deploy-plugin PLUGIN=cnv
 
       - name: Deploy osac plugin
-        if: contains(env.ENABLED_PLUGINS, 'osac')
+        if: contains(format(',{0},', env.ENABLED_PLUGINS), ',osac,')
         id: deploy_osac
         run: make -f Makefile.ci deploy-plugin PLUGIN=osac
 

--- a/.github/workflows/e2e-deployment.yml
+++ b/.github/workflows/e2e-deployment.yml
@@ -8,6 +8,9 @@ name: E2E Deployment
 #
 # Both jobs run on every PR and nightly schedule. Manual dispatch allows
 # selecting which modes to run, skipping cleanup, and sending Slack notifications.
+#
+# Also callable as a reusable workflow (workflow_call) from other workflows
+# that need to run E2E with a custom plugin chain (e.g. e2e-osac.yml).
 
 # Cancel previous runs when a PR is updated
 concurrency:
@@ -49,6 +52,39 @@ on:
         required: false
         type: boolean
         default: false
+      enabled-plugins:
+        description: 'Comma-separated list of plugins to deploy (default: storage plugin only)'
+        required: false
+        type: string
+        default: ''
+      aap-license-file:
+        description: 'Path to AAP license file on the CI runner (required for OSAC deployments)'
+        required: false
+        type: string
+        default: ''
+  workflow_call:
+    inputs:
+      run-connected:
+        type: boolean
+        default: true
+      run-disconnected:
+        type: boolean
+        default: true
+      storage-plugin:
+        type: string
+        default: 'lvms'
+      skip-cleanup:
+        type: boolean
+        default: false
+      send-slack-notification:
+        type: boolean
+        default: false
+      enabled-plugins:
+        type: string
+        default: ''
+      aap-license-file:
+        type: string
+        default: ''
   pull_request:
     types: [opened, synchronize, reopened]
   merge_group:
@@ -65,6 +101,8 @@ jobs:
     timeout-minutes: 5
     outputs:
       should_run: ${{ steps.decision.outputs.should_run }}
+      run_connected: ${{ steps.decision.outputs.run_connected }}
+      run_disconnected: ${{ steps.decision.outputs.run_disconnected }}
       storage_plugins: ${{ steps.decision.outputs.storage_plugins }}
       storage_plugins_connected: ${{ steps.decision.outputs.storage_plugins_connected }}
 
@@ -111,7 +149,27 @@ jobs:
           # Determine whether to run and which storage plugins to test.
           # storage_plugins is a JSON array consumed by the job matrix.
           # ODF only runs in disconnected mode. Connected always uses lvms.
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          #
+          # run_connected / run_disconnected: honour caller inputs when present,
+          # default to running both modes. Resolved here (not at job level)
+          # because the inputs context is unreliable in workflow_call when the
+          # caller's event_name is inherited.
+          RUN_CONNECTED="${{ inputs.run-connected }}"
+          RUN_DISCONNECTED="${{ inputs.run-disconnected }}"
+          [[ -z "$RUN_CONNECTED" ]] && RUN_CONNECTED=true
+          [[ -z "$RUN_DISCONNECTED" ]] && RUN_DISCONNECTED=true
+
+          if [[ "${{ github.event_name }}" == "workflow_call" ]]; then
+            echo "should_run=true" >> $GITHUB_OUTPUT
+            PLUGIN="${{ inputs.storage-plugin || 'lvms' }}"
+            echo "storage_plugins=[\"${PLUGIN}\"]" >> $GITHUB_OUTPUT
+            if [[ "$PLUGIN" == "odf" ]]; then
+              echo "storage_plugins_connected=[\"lvms\"]" >> $GITHUB_OUTPUT
+            else
+              echo "storage_plugins_connected=[\"${PLUGIN}\"]" >> $GITHUB_OUTPUT
+            fi
+            echo "Called as reusable workflow - E2E will run (${PLUGIN})" | tee -a $GITHUB_STEP_SUMMARY
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "should_run=true" >> $GITHUB_OUTPUT
             PLUGIN="${{ inputs.storage-plugin || 'lvms' }}"
             echo "storage_plugins=[\"${PLUGIN}\"]" >> $GITHUB_OUTPUT
@@ -149,6 +207,9 @@ jobs:
             echo "To run E2E anyway, use manual workflow_dispatch" | tee -a $GITHUB_STEP_SUMMARY
           fi
 
+          echo "run_connected=${RUN_CONNECTED}" >> $GITHUB_OUTPUT
+          echo "run_disconnected=${RUN_DISCONNECTED}" >> $GITHUB_OUTPUT
+
   # ---------------------------------------------------------------------------
   # Connected mode E2E deployment
   # ---------------------------------------------------------------------------
@@ -157,7 +218,7 @@ jobs:
     needs: check-e2e-needed
     if: >-
       needs.check-e2e-needed.outputs.should_run == 'true' &&
-      (github.event_name != 'workflow_dispatch' || inputs.run-connected == true)
+      needs.check-e2e-needed.outputs.run_connected == 'true'
     runs-on: [self-hosted, enclave-large]
     timeout-minutes: 210
 
@@ -177,10 +238,11 @@ jobs:
       ENCLAVE_IRONIC_HTTPS: 'true'
       CLEANUP_AFTER: 'true'
       STORAGE_PLUGIN: ${{ matrix.storage-plugin }}
-      ENABLED_PLUGINS: ${{ matrix.storage-plugin }}
+      ENABLED_PLUGINS: ${{ inputs.enabled-plugins || matrix.storage-plugin }}
       OPENSHIFT_CI: "true"
       ENCLAVE_ENABLE_GPU_PASSTHROUGH: "false"
       LZ_OS_VARIANT: ${{ vars.LZ_OS_VARIANT }}
+      AAP_LICENSE_FILE: ${{ inputs.aap-license-file }}
 
     steps:
       - name: Checkout code
@@ -412,7 +474,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Cleanup infrastructure
-        if: always() && (github.event_name != 'workflow_dispatch' || inputs.skip-cleanup != true)
+        if: always() && inputs.skip-cleanup != true
         run: |
           echo "## Cleanup Infrastructure" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -439,7 +501,7 @@ jobs:
           fi
 
       - name: Cleanup skipped notice
-        if: always() && github.event_name == 'workflow_dispatch' && inputs.skip-cleanup == true
+        if: always() && inputs.skip-cleanup == true
         run: |
           echo "## Cleanup Skipped" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -561,7 +623,7 @@ jobs:
     needs: check-e2e-needed
     if: >-
       needs.check-e2e-needed.outputs.should_run == 'true' &&
-      (github.event_name != 'workflow_dispatch' || inputs.run-disconnected == true)
+      needs.check-e2e-needed.outputs.run_disconnected == 'true'
     runs-on: ${{ matrix.storage-plugin == 'odf' && fromJSON('["self-hosted", "enclave-large", "odf"]') || fromJSON('["self-hosted", "enclave-large"]') }}
     timeout-minutes: ${{ github.event_name == 'schedule' && 600 || 360 }}
 
@@ -580,10 +642,11 @@ jobs:
       ENCLAVE_DEPLOYMENT_MODE: disconnected
       CLEANUP_AFTER: 'true'
       STORAGE_PLUGIN: ${{ matrix.storage-plugin }}
-      ENABLED_PLUGINS: ${{ matrix.storage-plugin }}
+      ENABLED_PLUGINS: ${{ inputs.enabled-plugins || matrix.storage-plugin }}
       OPENSHIFT_CI: "true"
       ENCLAVE_ENABLE_GPU_PASSTHROUGH: "false"
       LZ_OS_VARIANT: ${{ vars.LZ_OS_VARIANT }}
+      AAP_LICENSE_FILE: ${{ inputs.aap-license-file }}
 
     steps:
       - name: Checkout code
@@ -831,7 +894,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Cleanup infrastructure
-        if: always() && (github.event_name != 'workflow_dispatch' || inputs.skip-cleanup != true)
+        if: always() && inputs.skip-cleanup != true
         run: |
           echo "## Cleanup Infrastructure" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -858,7 +921,7 @@ jobs:
           fi
 
       - name: Cleanup skipped notice
-        if: always() && github.event_name == 'workflow_dispatch' && inputs.skip-cleanup == true
+        if: always() && inputs.skip-cleanup == true
         run: |
           echo "## Cleanup Skipped" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/e2e-osac.yml
+++ b/.github/workflows/e2e-osac.yml
@@ -20,6 +20,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
+      - 'plugins/lvms/**'
       - 'plugins/trust-manager/**'
       - 'plugins/rhbk/**'
       - 'plugins/authorino/**'

--- a/.github/workflows/e2e-osac.yml
+++ b/.github/workflows/e2e-osac.yml
@@ -30,7 +30,6 @@ on:
 
 permissions:
   contents: read
-  checks: write
 
 concurrency:
   group: e2e-osac-${{ github.event.pull_request.number || github.run_id }}

--- a/.github/workflows/e2e-osac.yml
+++ b/.github/workflows/e2e-osac.yml
@@ -1,0 +1,48 @@
+name: E2E OSAC
+
+# OSAC plugin stack E2E deployment (connected mode).
+# Triggers on changes to OSAC-related plugins or manual dispatch.
+# Calls the reusable e2e-deployment workflow with the OSAC plugin chain.
+
+on:
+  workflow_dispatch:
+    inputs:
+      skip-cleanup:
+        description: 'Skip cleanup after deployment (leave infrastructure running)'
+        required: false
+        type: boolean
+        default: false
+      send-slack-notification:
+        description: 'Send Slack notification on completion'
+        required: false
+        type: boolean
+        default: false
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'plugins/trust-manager/**'
+      - 'plugins/rhbk/**'
+      - 'plugins/authorino/**'
+      - 'plugins/aap/**'
+      - 'plugins/osac/**'
+      - '.github/workflows/e2e-osac.yml'
+
+permissions:
+  contents: read
+  checks: write
+
+concurrency:
+  group: e2e-osac-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  e2e-osac:
+    uses: ./.github/workflows/e2e-deployment.yml
+    with:
+      run-connected: true
+      run-disconnected: false
+      enabled-plugins: 'lvms,trust-manager,rhbk,authorino,aap,osac'
+      aap-license-file: '/etc/enclave-ci/aap-license.zip'
+      skip-cleanup: ${{ inputs.skip-cleanup || false }}
+      send-slack-notification: ${{ inputs.send-slack-notification || false }}
+    secrets: inherit

--- a/scripts/deployment/deploy_plugin.sh
+++ b/scripts/deployment/deploy_plugin.sh
@@ -141,6 +141,8 @@ if [ -n "${AAP_LICENSE_FILE:-}" ]; then
     info "Copying AAP license file to Landing Zone: $LZ_AAP_LICENSE"
     # shellcheck disable=SC2086  # SSH_OPTS needs word splitting
     scp $SSH_OPTS "$AAP_LICENSE_FILE" "${LZ_SSH}:${LZ_AAP_LICENSE}"
+    # shellcheck disable=SC2086  # SSH_OPTS needs word splitting
+    ssh $SSH_OPTS "$LZ_SSH" "chmod 600 '$LZ_AAP_LICENSE'"
     EXTRA_VARS_CONTENT="${EXTRA_VARS_CONTENT}osacAapLicenseFile: ${LZ_AAP_LICENSE}
 "
     # Generate OSAC plugin config on LZ if it doesn't exist (CI environments)
@@ -153,6 +155,7 @@ if [ -n "${AAP_LICENSE_FILE:-}" ]; then
 osacAapLicenseFile: "${LZ_AAP_LICENSE}"
 osacProfilesList:
   - caas
+  - vmaas
 OSAC_EOF
     fi
 fi

--- a/scripts/deployment/deploy_plugin.sh
+++ b/scripts/deployment/deploy_plugin.sh
@@ -132,7 +132,7 @@ if [ -n "${ENABLED_PLUGINS:-}" ]; then
 fi
 
 # Copy AAP license file to Landing Zone if AAP_LICENSE_FILE is set
-if [ -n "${AAP_LICENSE_FILE:-}" ]; then
+if [ -n "${AAP_LICENSE_FILE:-}" ] && { [ "$PLUGIN_NAME" = "aap" ] || [ "$PLUGIN_NAME" = "osac" ]; }; then
     if [ ! -f "$AAP_LICENSE_FILE" ]; then
         error "AAP license file not found: $AAP_LICENSE_FILE"
         exit 1

--- a/scripts/deployment/deploy_plugin.sh
+++ b/scripts/deployment/deploy_plugin.sh
@@ -131,6 +131,32 @@ if [ -n "${ENABLED_PLUGINS:-}" ]; then
     info "Enabled plugins: $ENABLED_PLUGINS"
 fi
 
+# Copy AAP license file to Landing Zone if AAP_LICENSE_FILE is set
+if [ -n "${AAP_LICENSE_FILE:-}" ]; then
+    if [ ! -f "$AAP_LICENSE_FILE" ]; then
+        error "AAP license file not found: $AAP_LICENSE_FILE"
+        exit 1
+    fi
+    LZ_AAP_LICENSE="${LZ_HOME}/aap-license.zip"
+    info "Copying AAP license file to Landing Zone: $LZ_AAP_LICENSE"
+    # shellcheck disable=SC2086  # SSH_OPTS needs word splitting
+    scp $SSH_OPTS "$AAP_LICENSE_FILE" "${LZ_SSH}:${LZ_AAP_LICENSE}"
+    EXTRA_VARS_CONTENT="${EXTRA_VARS_CONTENT}osacAapLicenseFile: ${LZ_AAP_LICENSE}
+"
+    # Generate OSAC plugin config on LZ if it doesn't exist (CI environments)
+    # shellcheck disable=SC2086  # SSH_OPTS needs word splitting
+    if ! ssh $SSH_OPTS "$LZ_SSH" "test -f $LZ_ENCLAVE_DIR/config/plugins/osac.yaml"; then
+        info "Generating config/plugins/osac.yaml on Landing Zone"
+        # shellcheck disable=SC2086,SC2087  # SSH_OPTS needs word splitting, we want client-side expansion
+        ssh $SSH_OPTS "$LZ_SSH" "mkdir -p $LZ_ENCLAVE_DIR/config/plugins && cat > $LZ_ENCLAVE_DIR/config/plugins/osac.yaml" <<OSAC_EOF
+---
+osacAapLicenseFile: "${LZ_AAP_LICENSE}"
+osacProfilesList:
+  - caas
+OSAC_EOF
+    fi
+fi
+
 # Create the extra vars file on Landing Zone
 # shellcheck disable=SC2087,SC2086  # We want client-side expansion of $EXTRA_VARS_CONTENT
 ssh $SSH_OPTS "$LZ_SSH" "cat > $LZ_ENCLAVE_DIR/phase_vars.yaml" <<EOF

--- a/scripts/deployment/deploy_plugin.sh
+++ b/scripts/deployment/deploy_plugin.sh
@@ -155,7 +155,6 @@ if [ -n "${AAP_LICENSE_FILE:-}" ]; then
 osacAapLicenseFile: "${LZ_AAP_LICENSE}"
 osacProfilesList:
   - caas
-  - vmaas
 OSAC_EOF
     fi
 fi

--- a/scripts/verification/collect_ci_artifacts.sh
+++ b/scripts/verification/collect_ci_artifacts.sh
@@ -800,6 +800,21 @@ collect_cluster_problem_pod_logs() {
             oc describe pod -n \$ns \$name > /tmp/problem-pods-${TIMESTAMP}/\${ns}_\${name}_describe.txt 2>&1 || true
         done
 
+        # Get CrashLoopBackOff/restarting pods (Running phase but containers failing)
+        oc get pods --all-namespaces -o json | \
+        jq -r '.items[] | select(.status.phase == \"Running\") | select((.status.containerStatuses // [])[] | (.state.waiting != null) or (.restartCount >= 3)) | \"\\(.metadata.namespace)/\\(.metadata.name)\"' | \
+        sort -u | head -20 | \
+        while read pod; do
+            ns=\${pod%/*}
+            name=\${pod#*/}
+            # Skip if already collected above
+            [ -f /tmp/problem-pods-${TIMESTAMP}/\${ns}_\${name}.log ] && continue
+            echo \"Collecting logs for CrashLoopBackOff pod \$ns/\$name\"
+            oc logs -n \$ns \$name --all-containers --prefix --tail=500 > /tmp/problem-pods-${TIMESTAMP}/\${ns}_\${name}.log 2>&1 || true
+            oc logs -n \$ns \$name --all-containers --prefix --tail=500 --previous > /tmp/problem-pods-${TIMESTAMP}/\${ns}_\${name}_previous.log 2>&1 || true
+            oc describe pod -n \$ns \$name > /tmp/problem-pods-${TIMESTAMP}/\${ns}_\${name}_describe.txt 2>&1 || true
+        done
+
         # Tar it up
         cd /tmp && tar czf problem-pods-${TIMESTAMP}.tar.gz problem-pods-${TIMESTAMP}/ 2>/dev/null
     " 2>&1 || warn "Could not collect problem pod logs"
@@ -808,6 +823,50 @@ collect_cluster_problem_pod_logs() {
     if scp $ssh_opts cloud-user@"$lz_ip":/tmp/problem-pods-${TIMESTAMP}.tar.gz "${OUTPUT_DIR}/cluster/" 2>/dev/null; then
         (cd "${OUTPUT_DIR}/cluster" && tar xzf problem-pods-${TIMESTAMP}.tar.gz && rm problem-pods-${TIMESTAMP}.tar.gz) || true
     fi
+}
+
+collect_cluster_plugin_diagnostics() {
+    local lz_ip="$1"
+    local ssh_opts="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -q"
+
+    if [ -z "${ENABLED_PLUGINS:-}" ]; then
+        return
+    fi
+
+    info "Collecting plugin namespace diagnostics..."
+    mkdir -p "${OUTPUT_DIR}/cluster/plugin-diagnostics"
+
+    # Map plugins to their namespaces (deduplicated)
+    local namespaces=()
+    IFS=',' read -ra plugins <<< "$ENABLED_PLUGINS"
+    for plugin in "${plugins[@]}"; do
+        plugin="${plugin// /}"
+        case "$plugin" in
+            osac|aap|authorino) namespaces+=("osac") ;;
+            rhbk) namespaces+=("keycloak") ;;
+            trust-manager) namespaces+=("cert-manager") ;;
+        esac
+    done
+
+    # Deduplicate
+    local unique_ns
+    unique_ns=$(printf '%s\n' "${namespaces[@]}" | sort -u)
+
+    for ns in $unique_ns; do
+        info "Collecting diagnostics for namespace: $ns"
+        ssh $ssh_opts cloud-user@"$lz_ip" "
+            export KUBECONFIG=/home/cloud-user/ocp-cluster/auth/kubeconfig
+
+            echo '=== Deployments ==='
+            oc get deployments -n $ns -o wide 2>&1
+            echo ''
+            echo '=== Pods ==='
+            oc get pods -n $ns -o wide 2>&1
+            echo ''
+            echo '=== Events ==='
+            oc get events -n $ns --sort-by='.lastTimestamp' 2>&1
+        " > "${OUTPUT_DIR}/cluster/plugin-diagnostics/${ns}.txt" 2>&1 || warn "Could not collect diagnostics for namespace $ns"
+    done
 }
 
 #####################################
@@ -933,6 +992,7 @@ collect_full() {
     collect_cluster_events "$lz_ip"
     collect_cluster_pods "$lz_ip"
     collect_cluster_problem_pod_logs "$lz_ip"
+    collect_cluster_plugin_diagnostics "$lz_ip"
 
     info "✓ Full collection complete"
 }

--- a/scripts/verification/collect_ci_artifacts.sh
+++ b/scripts/verification/collect_ci_artifacts.sh
@@ -849,6 +849,9 @@ collect_cluster_plugin_diagnostics() {
     done
 
     # Deduplicate
+    if [ ${#namespaces[@]} -eq 0 ]; then
+        return
+    fi
     local unique_ns
     unique_ns=$(printf '%s\n' "${namespaces[@]}" | sort -u)
 

--- a/scripts/verification/collect_ci_artifacts.sh
+++ b/scripts/verification/collect_ci_artifacts.sh
@@ -845,6 +845,7 @@ collect_cluster_plugin_diagnostics() {
             osac|aap|authorino) namespaces+=("osac") ;;
             rhbk) namespaces+=("keycloak") ;;
             trust-manager) namespaces+=("cert-manager") ;;
+            cnv) namespaces+=("openshift-cnv") ;;
         esac
     done
 


### PR DESCRIPTION
## Summary

- Make `e2e-deployment.yml` callable as a reusable workflow (`workflow_call`) with inputs for plugin chain, AAP license file, run mode selection, and cleanup/notification controls
- Add `e2e-osac.yml` — thin caller workflow that deploys the OSAC plugin stack (`lvms → trust-manager → rhbk → authorino → aap → osac`) in connected mode
- Add explicit deploy-plugin steps for each OSAC addon plugin (trust-manager, rhbk, authorino, aap, cnv, osac) to both connected and disconnected E2E jobs, conditionally run based on `enabled-plugins`
- Add AAP license file handling to `deploy_plugin.sh` for CI environments (copies license to LZ, generates `osac.yaml` with `osacProfilesList: [caas]`)

The job calls `make deploy-plugin` separately for each addon because addon plugin installation from `bootstrap.sh` was temporarily removed in #476.

Depends on #525.

## Changes to `e2e-deployment.yml`

- `workflow_call` trigger with inputs mirroring `workflow_dispatch` plus `enabled-plugins` and `aap-license-file`
- `check-e2e-needed` resolves `run_connected`/`run_disconnected` from caller inputs (needed because the `inputs` context is unreliable in `workflow_call`)
- Job conditions use resolved outputs instead of checking `inputs` directly
- `ENABLED_PLUGINS` and `AAP_LICENSE_FILE` env vars set from inputs
- Explicit conditional addon plugin deploy steps (trust-manager, rhbk, authorino, aap, cnv, osac) in both connected and disconnected jobs
- Cleanup conditions simplified (work for both dispatch and call)

## Adding more OSAC CI modes

To add disconnected mode, update `e2e-osac.yml`:
```yaml
run-disconnected: true
```

Or create a separate `e2e-osac-disconnected.yml` caller for independent triggers.

## Test plan

- [x] Verify `yamllint` passes on both workflow files
- [x] Verify `shellcheck` passes on `deploy_plugin.sh`
- [ ] Verify existing E2E jobs are unaffected (no behavioral change when `enabled-plugins` is empty)
- [ ] Manual dispatch of `E2E OSAC` workflow deploys the full plugin chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Made the E2E deployment workflow reusable with selectable connected/disconnected execution modes, configurable plugins, and optional AAP license path support.
  * Added an OSAC-dedicated E2E workflow that runs in connected mode with OSAC-related plugins enabled.

* **Improvements**
  * Improved Landing Zone plugin deployment to inject an AAP license file when provided.
  * Enhanced “full” CI artifact collection with additional problem-pod log capture and plugin-focused namespace diagnostics.

* **Chores**
  * Simplified E2E cleanup behavior for reusable runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->