### PR TITLE
fix: deploy Cincinnati UpdateService to all clusters except local-cluster

### DIFF
--- a/operators/cincinnati-operator/tasks.yaml
+++ b/operators/cincinnati-operator/tasks.yaml
@@ -102,12 +102,10 @@
       spec:
         clusterSelector:
           matchExpressions:
-          - key: cluster.open-cluster-management.io/clusterset
-            operator: In
+          - key: local-cluster
+            operator: NotIn
             values:
-            - "account"
-            - "default"
-            - "platform"
+            - "true"
   register: r_acm_placementrule_update_service
   retries: "{{ k8s_retries }}"
   delay: "{{ k8s_delay }}"


### PR DESCRIPTION
## Summary
- Changed Cincinnati UpdateService PlacementRule from clusterset-based selection to label-based selection
- Now deploys to all managed clusters except local-cluster
- Aligns with the pattern used in LVMS and ODF plugins

## Changes
- Modified `operators/cincinnati-operator/tasks.yaml` PlacementRule to use `local-cluster: NotIn ["true"]` selector instead of `clusterset: In ["account", "default", "platform"]`

## Why
The previous clusterset-based approach limited UpdateService deployment to specific clustersets. The new approach ensures all managed clusters receive update service configuration regardless of their clusterset assignment.

## Test Plan
- Verify PlacementRule targets all managed clusters
- Confirm local-cluster is excluded from placement
- Check that UpdateService policy is applied to all spoke clusters