### PR TITLE
Allow VM resource overrides via environment variables

### DIFF
--- a/scripts/infrastructure/provision_landing_zone.sh
+++ b/scripts/infrastructure/provision_landing_zone.sh
@@ -324,8 +324,8 @@ info "✓ Disk prepared in pool"
 info "Creating Landing Zone VM with virt-install..."
 sudo virt-install \
     --name "$LZ_VM_NAME" \
-    --memory 16384 \
-    --vcpus 16 \
+    --memory "${LANDINGZONE_MEMORY:-16384}" \
+    --vcpus "${LANDINGZONE_VCPU:-16}" \
     --disk vol=${POOL_NAME}/${LZ_VM_NAME}.qcow2,bus=virtio \
     --disk "${LZ_WORKING_DIR}/cloud-init.iso,device=cdrom,bus=sata" \
     --network network=${BMC_NETWORK_NAME} \

--- a/scripts/setup/configure_devscripts.sh
+++ b/scripts/setup/configure_devscripts.sh
@@ -143,9 +143,9 @@ export VM_EXTRADISKS_SIZE="${VM_EXTRADISKS_SIZE_VAL}"
 # =============================================================================
 
 # Landing Zone VM runs Enclave Lab and deployment tools
-export LANDINGZONE_MEMORY=${LANDINGZONE_MEMORY:-8192}    # 8 GB RAM
+export LANDINGZONE_MEMORY=${LANDINGZONE_MEMORY:-16384}   # 16 GB RAM
 export LANDINGZONE_DISK=${LANDINGZONE_DISK_VAL}
-export LANDINGZONE_VCPU=${LANDINGZONE_VCPU:-4}         # 4 vCPUs
+export LANDINGZONE_VCPU=${LANDINGZONE_VCPU:-16}          # 16 vCPUs
 
 # =============================================================================
 # Network Configuration

--- a/scripts/setup/configure_devscripts.sh
+++ b/scripts/setup/configure_devscripts.sh
@@ -75,7 +75,7 @@ ENCLAVE_NUM_MASTERS="${ENCLAVE_NUM_MASTERS:-3}"
 ENCLAVE_NUM_LANDINGZONE="${ENCLAVE_NUM_LANDINGZONE:-1}"
 
 # VM extra disk size: 1200G for disconnected (mirroring), 60G for connected
-MASTER_MEMORY_VAL=32768    # 32 GB
+MASTER_MEMORY_VAL=${MASTER_MEMORY_VAL:-32768}    # 32 GB
 DEPLOYMENT_MODE="${ENCLAVE_DEPLOYMENT_MODE:-disconnected}"
 if [ "$DEPLOYMENT_MODE" = "connected" ]; then
     VM_EXTRADISKS_SIZE_VAL="60G"
@@ -87,8 +87,8 @@ fi
 # With ODF, storage is provided by Ceph on the LZ -- not local LVMS disks on masters --
 # so masters need smaller extra disks while the LZ needs a larger disk for Ceph OSDs.
 STORAGE_PLUGIN="${STORAGE_PLUGIN:-lvms}"
-MASTER_VCPU_VAL=12
-LANDINGZONE_DISK_VAL=60
+MASTER_VCPU_VAL=${MASTER_VCPU_VAL:-12}
+LANDINGZONE_DISK_VAL=${LANDINGZONE_DISK_VAL:-60}
 if [ "$STORAGE_PLUGIN" = "odf" ]; then
     MASTER_VCPU_VAL=16              # 16 vCPUs (up from 12)
     MASTER_MEMORY_VAL=$((MASTER_MEMORY_VAL + 16384)) # +16 GB RAM (ODF/rook/noobaa + Quay)
@@ -143,9 +143,9 @@ export VM_EXTRADISKS_SIZE="${VM_EXTRADISKS_SIZE_VAL}"
 # =============================================================================
 
 # Landing Zone VM runs Enclave Lab and deployment tools
-export LANDINGZONE_MEMORY=8192    # 8 GB RAM
+export LANDINGZONE_MEMORY=${LANDINGZONE_MEMORY:-8192}    # 8 GB RAM
 export LANDINGZONE_DISK=${LANDINGZONE_DISK_VAL}
-export LANDINGZONE_VCPU=4         # 4 vCPUs
+export LANDINGZONE_VCPU=${LANDINGZONE_VCPU:-4}         # 4 vCPUs
 
 # =============================================================================
 # Network Configuration

--- a/scripts/setup/configure_devscripts.sh
+++ b/scripts/setup/configure_devscripts.sh
@@ -75,7 +75,6 @@ ENCLAVE_NUM_MASTERS="${ENCLAVE_NUM_MASTERS:-3}"
 ENCLAVE_NUM_LANDINGZONE="${ENCLAVE_NUM_LANDINGZONE:-1}"
 
 # VM extra disk size: 1200G for disconnected (mirroring), 60G for connected
