### PR TITLE
Harden TLS chain validation and CA resolution

### DIFF
--- a/.github/workflows/Dockerfile.ci
+++ b/.github/workflows/Dockerfile.ci
@@ -14,6 +14,7 @@ RUN dnf install -y --allowerasing \
     ca-certificates \
     curl \
     make \
+    openssl \
     shellcheck \
     python3 \
     python3-pip \

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -215,6 +215,8 @@ step_validate() {
     echo "Validating Config .. "  | tee -a ${log}
     ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/validation/validate-schema.yaml $EXTRA_VARS --tags validate-config
     bash ./validations.sh 2>&1 | tee -a ${log}
+    enclave tools check-root-ca --config "${certs_vars}" 2>&1 | tee -a ${log}
+    enclave tools check-certificate-chains --config "${certs_vars}" 2>&1 | tee -a ${log}
     step_done
 }
 

--- a/config/certificates.example.yaml
+++ b/config/certificates.example.yaml
@@ -43,6 +43,23 @@ sslIngressCertificateFullChain: |
   -----END CERTIFICATE-----
 
 # Root CA Certificate
+# The self-signed root CA that signs the last certificate in the fullchain fields.
+# This supplies only the terminal root CA; all intermediate certificates must already
+# be present in the fullchain fields. sslCACertificate does not rebuild missing
+# intermediates.
+#
+# Required when:
+#   - The fullchain ends with a non-self-signed (cross-signed) certificate, e.g.
+#     Let's Encrypt ISRG Root X2, and the root CA is not in the RHEL 10 system
+#     trust store (/etc/pki/tls/certs/ca-bundle.crt).
+#   - Only a leaf certificate is present in the fullchain (no intermediate).
+#   - A private/custom CA whose root is not in the system trust store.
+#
+# Not required when the fullchain already ends with a self-signed root CA, or
+# when the signing CA is present in the RHEL 10 system trust store.
+#
+# Validate the full configuration with:
+#   enclave tools check-certificate-chains --config config/certificates.yaml
 sslCACertificate: |
   -----BEGIN CERTIFICATE-----
   YOUR_ROOT_CA_CERTIFICATE

--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -1025,7 +1025,7 @@ sslAPICertificateFullChain: |
 **Certificate requirements**:
 - Subject Alternative Name (SAN) must include: `api.{{ clusterName }}.{{ baseDomain }}`
 - Must be valid (not expired)
-- Should include full chain (server + intermediate + root)
+- Typically contains the server certificate and any intermediate CA(s). Including the root CA is optional per TLS standards; if omitted, provide it via `sslCACertificate` if the signing CA is not present in the RHEL 10 system trust store (`/etc/pki/tls/certs/ca-bundle.crt`).
 
 ### Ingress Certificate
 
@@ -1068,6 +1068,7 @@ sslIngressCertificateFullChain: |
   - `apps.{{ clusterName }}.{{ baseDomain }}`
 - Wildcard certificate recommended
 - Must be valid (not expired)
+- Typically contains the server certificate and any intermediate CA(s). Including the root CA is optional per TLS standards; if omitted, provide it via `sslCACertificate` if the signing CA is not present in the RHEL 10 system trust store (`/etc/pki/tls/certs/ca-bundle.crt`).
 
 **Obtaining certificates**:
 - Use Let's Encrypt (certbot)
@@ -1078,16 +1079,36 @@ sslIngressCertificateFullChain: |
 
 #### `sslCACertificate`
 
-**Description**: Root CA certificate.
+**Description**: Root CA certificate — the self-signed root that signs the last certificate in the fullchain fields.
 
 **Type**: String (PEM format)
 
