### PR TITLE
Add trust quay ca in update service migration

### DIFF
--- a/playbooks/tasks/migrations.yaml
+++ b/playbooks/tasks/migrations.yaml
@@ -27,3 +27,7 @@
 - name: Enclave kubeconfig symlink migration
   ansible.builtin.include_tasks:
     file: migrations/setup_enclave_kubeconfig_symlink.yaml
+
+- name: Trust quay registry CA for image config
+  ansible.builtin.include_tasks:
+    file: trust_quay_registry_ca_for_image_config.yaml


### PR DESCRIPTION
it is needed to make sure that update service works fine by adding the needed root CA to the trust store configmap it mounts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a conditional migration step to improve upgrade handling in supported environments.
  * Updated the migration flow to run an additional registry-related configuration step after the existing kubeconfig migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->