### PR TITLE
fix: reject running bootstrap.sh as root

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2,6 +2,11 @@
 set -o pipefail
 set -e
 
+if [ "$(id -u)" -eq 0 ]; then
+    echo "Error: This script must not be run as root (it invokes sudo where needed)."
+    exit 1
+fi
+
 usage() {
     echo "Usage: $0 [OPTIONS]"
     echo ""


### PR DESCRIPTION
## Summary
- `bootstrap.sh` now exits with an error if invoked as root, since it already escalates privileges itself via `sudo` where needed (e.g. `setup_env.sh`).

## Test plan
- [x] `bash -n bootstrap.sh` (syntax check)
- [x] Manually verified `sudo ./bootstrap.sh` exits early with the error message

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The setup script now stops immediately if it’s run with root privileges, showing a clear error message and handling elevated steps safely when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->