### PR TITLE
fix: handle null lzBmcHostname in ironic HTTPS certificate validation

### DIFF
--- a/validations.sh
+++ b/validations.sh
@@ -312,7 +312,8 @@ checkCerts ingress "*.apps.$cluster_fqdn" .sslIngressCertificateKey .sslIngressC
 
 # Check Ironic HTTPS certificate (optional)
 lz_bmc_ip=$(getValue .lzBmcIP)
-lz_bmc_hostname=$(getValue .lzBmcHostname 2>/dev/null || echo "")
+lz_bmc_hostname=$(getValue .lzBmcHostname)
+[[ "$lz_bmc_hostname" == "null" ]] && lz_bmc_hostname=""
 ironic_cert_name="${lz_bmc_hostname:-$lz_bmc_ip}"
 ironic_https_cert=$(getValue .ironicHTTPSCertificate)
 if [[ -n "$ironic_https_cert" && "$ironic_https_cert" != "null" ]]; then


### PR DESCRIPTION
## Summary
Fixes a bug in `validations.sh` where the ironic HTTPS certificate validation fails with "Certificate is not valid for name null" when `lzBmcHostname` is not provided in the configuration (only IP is provided, as with self-signed certificates).

## Root Cause
When `.lzBmcHostname` is not set in the YAML, `getValue` returns the literal string `"null"` (jq's output for missing keys), not an empty string. The bash `${lz_bmc_hostname:-$lz_bmc_ip}` fallback only triggers for empty/unset variables, so `ironic_cert_name` was being set to the literal string `"null"`.

## Changes
- Line 315: Removed the incorrect `2>/dev/null || echo ""` workaround from the `getValue` call
- Line 316: Added explicit null check `[[ "$lz_bmc_hostname" == "null" ]] && lz_bmc_hostname=""` to ensure the bash fallback works correctly

This matches the existing pattern used for `ironic_https_cert` on line 318.

## Testing
With this fix, `validations.sh` should pass when `ironicHTTPSCertificate` and `ironicHTTPSKey` are provided but no hostname is provided (only IP), as in the case of self-signed certificates.

Fixes https://github.com/gori-project/GoRI/issues/934

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of the optional BMC hostname value so missing data is treated more reliably.
  * Prevents empty or unavailable hostname values from causing unexpected validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->