### PR TITLE
OSAC-1535: Fix E2E OSAC workflow startup_failure

### DIFF
--- a/.github/workflows/e2e-osac.yml
+++ b/.github/workflows/e2e-osac.yml
@@ -28,15 +28,15 @@ on:
       - 'plugins/osac/**'
       - '.github/workflows/e2e-osac.yml'
 
-permissions:
-  contents: read
-
 concurrency:
   group: e2e-osac-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:
   e2e-osac:
+    permissions:
+      contents: read
+      checks: write  # required by e2e-deployment.yml for check-run updates
     uses: ./.github/workflows/e2e-deployment.yml
     with:
       run-connected: true


### PR DESCRIPTION
## Summary
- Add `checks: write` permission to `e2e-osac.yml` workflow
- The reusable `e2e-deployment.yml` requires `checks: write` to post check results, but `e2e-osac.yml` only granted `contents: read`, causing `startup_failure` on every run since the workflow was created

## Test plan
- [x] Verify E2E OSAC workflow no longer fails with `startup_failure`
- [x] Confirm the workflow runs end-to-end when triggered by plugin changes

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the reliability of end-to-end validation by allowing test runs to update check statuses properly during connected OSAC execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->