### PR TITLE
[WIP] Wait for MCO rollout after plugin mirroring

### DIFF
--- a/playbooks/tasks/mirror_plugin.yaml
+++ b/playbooks/tasks/mirror_plugin.yaml
@@ -141,6 +141,13 @@
     - r_plugin_mirror is defined
     - r_plugin_mirror is success
 
+- name: Wait for MachineConfigPool to finish updating after LZ mirrors
+  ansible.builtin.include_tasks: wait_mcp.yaml
+  when:
+    - plugin.installOperators | default(true)
+    - r_plugin_mirror is defined
+    - r_plugin_mirror is success
+
 - name: Wait for updated CatalogSource to be ready
   kubernetes.core.k8s_info:
     api_version: operators.coreos.com/v1alpha1
@@ -278,6 +285,13 @@
     apply:
       environment:
         KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  when:
+    - plugin.installOperators | default(true)
+    - r_plugin_mirror_quay is defined
+    - r_plugin_mirror_quay is success
+
+- name: Wait for MachineConfigPool to finish updating after Quay Enterprise mirrors
+  ansible.builtin.include_tasks: wait_mcp.yaml
   when:
     - plugin.installOperators | default(true)
     - r_plugin_mirror_quay is defined

--- a/playbooks/tasks/wait_mcp.yaml
+++ b/playbooks/tasks/wait_mcp.yaml
@@ -1,0 +1,65 @@
+---
+- name: Wait for MachineConfigPool to detect pending changes (if any)
+  kubernetes.core.k8s_info:
+    api_version: machineconfiguration.openshift.io/v1
+    kind: MachineConfigPool
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  register: r_mcp_detect
+  retries: 6
+  delay: 30
+  failed_when: false
+  until: >-
+    (
+      r_mcp_detect.resources | default([])
+      | rejectattr('spec.paused', 'equalto', true)
+      | map(attribute='status.conditions')
+      | flatten
+      | selectattr('type', 'equalto', 'Updating')
+      | selectattr('status', 'equalto', 'True')
+      | list
+      | length
+    ) > 0
+
+- name: Wait for MachineConfigPool to finish updating
+  kubernetes.core.k8s_info:
+    api_version: machineconfiguration.openshift.io/v1
+    kind: MachineConfigPool
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  register: r_mcp
+  retries: 60
+  delay: 30
+  until: >-
+    (
+      r_mcp.resources | default([])
+      | rejectattr('spec.paused', 'equalto', true)
+      | map(attribute='status.conditions')
+      | flatten
+      | selectattr('type', 'equalto', 'Updating')
+      | selectattr('status', 'equalto', 'True')
+      | list
+      | length
+    ) == 0
+    and
+    (
+      r_mcp.resources | default([])
+      | rejectattr('spec.paused', 'equalto', true)
+      | map(attribute='status.conditions')
+      | flatten
+      | selectattr('type', 'equalto', 'Updated')
+      | rejectattr('status', 'equalto', 'True')
+      | list
+      | length
+    ) == 0
+    and
+    (
+      r_mcp.resources | default([])
+      | rejectattr('spec.paused', 'equalto', true)
+      | map(attribute='status.conditions')
+      | flatten
+      | selectattr('type', 'equalto', 'Degraded')
+      | selectattr('status', 'equalto', 'True')
+      | list
+      | length
+    ) == 0

--- a/playbooks/tasks/wait_mcp.yaml
+++ b/playbooks/tasks/wait_mcp.yaml
@@ -21,6 +21,80 @@
       | length
     ) > 0
 
