### PR TITLE
fix: make quay-registry-ca ConfigMap name configurable for partner overlays

### DIFF
--- a/config/global.example.yaml
+++ b/config/global.example.yaml
@@ -124,7 +124,7 @@ storage_plugin: lvms
 # ConfigMap name for Quay registry CA certificates (default: quay-registry-ca)
 # Partner overlays that replace image.config.spec.additionalTrustedCA must include
 # the 'updateservice-registry' key from this ConfigMap to prevent UpdateService failures.
-# quay_registry_ca_configmap_name: quay-registry-ca
+# quayRegistryCAConfigmapName: quay-registry-ca
 
 # Additional NTP sources for cluster nodes (no additional servers by default)
 # defaultNtpServers:

--- a/config/global.example.yaml
+++ b/config/global.example.yaml
@@ -121,6 +121,11 @@ storage_plugin: lvms
 # post-mirror prefetch pinning (e.g. faster iteration or when MCO pin step is unwanted).
 # quayPinnedImageSetEnabled: false
 
+# ConfigMap name for Quay registry CA certificates (default: quay-registry-ca)
+# Partner overlays that replace image.config.spec.additionalTrustedCA must include
+# the 'updateservice-registry' key from this ConfigMap to prevent UpdateService failures.
+# quay_registry_ca_configmap_name: quay-registry-ca
+
 # Additional NTP sources for cluster nodes (no additional servers by default)
 # defaultNtpServers:
 #  - YOUR_NTP_SERVER_1

--- a/defaults/deployment.yaml
+++ b/defaults/deployment.yaml
@@ -24,3 +24,9 @@ enabled_plugins:
 
 # Default pull secret path. Override in config/global.yaml if stored elsewhere.
 pullSecretPath: "{{ workingDir }}/config/pull-secret.json"
+
+# ConfigMap name for Quay registry CA certificates used by image.config and UpdateService.
+# Partner overlays that replace image.config.spec.additionalTrustedCA must include the
+# 'updateservice-registry' key from this ConfigMap to prevent UpdateService reconciliation failures.
+# See: https://github.com/gori-project/GoRI/issues/924
+quay_registry_ca_configmap_name: quay-registry-ca

--- a/defaults/deployment.yaml
+++ b/defaults/deployment.yaml
@@ -29,4 +29,4 @@ pullSecretPath: "{{ workingDir }}/config/pull-secret.json"
 # Partner overlays that replace image.config.spec.additionalTrustedCA must include the
 # 'updateservice-registry' key from this ConfigMap to prevent UpdateService reconciliation failures.
 # See: https://github.com/gori-project/GoRI/issues/924
-quay_registry_ca_configmap_name: quay-registry-ca
+quayRegistryCAConfigmapName: quay-registry-ca

--- a/playbooks/tasks/trust_quay_registry_ca_for_image_config.yaml
+++ b/playbooks/tasks/trust_quay_registry_ca_for_image_config.yaml
@@ -49,7 +49,7 @@
       apiVersion: v1
       kind: ConfigMap
       metadata:
-        name: quay-registry-ca
+        name: "{{ quay_registry_ca_configmap_name }}"
         namespace: openshift-config
       data: "{{ quay_registry_ca_configmap_data }}"
   environment:
@@ -59,7 +59,7 @@
   when:
     - image_config_trusted_ca_name.rc == 0
     - image_config_trusted_ca_name.stdout | trim | length > 0
-    - image_config_trusted_ca_name.stdout | trim != 'quay-registry-ca'
+    - image_config_trusted_ca_name.stdout | trim != quay_registry_ca_configmap_name
   kubernetes.core.k8s:
     state: patched
     kind: ConfigMap
@@ -85,7 +85,7 @@
     definition:
       spec:
         additionalTrustedCA:
-          name: quay-registry-ca
+          name: "{{ quay_registry_ca_configmap_name }}"
   environment:
     KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
 

--- a/playbooks/tasks/trust_quay_registry_ca_for_image_config.yaml
+++ b/playbooks/tasks/trust_quay_registry_ca_for_image_config.yaml
@@ -49,7 +49,7 @@
       apiVersion: v1
       kind: ConfigMap
       metadata:
-        name: "{{ quay_registry_ca_configmap_name }}"
+        name: "{{ quayRegistryCAConfigmapName }}"
         namespace: openshift-config
       data: "{{ quay_registry_ca_configmap_data }}"
   environment:
@@ -59,7 +59,7 @@
   when:
     - image_config_trusted_ca_name.rc == 0
     - image_config_trusted_ca_name.stdout | trim | length > 0
-    - image_config_trusted_ca_name.stdout | trim != quay_registry_ca_configmap_name
+    - image_config_trusted_ca_name.stdout | trim != quayRegistryCAConfigmapName
   kubernetes.core.k8s:
     state: patched
     kind: ConfigMap