+**When required**:
+- **Required** when the fullchain ends with a non-self-signed certificate (e.g. a cross-signed root such as Let's Encrypt ISRG Root X2) and the signing CA is not present in the RHEL 10 system trust store (`/etc/pki/tls/certs/ca-bundle.crt`).
+- **Required** when only a leaf certificate is present in the fullchain (no intermediate). The leaf must be signed by this CA.
+- **Required** when using a custom (private) CA whose root is not in the system trust store.
+
 **Example**:
+
 ```yaml
 sslCACertificate: |
   -----BEGIN CERTIFICATE-----
-  ... (server certificate)
+  ... (root CA certificate)
   -----END CERTIFICATE-----
+```
+
+### Certificate chain validation
+
+Certificate chains are automatically validated during installation by `enclave tools check-certificate-chains` (called from `bootstrap.sh`). The tool checks each fullchain field against these rules:
+
+1. **Completeness**: if the chain ends with a non-self-signed certificate, `sslCACertificate` must be set and must sign the last certificate.
+2. **Single-cert chains**: if only a leaf certificate is provided, `sslCACertificate` must be set.
+3. **Consistency**: if the chain ends with a self-signed root and `sslCACertificate` is also set, the CA must verify that root (a root CA verifies against itself).
+
+To validate manually (if enclave cli is installed):
+
+```bash
+enclave tools check-certificate-chains --config config/certificates.yaml
 ```
 
 ### Ironic HTTPS Certificate (Optional)

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -403,7 +403,10 @@ sslAPICertificateKey: |
 
 sslAPICertificateFullChain: |
   -----BEGIN CERTIFICATE-----
-  ... (certificate chain)
+  ... (server certificate)
+  -----END CERTIFICATE-----
+  -----BEGIN CERTIFICATE-----
+  ... (intermediate CA, if applicable)
   -----END CERTIFICATE-----
 
 # Ingress Certificate (for *.apps domain)
@@ -414,7 +417,16 @@ sslIngressCertificateKey: |
 
 sslIngressCertificateFullChain: |
   -----BEGIN CERTIFICATE-----
-  ... (certificate chain)
+  ... (server certificate)
+  -----END CERTIFICATE-----
+  -----BEGIN CERTIFICATE-----
+  ... (intermediate CA, if applicable)
+  -----END CERTIFICATE-----
+
+# Root CA certificate
+sslCACertificate: |
+  -----BEGIN CERTIFICATE-----
+  ... (root CA certificate)
   -----END CERTIFICATE-----
 ```
 

--- a/playbooks/common/load-vars.yaml
+++ b/playbooks/common/load-vars.yaml
@@ -14,6 +14,28 @@
   ansible.builtin.include_vars: "{{ item }}"
   loop: "{{ user_config_files }}"
 
+- name: Resolve sslCACertificate from system trust store if not provided
+  when:
+    - sslCACertificate is not defined or not sslCACertificate
+    - (sslAPICertificateFullChain is defined and sslAPICertificateFullChain) or
+      (sslIngressCertificateFullChain is defined and sslIngressCertificateFullChain)
+  block:
+    - name: Get root CA from system trust store since it is not provided in the config
+      ansible.builtin.command:
+        argv:
+          - enclave
+          - tools
+          - get-root-ca
+          - --chain-pem
+          - "{{ (sslAPICertificateFullChain | default('', true)) or (sslIngressCertificateFullChain | default('', true)) }}"
+      register: r_root_ca
+      changed_when: false
+
+    - name: Set sslCACertificate from system trust store
+      ansible.builtin.set_fact:
+        sslCACertificate: "{{ r_root_ca.stdout | trim }}"
+      when: r_root_ca.rc == 0 and r_root_ca.stdout | trim | length > 0
+
 - name: Write SSH public key to file if content provided
   when: sshPubKey is defined and sshPubKey | length > 0
   block:

--- a/playbooks/tasks/trust_quay_registry_ca_for_image_config.yaml
+++ b/playbooks/tasks/trust_quay_registry_ca_for_image_config.yaml
@@ -9,16 +9,17 @@
   ansible.builtin.set_fact:
     quay_registry_hostname: "registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}"
 
+- name: Build Quay registry CA resolve command arguments
+  ansible.builtin.set_fact:
+    _resolve_quay_ca_argv: >-
+      {{ ['enclave', 'tools', 'resolve-quay-registry-ca',
+          '--hostname', quay_registry_hostname,
+          '--oc', workingDir + '/bin/oc']
+         + (['--ca-pem', sslCACertificate] if sslCACertificate is defined and sslCACertificate | length > 0 else []) }}
+
 - name: Resolve Quay registry CA PEM for trust ConfigMap
   ansible.builtin.command:
-    argv:
-      - enclave
-      - tools
-      - resolve-quay-registry-ca
-      - --hostname
-      - "{{ quay_registry_hostname }}"
-      - --oc
-      - "{{ workingDir }}/bin/oc"
+    argv: "{{ _resolve_quay_ca_argv }}"
   environment:
     KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
   register: quay_registry_ca_resolved

--- a/src/enclave/tools/cert_utils.py
+++ b/src/enclave/tools/cert_utils.py
@@ -1,0 +1,112 @@
+"""Shared certificate utilities for PEM parsing and self-signed detection."""
+
+import logging
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_OPENSSL_TIMEOUT_SECONDS = 10
+_PEM_BLOCK = re.compile(
+    r"-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----",
+    re.DOTALL,
+)
+
+
+def openssl_verify(ca_pem: str, cert_pem: str) -> bool:
+    """Return True if ca_pem signs cert_pem according to openssl verify.
+
+    Verification is isolated from the system trust store via -no-CAfile/-no-CApath
+    so only the explicitly provided CA is consulted. Raises RuntimeError on timeout
+    or missing openssl binary.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        work = Path(tmpdir)
+        ca_path = work / "ca.pem"
+        cert_path = work / "cert.pem"
+        ca_path.write_text(ca_pem, encoding="utf-8")
+        cert_path.write_text(cert_pem, encoding="utf-8")
+        try:
+            result = subprocess.run(
+                [
+                    "openssl",
+                    "verify",
+                    "-no-CAfile",
+                    "-no-CApath",
+                    "-CAfile",
+                    str(ca_path),
+                    str(cert_path),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=_OPENSSL_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired as exc:
+            msg = "openssl verify timed out"
+            raise RuntimeError(msg) from exc
+        except OSError as exc:
+            msg = "openssl not found"
+            raise RuntimeError(msg) from exc
+    return result.returncode == 0
+
+
+def pem_blocks(pem_text: str) -> list[str]:
+    """Return all PEM certificate blocks found in pem_text, in order."""
+    return _PEM_BLOCK.findall(pem_text or "")
+
+
+def is_self_signed(cert_pem: str) -> bool:
+    """Return True if cert_pem is self-signed.
+
+    Two-step check: fast DN equality pre-filter (self-issued), then an actual
+    signature verification using openssl verify -check_ss_sig so that a cert
+    whose issuer==subject but was signed by a different key returns False.
+    Returns False when openssl is unavailable, times out, or returns a non-zero exit code.
+    """
+    try:
+        result = subprocess.run(
+            ["openssl", "x509", "-noout", "-issuer", "-subject", "-nameopt", "RFC2253"],
+            input=cert_pem,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_OPENSSL_TIMEOUT_SECONDS,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.warning("openssl unavailable: %s", exc)
+        return False
+    if result.returncode != 0:
+        return False
+    issuer_match = re.search(r"^issuer=(.+)$", result.stdout, re.MULTILINE)
+    subject_match = re.search(r"^subject=(.+)$", result.stdout, re.MULTILINE)
+    if not issuer_match or not subject_match:
+        return False
+    if issuer_match.group(1).strip() != subject_match.group(1).strip():
+        return False
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cert_path = Path(tmpdir) / "cert.pem"
+        cert_path.write_text(cert_pem, encoding="utf-8")
+        try:
+            verify = subprocess.run(
+                [
+                    "openssl",
+                    "verify",
+                    "-no-CAfile",
+                    "-no-CApath",
+                    "-check_ss_sig",
+                    "-CAfile",
+                    str(cert_path),
+                    str(cert_path),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=_OPENSSL_TIMEOUT_SECONDS,
+            )
+        except (subprocess.TimeoutExpired, OSError) as exc:
+            logger.warning("openssl self-signature check unavailable: %s", exc)
+            return False
+    return verify.returncode == 0

--- a/src/enclave/tools/check_certificate_chains.py
+++ b/src/enclave/tools/check_certificate_chains.py
@@ -1,0 +1,98 @@
+"""Certificate chain completeness and CA consistency checks."""
+
+import logging
+import sys
+from pathlib import Path
+
+import yaml
+
+from enclave.tools.cert_utils import is_self_signed, openssl_verify, pem_blocks
+from enclave.tools.system_ca import find_system_ca_for_chain
+
+logger = logging.getLogger(__name__)
+
+_CHAIN_FIELDS = ("sslAPICertificateFullChain", "sslIngressCertificateFullChain")
+
+
+class CertificateValidationError(Exception):
+    """Raised when certificate chain validation fails."""
+
+
+def _check_chain(field: str, chain_pem: str, ca_pem: str) -> str | None:
+    """Return an issue string if the chain has a completeness or consistency problem, else None."""
+    certs = pem_blocks(chain_pem)
+    if not certs:
+        return f"{field}: configured but contains no PEM certificate blocks — check the value"
+    if is_self_signed(certs[-1]):
+        return (
+            f"{field}: chain ends with a self-signed root but sslCACertificate "
+            f"does not verify it — they may belong to different CA hierarchies."
+            if ca_pem and not openssl_verify(ca_pem, certs[-1])
+            else None
+        )
+    if not ca_pem:
+        try:
+            system_ca = find_system_ca_for_chain(chain_pem)
+        except RuntimeError:
+            system_ca = None
+        if system_ca:
+            logger.info("%s: using CA found in system trust store", field)
+            return None
+        return (
+            f"{field}: chain ends with a non-self-signed certificate, "
+            f"no sslCACertificate was provided, and no matching CA was found "
+            f"in the system trust store (/etc/pki/tls/certs/ca-bundle.crt)."
+        )
+    if openssl_verify(ca_pem, certs[-1]):
+        logger.info("%s: sslCACertificate correctly completes the chain", field)
+        return None
+    return (
+        f"{field}: chain is incomplete and sslCACertificate does not "
+        f"sign its last certificate — the CA will not complete the chain."
+    )
+
+
+def check_certificate_chains(config_path: str) -> None:
+    """Check that certificate chains are complete and the CA is consistent.
+
+    Raises CertificateValidationError when a chain ends with a non-self-signed
+    certificate and either sslCACertificate is not set, or the provided CA does not
+    sign the last certificate in the chain. Also raises when a complete chain (ending
+    with a self-signed root) is inconsistent with the provided sslCACertificate.
+    """
+    try:
+        text = Path(config_path).read_text(encoding="utf-8")
+    except OSError as exc:
+        msg = f"cannot read {config_path}: {exc}"
+        raise CertificateValidationError(msg) from exc
+
+    try:
+        raw = yaml.safe_load(text) or {}
+    except yaml.YAMLError as exc:
+        msg = f"cannot parse {config_path}: {exc}"
+        raise CertificateValidationError(msg) from exc
+
+    if not isinstance(raw, dict):
+        msg = f"{config_path}: expected a YAML mapping, got {type(raw).__name__}"
+        raise CertificateValidationError(msg)
+
+    ca_pem: str = raw.get("sslCACertificate") or ""
+    issues: list[str] = []
+
+    for field in _CHAIN_FIELDS:
+        chain_pem: str = raw.get(field) or ""
+        if not chain_pem:
+            continue
+        issue = _check_chain(field, chain_pem, ca_pem)
+        if issue:
+            issues.append(issue)
+
+    if issues:
+        raise CertificateValidationError("\n".join(issues))
+
+    logger.debug("certificate chain check passed")
+
+
+def main(config_path: str) -> None:
+    check_certificate_chains(config_path)
+    sys.stdout.write("Certificate chain check passed.\n")

--- a/src/enclave/tools/cli.py
+++ b/src/enclave/tools/cli.py
@@ -1,8 +1,35 @@
-import click
+import logging
+from pathlib import Path
+from typing import Any
 
+import click
+import yaml
+
+from enclave.tools.cert_utils import pem_blocks
+from enclave.tools.check_certificate_chains import (
+    CertificateValidationError,
+    main as check_certificate_chains_main,
+)
 from enclave.tools.node_image_digests import main as collect_node_image_digests_main
 from enclave.tools.quay_registry_ca import main as quay_registry_ca_main
+from enclave.tools.system_ca import find_system_ca_for_chain
 from enclave.utils import KubeconfigGroup
+
+logger = logging.getLogger(__name__)
+
+
+def _load_certs_config(config_path: str) -> dict[str, Any]:
+    try:
+        raw = yaml.safe_load(Path(config_path).read_text(encoding="utf-8")) or {}
+    except OSError as exc:
+        raise click.ClickException(f"cannot read {config_path}: {exc}") from exc
+    except yaml.YAMLError as exc:
+        raise click.ClickException(f"cannot parse {config_path}: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise click.ClickException(
+            f"{config_path}: expected a YAML mapping, got {type(raw).__name__}"
+        )
+    return raw
 
 
 @click.group(cls=KubeconfigGroup)
@@ -18,10 +45,34 @@ def cli() -> None:
     show_default=True,
     help="Path to the oc binary.",
 )
-def resolve_quay_registry_ca(hostname: str, oc: str) -> None:
+@click.option(
+    "--ca-pem",
+    default=None,
+    help="PEM-encoded CA certificate to complete an incomplete TLS chain.",
+)
+@click.option(
+    "--certificates-config",
+    default=None,
+    type=click.Path(exists=True, dir_okay=False),
+    help="Path to certificates.yaml; sslCACertificate is used to complete the TLS chain.",
+)
+def resolve_quay_registry_ca(
+    hostname: str, oc: str, ca_pem: str | None, certificates_config: str | None
+) -> None:
     """Print the CA PEM that trusts the Quay registry route TLS certificate."""
+    if ca_pem is not None and certificates_config is not None:
+        raise click.UsageError(
+            "--ca-pem and --certificates-config are mutually exclusive"
+        )
+    resolved_ca_pem = ca_pem or ""
+    if certificates_config is not None:
+        raw = _load_certs_config(certificates_config)
+        ca_raw = raw.get("sslCACertificate")
+        resolved_ca_pem = (ca_raw if isinstance(ca_raw, str) else "").strip()
+    if ca_pem is not None and not ca_pem.strip():
+        raise click.BadParameter("must not be empty", param_hint="--ca-pem")
     try:
-        quay_registry_ca_main(hostname, oc=oc)
+        quay_registry_ca_main(hostname, oc=oc, ca_pem=resolved_ca_pem)
     except RuntimeError as exc:
         raise click.ClickException(str(exc)) from exc
 
@@ -61,6 +112,106 @@ def collect_node_image_digests(
     except (TimeoutError, ValueError, TypeError) as exc:
         raise click.ClickException(str(exc)) from exc
 
+
+@cli.command("check-certificate-chains")
+@click.option(
+    "--config",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False),
+    help="Path to certificates.yaml.",
+)
+def check_certificate_chains(config: str) -> None:
+    """Check certificate chain completeness and CA consistency."""
+    try:
+        check_certificate_chains_main(config)
+    except CertificateValidationError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@cli.command("get-root-ca")
+@click.option(
+    "--config",
+    default=None,
+    type=click.Path(exists=True, dir_okay=False),
+    help="Path to certificates.yaml; sslAPICertificateFullChain or sslIngressCertificateFullChain is used.",
+)
+@click.option(
+    "--chain-pem",
+    default=None,
+    help="Inline PEM of the certificate fullchain to look up.",
+)
+def get_root_ca(config: str | None, chain_pem: str | None) -> None:
+    """Print the root CA PEM from the RHEL 10 system trust store that signs the given chain."""
+    if config is not None and chain_pem is not None:
+        raise click.UsageError("--config and --chain-pem are mutually exclusive")
+    if config is None and chain_pem is None:
+        raise click.UsageError("one of --config or --chain-pem is required")
+    resolved_chain = chain_pem or ""
+    if config is not None:
+        raw = _load_certs_config(config)
+        api_chain = raw.get("sslAPICertificateFullChain")
+        ingress_chain = raw.get("sslIngressCertificateFullChain")
+        resolved_chain = (
+            (api_chain if isinstance(api_chain, str) else None)
+            or (ingress_chain if isinstance(ingress_chain, str) else None)
+            or ""
+        )
+        if not resolved_chain:
+            raise click.ClickException(
+                f"{config}: sslAPICertificateFullChain and sslIngressCertificateFullChain are both unset or empty"
+            )
+    try:
+        ca_pem = find_system_ca_for_chain(resolved_chain)
+    except (ValueError, RuntimeError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    if ca_pem is None:
+        raise click.ClickException("no matching CA found in system trust store")
+    click.echo(ca_pem, nl=False)
+
+
+@cli.command("check-root-ca")
+@click.option(
+    "--config",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False),
+    help="Path to certificates.yaml.",
+)
+def check_root_ca(config: str) -> None:
+    """Check that a root CA is available for the configured certificate chains."""
+    raw = _load_certs_config(config)
+    api_chain = raw.get("sslAPICertificateFullChain")
+    ingress_chain = raw.get("sslIngressCertificateFullChain")
+    chain_pem = (
+        (api_chain if isinstance(api_chain, str) else None)
+        or (ingress_chain if isinstance(ingress_chain, str) else None)
+        or ""
+    )
+    if not chain_pem:
+        logger.info("No TLS certificate chains configured; skipping root CA check.")
+        return
+    ca_raw = raw.get("sslCACertificate")
+    ca_pem = (ca_raw if isinstance(ca_raw, str) else "").strip()
+    if ca_pem:
+        if not pem_blocks(ca_pem):
+            raise click.ClickException(
+                "sslCACertificate contains no valid PEM certificate blocks"
+            )
+        return
+    try:
+        ca_result = find_system_ca_for_chain(chain_pem)
+    except (ValueError, RuntimeError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    if ca_result is None:
+        raise click.ClickException(
+            "sslCACertificate is not set and no matching CA was found in the "
+            "system trust store (/etc/pki/tls/certs/ca-bundle.crt). "
+            "Set sslCACertificate in certificates.yaml."
+        )
+
+
+check_certificate_chains.no_kubeconfig = True  # type: ignore[attr-defined]
+get_root_ca.no_kubeconfig = True  # type: ignore[attr-defined]
+check_root_ca.no_kubeconfig = True  # type: ignore[attr-defined]
 
 if __name__ == "__main__":
     cli()

--- a/src/enclave/tools/node_image_digests.py
+++ b/src/enclave/tools/node_image_digests.py
@@ -1,7 +1,5 @@
 """Collect PinnedImageSet-format digest refs from crictl images JSON on a node."""
 
-from __future__ import annotations
-
 import json
 import logging
 import re

--- a/src/enclave/tools/quay_registry_ca.py
+++ b/src/enclave/tools/quay_registry_ca.py
@@ -1,32 +1,26 @@
 """Resolve the CA PEM used to trust the Quay registry route for OSUS and image pulls."""
 
-from __future__ import annotations
-
 import base64
 import binascii
 import logging
-import re
 import subprocess
 import sys
-import tempfile
-from pathlib import Path
+
+from enclave.tools.cert_utils import is_self_signed, openssl_verify, pem_blocks
+from enclave.tools.system_ca import find_system_ca_for_chain
 
 logger = logging.getLogger(__name__)
 
 _TLS_CONNECT_TIMEOUT_SECONDS = 60
 _OC_COMMAND_TIMEOUT_SECONDS = 30
-_OPENSSL_VERIFY_TIMEOUT_SECONDS = 10
-_PEM_BLOCK = re.compile(
-    r"-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----",
-    re.DOTALL,
-)
-
-
-def pem_blocks(pem_text: str) -> list[str]:
-    return _PEM_BLOCK.findall(pem_text or "")
 
 
 def get_router_ca_pem(*, oc: str = "oc") -> str:
+    """Return the PEM-encoded router CA from the openshift-ingress-operator secret.
+
+    Returns an empty string when the secret is absent or empty.
+    Raises RuntimeError on oc timeout, missing binary, or malformed secret data.
+    """
     try:
         result = subprocess.run(
             [
@@ -60,6 +54,11 @@ def get_router_ca_pem(*, oc: str = "oc") -> str:
 
 
 def fetch_tls_chain_pem(hostname: str, *, port: int = 443) -> str:
+    """Return all PEM blocks from the TLS certificate chain presented by hostname:port.
+
+    Uses openssl s_client -showcerts. Returns an empty string when no PEM blocks are
+    found. Raises RuntimeError on connection timeout or missing openssl binary.
+    """
     try:
         result = subprocess.run(
             [
@@ -86,129 +85,13 @@ def fetch_tls_chain_pem(hostname: str, *, port: int = 443) -> str:
     return "\n".join(pem_blocks(result.stdout + result.stderr))
 
 
-def _openssl_verify(ca_pem: str, cert_pem: str) -> bool:
-    with tempfile.TemporaryDirectory() as tmpdir:
-        work = Path(tmpdir)
-        ca_path = work / "ca.pem"
-        cert_path = work / "cert.pem"
-        ca_path.write_text(ca_pem, encoding="utf-8")
-        cert_path.write_text(cert_pem, encoding="utf-8")
-        try:
-            result = subprocess.run(
-                [
-                    "openssl",
-                    "verify",
-                    "-no-CAfile",
-                    "-no-CApath",
-                    "-CAfile",
-                    str(ca_path),
-                    str(cert_path),
-                ],
-                capture_output=True,
-                text=True,
-                check=False,
-                timeout=_OPENSSL_VERIFY_TIMEOUT_SECONDS,
-            )
-        except subprocess.TimeoutExpired as exc:
-            msg = "openssl verify timed out"
-            raise RuntimeError(msg) from exc
-        except OSError as exc:
-            msg = "openssl not found"
-            raise RuntimeError(msg) from exc
-    return result.returncode == 0
+def chain_trust_anchor_pem(chain: list[str], ca_pem: str = "") -> str:
+    """Return the CA bundle PEM that should be trusted to verify the TLS chain.
 
-
-def _get_cert_issuer(cert_pem: str) -> str:
-    """Extract the issuer DN from a certificate in RFC2253 format."""
-    try:
-        result = subprocess.run(
-            ["openssl", "x509", "-noout", "-issuer", "-nameopt", "RFC2253"],
-            input=cert_pem,
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=_OPENSSL_VERIFY_TIMEOUT_SECONDS,
-        )
-    except (subprocess.TimeoutExpired, OSError):
-        return ""
-
-    if result.returncode != 0:
-        return ""
-
-    # Output format: "issuer=CN=Root CA,O=Org,C=US"
-    match = re.match(r"issuer=(.+)", result.stdout.strip())
-    return match.group(1) if match else ""
-
-
-def _get_cert_subject(cert_pem: str) -> str:
-    """Extract the subject DN from a certificate in RFC2253 format."""
-    try:
-        result = subprocess.run(
-            ["openssl", "x509", "-noout", "-subject", "-nameopt", "RFC2253"],
-            input=cert_pem,
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=_OPENSSL_VERIFY_TIMEOUT_SECONDS,
-        )
-    except (subprocess.TimeoutExpired, OSError):
-        return ""
-
-    if result.returncode != 0:
-        return ""
-
-    # Output format: "subject=CN=Intermediate CA,O=Org,C=US"
-    match = re.match(r"subject=(.+)", result.stdout.strip())
-    return match.group(1) if match else ""
-
-
-def _find_root_ca_in_system_store(issuer_dn: str) -> str | None:
-    """
-    Find the root CA certificate in system CA stores matching the given issuer DN.
-
-    Args:
-        issuer_dn: The issuer DN to search for (RFC2253 format)
-
-    Returns:
-        PEM content of the root CA, or None if not found
-    """
-    # Common system CA paths (RHEL/Fedora, Debian/Ubuntu)
-    ca_paths = [
-        Path("/etc/pki/tls/certs/ca-bundle.crt"),
-        Path("/etc/ssl/certs/ca-certificates.crt"),
-    ]
-
-    for bundle_path in ca_paths:
-        if not bundle_path.exists():
-            continue
-
-        try:
-            bundle_content = bundle_path.read_text(encoding="utf-8")
-            # System CA bundles contain multiple certs
-            for cert_pem in pem_blocks(bundle_content):
-                subject = _get_cert_subject(cert_pem)
-                if subject and subject == issuer_dn:
-                    logger.debug("Found root CA in %s", bundle_path)
-                    return cert_pem
-        except (OSError, UnicodeDecodeError) as exc:
-            logger.debug("Error reading %s: %s", bundle_path, exc)
-            continue
-
-    return None
-
-
-def _chain_trust_anchor_pem(chain: list[str]) -> str:
-    """
-    Return complete CA PEM bundle from a fetched TLS chain.
-
-    Includes all intermediate CAs from the chain, plus attempts to find
-    and append the root CA from the system trust store if the chain is incomplete.
-
-    Args:
-        chain: List of PEM certificates from TLS handshake [leaf, intermediate(s)...]
-
-    Returns:
-        Complete CA bundle with intermediates + root CA (if found)
+    Skips the leaf (chain[0]) and returns all remaining CA certificates. If the last
+    certificate is not self-signed and ca_pem is provided, verifies that ca_pem signs
+    it and appends ca_pem to complete the chain. Raises RuntimeError when the chain
+    contains only a leaf or when ca_pem fails to verify the last certificate.
     """
     ca_certs = chain[1:]
     if not ca_certs:
@@ -217,37 +100,33 @@ def _chain_trust_anchor_pem(chain: list[str]) -> str:
         )
         raise RuntimeError(msg)
 
-    # Check if the last cert in the chain is self-signed (i.e., a root CA)
-    last_cert = ca_certs[-1]
-    issuer = _get_cert_issuer(last_cert)
-    subject = _get_cert_subject(last_cert)
-
-    if issuer and subject and issuer == subject:
-        # Chain already contains a self-signed root CA
+    if is_self_signed(ca_certs[-1]):
         logger.debug("TLS chain contains self-signed root CA")
         return "\n".join(ca_certs) + "\n"
 
-    # Chain is incomplete - try to find the root CA from system store
-    if not issuer:
-        logger.warning("Could not determine issuer from last intermediate CA")
-        return "\n".join(ca_certs) + "\n"
+    if ca_pem:
+        if not openssl_verify(ca_pem, ca_certs[-1]):
+            msg = "provided --ca-pem does not verify the last certificate in the TLS chain"
+            raise RuntimeError(msg)
+        logger.info("Completing certificate chain with provided CA")
+        return "\n".join([*ca_certs, ca_pem.strip()]) + "\n"
 
-    logger.debug("Searching for root CA with subject: %s", issuer)
-    root_ca = _find_root_ca_in_system_store(issuer)
-
-    if root_ca:
-        logger.info("Completed certificate chain with root CA from system trust store")
-        return "\n".join([*ca_certs, root_ca]) + "\n"
+    try:
+        system_ca = find_system_ca_for_chain("\n".join(ca_certs))
+    except RuntimeError:
+        system_ca = None
+    if system_ca:
+        logger.info("Completing certificate chain with CA from system trust store")
+        return "\n".join([*ca_certs, system_ca.strip()]) + "\n"
 
     logger.warning(
-        "Root CA not found in system trust store for issuer: %s. "
-        "UpdateService may fail to verify the registry certificate in disconnected mode.",
-        issuer,
+        "TLS chain is incomplete (last certificate is not self-signed) and no CA "
+        "provided. UpdateService may fail to verify the registry certificate."
     )
     return "\n".join(ca_certs) + "\n"
 
 
-def resolve_registry_ca_pem(hostname: str, *, oc: str = "oc") -> str:
+def resolve_registry_ca_pem(hostname: str, *, oc: str = "oc", ca_pem: str = "") -> str:
     """Return PEM for the CA that should trust the registry route certificate."""
     router_ca = get_router_ca_pem(oc=oc).strip()
     chain = pem_blocks(fetch_tls_chain_pem(hostname))
@@ -256,13 +135,14 @@ def resolve_registry_ca_pem(hostname: str, *, oc: str = "oc") -> str:
         raise RuntimeError(msg)
 
     leaf = chain[0]
-    if router_ca and _openssl_verify(router_ca, leaf):
+    if router_ca and openssl_verify(router_ca, leaf):
         logger.debug("using router-ca to trust %s", hostname)
         return f"{router_ca}\n"
 
     logger.debug("using TLS chain CA bundle to trust %s", hostname)
-    return _chain_trust_anchor_pem(chain)
+    return chain_trust_anchor_pem(chain, ca_pem=ca_pem)
 
 
-def main(hostname: str, *, oc: str = "oc") -> None:
-    sys.stdout.write(resolve_registry_ca_pem(hostname, oc=oc))
+def main(hostname: str, *, oc: str = "oc", ca_pem: str = "") -> None:
+    """Print the CA PEM that should be trusted to verify the Quay registry route."""
+    sys.stdout.write(resolve_registry_ca_pem(hostname, oc=oc, ca_pem=ca_pem))

--- a/src/enclave/tools/system_ca.py
+++ b/src/enclave/tools/system_ca.py
@@ -1,0 +1,44 @@
+"""RHEL 10 system trust store CA discovery for certificate chain completion."""
+
+import logging
+from pathlib import Path
+
+from enclave.tools.cert_utils import is_self_signed, openssl_verify, pem_blocks
+
+logger = logging.getLogger(__name__)
+
+RHEL_TRUST_STORE = Path("/etc/pki/tls/certs/ca-bundle.crt")
+
+
+def find_system_ca_for_chain(chain_pem: str) -> str | None:
+    """Return the PEM of the first RHEL 10 trust store CA that signs the last cert.
+
+    Raises ValueError when chain_pem contains no PEM certificate blocks.
+    Raises RuntimeError when the RHEL trust store cannot be read.
+    Returns None when the chain ends with a self-signed root (no CA needed) or
+    when no CA in the store verifies the last certificate.
+    """
+    certs = pem_blocks(chain_pem)
+    if not certs:
+        raise ValueError("no PEM blocks in chain")
+    last_cert = certs[-1]
+    if is_self_signed(last_cert):
+        logger.debug(
+            "find_system_ca_for_chain: chain ends with self-signed root; no CA needed"
+        )
+        return None
+    try:
+        bundle_text = RHEL_TRUST_STORE.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger.warning("find_system_ca_for_chain: trust store unavailable: %s", exc)
+        raise RuntimeError(f"system trust store unavailable: {exc}") from exc
+    for ca_pem in pem_blocks(bundle_text):
+        if openssl_verify(ca_pem, last_cert):
+            logger.info(
+                "find_system_ca_for_chain: found matching CA in %s", RHEL_TRUST_STORE
+            )
+            return ca_pem
+    logger.warning(
+        "find_system_ca_for_chain: no matching CA found in %s", RHEL_TRUST_STORE
+    )
+    return None

--- a/src/enclave/utils.py
+++ b/src/enclave/utils.py
@@ -58,6 +58,10 @@ def setup_kubeconfig() -> None:
 
 class KubeconfigGroup(click.Group):
     def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
+        # Read the subcommand name from the raw args list before super() consumes it.
+        # The group itself has no positional options, so the first non-flag token is
+        # always the subcommand name (help flags cause early exit inside super()).
+        subcommand_name = next((a for a in args if not a.startswith("-")), None)
         remaining = super().parse_args(ctx, args)
         # ctx.args holds the subcommand's own args (empty when no subcommand was given, or
         # when a bare subcommand name was given with no further args). Only check kubeconfig
@@ -66,10 +70,14 @@ class KubeconfigGroup(click.Group):
         if not ctx.resilient_parsing and ctx.args:
             help_flags = set(ctx.help_option_names or ["--help", "-h"])
             if not any(f in ctx.args for f in help_flags):
-                try:
-                    setup_kubeconfig()
-                except KubeconfigNotFoundError as exc:
-                    raise click.ClickException(str(exc)) from exc
+                subcommand = (
+                    self.get_command(ctx, subcommand_name) if subcommand_name else None
+                )
+                if not (subcommand and getattr(subcommand, "no_kubeconfig", False)):
+                    try:
+                        setup_kubeconfig()
+                    except KubeconfigNotFoundError as exc:
+                        raise click.ClickException(str(exc)) from exc
         return remaining
 
 

--- a/src/tests/cert_helpers.py
+++ b/src/tests/cert_helpers.py
@@ -1,0 +1,197 @@
+"""Shared openssl helper functions for certificate generation in tests."""
+
+import subprocess
+from pathlib import Path
+
+
+def generate_ca(tmp_path: Path, cn: str) -> tuple[str, Path, Path]:
+    """Generate a self-signed CA. Returns (cert_pem, cert_path, key_path)."""
+    key_path = tmp_path / f"{cn}.key"
+    cert_path = tmp_path / f"{cn}.crt"
+    # Generate a P-256 EC private key and a self-signed X.509 certificate in one
+    # step. -x509 produces a cert instead of a CSR; -nodes skips key encryption.
+    subprocess.run(
+        [
+            "openssl",
+            "req",
+            "-x509",
+            "-newkey",
+            "ec",
+            "-pkeyopt",
+            "ec_paramgen_curve:P-256",
+            "-keyout",
+            str(key_path),
+            "-out",
+            str(cert_path),
+            "-days",
+            "1",
+            "-nodes",
+            "-subj",
+            f"/CN={cn}",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return cert_path.read_text(encoding="utf-8").strip(), cert_path, key_path
+
+
+def generate_signed_leaf(
+    tmp_path: Path, ca_cert_path: Path, ca_key_path: Path, cn: str
+) -> str:
+    """Generate a cert signed by the given CA. Returns cert_pem (stripped)."""
+    leaf_key = tmp_path / "leaf.key"
+    # Generate a P-256 EC private key for the leaf certificate.
+    subprocess.run(
+        [
+            "openssl",
+            "genpkey",
+            "-algorithm",
+            "EC",
+            "-pkeyopt",
+            "ec_paramgen_curve:P-256",
+            "-out",
+            str(leaf_key),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    leaf_csr = tmp_path / "leaf.csr"
+    # Create a Certificate Signing Request (CSR) using the leaf key.
+    subprocess.run(
+        [
+            "openssl",
+            "req",
+            "-new",
+            "-key",
+            str(leaf_key),
+            "-out",
+            str(leaf_csr),
+            "-subj",
+            f"/CN={cn}",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    leaf_cert = tmp_path / "leaf.crt"
+    # Sign the CSR with the CA's certificate and key, producing the leaf cert.
+    # -set_serial supplies a fixed serial number (required when not using a CA database).
+    subprocess.run(
+        [
+            "openssl",
+            "x509",
+            "-req",
+            "-in",
+            str(leaf_csr),
+            "-CA",
+            str(ca_cert_path),
+            "-CAkey",
+            str(ca_key_path),
+            "-out",
+            str(leaf_cert),
+            "-days",
+            "1",
+            "-set_serial",
+            "01",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return leaf_cert.read_text(encoding="utf-8").strip()
+
+
+def generate_self_issued_not_self_signed_cert(tmp_path: Path) -> str:
+    """Generate a cert that is self-issued (issuer==subject) but NOT self-signed.
+
+    The cert has subject=CN=Cross CA and issuer=CN=Cross CA because the signing CA
+    was created with the same subject DN. However, the public key embedded in the cert
+    belongs to a different keypair, so the self-signature check fails.
+    """
+    signing_key = tmp_path / "signing.key"
+    signing_cert = tmp_path / "signing.crt"
+    # Create the signing CA with CN=Cross CA. Its key will be used to sign the
+    # subject cert, making that cert's issuer field read "CN=Cross CA".
+    subprocess.run(
+        [
+            "openssl",
+            "req",
+            "-x509",
+            "-newkey",
+            "ec",
+            "-pkeyopt",
+            "ec_paramgen_curve:P-256",
+            "-keyout",
+            str(signing_key),
+            "-out",
+            str(signing_cert),
+            "-days",
+            "1",
+            "-nodes",
+            "-subj",
+            "/CN=Cross CA",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    subject_key = tmp_path / "subject.key"
+    # Generate a separate, independent key for the subject cert. This is the
+    # key pair that will be embedded in the cross cert's SubjectPublicKeyInfo —
+    # distinct from the signing CA's key despite the identical subject DN.
+    subprocess.run(
+        [
+            "openssl",
+            "genpkey",
+            "-algorithm",
+            "EC",
+            "-pkeyopt",
+            "ec_paramgen_curve:P-256",
+            "-out",
+            str(subject_key),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    subject_csr = tmp_path / "subject.csr"
+    # Create a CSR for the subject cert. Using the same DN (/CN=Cross CA) means
+    # issuer and subject will match in the final cert, satisfying the self-issued
+    # condition while the public key belongs to a different keypair.
+    subprocess.run(
+        [
+            "openssl",
+            "req",
+            "-new",
+            "-key",
+            str(subject_key),
+            "-out",
+            str(subject_csr),
+            "-subj",
+            "/CN=Cross CA",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    cross_cert = tmp_path / "cross.crt"
+    # Sign the CSR with the signing CA's key. The result is a cert whose
+    # issuer == subject == CN=Cross CA but whose signature was made by a
+    # different private key, so -check_ss_sig verification will fail.
+    subprocess.run(
+        [
+            "openssl",
+            "x509",
+            "-req",
+            "-in",
+            str(subject_csr),
+            "-CA",
+            str(signing_cert),
+            "-CAkey",
+            str(signing_key),
+            "-out",
+            str(cross_cert),
+            "-days",
+            "1",
+            "-set_serial",
+            "01",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return cross_cert.read_text(encoding="utf-8").strip()

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1,8 +1,81 @@
+from pathlib import Path
 from subprocess import CompletedProcess
 
 import pytest
 
+from tests.cert_helpers import generate_ca, generate_signed_leaf
 from tests.fixtures import OcResultFactory
+
+
+@pytest.fixture
+def leaf_pem() -> str:
+    """Syntactic fake PEM string representing a leaf certificate."""
+    return """-----BEGIN CERTIFICATE-----
+leaf
+-----END CERTIFICATE-----"""
+
+
+@pytest.fixture
+def intermediate_pem() -> str:
+    """Syntactic fake PEM string representing an intermediate CA certificate."""
+    return """-----BEGIN CERTIFICATE-----
+intermediate
+-----END CERTIFICATE-----"""
+
+
+@pytest.fixture
+def root_pem() -> str:
+    """Syntactic fake PEM string representing a root CA certificate."""
+    return """-----BEGIN CERTIFICATE-----
+root
+-----END CERTIFICATE-----"""
+
+
+@pytest.fixture
+def router_ca_pem() -> str:
+    """Syntactic fake PEM string representing an OpenShift router CA certificate."""
+    return """-----BEGIN CERTIFICATE-----
+router-ca
+-----END CERTIFICATE-----"""
+
+
+@pytest.fixture
+def ca_pem() -> str:
+    """Syntactic fake PEM string representing a generic CA certificate."""
+    return """-----BEGIN CERTIFICATE-----
+ca
+-----END CERTIFICATE-----"""
+
+
+@pytest.fixture
+def chain_pem() -> str:
+    """Syntactic fake PEM string representing a certificate chain entry."""
+    return """-----BEGIN CERTIFICATE-----
+chain
+-----END CERTIFICATE-----"""
+
+
+@pytest.fixture(scope="module")
+def module_ca(tmp_path_factory: pytest.TempPathFactory) -> tuple[str, Path, Path]:
+    """Self-signed CA generated once per module: (cert_pem, cert_path, key_path)."""
+    return generate_ca(tmp_path_factory.mktemp("ca"), "Module CA")
+
+
+@pytest.fixture(scope="module")
+def module_ca_pem(module_ca: tuple[str, Path, Path]) -> str:
+    """PEM text of the module-scoped self-signed CA certificate."""
+    return module_ca[0]
+
+
+@pytest.fixture(scope="module")
+def module_leaf_pem(
+    tmp_path_factory: pytest.TempPathFactory, module_ca: tuple[str, Path, Path]
+) -> str:
+    """PEM text of a leaf certificate signed by module_ca (issuer ≠ subject)."""
+    _, ca_cert_path, ca_key_path = module_ca
+    return generate_signed_leaf(
+        tmp_path_factory.mktemp("leaf"), ca_cert_path, ca_key_path, "Leaf"
+    )
 
 
 @pytest.fixture

--- a/src/tests/test_cert_utils.py
+++ b/src/tests/test_cert_utils.py
@@ -1,0 +1,80 @@
+"""Tests for cert_utils: pem_blocks, is_self_signed, openssl_verify.
+
+This module is the authoritative test source for openssl subprocess calls and
+certificate parsing. Mocking subprocess.run is intentionally absent — if the
+real openssl invocations are wrong (wrong flags, wrong arg order, wrong
+temp-file handling), mocked tests cannot catch it. All tests use real openssl
+binaries via module-scoped fixtures that generate certificates once per run.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from enclave.tools.cert_utils import is_self_signed, openssl_verify, pem_blocks
+from tests.cert_helpers import generate_ca, generate_self_issued_not_self_signed_cert
+
+
+def test_pem_blocks_splits_multiple_certificates(
+    module_ca_pem: str, module_leaf_pem: str
+) -> None:
+    """Split a multi-cert PEM string into individual blocks using real certs."""
+    chain = f"{module_ca_pem}\n{module_leaf_pem}\n"
+    assert pem_blocks(chain) == [module_ca_pem, module_leaf_pem]
+
+
+def test_is_self_signed_returns_false_when_issuer_differs(module_leaf_pem: str) -> None:
+    """Return False when issuer (CA) and subject (Leaf) differ."""
+    assert is_self_signed(module_leaf_pem) is False
+
+
+def test_is_self_signed_returns_false_on_invalid_input() -> None:
+    """Return False when the input is not a valid PEM certificate."""
+    assert is_self_signed("not a certificate") is False
+
+
+def test_is_self_signed_returns_false_when_openssl_missing(
+    monkeypatch: pytest.MonkeyPatch, module_ca_pem: str
+) -> None:
+    """Return False when openssl is not found in PATH."""
+    monkeypatch.setenv("PATH", "")
+    assert is_self_signed(module_ca_pem) is False
+
+
+def test_openssl_verify_raises_when_openssl_missing(
+    monkeypatch: pytest.MonkeyPatch, module_ca_pem: str
+) -> None:
+    """Raise RuntimeError when openssl is not found in PATH."""
+    monkeypatch.setenv("PATH", "")
+    with pytest.raises(RuntimeError, match="openssl not found"):
+        openssl_verify(module_ca_pem, module_ca_pem)
+
+
+def test_openssl_verify_self_signed_cert_verifies_against_itself(
+    module_ca_pem: str,
+) -> None:
+    """A self-signed CA certificate verifies against itself."""
+    assert openssl_verify(module_ca_pem, module_ca_pem) is True
+
+
+def test_openssl_verify_self_signed_cert_fails_against_different_ca(
+    tmp_path: Path, module_ca_pem: str
+) -> None:
+    """A self-signed CA does not verify a certificate from a different CA."""
+    ca2_pem, _, _ = generate_ca(tmp_path, "CA 2")
+    assert openssl_verify(module_ca_pem, ca2_pem) is False
+
+
+def test_is_self_signed_returns_true_for_genuinely_self_signed_cert(
+    module_ca_pem: str,
+) -> None:
+    """A genuinely self-signed CA cert is correctly identified as self-signed."""
+    assert is_self_signed(module_ca_pem) is True
+
+
+def test_is_self_signed_returns_false_for_self_issued_but_not_self_signed(
+    tmp_path: Path,
+) -> None:
+    """A cert with issuer==subject but signed by a different key is not self-signed."""
+    cross_pem = generate_self_issued_not_self_signed_cert(tmp_path)
+    assert is_self_signed(cross_pem) is False

--- a/src/tests/test_check_certificate_chains.py
+++ b/src/tests/test_check_certificate_chains.py
@@ -1,0 +1,316 @@
+"""Tests for check_certificate_chains: chain completeness and CA consistency validation."""
+
+from pathlib import Path
+
+import pytest
+from pytest_mock import MockerFixture
+
+from enclave.tools.check_certificate_chains import (
+    CertificateValidationError,
+    check_certificate_chains,
+    main,
+)
+
+
+def _write_certs(tmp_path: Path, **kwargs: str) -> str:
+    content = "\n".join(
+        f"{k}: |\n  " + v.replace("\n", "\n  ") for k, v in kwargs.items()
+    )
+    path = tmp_path / "certificates.yaml"
+    path.write_text(content, encoding="utf-8")
+    return str(path)
+
+
+def test_check_passes_when_chain_ends_with_self_signed_root(
+    mocker: MockerFixture, tmp_path: Path, leaf_pem: str, root_pem: str
+) -> None:
+    """Pass when the chain ends with a self-signed root."""
+    mocker.patch(
+        "enclave.tools.check_certificate_chains.is_self_signed", return_value=True
+    )
+    path = _write_certs(
+        tmp_path,
+        sslAPICertificateFullChain=f"{leaf_pem}\n{root_pem}",
+    )
+    check_certificate_chains(path)
+
+
+def test_check_passes_when_ca_matches_self_signed_root(
+    mocker: MockerFixture, tmp_path: Path, leaf_pem: str, root_pem: str
+) -> None:
+    """Pass when sslCACertificate verifies a self-signed root."""
+    mock_is_self_signed = mocker.patch(
+        "enclave.tools.check_certificate_chains.is_self_signed", return_value=True
+    )
+    mock_openssl_verify = mocker.patch(
+        "enclave.tools.check_certificate_chains.openssl_verify", return_value=True
+    )
+    path = _write_certs(
+        tmp_path,
+        sslAPICertificateFullChain=f"{leaf_pem}\n{root_pem}",
+        sslCACertificate=root_pem,
+    )
+    check_certificate_chains(path)
+    mock_is_self_signed.assert_called_once_with(root_pem)
+    mock_openssl_verify.assert_called_once_with(root_pem, root_pem)
+
+
+def test_check_raises_when_ca_does_not_match_self_signed_root(
+    mocker: MockerFixture,
+    tmp_path: Path,
+    leaf_pem: str,
+    root_pem: str,
+    intermediate_pem: str,
+) -> None:
+    """Raise when sslCACertificate does not verify the self-signed root."""
+    mocker.patch(
+        "enclave.tools.check_certificate_chains.is_self_signed", return_value=True
+    )
+    mocker.patch(
+        "enclave.tools.check_certificate_chains.openssl_verify", return_value=False
+    )
+    path = _write_certs(
+        tmp_path,
+        sslAPICertificateFullChain=f"{leaf_pem}\n{root_pem}",
+        sslCACertificate=intermediate_pem,
+    )
+    with pytest.raises(CertificateValidationError, match="sslAPICertificateFullChain"):
+        check_certificate_chains(path)
+
+
+def test_check_passes_when_chain_incomplete_but_ca_pem_set(
+    mocker: MockerFixture,
+    tmp_path: Path,
+    leaf_pem: str,
+    intermediate_pem: str,
+    root_pem: str,
+) -> None:
+    """Pass when an incomplete chain is completed by sslCACertificate."""
+    mocker.patch(
+        "enclave.tools.check_certificate_chains.is_self_signed", return_value=False
+    )
+    mocker.patch(
+        "enclave.tools.check_certificate_chains.openssl_verify", return_value=True
+    )
+    path = _write_certs(
+        tmp_path,
+        sslAPICertificateFullChain=f"{leaf_pem}\n{intermediate_pem}",
+        sslCACertificate=root_pem,
+    )
+    check_certificate_chains(path)
+
+
+def test_check_raises_when_ca_does_not_sign_last_chain_cert(
+    mocker: MockerFixture,
+    tmp_path: Path,
+    leaf_pem: str,
+    intermediate_pem: str,
+    root_pem: str,
+) -> None:
+    """Raise when sslCACertificate does not sign the last chain cert."""
+    mocker.patch(
+        "enclave.tools.check_certificate_chains.is_self_signed", return_value=False
+    )
+    mocker.patch(
+        "enclave.tools.check_certificate_chains.openssl_verify", return_value=False
+    )
+    path = _write_certs(
+        tmp_path,
+        sslAPICertificateFullChain=f"{leaf_pem}\n{intermediate_pem}",
+        sslCACertificate=root_pem,
+    )
+    with pytest.raises(CertificateValidationError, match="sslAPICertificateFullChain"):
+        check_certificate_chains(path)
+
+
+def test_check_raises_when_api_chain_incomplete_without_ca(
+    mocker: MockerFixture, tmp_path: Path, leaf_pem: str, intermediate_pem: str
+) -> None:
+    """Raise when API chain is incomplete and no sslCACertificate is set."""
+    mocker.patch(
+        "enclave.tools.check_certificate_chains.is_self_signed", return_value=False
+    )
+    path = _write_certs(
+        tmp_path,
+        sslAPICertificateFullChain=f"{leaf_pem}\n{intermediate_pem}",
+    )
+    with pytest.raises(CertificateValidationError, match="sslAPICertificateFullChain"):
+        check_certificate_chains(path)
+
+
+def test_check_raises_when_ingress_chain_incomplete_without_ca(
+    mocker: MockerFixture, tmp_path: Path, leaf_pem: str, intermediate_pem: str
+) -> None:
+    """Raise when ingress chain is incomplete and no sslCACertificate is set."""
+    mocker.patch(
+        "enclave.tools.check_certificate_chains.is_self_signed", return_value=False
+    )
+    path = _write_certs(
+        tmp_path,
+        sslIngressCertificateFullChain=f"{leaf_pem}\n{intermediate_pem}",
+    )
+    with pytest.raises(
+        CertificateValidationError, match="sslIngressCertificateFullChain"
+    ):
+        check_certificate_chains(path)
+
+
+def test_check_reports_both_fields_when_both_incomplete(
+    mocker: MockerFixture, tmp_path: Path, leaf_pem: str, intermediate_pem: str
+) -> None:
+    """Report both field names when both chains are incomplete."""
+    mocker.patch(
+        "enclave.tools.check_certificate_chains.is_self_signed", return_value=False
+    )
+    path = _write_certs(
+        tmp_path,
+        sslAPICertificateFullChain=f"{leaf_pem}\n{intermediate_pem}",
+        sslIngressCertificateFullChain=f"{leaf_pem}\n{intermediate_pem}",
+    )
+    with pytest.raises(CertificateValidationError) as exc_info:
+        check_certificate_chains(path)
+    msg = str(exc_info.value)
+    assert "sslAPICertificateFullChain" in msg
+    assert "sslIngressCertificateFullChain" in msg
+
+
+def test_check_skips_absent_chain_fields(tmp_path: Path) -> None:
+    """Skip fields that are absent or empty in the config."""
+    path = tmp_path / "certificates.yaml"
+    path.write_text("ironicHTTPSCertificate: ''\n", encoding="utf-8")
+    check_certificate_chains(str(path))
+
+
+def test_check_raises_leaf_only_chain_without_ca(
+    mocker: MockerFixture, tmp_path: Path, leaf_pem: str
+) -> None:
+    """Raise when only a leaf cert is present and no sslCACertificate is set."""
+    mocker.patch(
+        "enclave.tools.check_certificate_chains.is_self_signed", return_value=False
+    )
+    path = _write_certs(tmp_path, sslAPICertificateFullChain=leaf_pem)
+    with pytest.raises(CertificateValidationError, match="sslAPICertificateFullChain"):
+        check_certificate_chains(str(path))
+
+
+def test_check_passes_leaf_only_chain_when_ca_set(
+    mocker: MockerFixture, tmp_path: Path, leaf_pem: str, root_pem: str
+) -> None:
+    """Pass when a leaf-only chain is completed by sslCACertificate."""
+    mocker.patch(
+        "enclave.tools.check_certificate_chains.is_self_signed", return_value=False
+    )
+    mocker.patch(
+        "enclave.tools.check_certificate_chains.openssl_verify", return_value=True
+    )
+    path = _write_certs(
+        tmp_path,
+        sslAPICertificateFullChain=leaf_pem,
+        sslCACertificate=root_pem,
+    )
+    check_certificate_chains(str(path))
+
+
+def test_check_raises_when_chain_has_content_but_no_pem_blocks(
+    tmp_path: Path,
+) -> None:
+    """Raise when a chain field is set to text that contains no PEM certificate blocks."""
+    path = _write_certs(tmp_path, sslAPICertificateFullChain="not a certificate")
+    with pytest.raises(CertificateValidationError, match="no PEM certificate blocks"):
+        check_certificate_chains(str(path))
+
+
+def test_check_raises_on_missing_file() -> None:
+    """Raise when the config file does not exist."""
+    with pytest.raises(CertificateValidationError, match="cannot read"):
+        check_certificate_chains("/nonexistent/path/certificates.yaml")
+
+
+def test_check_raises_on_invalid_yaml(tmp_path: Path) -> None:
+    """Raise when the config file contains invalid YAML."""
+    path = tmp_path / "certificates.yaml"
+    path.write_text("key: [\nbad yaml", encoding="utf-8")
+    with pytest.raises(CertificateValidationError, match="cannot parse"):
+        check_certificate_chains(str(path))
+
+
+def test_check_raises_on_non_mapping_yaml(tmp_path: Path) -> None:
+    """Raise when the config file is not a YAML mapping."""
+    path = tmp_path / "certificates.yaml"
+    path.write_text("- item1\n- item2\n", encoding="utf-8")
+    with pytest.raises(CertificateValidationError, match="expected a YAML mapping"):
+        check_certificate_chains(str(path))
+
+
+def test_check_passes_via_system_store_when_no_ca_set(
+    mocker: MockerFixture,
+    tmp_path: Path,
+    leaf_pem: str,
+    intermediate_pem: str,
+    root_pem: str,
+) -> None:
+    """Pass when no sslCACertificate is set but the system trust store provides one."""
+    mock_is_self_signed = mocker.patch(
+        "enclave.tools.check_certificate_chains.is_self_signed", return_value=False
+    )
+    mock_find_system_ca = mocker.patch(
+        "enclave.tools.check_certificate_chains.find_system_ca_for_chain",
+        return_value=root_pem,
+    )
+    mock_openssl_verify = mocker.patch(
+        "enclave.tools.check_certificate_chains.openssl_verify", return_value=True
+    )
+    full_chain = f"{leaf_pem}\n{intermediate_pem}"
+    path = _write_certs(
+        tmp_path,
+        sslAPICertificateFullChain=full_chain,
+    )
+    check_certificate_chains(path)
+    mock_is_self_signed.assert_called_once_with(intermediate_pem)
+    mock_find_system_ca.assert_called_once_with(full_chain)
+    mock_openssl_verify.assert_not_called()
+
+
+def test_check_raises_when_system_store_also_has_no_match(
+    mocker: MockerFixture, tmp_path: Path, leaf_pem: str, intermediate_pem: str
+) -> None:
+    """Raise when neither sslCACertificate nor the system trust store has a match."""
+    mocker.patch(
+        "enclave.tools.check_certificate_chains.is_self_signed", return_value=False
+    )
+    mocker.patch(
+        "enclave.tools.check_certificate_chains.find_system_ca_for_chain",
+        return_value=None,
+    )
+    path = _write_certs(
+        tmp_path,
+        sslAPICertificateFullChain=f"{leaf_pem}\n{intermediate_pem}",
+    )
+    with pytest.raises(CertificateValidationError, match="sslAPICertificateFullChain"):
+        check_certificate_chains(path)
+
+
+def test_main_writes_success_message_to_stdout(
+    mocker: MockerFixture,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Write 'Certificate chain check passed.' to stdout on success."""
+    mocker.patch("enclave.tools.check_certificate_chains.check_certificate_chains")
+    main(str(tmp_path / "certs.yaml"))
+    assert capsys.readouterr().out == "Certificate chain check passed.\n"
+
+
+def test_main_propagates_validation_error(
+    mocker: MockerFixture,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Propagate CertificateValidationError without writing to stdout."""
+    mocker.patch(
+        "enclave.tools.check_certificate_chains.check_certificate_chains",
+        side_effect=CertificateValidationError("chain incomplete"),
+    )
+    with pytest.raises(CertificateValidationError, match="chain incomplete"):
+        main(str(tmp_path / "certs.yaml"))
+    assert capsys.readouterr().out == ""

--- a/src/tests/test_quay_registry_ca.py
+++ b/src/tests/test_quay_registry_ca.py
@@ -1,38 +1,24 @@
-from pathlib import Path
+"""Tests for quay_registry_ca: TLS chain resolution and CA trust anchor selection."""
+
 from subprocess import CompletedProcess, TimeoutExpired
 
 import pytest
 from pytest_mock import MockerFixture
 
+from enclave.tools.cert_utils import pem_blocks
 from enclave.tools.quay_registry_ca import (
-    _chain_trust_anchor_pem,
-    _find_root_ca_in_system_store,
-    _get_cert_issuer,
-    _get_cert_subject,
-    _openssl_verify,
+    chain_trust_anchor_pem,
     fetch_tls_chain_pem,
     get_router_ca_pem,
-    pem_blocks,
+    main,
     resolve_registry_ca_pem,
 )
-
-_LEAF = """-----BEGIN CERTIFICATE-----
-leaf
------END CERTIFICATE-----"""
-_INTERMEDIATE = """-----BEGIN CERTIFICATE-----
-intermediate
------END CERTIFICATE-----"""
-_ROOT = """-----BEGIN CERTIFICATE-----
-root
------END CERTIFICATE-----"""
-_ROUTER_CA = """-----BEGIN CERTIFICATE-----
-router-ca
------END CERTIFICATE-----"""
 
 
 def test_fetch_tls_chain_pem_timeout_raises_runtime_error(
     mocker: MockerFixture,
 ) -> None:
+    """Raise RuntimeError when openssl s_client times out."""
     mocker.patch(
         "enclave.tools.quay_registry_ca.subprocess.run",
         side_effect=TimeoutExpired(cmd=["openssl", "s_client"], timeout=60),
@@ -41,9 +27,22 @@ def test_fetch_tls_chain_pem_timeout_raises_runtime_error(
         fetch_tls_chain_pem("registry.example.com")
 
 
+def test_fetch_tls_chain_pem_missing_openssl_raises_runtime_error(
+    mocker: MockerFixture,
+) -> None:
+    """Raise RuntimeError when openssl binary is not found."""
+    mocker.patch(
+        "enclave.tools.quay_registry_ca.subprocess.run",
+        side_effect=FileNotFoundError(2, "No such file or directory", "openssl"),
+    )
+    with pytest.raises(RuntimeError, match="openssl not found"):
+        fetch_tls_chain_pem("registry.example.com")
+
+
 def test_get_router_ca_pem_invalid_base64_raises_runtime_error(
     mocker: MockerFixture,
 ) -> None:
+    """Raise RuntimeError when the router-ca secret contains invalid base64."""
     mocker.patch(
         "enclave.tools.quay_registry_ca.subprocess.run",
         return_value=CompletedProcess(
@@ -57,6 +56,7 @@ def test_get_router_ca_pem_invalid_base64_raises_runtime_error(
 def test_get_router_ca_pem_missing_oc_raises_runtime_error(
     mocker: MockerFixture,
 ) -> None:
+    """Raise RuntimeError when oc binary is not found."""
     mocker.patch(
         "enclave.tools.quay_registry_ca.subprocess.run",
         side_effect=FileNotFoundError(2, "No such file or directory", "/bin/oc"),
@@ -65,93 +65,144 @@ def test_get_router_ca_pem_missing_oc_raises_runtime_error(
         get_router_ca_pem(oc="/bin/oc")
 
 
-def test_fetch_tls_chain_pem_missing_openssl_raises_runtime_error(
+def test_chain_trust_anchor_pem_leaf_only_raises(leaf_pem: str) -> None:
+    """Raise RuntimeError when only a leaf certificate is present."""
+    with pytest.raises(RuntimeError, match="only a leaf certificate"):
+        chain_trust_anchor_pem([leaf_pem])
+
+
+def test_chain_trust_anchor_pem_with_self_signed_last_cert(
     mocker: MockerFixture,
+    leaf_pem: str,
+    root_pem: str,
 ) -> None:
+    """Return the self-signed root when the chain ends with one."""
+    mocker.patch("enclave.tools.quay_registry_ca.is_self_signed", return_value=True)
+    chain = pem_blocks(f"{leaf_pem}\n{root_pem}\n")
+    assert chain_trust_anchor_pem(chain) == f"{root_pem}\n"
+
+
+def test_chain_trust_anchor_pem_returns_all_non_leaf_certs(
+    mocker: MockerFixture,
+    leaf_pem: str,
+    intermediate_pem: str,
+    root_pem: str,
+) -> None:
+    """Return all certs except the leaf (intermediate + root)."""
+    mocker.patch("enclave.tools.quay_registry_ca.is_self_signed", return_value=True)
+    chain = pem_blocks(f"{leaf_pem}\n{intermediate_pem}\n{root_pem}\n")
+    assert chain_trust_anchor_pem(chain) == f"{intermediate_pem}\n{root_pem}\n"
+
+
+def test_chain_trust_anchor_pem_appends_ca_pem_when_chain_incomplete(
+    mocker: MockerFixture,
+    leaf_pem: str,
+    intermediate_pem: str,
+    root_pem: str,
+) -> None:
+    """Append ca_pem to the anchor when it verifies the last chain cert."""
+    mocker.patch("enclave.tools.quay_registry_ca.is_self_signed", return_value=False)
+    mocker.patch("enclave.tools.quay_registry_ca.openssl_verify", return_value=True)
+    chain = pem_blocks(f"{leaf_pem}\n{intermediate_pem}\n")
+    assert (
+        chain_trust_anchor_pem(chain, ca_pem=root_pem)
+        == f"{intermediate_pem}\n{root_pem}\n"
+    )
+
+
+def test_chain_trust_anchor_pem_returns_incomplete_chain_without_ca_pem(
+    mocker: MockerFixture,
+    leaf_pem: str,
+    intermediate_pem: str,
+) -> None:
+    """Return the non-leaf portion of an incomplete chain when no ca_pem or system CA."""
+    mocker.patch("enclave.tools.quay_registry_ca.is_self_signed", return_value=False)
     mocker.patch(
-        "enclave.tools.quay_registry_ca.subprocess.run",
-        side_effect=FileNotFoundError(2, "No such file or directory", "openssl"),
+        "enclave.tools.quay_registry_ca.find_system_ca_for_chain", return_value=None
     )
-    with pytest.raises(RuntimeError, match="openssl not found"):
-        fetch_tls_chain_pem("registry.example.com")
+    chain = pem_blocks(f"{leaf_pem}\n{intermediate_pem}\n")
+    assert chain_trust_anchor_pem(chain) == f"{intermediate_pem}\n"
 
 
-def test_openssl_verify_missing_openssl_raises_runtime_error(
+def test_chain_trust_anchor_pem_completes_chain_from_system_trust_store(
     mocker: MockerFixture,
+    leaf_pem: str,
+    intermediate_pem: str,
+    root_pem: str,
 ) -> None:
+    """Complete the chain with a CA from the system trust store when no ca_pem is given."""
+    mocker.patch("enclave.tools.quay_registry_ca.is_self_signed", return_value=False)
     mocker.patch(
-        "enclave.tools.quay_registry_ca.subprocess.run",
-        side_effect=FileNotFoundError(2, "No such file or directory", "openssl"),
+        "enclave.tools.quay_registry_ca.find_system_ca_for_chain",
+        return_value=root_pem,
     )
-    with pytest.raises(RuntimeError, match="openssl not found"):
-        _openssl_verify(_ROUTER_CA, _LEAF)
+    chain = pem_blocks(f"{leaf_pem}\n{intermediate_pem}\n")
+    assert chain_trust_anchor_pem(chain) == f"{intermediate_pem}\n{root_pem}\n"
 
 
-def test_openssl_verify_isolates_from_system_trust_store(
+def test_chain_trust_anchor_pem_raises_when_ca_pem_does_not_verify(
     mocker: MockerFixture,
+    leaf_pem: str,
+    intermediate_pem: str,
+    root_pem: str,
 ) -> None:
-    mock_run = mocker.patch(
-        "enclave.tools.quay_registry_ca.subprocess.run",
-        return_value=CompletedProcess(
-            args=["openssl"], returncode=0, stdout="", stderr=""
-        ),
-    )
-    _openssl_verify(_ROUTER_CA, _LEAF)
-    cmd = mock_run.call_args[0][0]
-    assert "-no-CAfile" in cmd
-    assert "-no-CApath" in cmd
-
-
-def test_pem_blocks_splits_multiple_certificates() -> None:
-    chain = f"{_LEAF}\n{_ROOT}\n"
-    assert pem_blocks(chain) == [_LEAF, _ROOT]
+    """Raise RuntimeError when ca_pem does not verify the last chain cert."""
+    mocker.patch("enclave.tools.quay_registry_ca.is_self_signed", return_value=False)
+    mocker.patch("enclave.tools.quay_registry_ca.openssl_verify", return_value=False)
+    chain = pem_blocks(f"{leaf_pem}\n{intermediate_pem}\n")
+    with pytest.raises(RuntimeError, match="does not verify the last certificate"):
+        chain_trust_anchor_pem(chain, ca_pem=root_pem)
 
 
 def test_resolve_registry_ca_pem_uses_router_ca_when_it_verifies(
     mocker: MockerFixture,
+    router_ca_pem: str,
+    leaf_pem: str,
+    root_pem: str,
 ) -> None:
+    """Use the router CA when it verifies the chain."""
     mocker.patch(
-        "enclave.tools.quay_registry_ca.get_router_ca_pem", return_value=_ROUTER_CA
+        "enclave.tools.quay_registry_ca.get_router_ca_pem", return_value=router_ca_pem
     )
     mocker.patch(
         "enclave.tools.quay_registry_ca.fetch_tls_chain_pem",
-        return_value=f"{_LEAF}\n{_ROOT}\n",
+        return_value=f"{leaf_pem}\n{root_pem}\n",
     )
-    mocker.patch("enclave.tools.quay_registry_ca._openssl_verify", return_value=True)
-    assert resolve_registry_ca_pem("registry.example.com") == f"{_ROUTER_CA.strip()}\n"
-
-
-def test_chain_trust_anchor_pem_returns_all_non_leaf_certs() -> None:
-    chain = pem_blocks(f"{_LEAF}\n{_INTERMEDIATE}\n{_ROOT}\n")
-    assert _chain_trust_anchor_pem(chain) == f"{_INTERMEDIATE}\n{_ROOT}\n"
-
-
-def test_chain_trust_anchor_pem_leaf_only_raises() -> None:
-    with pytest.raises(RuntimeError, match="only a leaf certificate"):
-        _chain_trust_anchor_pem([_LEAF])
+    mocker.patch("enclave.tools.quay_registry_ca.openssl_verify", return_value=True)
+    assert (
+        resolve_registry_ca_pem("registry.example.com") == f"{router_ca_pem.strip()}\n"
+    )
 
 
 def test_resolve_registry_ca_pem_falls_back_to_chain_ca_bundle(
     mocker: MockerFixture,
+    router_ca_pem: str,
+    leaf_pem: str,
+    intermediate_pem: str,
+    root_pem: str,
 ) -> None:
+    """Fall back to chain CA bundle when router CA does not verify."""
     mocker.patch(
-        "enclave.tools.quay_registry_ca.get_router_ca_pem", return_value=_ROUTER_CA
+        "enclave.tools.quay_registry_ca.get_router_ca_pem", return_value=router_ca_pem
     )
     mocker.patch(
         "enclave.tools.quay_registry_ca.fetch_tls_chain_pem",
-        return_value=f"{_LEAF}\n{_INTERMEDIATE}\n{_ROOT}\n",
+        return_value=f"{leaf_pem}\n{intermediate_pem}\n{root_pem}\n",
     )
-    mocker.patch("enclave.tools.quay_registry_ca._openssl_verify", return_value=False)
+    mocker.patch("enclave.tools.quay_registry_ca.openssl_verify", return_value=False)
+    mocker.patch("enclave.tools.quay_registry_ca.is_self_signed", return_value=True)
     assert resolve_registry_ca_pem("registry.example.com") == (
-        f"{_INTERMEDIATE}\n{_ROOT}\n"
+        f"{intermediate_pem}\n{root_pem}\n"
     )
 
 
 def test_resolve_registry_ca_pem_empty_chain_raises(
     mocker: MockerFixture,
+    router_ca_pem: str,
 ) -> None:
+    """Raise RuntimeError when the fetched chain is empty."""
     mocker.patch(
-        "enclave.tools.quay_registry_ca.get_router_ca_pem", return_value=_ROUTER_CA
+        "enclave.tools.quay_registry_ca.get_router_ca_pem", return_value=router_ca_pem
     )
     mocker.patch("enclave.tools.quay_registry_ca.fetch_tls_chain_pem", return_value="")
     with pytest.raises(RuntimeError, match="unable to fetch TLS certificate chain"):
@@ -160,143 +211,56 @@ def test_resolve_registry_ca_pem_empty_chain_raises(
 
 def test_resolve_registry_ca_pem_leaf_only_chain_raises(
     mocker: MockerFixture,
+    router_ca_pem: str,
+    leaf_pem: str,
 ) -> None:
+    """Raise RuntimeError when the chain has only a leaf certificate."""
     mocker.patch(
-        "enclave.tools.quay_registry_ca.get_router_ca_pem", return_value=_ROUTER_CA
+        "enclave.tools.quay_registry_ca.get_router_ca_pem", return_value=router_ca_pem
     )
     mocker.patch(
         "enclave.tools.quay_registry_ca.fetch_tls_chain_pem",
-        return_value=f"{_LEAF}\n",
+        return_value=f"{leaf_pem}\n",
     )
-    mocker.patch("enclave.tools.quay_registry_ca._openssl_verify", return_value=False)
+    mocker.patch("enclave.tools.quay_registry_ca.openssl_verify", return_value=False)
     with pytest.raises(RuntimeError, match="only a leaf certificate"):
         resolve_registry_ca_pem("registry.example.com")
 
 
-def test_get_cert_subject_extracts_subject_dn(mocker: MockerFixture) -> None:
-    mocker.patch(
-        "enclave.tools.quay_registry_ca.subprocess.run",
-        return_value=CompletedProcess(
-            args=["openssl"],
-            returncode=0,
-            stdout="subject=CN=Test CA,O=Test Org,C=US\n",
-            stderr="",
-        ),
-    )
-    assert _get_cert_subject(_ROOT) == "CN=Test CA,O=Test Org,C=US"
-
-
-def test_get_cert_issuer_extracts_issuer_dn(mocker: MockerFixture) -> None:
-    mocker.patch(
-        "enclave.tools.quay_registry_ca.subprocess.run",
-        return_value=CompletedProcess(
-            args=["openssl"],
-            returncode=0,
-            stdout="issuer=CN=Root CA,O=Test Org,C=US\n",
-            stderr="",
-        ),
-    )
-    assert _get_cert_issuer(_INTERMEDIATE) == "CN=Root CA,O=Test Org,C=US"
-
-
-def test_find_root_ca_in_system_store_finds_matching_cert(
-    mocker: MockerFixture, tmp_path: Path
-) -> None:
-    # Create a mock CA bundle file
-    ca_bundle = tmp_path / "ca-bundle.crt"
-    ca_bundle.write_text(f"{_ROOT}\n{_INTERMEDIATE}\n", encoding="utf-8")
-
-    # Mock Path.exists and read_text
-    mocker.patch("enclave.tools.quay_registry_ca.Path.exists", return_value=True)
-    mocker.patch(
-        "enclave.tools.quay_registry_ca.Path.read_text",
-        return_value=ca_bundle.read_text(),
-    )
-
-    # Mock _get_cert_subject to return matching DN
-    mocker.patch(
-        "enclave.tools.quay_registry_ca._get_cert_subject",
-        side_effect=["CN=Root CA,O=Test,C=US", "CN=Other,O=Test,C=US"],
-    )
-
-    result = _find_root_ca_in_system_store("CN=Root CA,O=Test,C=US")
-    assert result == _ROOT
-
-
-def test_find_root_ca_in_system_store_returns_none_when_not_found(
+def test_resolve_registry_ca_pem_completes_chain_with_ca_pem(
     mocker: MockerFixture,
+    router_ca_pem: str,
+    leaf_pem: str,
+    intermediate_pem: str,
+    root_pem: str,
 ) -> None:
-    mocker.patch("enclave.tools.quay_registry_ca.Path.exists", return_value=True)
+    """Append ca_pem to the anchor when it completes the chain."""
     mocker.patch(
-        "enclave.tools.quay_registry_ca.Path.read_text", return_value=f"{_ROOT}\n"
+        "enclave.tools.quay_registry_ca.get_router_ca_pem", return_value=router_ca_pem
     )
     mocker.patch(
-        "enclave.tools.quay_registry_ca._get_cert_subject",
-        return_value="CN=Different,O=Test,C=US",
+        "enclave.tools.quay_registry_ca.fetch_tls_chain_pem",
+        return_value=f"{leaf_pem}\n{intermediate_pem}\n",
     )
-
-    result = _find_root_ca_in_system_store("CN=Not Found,O=Test,C=US")
-    assert result is None
-
-
-def test_chain_trust_anchor_pem_with_self_signed_root(mocker: MockerFixture) -> None:
-    # Mock issuer and subject to be the same (self-signed)
+    # First call: router-ca does not verify the leaf → fall back to chain.
+    # Second call: provided ca_pem verifies the last chain cert → append it.
     mocker.patch(
-        "enclave.tools.quay_registry_ca._get_cert_issuer",
-        return_value="CN=Root CA,O=Test,C=US",
+        "enclave.tools.quay_registry_ca.openssl_verify", side_effect=[False, True]
     )
-    mocker.patch(
-        "enclave.tools.quay_registry_ca._get_cert_subject",
-        return_value="CN=Root CA,O=Test,C=US",
-    )
-
-    chain = pem_blocks(f"{_LEAF}\n{_ROOT}\n")
-    result = _chain_trust_anchor_pem(chain)
-    assert result == f"{_ROOT}\n"
+    mocker.patch("enclave.tools.quay_registry_ca.is_self_signed", return_value=False)
+    result = resolve_registry_ca_pem("registry.example.com", ca_pem=root_pem)
+    assert result == f"{intermediate_pem}\n{root_pem}\n"
 
 
-def test_chain_trust_anchor_pem_completes_chain_from_system_store(
+def test_main_writes_resolved_ca_to_stdout(
     mocker: MockerFixture,
+    router_ca_pem: str,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
-    # Intermediate is not self-signed
+    """Write the CA PEM returned by resolve_registry_ca_pem to stdout."""
     mocker.patch(
-        "enclave.tools.quay_registry_ca._get_cert_issuer",
-        return_value="CN=Root CA,O=Test,C=US",
+        "enclave.tools.quay_registry_ca.resolve_registry_ca_pem",
+        return_value=f"{router_ca_pem}\n",
     )
-    mocker.patch(
-        "enclave.tools.quay_registry_ca._get_cert_subject",
-        return_value="CN=Intermediate CA,O=Test,C=US",
-    )
-    # Mock finding the root CA
-    mocker.patch(
-        "enclave.tools.quay_registry_ca._find_root_ca_in_system_store",
-        return_value=_ROOT,
-    )
-
-    chain = pem_blocks(f"{_LEAF}\n{_INTERMEDIATE}\n")
-    result = _chain_trust_anchor_pem(chain)
-    assert result == f"{_INTERMEDIATE}\n{_ROOT}\n"
-
-
-def test_chain_trust_anchor_pem_incomplete_chain_without_root_in_system(
-    mocker: MockerFixture,
-) -> None:
-    # Intermediate is not self-signed
-    mocker.patch(
-        "enclave.tools.quay_registry_ca._get_cert_issuer",
-        return_value="CN=Root CA,O=Test,C=US",
-    )
-    mocker.patch(
-        "enclave.tools.quay_registry_ca._get_cert_subject",
-        return_value="CN=Intermediate CA,O=Test,C=US",
-    )
-    # Root CA not found in system store
-    mocker.patch(
-        "enclave.tools.quay_registry_ca._find_root_ca_in_system_store",
-        return_value=None,
-    )
-
-    chain = pem_blocks(f"{_LEAF}\n{_INTERMEDIATE}\n")
-    result = _chain_trust_anchor_pem(chain)
-    # Should return intermediate only, with a warning logged
-    assert result == f"{_INTERMEDIATE}\n"
+    main("registry.example.com")
+    assert capsys.readouterr().out == f"{router_ca_pem}\n"

--- a/src/tests/test_system_ca.py
+++ b/src/tests/test_system_ca.py
@@ -1,0 +1,122 @@
+"""Tests for system_ca: RHEL 10 trust store CA discovery."""
+
+from pathlib import Path
+
+import pytest
+from pytest_mock import MockerFixture
+
+from enclave.tools.system_ca import find_system_ca_for_chain
+from tests.cert_helpers import generate_ca
+
+
+def test_find_raises_when_chain_empty() -> None:
+    """Raise ValueError when the chain has no PEM blocks."""
+    with pytest.raises(ValueError, match="no PEM blocks in chain"):
+        find_system_ca_for_chain("")
+
+
+def test_find_raises_when_chain_has_no_pem_blocks() -> None:
+    """Raise ValueError when the chain string contains no PEM certificate blocks."""
+    with pytest.raises(ValueError, match="no PEM blocks in chain"):
+        find_system_ca_for_chain("not a certificate")
+
+
+def test_find_returns_none_when_chain_self_signed(
+    mocker: MockerFixture, root_pem: str
+) -> None:
+    """Return None when the last certificate in the chain is self-signed."""
+    mocker.patch("enclave.tools.system_ca.is_self_signed", return_value=True)
+    assert find_system_ca_for_chain(root_pem) is None
+
+
+def test_find_raises_when_trust_store_missing(
+    mocker: MockerFixture, intermediate_pem: str
+) -> None:
+    """Raise RuntimeError when the RHEL trust store file is not available."""
+    mocker.patch("enclave.tools.system_ca.is_self_signed", return_value=False)
+    mocker.patch(
+        "enclave.tools.system_ca.RHEL_TRUST_STORE",
+        new=Path("/nonexistent/ca-bundle.crt"),
+    )
+    with pytest.raises(RuntimeError, match="system trust store unavailable"):
+        find_system_ca_for_chain(intermediate_pem)
+
+
+def test_find_returns_none_when_no_ca_matches(
+    mocker: MockerFixture, tmp_path: Path, intermediate_pem: str, root_pem: str
+) -> None:
+    """Return None when no CA in the trust store verifies the chain's last cert."""
+    mocker.patch("enclave.tools.system_ca.is_self_signed", return_value=False)
+    mocker.patch("enclave.tools.system_ca.openssl_verify", return_value=False)
+    bundle = tmp_path / "ca-bundle.crt"
+    bundle.write_text(root_pem, encoding="utf-8")
+    mocker.patch("enclave.tools.system_ca.RHEL_TRUST_STORE", new=bundle)
+    assert find_system_ca_for_chain(intermediate_pem) is None
+
+
+def test_find_returns_first_matching_ca(
+    mocker: MockerFixture, tmp_path: Path, intermediate_pem: str
+) -> None:
+    """Return the first CA that verifies the chain's last certificate."""
+    mocker.patch("enclave.tools.system_ca.is_self_signed", return_value=False)
+    verify = mocker.patch(
+        "enclave.tools.system_ca.openssl_verify", side_effect=[False, True]
+    )
+    ca_a = "-----BEGIN CERTIFICATE-----\nca-a\n-----END CERTIFICATE-----"
+    ca_b = "-----BEGIN CERTIFICATE-----\nca-b\n-----END CERTIFICATE-----"
+    bundle = tmp_path / "ca-bundle.crt"
+    bundle.write_text(f"{ca_a}\n{ca_b}\n", encoding="utf-8")
+    mocker.patch("enclave.tools.system_ca.RHEL_TRUST_STORE", new=bundle)
+    result = find_system_ca_for_chain(intermediate_pem)
+    assert result == ca_b
+    assert verify.call_count == 2
+
+
+def test_find_integration_matches_ca_in_bundle(
+    mocker: MockerFixture, tmp_path: Path, module_ca_pem: str, module_leaf_pem: str
+) -> None:
+    """Integration: discover the real CA from a synthetic trust store bundle."""
+    bundle = tmp_path / "ca-bundle.crt"
+    bundle.write_text(module_ca_pem, encoding="utf-8")
+    mocker.patch("enclave.tools.system_ca.RHEL_TRUST_STORE", new=bundle)
+    result = find_system_ca_for_chain(module_leaf_pem)
+    assert result is not None
+    assert "BEGIN CERTIFICATE" in result
+
+
+def test_find_integration_returns_none_when_ca_not_in_bundle(
+    mocker: MockerFixture, tmp_path: Path, module_leaf_pem: str
+) -> None:
+    """Integration: return None when no CA in the bundle signs the chain."""
+    # Generate a second, unrelated CA and put only that in the bundle.
+    # module_leaf_pem was signed by module_ca, which is absent from the bundle.
+    ca_b_pem, _, _ = generate_ca(tmp_path, "CA B")
+    bundle = tmp_path / "ca-bundle.crt"
+    bundle.write_text(ca_b_pem, encoding="utf-8")
+    mocker.patch("enclave.tools.system_ca.RHEL_TRUST_STORE", new=bundle)
+    assert find_system_ca_for_chain(module_leaf_pem) is None
+
+
+def test_find_integration_returns_none_when_chain_is_self_signed(
+    mocker: MockerFixture, tmp_path: Path, module_ca_pem: str
+) -> None:
+    """Integration: return None when the chain ends with a self-signed root."""
+    bundle = tmp_path / "ca-bundle.crt"
+    bundle.write_text(module_ca_pem, encoding="utf-8")
+    mocker.patch("enclave.tools.system_ca.RHEL_TRUST_STORE", new=bundle)
+    assert find_system_ca_for_chain(module_ca_pem) is None
+
+
+@pytest.mark.parametrize("exc", [OSError("no permission"), PermissionError("denied")])
+def test_find_raises_on_trust_store_read_error(
+    mocker: MockerFixture, exc: Exception, intermediate_pem: str
+) -> None:
+    """Raise RuntimeError when reading the trust store raises an OSError."""
+    mocker.patch("enclave.tools.system_ca.is_self_signed", return_value=False)
+    mocker.patch(
+        "enclave.tools.system_ca.RHEL_TRUST_STORE",
+        new=Path("/fake/ca-bundle.crt"),
+    )
+    mocker.patch.object(Path, "read_text", side_effect=exc)
+    with pytest.raises(RuntimeError, match="system trust store unavailable"):
+        find_system_ca_for_chain(intermediate_pem)

--- a/src/tests/test_tools_cli.py
+++ b/src/tests/test_tools_cli.py
@@ -1,26 +1,32 @@
+"""Tests for the enclave tools CLI: resolve-quay-registry-ca, check-certificate-chains, collect-node-image-digests."""
+
 from pathlib import Path
 
 from click.testing import CliRunner
 from pytest_mock import MockerFixture
 
+from enclave.tools.check_certificate_chains import CertificateValidationError
 from enclave.tools.cli import cli
 
 _KC = {"KUBECONFIG": "/fake/kubeconfig"}
 
 
 def test_tools_cli_help() -> None:
+    """Show help and exit 0."""
     result = CliRunner().invoke(cli, ["--help"])
     assert result.exit_code == 0
     assert "Enclave tools CLI" in result.output
 
 
 def test_resolve_quay_registry_ca_help() -> None:
+    """Show --hostname option in help."""
     result = CliRunner().invoke(cli, ["resolve-quay-registry-ca", "--help"], env=_KC)
     assert result.exit_code == 0
     assert "--hostname" in result.output
 
 
 def test_resolve_quay_registry_ca_forwards_args(mocker: MockerFixture) -> None:
+    """Forward hostname and oc to quay_registry_ca_main."""
     mock_reconcile = mocker.patch("enclave.tools.cli.quay_registry_ca_main")
     result = CliRunner().invoke(
         cli,
@@ -34,10 +40,211 @@ def test_resolve_quay_registry_ca_forwards_args(mocker: MockerFixture) -> None:
         env=_KC,
     )
     assert result.exit_code == 0
-    mock_reconcile.assert_called_once_with("registry.example.com", oc="/usr/bin/oc")
+    mock_reconcile.assert_called_once_with(
+        "registry.example.com", oc="/usr/bin/oc", ca_pem=""
+    )
+
+
+def test_resolve_quay_registry_ca_forwards_ca_pem(
+    mocker: MockerFixture, root_pem: str
+) -> None:
+    """Forward --ca-pem to quay_registry_ca_main."""
+    mock_main = mocker.patch("enclave.tools.cli.quay_registry_ca_main")
+    result = CliRunner().invoke(
+        cli,
+        [
+            "resolve-quay-registry-ca",
+            "--hostname",
+            "registry.example.com",
+            "--ca-pem",
+            root_pem + "\n",
+        ],
+        env=_KC,
+    )
+    assert result.exit_code == 0
+    mock_main.assert_called_once_with(
+        "registry.example.com",
+        oc="oc",
+        ca_pem=root_pem + "\n",
+    )
+
+
+def test_resolve_quay_registry_ca_rejects_empty_ca_pem() -> None:
+    """Reject a blank --ca-pem value."""
+    result = CliRunner().invoke(
+        cli,
+        [
+            "resolve-quay-registry-ca",
+            "--hostname",
+            "registry.example.com",
+            "--ca-pem",
+            "   ",
+        ],
+        env=_KC,
+    )
+    assert result.exit_code != 0
+    assert "must not be empty" in result.output
+
+
+def test_resolve_quay_registry_ca_forwards_certificates_config(
+    mocker: MockerFixture, tmp_path: Path, root_pem: str
+) -> None:
+    """Read sslCACertificate from --certificates-config and forward it."""
+    mock_main = mocker.patch("enclave.tools.cli.quay_registry_ca_main")
+    config_file = tmp_path / "certificates.yaml"
+    # Build a valid YAML block scalar: each PEM line must be indented.
+    indented = "\n".join("  " + line for line in root_pem.split("\n"))
+    config_file.write_text(f"sslCACertificate: |\n{indented}\n", encoding="utf-8")
+    result = CliRunner().invoke(
+        cli,
+        [
+            "resolve-quay-registry-ca",
+            "--hostname",
+            "registry.example.com",
+            "--certificates-config",
+            str(config_file),
+        ],
+        env=_KC,
+    )
+    assert result.exit_code == 0
+    mock_main.assert_called_once_with(
+        "registry.example.com",
+        oc="oc",
+        ca_pem=root_pem,
+    )
+
+
+def test_resolve_quay_registry_ca_forwards_empty_ca_pem_when_ssl_ca_certificate_absent(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    """Call through with ca_pem='' when sslCACertificate is absent from config."""
+    mock_main = mocker.patch("enclave.tools.cli.quay_registry_ca_main")
+    config_file = tmp_path / "certificates.yaml"
+    config_file.write_text(
+        "sslAPICertificateFullChain: |\n  something\n", encoding="utf-8"
+    )
+    result = CliRunner().invoke(
+        cli,
+        [
+            "resolve-quay-registry-ca",
+            "--hostname",
+            "registry.example.com",
+            "--certificates-config",
+            str(config_file),
+        ],
+        env=_KC,
+    )
+    assert result.exit_code == 0
+    mock_main.assert_called_once_with("registry.example.com", oc="oc", ca_pem="")
+
+
+def test_resolve_quay_registry_ca_rejects_non_mapping_certificates_config(
+    tmp_path: Path,
+) -> None:
+    """Reject a --certificates-config that is not a YAML mapping."""
+    config_file = tmp_path / "certificates.yaml"
+    config_file.write_text("- item1\n- item2\n", encoding="utf-8")
+    result = CliRunner().invoke(
+        cli,
+        [
+            "resolve-quay-registry-ca",
+            "--hostname",
+            "registry.example.com",
+            "--certificates-config",
+            str(config_file),
+        ],
+        env=_KC,
+    )
+    assert result.exit_code != 0
+    assert "YAML mapping" in result.output
+
+
+def test_resolve_quay_registry_ca_treats_non_string_ssl_ca_certificate_as_empty(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    """Treat a non-string sslCACertificate (e.g. list) as absent and call through with ca_pem=''."""
+    mock_main = mocker.patch("enclave.tools.cli.quay_registry_ca_main")
+    config_file = tmp_path / "certificates.yaml"
+    config_file.write_text(
+        "sslCACertificate:\n  - item1\n  - item2\n", encoding="utf-8"
+    )
+    result = CliRunner().invoke(
+        cli,
+        [
+            "resolve-quay-registry-ca",
+            "--hostname",
+            "registry.example.com",
+            "--certificates-config",
+            str(config_file),
+        ],
+        env=_KC,
+    )
+    assert result.exit_code == 0
+    mock_main.assert_called_once_with("registry.example.com", oc="oc", ca_pem="")
+
+
+def test_resolve_quay_registry_ca_reports_yaml_parse_error(
+    tmp_path: Path,
+) -> None:
+    """Report 'cannot parse' (not 'cannot read') for invalid YAML syntax."""
+    config_file = tmp_path / "certificates.yaml"
+    config_file.write_text("key: [\nbad yaml", encoding="utf-8")
+    result = CliRunner().invoke(
+        cli,
+        [
+            "resolve-quay-registry-ca",
+            "--hostname",
+            "registry.example.com",
+            "--certificates-config",
+            str(config_file),
+        ],
+        env=_KC,
+    )
+    assert result.exit_code != 0
+    assert "cannot parse" in result.output
+
+
+def test_resolve_quay_registry_ca_rejects_missing_certificates_config() -> None:
+    """Reject a non-existent --certificates-config path."""
+    result = CliRunner().invoke(
+        cli,
+        [
+            "resolve-quay-registry-ca",
+            "--hostname",
+            "registry.example.com",
+            "--certificates-config",
+            "/nonexistent/certificates.yaml",
+        ],
+        env=_KC,
+    )
+    assert result.exit_code != 0
+
+
+def test_resolve_quay_registry_ca_rejects_both_ca_pem_and_certificates_config(
+    tmp_path: Path, root_pem: str
+) -> None:
+    """Reject when both --ca-pem and --certificates-config are supplied."""
+    config_file = tmp_path / "certificates.yaml"
+    config_file.write_text(f"sslCACertificate: |\n  {root_pem}\n", encoding="utf-8")
+    result = CliRunner().invoke(
+        cli,
+        [
+            "resolve-quay-registry-ca",
+            "--hostname",
+            "registry.example.com",
+            "--ca-pem",
+            f"{root_pem}\n",
+            "--certificates-config",
+            str(config_file),
+        ],
+        env=_KC,
+    )
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output
 
 
 def test_resolve_quay_registry_ca_runtime_error(mocker: MockerFixture) -> None:
+    """Surface a RuntimeError from quay_registry_ca_main as a non-zero exit."""
     mocker.patch(
         "enclave.tools.cli.quay_registry_ca_main",
         side_effect=RuntimeError(
@@ -53,7 +260,59 @@ def test_resolve_quay_registry_ca_runtime_error(mocker: MockerFixture) -> None:
     assert "unable to resolve registry CA for registry.example.com" in result.output
 
 
+def test_check_certificate_chains_help() -> None:
+    """Show --config option in help."""
+    result = CliRunner().invoke(cli, ["check-certificate-chains", "--help"])
+    assert result.exit_code == 0
+    assert "--config" in result.output
+
+
+def test_check_certificate_chains_forwards_config(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    """Forward --config path to check_certificate_chains_main."""
+    mock_main = mocker.patch("enclave.tools.cli.check_certificate_chains_main")
+    config_file = tmp_path / "certificates.yaml"
+    config_file.write_text("", encoding="utf-8")
+    result = CliRunner().invoke(
+        cli,
+        ["check-certificate-chains", "--config", str(config_file)],
+    )
+    assert result.exit_code == 0
+    mock_main.assert_called_once_with(str(config_file))
+
+
+def test_check_certificate_chains_reports_runtime_error(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    """Surface a CertificateValidationError as a non-zero exit with field name."""
+    mocker.patch(
+        "enclave.tools.cli.check_certificate_chains_main",
+        side_effect=CertificateValidationError(
+            "sslAPICertificateFullChain: chain ends with a non-self-signed certificate"
+        ),
+    )
+    config_file = tmp_path / "certificates.yaml"
+    config_file.write_text("", encoding="utf-8")
+    result = CliRunner().invoke(
+        cli,
+        ["check-certificate-chains", "--config", str(config_file)],
+    )
+    assert result.exit_code != 0
+    assert "sslAPICertificateFullChain" in result.output
+
+
+def test_check_certificate_chains_rejects_missing_file() -> None:
+    """Reject a non-existent --config path."""
+    result = CliRunner().invoke(
+        cli,
+        ["check-certificate-chains", "--config", "/nonexistent/certificates.yaml"],
+    )
+    assert result.exit_code != 0
+
+
 def test_collect_node_image_digests_help() -> None:
+    """Show expected options in help."""
     result = CliRunner().invoke(cli, ["collect-node-image-digests", "--help"], env=_KC)
     assert result.exit_code == 0
     assert "--node" in result.output
@@ -64,6 +323,7 @@ def test_collect_node_image_digests_help() -> None:
 def test_collect_node_image_digests_forwards_args(
     mocker: MockerFixture, tmp_path: Path
 ) -> None:
+    """Forward node, oc, and raw-output-file to collect_node_image_digests_main."""
     mock_main = mocker.patch("enclave.tools.cli.collect_node_image_digests_main")
     raw_output_file = tmp_path / "node-0.log"
     result = CliRunner().invoke(
@@ -97,3 +357,264 @@ def test_kubeconfig_missing_fails(mocker: MockerFixture) -> None:
     )
     assert result.exit_code != 0
     assert "KUBECONFIG" in result.output
+
+
+def test_get_root_ca_help() -> None:
+    """Show --config and --chain-pem options in help."""
+    result = CliRunner().invoke(cli, ["get-root-ca", "--help"])
+    assert result.exit_code == 0
+    assert "--config" in result.output
+    assert "--chain-pem" in result.output
+
+
+def test_get_root_ca_from_chain_pem_option(
+    mocker: MockerFixture, ca_pem: str, leaf_pem: str
+) -> None:
+    """Print the CA PEM returned by find_system_ca_for_chain when --chain-pem is given."""
+    mocker.patch(
+        "enclave.tools.cli.find_system_ca_for_chain", return_value=ca_pem + "\n"
+    )
+    result = CliRunner().invoke(
+        cli,
+        [
+            "get-root-ca",
+            "--chain-pem",
+            leaf_pem + "\n",
+        ],
+    )
+    assert result.exit_code == 0
+    assert ca_pem + "\n" in result.output
+
+
+def test_get_root_ca_from_config_prints_ca(
+    mocker: MockerFixture, tmp_path: Path, ca_pem: str, chain_pem: str
+) -> None:
+    """Read the fullchain from --config and print the discovered CA PEM."""
+    mocker.patch(
+        "enclave.tools.cli.find_system_ca_for_chain", return_value=ca_pem + "\n"
+    )
+    config_file = tmp_path / "certificates.yaml"
+    indented = "\n".join("  " + line for line in (chain_pem + "\n").splitlines())
+    config_file.write_text(
+        f"sslAPICertificateFullChain: |\n{indented}\n", encoding="utf-8"
+    )
+    result = CliRunner().invoke(
+        cli,
+        ["get-root-ca", "--config", str(config_file)],
+    )
+    assert result.exit_code == 0
+    assert ca_pem + "\n" in result.output
+
+
+def test_get_root_ca_from_config_falls_back_to_ingress_chain(
+    mocker: MockerFixture, tmp_path: Path, ca_pem: str
+) -> None:
+    """Fall back to sslIngressCertificateFullChain when API chain is absent."""
+    mock_fn = mocker.patch(
+        "enclave.tools.cli.find_system_ca_for_chain", return_value=ca_pem + "\n"
+    )
+    chain = "-----BEGIN CERTIFICATE-----\ningress-chain\n-----END CERTIFICATE-----\n"
+    config_file = tmp_path / "certificates.yaml"
+    indented = "\n".join("  " + line for line in chain.splitlines())
+    config_file.write_text(
+        f"sslIngressCertificateFullChain: |\n{indented}\n", encoding="utf-8"
+    )
+    result = CliRunner().invoke(
+        cli,
+        ["get-root-ca", "--config", str(config_file)],
+    )
+    assert result.exit_code == 0
+    called_chain = mock_fn.call_args[0][0]
+    assert "ingress-chain" in called_chain
+
+
+def test_get_root_ca_not_found(mocker: MockerFixture, leaf_pem: str) -> None:
+    """Exit non-zero when find_system_ca_for_chain returns None."""
+    mocker.patch("enclave.tools.cli.find_system_ca_for_chain", return_value=None)
+    result = CliRunner().invoke(
+        cli,
+        [
+            "get-root-ca",
+            "--chain-pem",
+            leaf_pem + "\n",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "no matching CA" in result.output
+
+
+def test_get_root_ca_rejects_both_options(tmp_path: Path, leaf_pem: str) -> None:
+    """Exit non-zero when both --config and --chain-pem are supplied."""
+    config_file = tmp_path / "certificates.yaml"
+    config_file.write_text("sslAPICertificateFullChain: ''\n", encoding="utf-8")
+    result = CliRunner().invoke(
+        cli,
+        [
+            "get-root-ca",
+            "--config",
+            str(config_file),
+            "--chain-pem",
+            leaf_pem + "\n",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output
+
+
+def test_get_root_ca_rejects_neither_option() -> None:
+    """Exit non-zero when neither --config nor --chain-pem is supplied."""
+    result = CliRunner().invoke(cli, ["get-root-ca"])
+    assert result.exit_code != 0
+
+
+def test_get_root_ca_rejects_config_with_no_chains(tmp_path: Path) -> None:
+    """Exit non-zero when the config has no fullchain fields set."""
+    config_file = tmp_path / "certificates.yaml"
+    config_file.write_text("sslCACertificate: |\n  root\n", encoding="utf-8")
+    result = CliRunner().invoke(
+        cli,
+        ["get-root-ca", "--config", str(config_file)],
+    )
+    assert result.exit_code != 0
+    assert "sslAPICertificateFullChain" in result.output
+
+
+def test_get_root_ca_rejects_non_mapping_config(tmp_path: Path) -> None:
+    """Exit non-zero when --config is not a YAML mapping."""
+    config_file = tmp_path / "certificates.yaml"
+    config_file.write_text("- item1\n- item2\n", encoding="utf-8")
+    result = CliRunner().invoke(
+        cli,
+        ["get-root-ca", "--config", str(config_file)],
+    )
+    assert result.exit_code != 0
+    assert "YAML mapping" in result.output
+
+
+def test_get_root_ca_rejects_non_string_fullchain(tmp_path: Path) -> None:
+    """Exit non-zero when sslAPICertificateFullChain is a non-string (e.g. list)."""
+    config_file = tmp_path / "certificates.yaml"
+    config_file.write_text(
+        "sslAPICertificateFullChain:\n  - item1\n  - item2\n", encoding="utf-8"
+    )
+    result = CliRunner().invoke(
+        cli,
+        ["get-root-ca", "--config", str(config_file)],
+    )
+    assert result.exit_code != 0
+
+
+def test_get_root_ca_reports_yaml_parse_error(tmp_path: Path) -> None:
+    """Report 'cannot parse' (not 'cannot read') for invalid YAML syntax."""
+    config_file = tmp_path / "certificates.yaml"
+    config_file.write_text("key: [\nbad yaml", encoding="utf-8")
+    result = CliRunner().invoke(
+        cli,
+        ["get-root-ca", "--config", str(config_file)],
+    )
+    assert result.exit_code != 0
+    assert "cannot parse" in result.output
+
+
+def test_check_root_ca_help() -> None:
+    """Show --config option in help."""
+    result = CliRunner().invoke(cli, ["check-root-ca", "--help"])
+    assert result.exit_code == 0
+    assert "--config" in result.output
+
+
+def test_check_root_ca_passes_when_no_chain_configured(tmp_path: Path) -> None:
+    """Exit 0 when no TLS chains are configured."""
+    config_file = tmp_path / "certificates.yaml"
+    config_file.write_text("{}\n", encoding="utf-8")
+    result = CliRunner().invoke(
+        cli,
+        ["check-root-ca", "--config", str(config_file)],
+    )
+    assert result.exit_code == 0
+
+
+def test_check_root_ca_passes_when_ssl_ca_certificate_valid(
+    tmp_path: Path, chain_pem: str, ca_pem: str
+) -> None:
+    """Exit 0 when sslCACertificate is set and contains valid PEM blocks."""
+    config_file = tmp_path / "certificates.yaml"
+    chain_indented = "\n".join("  " + line for line in (chain_pem + "\n").splitlines())
+    ca_indented = "\n".join("  " + line for line in (ca_pem + "\n").splitlines())
+    config_file.write_text(
+        f"sslAPICertificateFullChain: |\n{chain_indented}\n"
+        f"sslCACertificate: |\n{ca_indented}\n",
+        encoding="utf-8",
+    )
+    result = CliRunner().invoke(
+        cli,
+        ["check-root-ca", "--config", str(config_file)],
+    )
+    assert result.exit_code == 0
+
+
+def test_check_root_ca_fails_when_ssl_ca_certificate_not_pem(
+    tmp_path: Path, chain_pem: str
+) -> None:
+    """Exit non-zero when sslCACertificate is set but contains no PEM blocks."""
+    config_file = tmp_path / "certificates.yaml"
+    chain_indented = "\n".join("  " + line for line in (chain_pem + "\n").splitlines())
+    config_file.write_text(
+        f"sslAPICertificateFullChain: |\n{chain_indented}\n"
+        "sslCACertificate: not-a-pem\n",
+        encoding="utf-8",
+    )
+    result = CliRunner().invoke(
+        cli,
+        ["check-root-ca", "--config", str(config_file)],
+    )
+    assert result.exit_code != 0
+    assert "no valid PEM certificate blocks" in result.output
+
+
+def test_check_root_ca_passes_when_trust_store_resolves(
+    mocker: MockerFixture, tmp_path: Path, ca_pem: str, chain_pem: str
+) -> None:
+    """Exit 0 when no sslCACertificate and the trust store resolves the CA."""
+    mocker.patch(
+        "enclave.tools.cli.find_system_ca_for_chain", return_value=ca_pem + "\n"
+    )
+    config_file = tmp_path / "certificates.yaml"
+    chain_indented = "\n".join("  " + line for line in (chain_pem + "\n").splitlines())
+    config_file.write_text(
+        f"sslAPICertificateFullChain: |\n{chain_indented}\n",
+        encoding="utf-8",
+    )
+    result = CliRunner().invoke(
+        cli,
+        ["check-root-ca", "--config", str(config_file)],
+    )
+    assert result.exit_code == 0
+
+
+def test_check_root_ca_fails_when_trust_store_returns_none(
+    mocker: MockerFixture, tmp_path: Path, chain_pem: str
+) -> None:
+    """Exit non-zero when no sslCACertificate and trust store finds nothing."""
+    mocker.patch("enclave.tools.cli.find_system_ca_for_chain", return_value=None)
+    config_file = tmp_path / "certificates.yaml"
+    chain_indented = "\n".join("  " + line for line in (chain_pem + "\n").splitlines())
+    config_file.write_text(
+        f"sslAPICertificateFullChain: |\n{chain_indented}\n",
+        encoding="utf-8",
+    )
+    result = CliRunner().invoke(
+        cli,
+        ["check-root-ca", "--config", str(config_file)],
+    )
+    assert result.exit_code != 0
+    assert "ca-bundle.crt" in result.output
+
+
+def test_check_root_ca_rejects_missing_file() -> None:
+    """Exit non-zero when --config path does not exist."""
+    result = CliRunner().invoke(
+        cli,
+        ["check-root-ca", "--config", "/nonexistent/certificates.yaml"],
+    )
+    assert result.exit_code != 0

--- a/validations.sh
+++ b/validations.sh
@@ -108,6 +108,33 @@ $cert_alt_names"
 
 }
 
+checkCACert(){
+    local check_name=$1
+    local cert_jq=$2
+    local ca_pem now_ts not_before not_after not_before_ts not_after_ts
+
+    ca_pem=$(getValue "$cert_jq")
+
+    if ! echo "$ca_pem" | openssl x509 -noout 2>/dev/null; then
+        validation fail "$check_name" "sslCACertificate is not a valid PEM certificate"
+    fi
+
+    now_ts=$(date +%s)
+    not_before=$(echo "$ca_pem" | openssl x509 -noout -startdate | cut -d= -f2)
+    not_after=$(echo "$ca_pem" | openssl x509 -noout -enddate | cut -d= -f2)
+    not_before_ts=$(date -d "$not_before" +%s)
+    not_after_ts=$(date -d "$not_after" +%s)
+
+    if [[ $now_ts -lt $not_before_ts ]]; then
+        validation fail "$check_name" "CA certificate not valid yet (starts on $not_before)"
+    fi
+    if [[ $now_ts -gt $not_after_ts ]]; then
+        validation fail "$check_name" "CA certificate is expired (expired on $not_after)"
+    fi
+
+    validation pass "$check_name" "CA certificate is valid"
+}
+
 checkIP(){
     local check_subnet_net ip_net prefix
     local check_name="$1"
@@ -309,6 +336,14 @@ validation_section ssl_certificates
 # Check SSL certificate validity
 checkCerts api api.$cluster_fqdn .sslAPICertificateKey .sslAPICertificateFullChain
 checkCerts ingress "*.apps.$cluster_fqdn" .sslIngressCertificateKey .sslIngressCertificateFullChain
+
+# Check CA certificate (optional)
+ca_cert=$(getValue .sslCACertificate)
+if [[ -n "$ca_cert" && "$ca_cert" != "null" ]]; then
+    checkCACert ssl_ca_certificate .sslCACertificate
+else
+    validation pass ssl_ca_certificate_skipped "sslCACertificate not configured. Skipping validation"
+fi
 
 # Check Ironic HTTPS certificate (optional)
 lz_bmc_ip=$(getValue .lzBmcIP)


### PR DESCRIPTION
Certificate chain completeness and CA consistency are now validated
before installation rather than discovered at runtime:

- Add check-certificate-chains (enclave tools check-certificate-chains)
  to report whether each configured fullchain is complete and verifiable
  against sslCACertificate or the RHEL 10 system trust store.
- Add `check-root-ca` CLI command to verify CA availability before deployment;
  exits 0 if no chains are configured, checks sslCACertificate for valid PEM
  blocks, or falls back to the system trust store
- Add new cert checks to bootstrap validation
- Replace system-trust-store scan in resolve-quay-registry-ca
  with an explicit CA supplied via --certificates-config / --ca-pem.
  When sslCACertificate is absent, fall back to find_system_ca_for_chain()
- Add get-root-ca (enclave tools get-root-ca) to look up the signing CA
  for a given fullchain in the RHEL 10 system trust store; load-vars uses
  it to set sslCACertificate as a runtime fact when absent from user config.
- Consolidate cert helpers (pem_blocks, openssl_verify, is_self_signed)
  in cert_utils.py. is_self_signed now does a real self-signature check
  via openssl verify -check_ss_sig instead of DN equality alone, so
  cross-signed roots (issuer==subject, wrong key) are correctly rejected.
- Add checkCACert() to validations.sh for PEM format and expiry checks
  at step_validate time.
- Document when sslCACertificate is required and how chain validation
  works; add certificates.example.yaml.

This is beneficial not only for update service but for the general bootstrap,
as we have found failing installations with LE certs that didn't specify
sslCACertificates showing SSL: CERTIFICATE_VERIFY_FAILED in [Wait for
kube-apiserver ClusterOperator to finish progressing and be healthy] step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  * Added installation-time SSL certificate chain validation and a manual `enclave tools check-certificate-chains --config ...` command.
  * Enhanced Quay registry CA resolution to support optional explicit `--ca-pem` or YAML-based `--certificates-config`.

- **Bug Fixes**
  * Improved handling of self-signed roots, incomplete chains, and mismatched CA/chain consistency checks.

- **Documentation**
  * Updated `config/certificates.yaml` guidance and deployment examples for fullchains and `sslCACertificate`.

- **Chores / Tests**
  * Expanded CLI, certificate, and system trust-store coverage; ensured CI installs OpenSSL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->