### PR TITLE
Update OSAC plugin for chart v0.0.5 and drop Authorino dependency

### DIFF
--- a/.github/workflows/e2e-osac.yml
+++ b/.github/workflows/e2e-osac.yml
@@ -23,7 +23,6 @@ on:
       - 'plugins/lvms/**'
       - 'plugins/trust-manager/**'
       - 'plugins/rhbk/**'
-      - 'plugins/authorino/**'
       - 'plugins/aap/**'
       - 'plugins/osac/**'
       - '.github/workflows/e2e-osac.yml'
@@ -41,7 +40,7 @@ jobs:
     with:
       run-connected: true
       run-disconnected: false
-      enabled-plugins: 'lvms,trust-manager,rhbk,authorino,aap,osac'
+      enabled-plugins: 'lvms,trust-manager,rhbk,aap,osac'
       aap-license-file: '/etc/enclave-ci/aap-license.zip'
       skip-cleanup: ${{ inputs.skip-cleanup || false }}
       send-slack-notification: ${{ inputs.send-slack-notification || false }}

--- a/experiences/bmaas/experience.yaml
+++ b/experiences/bmaas/experience.yaml
@@ -6,6 +6,5 @@ description: >-
 plugins:
   - name: trust-manager
   - name: rhbk
-  - name: authorino
   - name: aap
   - name: osac

--- a/experiences/caas/experience.yaml
+++ b/experiences/caas/experience.yaml
@@ -6,6 +6,5 @@ description: >-
 plugins:
   - name: trust-manager
   - name: rhbk
-  - name: authorino
   - name: aap
   - name: osac

--- a/experiences/vmaas/experience.yaml
+++ b/experiences/vmaas/experience.yaml
@@ -6,7 +6,6 @@ description: >-
 plugins:
   - name: trust-manager
   - name: rhbk
-  - name: authorino
   - name: aap
   - name: gpu-passthrough
   - name: osac

--- a/playbooks/tasks/helm_deploy.yaml
+++ b/playbooks/tasks/helm_deploy.yaml
@@ -115,7 +115,7 @@
   ansible.builtin.set_fact:
     _helm_log: "{{ workingDir }}/logs/helm-{{ plugin_name }}-{{ helm_chart.release }}.{{ lookup('pipe', 'date +%s') }}.log"
 
-- name: "Helm | Install {{ helm_chart.release }}"
+- name: "Helm | Install {{ helm_chart.release }}{{ ' v' ~ (helm_chart.version | default('')) if helm_chart.version is defined else '' }}"
   ansible.builtin.shell: |
     set -o pipefail
     {{ workingDir }}/bin/helm upgrade --install \

--- a/plugins/osac/plugin.yaml
+++ b/plugins/osac/plugin.yaml
@@ -12,7 +12,7 @@ helm:
   - release: osac
     namespace: osac
     chart: "oci://ghcr.io/osac-project/charts/osac"
-    version: "0.0.1"
+    version: "0.0.4"
     valuesTemplate: templates/values.yaml.j2
     createNamespace: true
     timeout: "45m"

--- a/plugins/osac/plugin.yaml
+++ b/plugins/osac/plugin.yaml
@@ -12,7 +12,7 @@ helm:
   - release: osac
     namespace: osac
     chart: "oci://ghcr.io/osac-project/charts/osac"
-    version: "0.0.4"
+    version: "0.0.5"
     valuesTemplate: templates/values.yaml.j2
     createNamespace: true
     timeout: "45m"

--- a/plugins/osac/tasks/post-validate.yaml
+++ b/plugins/osac/tasks/post-validate.yaml
@@ -119,25 +119,7 @@
         | list | length > 0
     fail_msg: "AAP instance {{ osac_aap_name }} is not ready in osac namespace"
 
-# 8. Authorino instance ready
-- name: Check Authorino instance in osac namespace
-  kubernetes.core.k8s_info:
-    api_version: operator.authorino.kuadrant.io/v1beta1
-    kind: Authorino
-    namespace: osac
-  register: __r_authorino
-
-- name: Assert Authorino instance is ready
-  ansible.builtin.assert:
-    that:
-      - __r_authorino.resources | length > 0
-      - __r_authorino.resources[0].status.conditions | default([])
-        | selectattr('type', 'equalto', 'Ready')
-        | selectattr('status', 'in', ['True', 'true'])
-        | list | length > 0
-    fail_msg: "Authorino instance not found or not ready in osac namespace"
-
-# 9. AAP bootstrap job completed
+# 8. AAP bootstrap job completed
 - name: Check AAP bootstrap job completed
   kubernetes.core.k8s_info:
     api_version: batch/v1
@@ -157,5 +139,5 @@
   ansible.builtin.debug:
     msg: >-
       OSAC post-validate passed: all fulfillment deployments running,
-      OSAC operator running, AAP instance ready, Authorino ready,
+      OSAC operator running, AAP instance ready,
       bootstrap job completed{{ ', PostgreSQL running' if not osacBYODatabase | bool else '' }}.

--- a/plugins/osac/templates/values.yaml.j2
+++ b/plugins/osac/templates/values.yaml.j2
@@ -34,6 +34,8 @@ operator:
 
 service:
   variant: openshift
+  externalHostname: "fulfillment-api-osac.{{ __r_ingress_config.resources[0].spec.domain }}"
+  internalHostname: "fulfillment-internal-api-osac.{{ __r_ingress_config.resources[0].spec.domain }}"
   images:
     service: "{{ osac_images.fulfillment_service }}"
     envoy: "{{ osac_images.envoy }}"
@@ -94,6 +96,9 @@ aap:
     cliImage: "{{ osac_images.cli }}"
     enabled: true
     image: "{{ osac_images.aap_bootstrap }}"
+
+bmf:
+  enabled: false
 
 dbMigrate:
   enabled: false


### PR DESCRIPTION
## Summary

- Bump OSAC Helm chart from 0.0.1 to 0.0.5
- Add required `externalHostname` and `internalHostname` to values template (mandatory since OSAC-1628)
- Disable bare-metal-fulfillment-operator (`bmf.enabled: false`) — avoids crashloop from missing OpenStack secrets when bmaas profile is not enabled
- Remove Authorino dependency from OSAC — fulfillment-service now handles JWT auth and OPA authorization natively (since [fulfillment-service@58c8ac44](https://github.com/osac-project/fulfillment-service/commit/58c8ac44)), the Authorino CR is no longer deployed by the chart
  - Remove `authorino` plugin from caas, vmaas, and bmaas experiences
  - Remove `authorino` from OSAC E2E workflow path triggers and enabled-plugins
  - Remove Authorino post-validate check
- Show chart version in Helm install task name for easier debugging

## Test plan

- [x] Deploy OSAC plugin on Enclave with `caas` and/or `vmaas` profiles
- [x] Verify `post-validate` passes without Authorino check
- [x] Verify BMF operator pod is not deployed
- [x] Verify fulfillment-service routes use correct hostnames
- [x] Confirm Helm install task shows `TASK [Helm | Install osac v0.0.5]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added service hostnames for external and internal access in generated deployment values.
  * Introduced a new optional component setting that is disabled by default.

* **Bug Fixes**
  * Updated OSAC-related setup to match the current plugin scope.
  * Removed an outdated readiness check from post-validation steps.

* **Chores**
  * Bumped the OSAC chart version.
  * Improved Helm install step naming to include the chart version when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->