### PR TITLE
OSAC-263: Add nightly schedule for OSAC E2E

### DIFF
--- a/.github/workflows/e2e-osac-schedule.yml
+++ b/.github/workflows/e2e-osac-schedule.yml
@@ -1,0 +1,29 @@
+name: E2E OSAC (Scheduled)
+
+# Nightly OSAC plugin stack E2E deployment. Dispatches the e2e-osac workflow
+# so the full OSAC plugin chain runs on a daily schedule.
+
+on:
+  schedule:
+    # Run daily at 06:00 UTC
+    - cron: '0 6 * * *'
+
+jobs:
+  dispatch-osac:
+    name: Dispatch OSAC E2E
+    runs-on: [self-hosted, pr-validation]
+    timeout-minutes: 5
+    permissions:
+      actions: write  # required by gh workflow run to dispatch e2e-osac.yml
+    steps:
+      - name: Trigger OSAC E2E
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF: ${{ github.ref }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh workflow run e2e-osac.yml \
+            --ref "${REF}" \
+            -f send-slack-notification=true \
+            -R "${REPO}"
+          echo "Dispatched OSAC E2E nightly run" | tee -a $GITHUB_STEP_SUMMARY

--- a/.github/workflows/e2e-osac.yml
+++ b/.github/workflows/e2e-osac.yml
@@ -37,6 +37,9 @@ concurrency:
 
 jobs:
   e2e-osac:
+    permissions:
+      contents: read
+      checks: write  # required by e2e-deployment.yml for check-run updates
     uses: ./.github/workflows/e2e-deployment.yml
     with:
       run-connected: true


### PR DESCRIPTION
## Summary
- Add a nightly dispatcher workflow (`e2e-osac-schedule.yml`) that triggers the OSAC E2E workflow daily at 06:00 UTC
- Follows the existing `e2e-odf-schedule.yml` dispatcher pattern
- Sends Slack notifications on completion

## Test plan
- [ ] Verify workflow syntax passes GitHub Actions validation
- [ ] Manually trigger the dispatcher workflow to confirm it dispatches `e2e-osac.yml`
- [ ] Confirm Slack notification is received on completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a scheduled daily automation that triggers an end-to-end OSAC workflow at 06:00 UTC.
  * The scheduled run now forwards the current branch/ref and enables Slack notification for the dispatched workflow.
  * A completion message is now shown in the run summary for easier tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->