### PR TITLE
[WIP] OSAC-1152: Update AAP operator version and add disconnected support

### DIFF
--- a/plugins/aap/plugin.yaml
+++ b/plugins/aap/plugin.yaml
@@ -5,10 +5,16 @@ order: 103
 
 operators:
   - name: ansible-automation-platform-operator
-    version: 2.5.0-0.1777407881
+    version: 2.5.0+0.1750901870
     channel: stable-2.5-cluster-scoped
-    init_version: 2.5.0-0.1777407881
+    init_version: 2.5.0+0.1750901870
     namespace: ansible-aap
     global: true
     csvNames:
       - aap-operator
+
+registries:
+  - location: "registry.redhat.io/ansible-automation-platform-25"
+    mirror: "ansible-automation-platform-25"
+  - location: "registry.redhat.io/ansible-automation-platform"
+    mirror: "ansible-automation-platform"


### PR DESCRIPTION
## Summary

- Update AAP operator to the latest version available in the `v4.20` catalog — the previous version was removed, causing both connected and disconnected deployments to fail during oc-mirror
- Add `registries` section for `ansible-automation-platform-25` and `ansible-automation-platform` namespaces, enabling the Quay Enterprise mirror step to pull AAP images from the LZ mirror via `registries.conf` in disconnected environments

## Test plan

- [x] Verify oc-mirror can find and mirror the AAP operator bundle with the updated version
- [x] Verify Quay Enterprise mirroring succeeds with the registries entries (25/25 images)
- [x] Verify AAP operator installs successfully (CSV phase: Succeeded)
- [ ] Full disconnected deployment end-to-end

Jira: [OSAC-1152](https://redhat.atlassian.net/browse/OSAC-1152)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated AAP operator version metadata.
  * Added registry mirror mappings for supported container images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->