### PR TITLE
set update service replicas to 1

### DIFF
--- a/operators/cincinnati-operator/tasks.yaml
+++ b/operators/cincinnati-operator/tasks.yaml
@@ -18,7 +18,7 @@
       spec:
         graphDataImage: registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/openshift/graph-image
         releases: registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/openshift/release-images
-        replicas: 3
+        replicas: 1
   register: r_update_service
   retries: "{{ k8s_retries }}"
   delay: "{{ k8s_delay }}"


### PR DESCRIPTION
hotfix for https://github.com/gori-project/GoRI/issues/924

setting replicas to 1 causes the operator to relax the PDB, which should allow for a successful install.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated UpdateService deployment configuration to reduce replica count from three to one instance in the openshift-update-service namespace, optimizing resource allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->