### PR TITLE
Validate UpdateService deployment pods are ready before completing install in disconnected

### DIFF
--- a/operators/cincinnati-operator/tasks.yaml
+++ b/operators/cincinnati-operator/tasks.yaml
@@ -1,4 +1,8 @@
 ---
+- name: Set UpdateService replicas
+  ansible.builtin.set_fact:
+    updateservice_replicas: 3
+
 # UpdateService requires image.config additionalTrustedCA with updateservice-registry
 # before graph-builder can scrape the mirrored release repository over TLS.
 - name: Trust Quay registry CA in image.config for UpdateService
@@ -18,7 +22,7 @@
       spec:
         graphDataImage: registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/openshift/graph-image
         releases: registry-quay-quay-enterprise.apps.{{ clusterName }}.{{ baseDomain }}/openshift/release-images
-        replicas: 3
+        replicas: "{{ updateservice_replicas }}"
   register: r_update_service
   retries: "{{ k8s_retries }}"
   delay: "{{ k8s_delay }}"
@@ -43,6 +47,26 @@
       | selectattr('status', 'equalto', 'True')
       | list | length > 0
     )
+
+- name: Wait for UpdateService deployment pods to be ready
+  when: disconnected | default(true) | bool
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: service
+    namespace: openshift-update-service
+  register: r_update_service_deployment
+  retries: 60
+  delay: 10
+  until: >-
+    r_update_service_deployment.resources | default([]) | length > 0
+    and r_update_service_deployment.resources[0].status.replicas | default(0) == updateservice_replicas
+    and r_update_service_deployment.resources[0].status.readyReplicas | default(0) == updateservice_replicas
+    and r_update_service_deployment.resources[0].status.updatedReplicas | default(0) == updateservice_replicas
+    and r_update_service_deployment.resources[0].status.availableReplicas | default(0) == updateservice_replicas
+  failed_when: false
 
 - name: Create ACM Policy for Update Service
   environment:


### PR DESCRIPTION
Adds validation that all UpdateService deployment pods are running and healthy before Enclave install completes. This ensures a functional UpdateService is handed over to partner overlays or day-2 operations.

Previously, Enclave only waited for the UpdateService CR to be created and the RegistryCACertFound condition, but did not verify the actual pods were running. This could allow install to complete with crash-looping UpdateService pods.

The new validation checks the deployment has all replicas ready, updated, and available. The replica count is now parameterized via updateservice_replicas fact for easier maintenance.

The validation is added with `failed_when: false` intentionally a soft readiness gate to observe behaviour without blocking installs or impacting customers, with the plan to harden it once confidence is gained.

This addresses scenarios where partner overlays apply certificate changes that affect UpdateService, ensuring baseline functionality before handoff.

Related: https://github.com/gori-project/GoRI/issues/924

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UpdateService deployments now support configurable replica counts (instead of a fixed value), making it easier to tailor scaling to different environments.
  * Enhanced rollout validation: the operator waits for UpdateService Deployment replica health (replicas, ready, updated, and available) to match the configured count after registry CA is detected, with the check running for disconnected setups by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->