-MASTER_MEMORY_VAL=${MASTER_MEMORY_VAL:-32768}    # 32 GB
 DEPLOYMENT_MODE="${ENCLAVE_DEPLOYMENT_MODE:-disconnected}"
 if [ "$DEPLOYMENT_MODE" = "connected" ]; then
     VM_EXTRADISKS_SIZE_VAL="60G"
@@ -87,14 +86,19 @@ fi
 # With ODF, storage is provided by Ceph on the LZ -- not local LVMS disks on masters --
 # so masters need smaller extra disks while the LZ needs a larger disk for Ceph OSDs.
 STORAGE_PLUGIN="${STORAGE_PLUGIN:-lvms}"
-MASTER_VCPU_VAL=${MASTER_VCPU_VAL:-12}
-LANDINGZONE_DISK_VAL=${LANDINGZONE_DISK_VAL:-60}
 if [ "$STORAGE_PLUGIN" = "odf" ]; then
-    MASTER_VCPU_VAL=16              # 16 vCPUs (up from 12)
-    MASTER_MEMORY_VAL=$((MASTER_MEMORY_VAL + 16384)) # +16 GB RAM (ODF/rook/noobaa + Quay)
-    VM_EXTRADISKS_SIZE_VAL="60G"    # Masters don't need large LVMS disks with ODF
-    LANDINGZONE_DISK_VAL=500        # Ceph OSDs store mirrored images on the LZ disk
+    MASTER_MEMORY_VAL_DEFAULT=49152    # 48 GB (32 GB base + 16 GB for ODF/rook/noobaa)
+    MASTER_VCPU_VAL_DEFAULT=16         # 16 vCPUs (up from 12)
+    LANDINGZONE_DISK_VAL_DEFAULT=500   # Ceph OSDs store mirrored images on the LZ disk
+    VM_EXTRADISKS_SIZE_VAL="60G"       # Masters don't need large LVMS disks with ODF
+else
+    MASTER_MEMORY_VAL_DEFAULT=32768    # 32 GB
+    MASTER_VCPU_VAL_DEFAULT=12
+    LANDINGZONE_DISK_VAL_DEFAULT=60
 fi
+MASTER_MEMORY_VAL=${MASTER_MEMORY_VAL:-$MASTER_MEMORY_VAL_DEFAULT}
+MASTER_VCPU_VAL=${MASTER_VCPU_VAL:-$MASTER_VCPU_VAL_DEFAULT}
+LANDINGZONE_DISK_VAL=${LANDINGZONE_DISK_VAL:-$LANDINGZONE_DISK_VAL_DEFAULT}
 
 # Create configuration file
 cat > "$CONFIG_FILE" <<EOF
@@ -143,9 +147,9 @@ export VM_EXTRADISKS_SIZE="${VM_EXTRADISKS_SIZE_VAL}"
 # =============================================================================
 
 # Landing Zone VM runs Enclave Lab and deployment tools
-export LANDINGZONE_MEMORY=${LANDINGZONE_MEMORY:-16384}   # 16 GB RAM
+export LANDINGZONE_MEMORY=${LANDINGZONE_MEMORY:-8192}    # 8 GB RAM
 export LANDINGZONE_DISK=${LANDINGZONE_DISK_VAL}
-export LANDINGZONE_VCPU=${LANDINGZONE_VCPU:-16}          # 16 vCPUs
+export LANDINGZONE_VCPU=${LANDINGZONE_VCPU:-4}           # 4 vCPUs
 
 # =============================================================================
 # Network Configuration


### PR DESCRIPTION
## Summary

- Allow `MASTER_MEMORY_VAL`, `MASTER_VCPU_VAL`, `LANDINGZONE_DISK_VAL`, `LANDINGZONE_MEMORY`, and `LANDINGZONE_VCPU` to be overridden via environment variables using the `${VAR:-default}` pattern
- Follows the same convention already used for `ENCLAVE_NUM_MASTERS` and `ENCLAVE_NUM_LANDINGZONE`
- Enables deployment on hosts with limited RAM (e.g., 64GB) by setting `MASTER_MEMORY_VAL=16384` before running make targets
- ODF-specific defaults (16 vCPUs, 48GB RAM, 500GB LZ disk) are set before user overrides, so users can override ODF values too

**Root cause:** On a 64GB bare-metal host, the default 32GB per master (3×32GB=96GB total) caused OOM kills during cluster installation. The script hardcoded values with no override mechanism.

## Test plan

- [ ] Verify default behavior unchanged: deploy without setting any override env vars, confirm VMs get default resources (32GB RAM, 12 vCPU, etc.)
- [ ] Verify override works: set `MASTER_MEMORY_VAL=16384` before running `make -f Makefile.ci environment`, confirm VMs get 16GB RAM
- [ ] Verify ODF defaults apply: with `STORAGE_PLUGIN=odf` and no overrides, confirm memory=49152, vcpu=16, lz_disk=500
- [ ] Verify ODF overrides work: with `STORAGE_PLUGIN=odf` and `MASTER_MEMORY_VAL=65536`, confirm user value wins
- [ ] Run `make -f Makefile.ci validate-shell` to confirm shellcheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)