@@ -85,7 +85,7 @@
     definition:
       spec:
         additionalTrustedCA:
-          name: "{{ quay_registry_ca_configmap_name }}"
+          name: "{{ quayRegistryCAConfigmapName }}"
   environment:
     KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
 

--- a/schemas/deployment.yaml
+++ b/schemas/deployment.yaml
@@ -30,13 +30,12 @@ properties:
       type: string
     description: >-
       List of plugins to deploy during the pipeline. Default: [storage_plugin].
-  quay_registry_ca_configmap_name:
+  quayRegistryCAConfigmapName:
     type: string
     description: >-
       ConfigMap name for Quay registry CA certificates used by image.config and UpdateService.
       Partner overlays that replace image.config.spec.additionalTrustedCA must include the
       'updateservice-registry' key from this ConfigMap to prevent UpdateService reconciliation failures.
-      Default: quay-registry-ca.
 required:
   - disconnected
   - fresh

--- a/schemas/deployment.yaml
+++ b/schemas/deployment.yaml
@@ -30,6 +30,13 @@ properties:
       type: string
     description: >-
       List of plugins to deploy during the pipeline. Default: [storage_plugin].
+  quay_registry_ca_configmap_name:
+    type: string
+    description: >-
+      ConfigMap name for Quay registry CA certificates used by image.config and UpdateService.
+      Partner overlays that replace image.config.spec.additionalTrustedCA must include the
+      'updateservice-registry' key from this ConfigMap to prevent UpdateService reconciliation failures.
+      Default: quay-registry-ca.
 required:
   - disconnected
   - fresh

--- a/schemas/global.yaml
+++ b/schemas/global.yaml
@@ -75,6 +75,13 @@ properties:
     description: >-
       Whether to apply a master PinnedImageSet after Quay mirror sync.
       Set to false to skip post-mirror image prefetch pinning.
+  quay_registry_ca_configmap_name:
+    type: string
+    description: >-
+      ConfigMap name for Quay registry CA certificates used by image.config and UpdateService.
+      Partner overlays that replace image.config.spec.additionalTrustedCA must include the
+      'updateservice-registry' key from this ConfigMap to prevent UpdateService reconciliation failures.
+      Default: quay-registry-ca.
   pullSecret:
     type: object
     description: Pull Secret

--- a/schemas/global.yaml
+++ b/schemas/global.yaml
@@ -75,13 +75,12 @@ properties:
     description: >-
       Whether to apply a master PinnedImageSet after Quay mirror sync.
       Set to false to skip post-mirror image prefetch pinning.
-  quay_registry_ca_configmap_name:
+  quayRegistryCAConfigmapName:
     type: string
     description: >-
       ConfigMap name for Quay registry CA certificates used by image.config and UpdateService.
       Partner overlays that replace image.config.spec.additionalTrustedCA must include the
       'updateservice-registry' key from this ConfigMap to prevent UpdateService reconciliation failures.
-      Default: quay-registry-ca.
   pullSecret:
     type: object
     description: Pull Secret


### PR DESCRIPTION
## Summary

Extract the hardcoded `quay-registry-ca` ConfigMap name into a global variable to support partner overlays that replace `image.config.spec.additionalTrustedCA`.

## Changes

- Add `quay_registry_ca_configmap_name` variable in `defaults/deployment.yaml`
- Replace all hardcoded `'quay-registry-ca'` references in `playbooks/tasks/trust_quay_registry_ca_for_image_config.yaml`
- Document the `updateservice-registry` key requirement for partner overlays

## Context

Partner overlays (e.g., IBM's mirror-registry setup) replace the `image.config.spec.additionalTrustedCA` ConfigMap to point to their own CA bundle. This breaks UpdateService reconciliation because the operator expects the `updateservice-registry` key to be present in the referenced ConfigMap.

By extracting the ConfigMap name to a global variable with inline documentation, partners can:
1. Discover the expected ConfigMap name in `defaults/deployment.yaml`
2. Understand the requirement to include the `updateservice-registry` key
3. Override the ConfigMap name if needed (via `config/global.yaml`)

## Related Issues

- https://github.com/gori-project/GoRI/issues/924

## Test Plan

- [ ] Verify existing deployments continue to work with default `quay-registry-ca` name
- [ ] Verify playbook creates ConfigMap with correct name
- [ ] Verify partner overlay documentation is clear about key requirement
- [ ] Run `make -f Makefile.ci validate` to ensure no linting issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of the trusted registry CA configuration so the cluster can reference the correct ConfigMap more reliably.
  * Reduced the chance of UpdateService reconciliation issues by aligning the registry CA reference with the expected configuration.
  
* **Documentation**
  * Added guidance on including the registry CA key in partner overlay configurations when using the registry trust setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->