### PR TITLE
OSAC-584: Make hardware configuration step idempotent

### DIFF
--- a/playbooks/03-deploy.yaml
+++ b/playbooks/03-deploy.yaml
@@ -9,6 +9,7 @@
 # - Copy mirror manifests (disconnected only)
 # - Generate Agent-Based Installer ISO
 # - Copy ISO to web server
+# - Skip hosts already Ready in the cluster (idempotent reruns)
 # - Setup Ironic and boot agent hosts via virtual media
 # - Wait for deployment to complete
 # - Detach virtual media from hosts
@@ -44,15 +45,23 @@
               tags: configure-abi
           tags: configure-abi
 
+        - name: Filter agent hosts already provisioned in the cluster
+          ansible.builtin.include_tasks:
+            file: tasks/configure_hardware_filter_hosts.yaml
+            apply:
+              tags: hardware
+          tags: hardware
+
         - name: Setup Ironic for hardware configuration
           ansible.builtin.include_tasks:
             file: tasks/configure_hardware_ironic_setup.yaml
             apply:
               tags: hardware
           tags: hardware
+          when: agent_hosts_to_provision | length > 0
 
         - name: Configure and boot hosts via Ironic
-          loop: "{{ agent_hosts }}"
+          loop: "{{ agent_hosts_to_provision }}"
           loop_control:
             loop_var: agent_host
           ansible.builtin.include_tasks:
@@ -62,7 +71,7 @@
           tags: hardware
 
         - name: Wait for all hosts to reach active state
-          loop: "{{ agent_hosts }}"
+          loop: "{{ agent_hosts_to_provision }}"
           loop_control:
             loop_var: agent_host
           ansible.builtin.include_tasks:
@@ -72,7 +81,7 @@
           tags: hardware
 
         - name: Detach virtual media from hosts
-          loop: "{{ agent_hosts }}"
+          loop: "{{ agent_hosts_to_provision }}"
           loop_control:
             loop_var: agent_host
             label: "{{ agent_host.name }}"

--- a/playbooks/tasks/configure_hardware_filter_hosts.yaml
+++ b/playbooks/tasks/configure_hardware_filter_hosts.yaml
@@ -1,0 +1,38 @@
+---
+# Skip hardware provisioning for agent hosts that are already Ready nodes
+# in the target cluster (idempotent reruns of Phase 3).
+
+- name: Query existing cluster nodes
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  kubernetes.core.k8s_info:
+    kind: Node
+  register: r_existing_nodes
+  ignore_errors: true
+  retries: 1
+  delay: 0
+
+- name: Initialize list of Ready cluster node names
+  ansible.builtin.set_fact:
+    ready_node_names: []
+
+- name: Collect names of Ready cluster nodes
+  ansible.builtin.set_fact:
+    ready_node_names: "{{ ready_node_names + [item.metadata.name] }}"
+  loop: "{{ r_existing_nodes.resources | default([]) }}"
+  loop_control:
+    label: "{{ item.metadata.name }}"
+  when: >-
+    item.status.conditions
+    | selectattr('type', 'equalto', 'Ready')
+    | selectattr('status', 'equalto', 'True')
+    | list | length > 0
+
+- name: Determine hosts still requiring hardware provisioning
+  ansible.builtin.set_fact:
+    agent_hosts_to_provision: "{{ agent_hosts | rejectattr('name', 'in', ready_node_names) | list }}"
+
+- name: Report hosts skipped as already provisioned
+  ansible.builtin.debug:
+    msg: "Skipping hardware provisioning for already-Ready nodes: {{ agent_hosts | selectattr('name', 'in', ready_node_names) | map(attribute='name') | list }}"
+  when: (agent_hosts | length) != (agent_hosts_to_provision | length)

--- a/playbooks/tasks/configure_hardware_filter_hosts.yaml
+++ b/playbooks/tasks/configure_hardware_filter_hosts.yaml
@@ -2,15 +2,30 @@
 # Skip hardware provisioning for agent hosts that are already Ready nodes
 # in the target cluster (idempotent reruns of Phase 3).
 
+- name: Check if cluster kubeconfig exists
+  ansible.builtin.stat:
+    path: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  register: r_kubeconfig
+
 - name: Query existing cluster nodes
   environment:
     KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
   kubernetes.core.k8s_info:
     kind: Node
   register: r_existing_nodes
+  when: r_kubeconfig.stat.exists
   ignore_errors: true
-  retries: 1
-  delay: 0
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_existing_nodes is not failed
+
+- name: Report inability to reach cluster despite existing kubeconfig
+  ansible.builtin.debug:
+    msg: >-
+      Kubeconfig exists but cluster Node state could not be determined
+      after {{ k8s_retries }} attempts; proceeding to provision all
+      agent_hosts.
+  when: r_kubeconfig.stat.exists and r_existing_nodes is failed
 
 - name: Initialize list of Ready cluster node names
   ansible.builtin.set_fact:


### PR DESCRIPTION
## Summary
- Rerunning Phase 3 (`playbooks/03-deploy.yaml`) after a cluster is already installed — or resuming an interrupted bootstrap — currently redeploys Ironic and reboots every `agent_host` via virtual media, even ones already serving as active cluster nodes (Ironic is torn down after every successful install, so a rerun recreates it from scratch with no cluster awareness).
- Adds `playbooks/tasks/configure_hardware_filter_hosts.yaml`, which queries the cluster's `Node` objects via the existing kubeconfig and computes `agent_hosts_to_provision` — the subset of `agent_hosts` that are not already `Ready` in the cluster.
- `03-deploy.yaml` now runs this filter before "Setup Ironic", skips deploying Ironic entirely when nothing needs provisioning, and loops the boot/wait/detach-vmedia steps over `agent_hosts_to_provision` instead of the full `agent_hosts` list.
- NotReady/missing nodes are never filtered out, so a broken or partially-bootstrapped host is still (re)provisioned. If the cluster API isn't reachable at all (fresh bootstrap), the check fails open and all hosts are provisioned as before — no behavior change for first-time installs.
- Per-node Ironic-level idempotency (`configure_hardware_ironic_boot/_wait/_detach_vmedia.yaml`) is untouched.

Ref: [OSAC-584](https://redhat.atlassian.net/browse/OSAC-584) (Enclave bootstrap idempotency)

## Test plan
- [x] `ansible-playbook playbooks/03-deploy.yaml --syntax-check`
- [x] `yamllint` / `ansible-lint` clean on both changed files
- [ ] End-to-end verification against a live/local cluster (e.g. sushy-tools): confirm a rerun after a completed install skips already-Ready hosts and does not reboot them, while a NotReady/missing host is still reprovisioned

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hardware provisioning to be safe to rerun without repeating work for hosts that are already ready.
  * Skips already-available agent hosts and only provisions the remaining ones.
  * Added clearer handling so follow-up setup steps run only when there are hosts left to provision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->