### PR TITLE
fix: isolate openssl verify from system trust store in quay registry CA check

### DIFF
--- a/src/enclave/tools/quay_registry_ca.py
+++ b/src/enclave/tools/quay_registry_ca.py
@@ -95,7 +95,15 @@ def _openssl_verify(ca_pem: str, cert_pem: str) -> bool:
         cert_path.write_text(cert_pem, encoding="utf-8")
         try:
             result = subprocess.run(
-                ["openssl", "verify", "-CAfile", str(ca_path), str(cert_path)],
+                [
+                    "openssl",
+                    "verify",
+                    "-no-CAfile",
+                    "-no-CApath",
+                    "-CAfile",
+                    str(ca_path),
+                    str(cert_path),
+                ],
                 capture_output=True,
                 text=True,
                 check=False,

--- a/src/tests/test_quay_registry_ca.py
+++ b/src/tests/test_quay_registry_ca.py
@@ -87,6 +87,21 @@ def test_openssl_verify_missing_openssl_raises_runtime_error(
         _openssl_verify(_ROUTER_CA, _LEAF)
 
 
+def test_openssl_verify_isolates_from_system_trust_store(
+    mocker: MockerFixture,
+) -> None:
+    mock_run = mocker.patch(
+        "enclave.tools.quay_registry_ca.subprocess.run",
+        return_value=CompletedProcess(
+            args=["openssl"], returncode=0, stdout="", stderr=""
+        ),
+    )
+    _openssl_verify(_ROUTER_CA, _LEAF)
+    cmd = mock_run.call_args[0][0]
+    assert "-no-CAfile" in cmd
+    assert "-no-CApath" in cmd
+
+
 def test_pem_blocks_splits_multiple_certificates() -> None:
     chain = f"{_LEAF}\n{_ROOT}\n"
     assert pem_blocks(chain) == [_LEAF, _ROOT]


### PR DESCRIPTION
The router-ca verification in resolve_registry_ca_pem used openssl verify without -no-CAfile/-no-CApath, so the system CA store was also consulted. On RHEL 10, ISRG Root X1 is trusted system-wide. When the Quay TLS chain includes Let's Encrypt E8 as the first cert (non-standard server ordering), _openssl_verify(router_ca, E8) succeeded causing a false positive that made the tool return the router-ca instead of the correct Let's Encrypt chain.

Adding -no-CAfile -no-CApath restricts verification to the explicitly provided CA only, matching the intent of the router-ca check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated certificate verification for Quay registry operations to enforce use of explicitly provided CA certificates while excluding system default trust sources.

* **Tests**
  * Added test coverage to verify certificate verification behavior isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->