### PR TITLE
OSAC-1149: Add disconnected support to authorino plugin

### DIFF
--- a/plugins/authorino/plugin.yaml
+++ b/plugins/authorino/plugin.yaml
@@ -10,3 +10,7 @@ operators:
     init_version: 1.3.0
     namespace: authorino-operator
     global: true
+
+registries:
+  - location: "registry.redhat.io/rhcl-1"
+    mirror: "rhcl-1"


### PR DESCRIPTION
## Summary

- Add `registries` section to the authorino plugin descriptor mapping `registry.redhat.io/rhcl-1` to a local mirror path
- The authorino operator images moved to the `rhcl-1` namespace (Red Hat Connectivity Link). Without this entry, the second mirroring stage (LZ → Quay Enterprise) fails because oc-mirror cannot resolve `rhcl-1` images from the LZ mirror, and spoke clusters have no IDMS rule to pull from Quay Enterprise

## Test plan

- [x] Verified stage 1 mirroring (upstream → LZ registry) succeeds for `rhcl-1` images on `openshift-qe-002`
- [x] Verify stage 2 mirroring (LZ → Quay Enterprise) succeeds with the `registries` entry
- [x] Verify IDMS is generated for spoke clusters mapping `registry.redhat.io/rhcl-1` → Quay Enterprise

Jira: [OSAC-1149](https://redhat.atlassian.net/browse/OSAC-1149)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added registry mirror support for the `authorino-operator`, helping image pulls use the configured mirror for Red Hat registry content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->