+- name: Set MCP updating detected fact
+  ansible.builtin.set_fact:
+    _mcp_updating_detected: >-
+      {{
+        r_mcp_detect.resources | default([])
+        | rejectattr('spec.paused', 'equalto', true)
+        | map(attribute='status.conditions')
+        | flatten
+        | selectattr('type', 'equalto', 'Updating')
+        | selectattr('status', 'equalto', 'True')
+        | list
+        | length > 0
+      }}
+
+- name: Scale down OpenShift Update Service to prevent PDB deadlock during MCO rollout
+  when:
+    - _mcp_updating_detected | bool
+    - storage_plugin | default('lvms') == 'lvms'
+  block:
+    - name: Get current UpdateService replica count
+      kubernetes.core.k8s_info:
+        api_version: updateservice.operator.openshift.io/v1
+        kind: UpdateService
+        name: service
+        namespace: openshift-update-service
+      environment:
+        KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+      register: r_update_service_info
+
+    - name: Save current UpdateService replica count
+      ansible.builtin.set_fact:
+        _update_service_replicas: "{{ r_update_service_info.resources[0].spec.replicas | default(1) }}"
+      when: r_update_service_info.resources | default([]) | length > 0
+
+    - name: Scale down UpdateService operator
+      ansible.builtin.command:
+        argv:
+          - "{{ workingDir }}/bin/oc"
+          - scale
+          - deployment
+          - updateservice-operator
+          - -n
+          - openshift-update-service
+          - --replicas=0
+      environment:
+        KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+
+    - name: Scale down UpdateService deployment
+      ansible.builtin.command:
+        argv:
+          - "{{ workingDir }}/bin/oc"
+          - scale
+          - deployment
+          - service
+          - -n
+          - openshift-update-service
+          - --replicas=0
+      environment:
+        KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+
+    - name: Wait for UpdateService pods to terminate
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Pod
+        namespace: openshift-update-service
+        label_selectors:
+          - app=service
+      environment:
+        KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+      register: r_update_service_pods
+      retries: 12
+      delay: 10
+      until: r_update_service_pods.resources | default([]) | length == 0
+
 - name: Wait for MachineConfigPool to finish updating
   kubernetes.core.k8s_info:
     api_version: machineconfiguration.openshift.io/v1
@@ -30,6 +104,7 @@
   register: r_mcp
   retries: 60
   delay: 30
+  when: _mcp_updating_detected | bool
   until: >-
     (
       r_mcp.resources | default([])
@@ -63,3 +138,59 @@
       | list
       | length
     ) == 0
+
+- name: Restore OpenShift Update Service after MCO rollout
+  when:
+    - _mcp_updating_detected | bool
+    - storage_plugin | default('lvms') == 'lvms'
+    - _update_service_replicas is defined
+  block:
+    - name: Scale up UpdateService operator
+      ansible.builtin.command:
+        argv:
+          - "{{ workingDir }}/bin/oc"
+          - scale
+          - deployment
+          - updateservice-operator
+          - -n
+          - openshift-update-service
+          - --replicas=1
+      environment:
+        KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+
+    - name: Scale up UpdateService deployment
+      ansible.builtin.command:
+        argv:
+          - "{{ workingDir }}/bin/oc"
+          - scale
+          - deployment
+          - service
+          - -n
+          - openshift-update-service
+          - "--replicas={{ _update_service_replicas }}"
+      environment:
+        KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+
+    - name: Wait for UpdateService pods to be ready
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Pod
+        namespace: openshift-update-service
+        label_selectors:
+          - app=service
+        field_selectors:
+          - status.phase=Running
+      environment:
+        KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+      register: r_update_service_ready
+      retries: 36
+      delay: 10
+      until: >-
+        r_update_service_ready.resources | default([])
+        | selectattr('status.containerStatuses', 'defined')
+        | map(attribute='status.containerStatuses')
+        | flatten
+        | rejectattr('ready', 'equalto', true)
+        | list | length == 0
+        and
+        r_update_service_ready.resources | default([]) | length >= (_update_service_replicas | int)

