### PR TITLE
Fix virtual media detach timing to prevent ISO reboot loop

### DIFF
--- a/playbooks/03-deploy.yaml
+++ b/playbooks/03-deploy.yaml
@@ -75,6 +75,7 @@
           loop: "{{ agent_hosts }}"
           loop_control:
             loop_var: agent_host
+            label: "{{ agent_host.name }}"
           ansible.builtin.include_tasks:
             file: tasks/configure_hardware_ironic_detach_vmedia.yaml
             apply:

--- a/playbooks/03-deploy.yaml
+++ b/playbooks/03-deploy.yaml
@@ -71,6 +71,16 @@
               tags: hardware
           tags: hardware
 
+        - name: Detach virtual media from hosts
+          loop: "{{ agent_hosts }}"
+          loop_control:
+            loop_var: agent_host
+          ansible.builtin.include_tasks:
+            file: tasks/configure_hardware_ironic_detach_vmedia.yaml
+            apply:
+              tags: hardware
+          tags: hardware
+
         - name: Pre-install validate plugins
           ansible.builtin.include_tasks:
             file: tasks/pre_install_validate_plugins.yaml

--- a/playbooks/tasks/configure_hardware_ironic_detach_vmedia.yaml
+++ b/playbooks/tasks/configure_hardware_ironic_detach_vmedia.yaml
@@ -51,5 +51,7 @@
     user: "{{ metal3_ironic_username }}"
     password: "{{ metal3_ironic_password }}"
     force_basic_auth: true
-    status_code: [204]
-  ignore_errors: true
+    status_code: [204, 404]
+  register: detach_result
+  failed_when:
+    - detach_result.status not in [204, 404]

--- a/playbooks/tasks/configure_hardware_ironic_detach_vmedia.yaml
+++ b/playbooks/tasks/configure_hardware_ironic_detach_vmedia.yaml
@@ -54,4 +54,4 @@
     status_code: [204, 404]
   register: detach_result
   failed_when:
-    - detach_result.status not in [204, 404]
+    - detach_result.status | default(0) not in [204, 404]

--- a/playbooks/tasks/wait_for_deployment.yaml
+++ b/playbooks/tasks/wait_for_deployment.yaml
@@ -11,13 +11,6 @@
   ansible.builtin.command: |
     {{ workingDir }}/bin/openshift-install --dir {{ workingDir }}/ocp-cluster/ agent wait-for install-complete  --log-level=debug
 
-- name: Detach virtual media from hosts
-  loop: "{{ agent_hosts }}"
-  loop_control:
-    loop_var: agent_host
-  ansible.builtin.include_tasks:
-    file: tasks/configure_hardware_ironic_detach_vmedia.yaml
-
 - name: Cleanup Ironic
   ansible.builtin.include_tasks:
     file: tasks/configure_hardware_ironic_cleanup.yaml


### PR DESCRIPTION
## Summary

Fixes https://github.com/gori-project/GoRI/issues/937

During Agent-Based Installer (ABI) deployments, hosts were booting back into the virtual media ISO instead of from disk after the installer wrote OpenShift and triggered a reboot, causing the deployment to block with `installing-pending-user-action`.

## Root Cause

The virtual media detach task was executed too late in the deployment flow - **after** waiting for `install-complete` in `wait_for_deployment.yaml`. The ABI installer reboots hosts mid-installation (after writing OS to disk) but before reaching `install-complete`, so virtual media was still attached during those critical mid-install reboots.

On systems where UEFI firmware prioritizes virtual media over disk, hosts would boot back into the ISO instead of from disk.

## Changes

- **`playbooks/03-deploy.yaml`**: Added virtual media detach immediately after all hosts reach Ironic `active` state and before `wait_for_deployment`
- **`playbooks/tasks/wait_for_deployment.yaml`**: Removed the duplicate (and too-late) detach task

## Impact

Virtual media is now detached as soon as Ironic confirms nodes are active (ISO successfully booted), ensuring the firmware's virtual media entry is removed before any installer-triggered reboots occur. All subsequent reboots will land on disk as expected.

## Testing

This fix addresses the exact sequence described in GoRI #937 and follows the recommended solution from that issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Virtual media detachment is now executed explicitly immediately after hosts reach an active state in the deployment workflow to keep systems clean.
  * The deployment wait phase no longer performs additional virtual media detachment, simplifying the transition from installation completion to cleanup.
  * Virtual media detachment now treats “not found” (HTTP 404) as non-fatal, while still failing on unexpected responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->