### PR TITLE
OSAC-1150: Add registries section to rhbk plugin for disconnected support

### DIFF
--- a/plugins/rhbk/plugin.yaml
+++ b/plugins/rhbk/plugin.yaml
@@ -14,3 +14,7 @@ operators:
 
 additionalImages:
   - registry.redhat.io/rhel9/postgresql-15:9.8
+
+registries:
+  - location: registry.redhat.io/rhbk
+    mirror: rhbk


### PR DESCRIPTION
## Summary

- Add `registries` section to the rhbk plugin for disconnected Quay Enterprise mirroring
- Without this, oc-mirror tries to pull `registry.redhat.io/rhbk/*` images directly from upstream during the Quay Enterprise re-mirror step, failing with unauthorized errors (the Quay pull secret has no Red Hat Registry credentials)

## Test plan

- [x] `make -f Makefile.ci validate-plugins` passes
- [x] Deploy rhbk plugin in disconnected mode — LZ mirror: 6 images (5 operator + 1 additional), Quay Enterprise re-mirror succeeds with registries redirect

Jira: [OSAC-1150](https://redhat.atlassian.net/browse/OSAC-1150)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a bundled PostgreSQL image reference from the plugin configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->