--- a/playbooks/tasks/wait_mcp.yaml
+++ b/playbooks/tasks/wait_mcp.yaml
@@ -13,6 +13,7 @@
     (
       r_mcp_detect.resources | default([])
       | rejectattr('spec.paused', 'equalto', true)
+      | selectattr('status.conditions', 'defined')
       | map(attribute='status.conditions')
       | flatten
       | selectattr('type', 'equalto', 'Updating')
@@ -27,6 +28,7 @@
       {{
         r_mcp_detect.resources | default([])
         | rejectattr('spec.paused', 'equalto', true)
+        | selectattr('status.conditions', 'defined')
         | map(attribute='status.conditions')
         | flatten
         | selectattr('type', 'equalto', 'Updating')
@@ -56,6 +58,7 @@
       when: r_update_service_info.resources | default([]) | length > 0
 
     - name: Scale down UpdateService operator
+      when: _update_service_replicas is defined
       ansible.builtin.command:
         argv:
           - "{{ workingDir }}/bin/oc"
@@ -67,8 +70,11 @@
           - --replicas=0
       environment:
         KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+      register: r_scale_down_operator
+      changed_when: r_scale_down_operator.rc == 0
 
     - name: Scale down UpdateService deployment
+      when: _update_service_replicas is defined
       ansible.builtin.command:
         argv:
           - "{{ workingDir }}/bin/oc"
@@ -80,8 +86,11 @@
           - --replicas=0
       environment:
         KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+      register: r_scale_down_service
+      changed_when: r_scale_down_service.rc == 0
 
     - name: Wait for UpdateService pods to terminate
+      when: _update_service_replicas is defined
       kubernetes.core.k8s_info:
         api_version: v1
         kind: Pod
@@ -109,6 +118,7 @@
     (
       r_mcp.resources | default([])
       | rejectattr('spec.paused', 'equalto', true)
+      | selectattr('status.conditions', 'defined')
       | map(attribute='status.conditions')
       | flatten
       | selectattr('type', 'equalto', 'Updating')
@@ -120,6 +130,7 @@
     (
       r_mcp.resources | default([])
       | rejectattr('spec.paused', 'equalto', true)
+      | selectattr('status.conditions', 'defined')
       | map(attribute='status.conditions')
       | flatten
       | selectattr('type', 'equalto', 'Updated')
@@ -131,6 +142,7 @@
     (
       r_mcp.resources | default([])
       | rejectattr('spec.paused', 'equalto', true)
+      | selectattr('status.conditions', 'defined')
       | map(attribute='status.conditions')
       | flatten
       | selectattr('type', 'equalto', 'Degraded')
@@ -157,6 +169,8 @@
           - --replicas=1
       environment:
         KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+      register: r_scale_up_operator
+      changed_when: r_scale_up_operator.rc == 0
 
     - name: Scale up UpdateService deployment
       ansible.builtin.command:
@@ -170,6 +184,8 @@
           - "--replicas={{ _update_service_replicas }}"
       environment:
         KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+      register: r_scale_up_service
+      changed_when: r_scale_up_service.rc == 0
 
     - name: Wait for UpdateService pods to be ready
       kubernetes.core.k8s_info:


### PR DESCRIPTION
## Summary

- Add MachineConfigPool wait after LZ mirror manifest apply (IDMS/ITMS) to prevent Quay Enterprise mirror from starting while nodes are being drained
- Add MachineConfigPool wait after Quay Enterprise mirror manifest apply to prevent operator installation from starting while nodes are being drained

Both oc-mirror stages apply IDMS/ITMS manifests that change `registries.conf` on cluster nodes, triggering MCO rolling updates. Without waiting, subsequent steps fail because Quay pods go down during node drains (503 Service Unavailable).

## Test plan

- [ ] Deploy a plugin with `additionalImages` (e.g. rhbk) in disconnected mode
- [ ] Verify MCO wait triggers after LZ mirror manifest apply
- [ ] Verify Quay Enterprise mirror succeeds without 503 errors
- [ ] Verify MCO wait triggers after Quay Enterprise mirror manifest apply
- [ ] Verify operator installation succeeds after MCO rollout completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Improvements

* Enhanced mirror operations with built-in synchronization checkpoints that pause until MachineConfigPool updates finish after applying both plugin landing-zone mirror manifests and Quay Enterprise mirror manifests.  
* Added more robust readiness checks to ensure pools complete updates without degradation before proceeding.  
* Improved reliability during LVM-based installs by temporarily pausing and restoring the update service while MachineConfigPool state converges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->