### PR TITLE
Fix cleanup script pool handling for multi-runner hosts

### DIFF
--- a/scripts/cleanup/cleanup.sh
+++ b/scripts/cleanup/cleanup.sh
@@ -364,11 +364,9 @@ for POOL_NAME in "${POOLS_TO_CLEAN[@]}"; do
             sudo virsh vol-delete --pool "$POOL_NAME" "$vol" 2>/dev/null || warning "  Failed to delete volume $vol"
         done < <(sudo virsh vol-list "$POOL_NAME" 2>/dev/null | awk 'NR>2 && NF {print $1}')
 
-        # Destroy if running
-        if sudo virsh pool-info "$POOL_NAME" 2>/dev/null | grep -qE "State:[[:space:]]+running$"; then
-            info "  Destroying running pool: $POOL_NAME"
-            sudo virsh pool-destroy "$POOL_NAME" 2>/dev/null || warning "  Failed to destroy $POOL_NAME"
-        fi
+        # Always attempt to destroy (stop) the pool before undefining
+        info "  Destroying pool: $POOL_NAME"
+        sudo virsh pool-destroy "$POOL_NAME" 2>/dev/null || true
 
         # Undefine
         info "  Undefining pool: $POOL_NAME"

--- a/scripts/cleanup/cleanup_infrastructure.sh
+++ b/scripts/cleanup/cleanup_infrastructure.sh
@@ -51,28 +51,57 @@ fi
 
 info "Checking for conflicting storage pools..."
 
-# Find any pools pointing to our target path
-CONFLICTING_POOLS=$(sudo virsh pool-list --all --name | while read -r pool; do
+# Build list of paths that belong to this cluster
+CLUSTER_POOL_PATHS=("${CLUSTER_WORKING_DIR}/pool")
+if [ -n "$CLUSTER_NAME" ]; then
+    CLUSTER_POOL_PATHS+=("${CLUSTER_WORKING_DIR}/landing-zone/${CLUSTER_NAME}")
+fi
+
+# Find pools that belong to this cluster by checking both name and path.
+# Dev-scripts may create pools with suffixes (-1, -lz, _pool), but on multi-runner
+# hypervisors another cluster could have a colliding name. Verify the pool's path
+# points to this cluster's directories before including it.
+POOLS_TO_CLEAN=()
+while IFS= read -r pool; do
+    pool="${pool%"${pool##*[! ]}"}"
     if [ -n "$pool" ]; then
         POOL_PATH=$(sudo virsh pool-dumpxml "$pool" 2>/dev/null | grep -oP '(?<=<path>).*(?=</path>)' || echo "")
-        if [ "$POOL_PATH" = "${CLUSTER_WORKING_DIR}/pool" ]; then
-            echo "$pool"
+        MATCHED=false
+
+        # Check if pool path points to one of this cluster's directories
+        for cluster_path in "${CLUSTER_POOL_PATHS[@]}"; do
+            if [ "$POOL_PATH" = "$cluster_path" ]; then
+                MATCHED=true
+                break
+            fi
+        done
+
+        # Also match by name pattern, but only if path is under our working dir
+        if [ "$MATCHED" = false ] && [ -n "$CLUSTER_NAME" ]; then
+            for PATTERN in "${CLUSTER_NAME}" "${CLUSTER_NAME}-1" "${CLUSTER_NAME}-lz" "${CLUSTER_NAME}_pool"; do
+                if [ "$pool" = "$PATTERN" ] && [[ "$POOL_PATH" == "${CLUSTER_WORKING_DIR}"* ]]; then
+                    MATCHED=true
+                    break
+                fi
+            done
+        fi
+
+        if [ "$MATCHED" = true ]; then
+            POOLS_TO_CLEAN+=("$pool")
         fi
     fi
-done)
+done < <(sudo virsh pool-list --all --name)
 
-if [ -n "$CONFLICTING_POOLS" ]; then
+if [ ${#POOLS_TO_CLEAN[@]} -gt 0 ]; then
     info "Found conflicting storage pools, removing them..."
-    echo "$CONFLICTING_POOLS" | while read -r pool; do
-        if [ -n "$pool" ]; then
-            info "  Removing pool: $pool"
-            # Destroy if running
-            if sudo virsh pool-info "$pool" 2>/dev/null | grep -qE "State:[[:space:]]+running$"; then
-                sudo virsh pool-destroy "$pool" 2>/dev/null || true
-            fi
-            # Undefine
-            sudo virsh pool-undefine "$pool" 2>/dev/null || true
+    for pool in "${POOLS_TO_CLEAN[@]}"; do
+        info "  Removing pool: $pool"
+        # Destroy if running
+        if sudo virsh pool-info "$pool" 2>/dev/null | grep -qE "State:[[:space:]]+running$"; then
+            sudo virsh pool-destroy "$pool" 2>/dev/null || true
         fi
+        # Undefine
+        sudo virsh pool-undefine "$pool" 2>/dev/null || true
     done
     success "Conflicting pools removed"
 else


### PR DESCRIPTION
## Summary

Fixes two pool cleanup bugs that surface on multi-runner hypervisors:

- **`cleanup_infrastructure.sh`** (pre-deployment): Pool name matching without path verification could delete pools belonging to other runners on the same host. Adds path-based verification before cleaning name-matched pools and trims trailing whitespace from `virsh pool-list` output.

- **`cleanup.sh`** (post-deployment / `make clean`): The conditional `pool-destroy` based on `pool-info` state check could be skipped when the pool's backing directory was already removed (causing `pool-info` to fail or the pool to transition to `inactive`). This left the pool active, making `pool-undefine` fail with "storage pool is still active". Fix: always attempt `pool-destroy` before `pool-undefine` — if the pool isn't active, `pool-destroy` fails harmlessly.

## Test plan

- [x] Verified on edge-23 (multi-runner hypervisor) that `cleanup_infrastructure.sh` only removes pools whose paths match the target cluster
- [x] Verified on edge-23 that `pool-destroy` + `pool-undefine` succeeds on both active and inactive pools
- [x] Verified that other runners' pools (`default`, `root`) are not affected by cleanup
- [ ] CI validation passes (shellcheck, ansible-lint, yamllint)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)