### PR TITLE
fix: complete certificate chain with root CA for external registries

### DIFF
--- a/src/enclave/tools/quay_registry_ca.py
+++ b/src/enclave/tools/quay_registry_ca.py
@@ -110,14 +110,132 @@ def _openssl_verify(ca_pem: str, cert_pem: str) -> bool:
     return result.returncode == 0
 
 
+def _get_cert_issuer(cert_pem: str) -> str:
+    """Extract the issuer DN from a certificate in RFC2253 format."""
+    try:
+        result = subprocess.run(
+            ["openssl", "x509", "-noout", "-issuer", "-nameopt", "RFC2253"],
+            input=cert_pem,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_OPENSSL_VERIFY_TIMEOUT_SECONDS,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return ""
+
+    if result.returncode != 0:
+        return ""
+
+    # Output format: "issuer=CN=Root CA,O=Org,C=US"
+    match = re.match(r"issuer=(.+)", result.stdout.strip())
+    return match.group(1) if match else ""
+
+
+def _get_cert_subject(cert_pem: str) -> str:
+    """Extract the subject DN from a certificate in RFC2253 format."""
+    try:
+        result = subprocess.run(
+            ["openssl", "x509", "-noout", "-subject", "-nameopt", "RFC2253"],
+            input=cert_pem,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_OPENSSL_VERIFY_TIMEOUT_SECONDS,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return ""
+
+    if result.returncode != 0:
+        return ""
+
+    # Output format: "subject=CN=Intermediate CA,O=Org,C=US"
+    match = re.match(r"subject=(.+)", result.stdout.strip())
+    return match.group(1) if match else ""
+
+
+def _find_root_ca_in_system_store(issuer_dn: str) -> str | None:
+    """
+    Find the root CA certificate in system CA stores matching the given issuer DN.
+
+    Args:
+        issuer_dn: The issuer DN to search for (RFC2253 format)
+
+    Returns:
+        PEM content of the root CA, or None if not found
+    """
+    # Common system CA paths (RHEL/Fedora, Debian/Ubuntu)
+    ca_paths = [
+        Path("/etc/pki/tls/certs/ca-bundle.crt"),
+        Path("/etc/ssl/certs/ca-certificates.crt"),
+    ]
+
+    for bundle_path in ca_paths:
+        if not bundle_path.exists():
+            continue
+
+        try:
+            bundle_content = bundle_path.read_text(encoding="utf-8")
+            # System CA bundles contain multiple certs
+            for cert_pem in pem_blocks(bundle_content):
+                subject = _get_cert_subject(cert_pem)
+                if subject and subject == issuer_dn:
+                    logger.debug("Found root CA in %s", bundle_path)
+                    return cert_pem
+        except (OSError, UnicodeDecodeError) as exc:
+            logger.debug("Error reading %s: %s", bundle_path, exc)
+            continue
+
+    return None
+
+
 def _chain_trust_anchor_pem(chain: list[str]) -> str:
-    """Return CA PEM bundle from a fetched TLS chain (all certs except the leaf)."""
+    """
+    Return complete CA PEM bundle from a fetched TLS chain.
+
+    Includes all intermediate CAs from the chain, plus attempts to find
+    and append the root CA from the system trust store if the chain is incomplete.
+
+    Args:
+        chain: List of PEM certificates from TLS handshake [leaf, intermediate(s)...]
+
+    Returns:
+        Complete CA bundle with intermediates + root CA (if found)
+    """
     ca_certs = chain[1:]
     if not ca_certs:
         msg = (
             "TLS chain contains only a leaf certificate; cannot determine trust anchor"
         )
         raise RuntimeError(msg)
+
+    # Check if the last cert in the chain is self-signed (i.e., a root CA)
+    last_cert = ca_certs[-1]
+    issuer = _get_cert_issuer(last_cert)
+    subject = _get_cert_subject(last_cert)
+
+    if issuer and subject and issuer == subject:
+        # Chain already contains a self-signed root CA
+        logger.debug("TLS chain contains self-signed root CA")
+        return "\n".join(ca_certs) + "\n"
+
+    # Chain is incomplete - try to find the root CA from system store
+    if not issuer:
+        logger.warning("Could not determine issuer from last intermediate CA")
+        return "\n".join(ca_certs) + "\n"
+
+    logger.debug("Searching for root CA with subject: %s", issuer)
+    root_ca = _find_root_ca_in_system_store(issuer)
+
+    if root_ca:
+        logger.info("Completed certificate chain with root CA from system trust store")
+        return "\n".join([*ca_certs, root_ca]) + "\n"
+
+    logger.warning(
+        "Root CA not found in system trust store for issuer: %s. "
+        "UpdateService may fail to verify the registry certificate in disconnected mode.",
+        issuer,
+    )
     return "\n".join(ca_certs) + "\n"
 
 

--- a/src/tests/test_quay_registry_ca.py
+++ b/src/tests/test_quay_registry_ca.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from subprocess import CompletedProcess, TimeoutExpired
 
 import pytest
@@ -5,6 +6,9 @@ from pytest_mock import MockerFixture
 
 from enclave.tools.quay_registry_ca import (
     _chain_trust_anchor_pem,
+    _find_root_ca_in_system_store,
+    _get_cert_issuer,
+    _get_cert_subject,
     _openssl_verify,
     fetch_tls_chain_pem,
     get_router_ca_pem,
@@ -152,3 +156,132 @@ def test_resolve_registry_ca_pem_leaf_only_chain_raises(
     mocker.patch("enclave.tools.quay_registry_ca._openssl_verify", return_value=False)
     with pytest.raises(RuntimeError, match="only a leaf certificate"):
         resolve_registry_ca_pem("registry.example.com")
+
+
+def test_get_cert_subject_extracts_subject_dn(mocker: MockerFixture) -> None:
+    mocker.patch(
+        "enclave.tools.quay_registry_ca.subprocess.run",
+        return_value=CompletedProcess(
+            args=["openssl"],
+            returncode=0,
+            stdout="subject=CN=Test CA,O=Test Org,C=US\n",
+            stderr="",
+        ),
+    )
+    assert _get_cert_subject(_ROOT) == "CN=Test CA,O=Test Org,C=US"
+
+
+def test_get_cert_issuer_extracts_issuer_dn(mocker: MockerFixture) -> None:
+    mocker.patch(
+        "enclave.tools.quay_registry_ca.subprocess.run",
+        return_value=CompletedProcess(
+            args=["openssl"],
+            returncode=0,
+            stdout="issuer=CN=Root CA,O=Test Org,C=US\n",
+            stderr="",
+        ),
+    )
+    assert _get_cert_issuer(_INTERMEDIATE) == "CN=Root CA,O=Test Org,C=US"
+
+
+def test_find_root_ca_in_system_store_finds_matching_cert(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    # Create a mock CA bundle file
+    ca_bundle = tmp_path / "ca-bundle.crt"
+    ca_bundle.write_text(f"{_ROOT}\n{_INTERMEDIATE}\n", encoding="utf-8")
+
+    # Mock Path.exists and read_text
+    mocker.patch("enclave.tools.quay_registry_ca.Path.exists", return_value=True)
+    mocker.patch(
+        "enclave.tools.quay_registry_ca.Path.read_text",
+        return_value=ca_bundle.read_text(),
+    )
+
+    # Mock _get_cert_subject to return matching DN
+    mocker.patch(
+        "enclave.tools.quay_registry_ca._get_cert_subject",
+        side_effect=["CN=Root CA,O=Test,C=US", "CN=Other,O=Test,C=US"],
+    )
+
+    result = _find_root_ca_in_system_store("CN=Root CA,O=Test,C=US")
+    assert result == _ROOT
+
+
+def test_find_root_ca_in_system_store_returns_none_when_not_found(
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch("enclave.tools.quay_registry_ca.Path.exists", return_value=True)
+    mocker.patch(
+        "enclave.tools.quay_registry_ca.Path.read_text", return_value=f"{_ROOT}\n"
+    )
+    mocker.patch(
+        "enclave.tools.quay_registry_ca._get_cert_subject",
+        return_value="CN=Different,O=Test,C=US",
+    )
+
+    result = _find_root_ca_in_system_store("CN=Not Found,O=Test,C=US")
+    assert result is None
+
+
+def test_chain_trust_anchor_pem_with_self_signed_root(mocker: MockerFixture) -> None:
+    # Mock issuer and subject to be the same (self-signed)
+    mocker.patch(
+        "enclave.tools.quay_registry_ca._get_cert_issuer",
+        return_value="CN=Root CA,O=Test,C=US",
+    )
+    mocker.patch(
+        "enclave.tools.quay_registry_ca._get_cert_subject",
+        return_value="CN=Root CA,O=Test,C=US",
+    )
+
+    chain = pem_blocks(f"{_LEAF}\n{_ROOT}\n")
+    result = _chain_trust_anchor_pem(chain)
+    assert result == f"{_ROOT}\n"
+
+
+def test_chain_trust_anchor_pem_completes_chain_from_system_store(
+    mocker: MockerFixture,
+) -> None:
+    # Intermediate is not self-signed
+    mocker.patch(
+        "enclave.tools.quay_registry_ca._get_cert_issuer",
+        return_value="CN=Root CA,O=Test,C=US",
+    )
+    mocker.patch(
+        "enclave.tools.quay_registry_ca._get_cert_subject",
+        return_value="CN=Intermediate CA,O=Test,C=US",
+    )
+    # Mock finding the root CA
+    mocker.patch(
+        "enclave.tools.quay_registry_ca._find_root_ca_in_system_store",
+        return_value=_ROOT,
+    )
+
+    chain = pem_blocks(f"{_LEAF}\n{_INTERMEDIATE}\n")
+    result = _chain_trust_anchor_pem(chain)
+    assert result == f"{_INTERMEDIATE}\n{_ROOT}\n"
+
+
+def test_chain_trust_anchor_pem_incomplete_chain_without_root_in_system(
+    mocker: MockerFixture,
+) -> None:
+    # Intermediate is not self-signed
+    mocker.patch(
+        "enclave.tools.quay_registry_ca._get_cert_issuer",
+        return_value="CN=Root CA,O=Test,C=US",
+    )
+    mocker.patch(
+        "enclave.tools.quay_registry_ca._get_cert_subject",
+        return_value="CN=Intermediate CA,O=Test,C=US",
+    )
+    # Root CA not found in system store
+    mocker.patch(
+        "enclave.tools.quay_registry_ca._find_root_ca_in_system_store",
+        return_value=None,
+    )
+
+    chain = pem_blocks(f"{_LEAF}\n{_INTERMEDIATE}\n")
+    result = _chain_trust_anchor_pem(chain)
+    # Should return intermediate only, with a warning logged
+    assert result == f"{_INTERMEDIATE}\n"


### PR DESCRIPTION
Reintroduce rh-ecosystem-edge/enclave#531
Reverts rh-ecosystem-edge/enclave#533

## Summary
Fixes UpdateService certificate verification failures when Quay registry uses external CAs (ZeroSSL, Let's Encrypt, etc.) in disconnected environments.

## Problem
UpdateService pods fail with `unable to get issuer certificate` when the Quay registry uses an externally-signed certificate. The TLS handshake typically returns only:
- Leaf certificate (registry cert)
- Intermediate CA (e.g., ZeroSSL ECC DV SSL CA 2)
- **Missing**: Root CA (not sent by server)

PR #526 returns `chain[1:]` which is the intermediate CA only. In disconnected/air-gapped deployments, UpdateService pods cannot fetch the missing root CA from the internet, causing certificate verification to fail.

## Root Cause Analysis
From the official Cincinnati operator code (`controllers/new.go`):
- The operator mounts the `updateservice-registry` ConfigMap key as `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem`
- UpdateService graph-builder loads this CA bundle (confirmed in pod logs)
- **The mechanism works correctly** - the issue is that the CA bundle is incomplete

The pod logs from issue #929 confirm:
```
Adding /etc/pki/ca-trust/extracted/pem/.../tls-ca-bundle.pem to certificates  ← CA loaded
certificate verify failed: unable to get issuer certificate  ← Root CA missing
```

## Solution
Enhanced `resolve-quay-registry-ca` tool to complete the certificate chain:

1. **Detect incomplete chains**: Check if the last cert is self-signed (root) or requires a parent
2. **Extract issuer DN**: Get the issuer from the last intermediate CA
3. **Search system CA stores**: Look for matching root CA in `/etc/pki/tls/certs/ca-bundle.crt` and `/etc/ssl/certs/ca-certificates.crt`
4. **Complete the chain**: Append root CA to the bundle if found

This leverages the fact that the deployment/bootstrap node typically has internet access and standard CA bundles with public root CAs (ZeroSSL, Let's Encrypt, etc.).

## Changes
- Added `_get_cert_subject()` - Extract subject DN from certificate
- Added `_get_cert_issuer()` - Extract issuer DN from certificate
- Added `_find_root_ca_in_system_store()` - Search for root CA in system bundles
- Enhanced `_chain_trust_anchor_pem()` - Complete chain with system root CA if needed
- Added 7 new tests covering all scenarios

## Testing
- ✅ All 129 tests pass
- ✅ Coverage: 91.77% (above 90% requirement)
- ✅ Linter: All checks passed
- ✅ Type checker: No issues found

## Behavior
- **Router-CA signed routes**: No change (uses router-ca as before)
- **External CA with complete chain**: Returns chain as-is
- **External CA with incomplete chain**: Appends root CA from system store
- **Root CA not found**: Returns intermediate only, logs warning (graceful degradation)

## Why This Works
The deployment node where Enclave runs typically has:
- Internet access during deployment
- Standard system CA bundles (`/etc/pki/tls/certs/ca-bundle.crt`)
- Public root CAs (ZeroSSL, Let's Encrypt, DigiCert, etc.)

We leverage these resources at deployment time to build the complete trust chain, which is then stored in the cluster's ConfigMap for the air-gapped UpdateService pods to use.

## Verification
Awaiting diagnostic output from IBM (issue #929) to confirm:
- How many certs are in their TLS chain
- Whether ZeroSSL root CA exists on their deployment node
- Whether manual verification works with the complete chain

Fixes https://github.com/gori-project/GoRI/issues/929
Related https://github.com/gori-project/GoRI/issues/924

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved certificate chain validation to detect and properly handle self-signed root certificates
  * Enhanced root CA discovery from system trust stores when certificate chains are incomplete

* **Tests**
  * Added comprehensive test coverage for certificate processing and chain validation scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->