### PR TITLE
Make NMStateConfig interface name configurable

### DIFF
--- a/config/cloud_infra.example.yaml
+++ b/config/cloud_infra.example.yaml
@@ -16,6 +16,7 @@ discovery_hosts:
   - name: YOUR_NODE_NAME              # Example: node01
     macAddress: YOUR_MAC_ADDRESS      # Example: 0c:c4:7a:62:fe:ec
     ipAddress: YOUR_IP_ADDRESS        # Should be in machineNetwork
+    interfaceName: eno1               # Optional: NIC name (default: eno1). Override for hardware with different naming (e.g., eno1np0)
     redfish: YOUR_REDFISH_IP          # IPMI/Redfish management IP
     rootDisk: YOUR_ROOT_DISK_PATH     # Example: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: YOUR_REDFISH_USER

--- a/config/cloud_infra.example.yaml
+++ b/config/cloud_infra.example.yaml
@@ -16,7 +16,7 @@ discovery_hosts:
   - name: YOUR_NODE_NAME              # Example: node01
     macAddress: YOUR_MAC_ADDRESS      # Example: 0c:c4:7a:62:fe:ec
     ipAddress: YOUR_IP_ADDRESS        # Should be in machineNetwork
-    interfaceName: eno1               # Optional: NIC name (default: eno1). Override for hardware with different naming (e.g., eno1np0)
+    # interfaceName: eno1np0          # Optional: NIC name (default: eno1). Override for hardware with different naming
     redfish: YOUR_REDFISH_IP          # IPMI/Redfish management IP
     rootDisk: YOUR_ROOT_DISK_PATH     # Example: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: YOUR_REDFISH_USER

--- a/playbooks/templates/nmstateconfig.yaml.j2
+++ b/playbooks/templates/nmstateconfig.yaml.j2
@@ -14,7 +14,7 @@ spec:
 {% else %}
   config:
    interfaces:
-   - name: eno1
+   - name: {{ discovery_host.interfaceName | default('eno1') }}
      type: ethernet
      state: up
      mac-address:  {{ discovery_host.macAddress }}
@@ -26,13 +26,13 @@ spec:
    routes:
      config:
      - next-hop-address:  {{ defaultGateway }}
-       next-hop-interface: eno1
+       next-hop-interface: {{ discovery_host.interfaceName | default('eno1') }}
        destination: 0.0.0.0/0
    dns-resolver:
      config:
        server:
          -  {{ defaultDNS }}
   interfaces:
-   - name: eno1
+   - name: {{ discovery_host.interfaceName | default('eno1') }}
      macAddress: {{ discovery_host.macAddress }}
 {% endif %}

--- a/schemas/definitions.yaml
+++ b/schemas/definitions.yaml
@@ -86,6 +86,10 @@ definitions:
       bmcSystemId:
         type: string
         description: Redfish system ID path component, defaults to '1'
+      interfaceName:
+        type: string
+        pattern: "^[a-zA-Z0-9]+$"
+        description: Network interface name (e.g., eno1, eno1np0). Defaults to 'eno1' if not specified.
       ipAddress:
         "$ref": "#/definitions/ipv4Address"
       macAddress:


### PR DESCRIPTION
## Summary

Makes the NIC interface name configurable in NMStateConfig templates to support hardware with non-standard network interface naming (e.g., `eno1np0` instead of `eno1`).

Addresses contributing factor in: https://github.com/gori-project/GoRI/issues/936

## Problem

The NMStateConfig template hardcoded `eno1` as the interface name in three places:
1. Interface definition name
2. Route next-hop-interface  
3. Interfaces mapping section

On hardware using biosdevname or different NIC naming schemes (e.g., `eno1np0`), the static IP configuration silently fails because the interface name doesn't match the actual hardware. The node falls back to DHCP, adding latency and potential network issues during discovery.

From issue #936:
> **NMStateConfig eno1 mismatch** — Template hardcodes name: eno1; actual NIC is eno1np0 on this hardware — static IP silently fails, node falls back to DHCP, adding further delay

## Changes

### 1. Add optional `interfaceName` field to discovery_hosts configuration
Users can now override the interface name per-host:

```yaml
discovery_hosts:
  - name: node01
    macAddress: 0c:c4:7a:62:fe:ec
    ipAddress: 192.168.1.10
    interfaceName: eno1np0  # Optional: defaults to 'eno1' if omitted
    redfish: 192.168.1.100
    # ... other fields
```

### 2. Update NMStateConfig template
Changed all three occurrences of hardcoded `eno1` to:
```jinja2
{{ discovery_host.interfaceName | default('eno1') }}
```

This maintains backward compatibility — existing configurations without `interfaceName` will continue using `eno1`.

### 3. Document in example configuration
Updated `config/cloud_infra.example.yaml` to show the optional field with usage notes.

## Testing

- **Backward compatibility:** Tested with configurations that don't specify `interfaceName` — defaults to `eno1` as before
- **Override:** Verified template renders correctly when `interfaceName: eno1np0` is specified

## Related

Part of fixes for GoRI #936 intermittent discovery failures. This PR addresses the NMStateConfig issue; PR #552 addresses the timeout and image service readiness issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional network interface name setting for discovery hosts, with a default of `eno1`.
  * Generated network configuration now uses the selected interface name consistently, including default routing.

* **Bug Fixes**
  * Improved compatibility for environments where the primary NIC is not named `eno1`.

* **Documentation**
  * Updated example configuration and schema details to reflect the new interface name option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->