### PR TITLE
OSAC-2139: Make OSAC plugin image overrides optional, delegate config-as-code-ig to chart

### DIFF
--- a/config/plugins/osac.example.yaml
+++ b/config/plugins/osac.example.yaml
@@ -19,3 +19,11 @@
 # Optional: bring your own database
 # osacBYODatabase: true
 # osacDatabaseUrl: "postgres://user@host:5432/dbname?sslmode=require"
+
+# Optional: override container images (chart defaults apply when unset)
+# osac_images:
+#   osac_operator: "ghcr.io/osac-project/osac-operator:v0.0.4"
+#   fulfillment_service: "ghcr.io/osac-project/fulfillment-service:v0.0.4"
+#   envoy: "docker.io/envoyproxy/envoy:v1.33.0"
+#   aap_bootstrap: "ghcr.io/osac-project/osac-aap:v0.0.4"
+#   cli: "quay.io/openshift/origin-cli:4.20.0"

--- a/plugins/osac/defaults.yaml
+++ b/plugins/osac/defaults.yaml
@@ -33,12 +33,3 @@ osac_db_database: service
 # AAP bootstrap
 osac_aap_project_git_uri: "https://github.com/osac-project/osac-aap"
 osac_aap_project_git_branch: main
-
-# Container images
-osac_images:
-  operator: "ghcr.io/osac-project/osac-operator"
-  operator_tag: "latest"
-  fulfillment_service: "ghcr.io/osac-project/fulfillment-service:latest"
-  envoy: "docker.io/envoyproxy/envoy:v1.33.0"
-  aap_bootstrap: "ghcr.io/osac-project/osac-aap:latest"
-  cli: "quay.io/openshift/origin-cli:4.20.0"

--- a/plugins/osac/schemas/config.yaml
+++ b/plugins/osac/schemas/config.yaml
@@ -1,5 +1,7 @@
 ---
+"$schema": "http://json-schema.org/draft-07/schema"
 type: object
+additionalProperties: false
 properties:
   osacAapLicenseFile:
     type: string
@@ -21,5 +23,27 @@ properties:
       Connection URL for external database. When provided with osacBYODatabase=true,
       post-operators.yaml creates the fulfillment-db secret from this value.
       If omitted, the user must pre-create the fulfillment-db secret manually.
+  osac_images:
+    type: object
+    additionalProperties: false
+    properties:
+      osac_operator:
+        type: string
+        description: "Override for osac-operator image (e.g. ghcr.io/osac-project/osac-operator:v0.0.4)"
+      fulfillment_service:
+        type: string
+        description: "Override for fulfillment-service image"
+      envoy:
+        type: string
+        description: "Override for envoy sidecar image"
+      aap_bootstrap:
+        type: string
+        description: "Override for AAP bootstrap image"
+      cli:
+        type: string
+        description: "Override for OpenShift CLI image"
+    description: >-
+      Optional container image overrides. When unset, the Helm chart's
+      built-in image references are used.
 required:
   - osacAapLicenseFile

--- a/plugins/osac/tasks/post-operators.yaml
+++ b/plugins/osac/tasks/post-operators.yaml
@@ -17,8 +17,7 @@
 #   11. Create postgres-client-cert-service Certificate CR (when not BYO)
 #   12. Wait for certificate issuance
 #   13. Create fulfillment-db secret (when not BYO, or BYO with osacDatabaseUrl)
-#   14. Create config-as-code-ig secret
-#   15. Create config-as-code-manifest-ig secret (AAP license)
+#   14. Create config-as-code-manifest-ig secret (AAP license)
 
 # =====================================================================
 # 1. Create osac namespace with ca-bundle label
@@ -729,26 +728,7 @@
   no_log: true
 
 # =====================================================================
-# 14. Create config-as-code-ig secret
-# =====================================================================
-
-- name: Create config-as-code-ig secret for bootstrap
-  kubernetes.core.k8s:
-    state: present
-    definition:
-      apiVersion: v1
-      kind: Secret
-      metadata:
-        name: config-as-code-ig
-        namespace: osac
-      type: Opaque
-      stringData:
-        AAP_EE_IMAGE: "{{ osac_images.aap_bootstrap }}"
-        AAP_PROJECT_GIT_URI: "{{ osac_aap_project_git_uri }}"
-        AAP_PROJECT_GIT_BRANCH: "{{ osac_aap_project_git_branch }}"
-
-# =====================================================================
-# 15. Create config-as-code-manifest-ig secret (AAP license)
+# 14. Create config-as-code-manifest-ig secret (AAP license)
 # =====================================================================
 
 - name: Create config-as-code-manifest-ig secret

--- a/plugins/osac/templates/values.yaml.j2
+++ b/plugins/osac/templates/values.yaml.j2
@@ -6,8 +6,10 @@
 operator:
   image:
     pullPolicy: Always
-    repository: "{{ osac_images.operator }}"
-    tag: "{{ osac_images.operator_tag }}"
+{% if osac_images is defined and osac_images.osac_operator is defined %}
+    repository: "{{ osac_images.osac_operator.rsplit(':', 1)[0] }}"
+    tag: "{{ osac_images.osac_operator.rsplit(':', 1)[1] }}"
+{% endif %}
   aap:
     insecureSkipVerify: "true"
     statusPollInterval: 30s
@@ -34,9 +36,15 @@ operator:
 
 service:
   variant: openshift
+{% if osac_images is defined and (osac_images.fulfillment_service is defined or osac_images.envoy is defined) %}
   images:
+{% if osac_images.fulfillment_service is defined %}
     service: "{{ osac_images.fulfillment_service }}"
+{% endif %}
+{% if osac_images.envoy is defined %}
     envoy: "{{ osac_images.envoy }}"
+{% endif %}
+{% endif %}
   certs:
     caBundle:
       configMap: ca-bundle
@@ -91,9 +99,20 @@ aap:
       name: "{{ osac_aap_name }}"
   bootstrap:
     backoffLimit: 15
+{% if osac_images is defined and osac_images.cli is defined %}
     cliImage: "{{ osac_images.cli }}"
+{% endif %}
     enabled: true
+{% if osac_images is defined and osac_images.aap_bootstrap is defined %}
     image: "{{ osac_images.aap_bootstrap }}"
+{% endif %}
+
+configAsCode:
+  projectGitUri: "{{ osac_aap_project_git_uri }}"
+  projectGitBranch: "{{ osac_aap_project_git_branch }}"
+{% if osac_images is defined and osac_images.aap_bootstrap is defined %}
+  eeImage: "{{ osac_images.aap_bootstrap }}"
+{% endif %}
 
 dbMigrate:
   enabled: false

--- a/plugins/osac/test-fixtures/schemas/config/invalid/unknown-images-property.yaml
+++ b/plugins/osac/test-fixtures/schemas/config/invalid/unknown-images-property.yaml
@@ -1,0 +1,4 @@
+---
+osacAapLicenseFile: "/home/cloud-user/aap-license.zip"
+osac_images:
+  osac_operatorr: "ghcr.io/osac-project/osac-operator:v0.0.4"

--- a/plugins/osac/test-fixtures/schemas/config/invalid/unknown-property.yaml
+++ b/plugins/osac/test-fixtures/schemas/config/invalid/unknown-property.yaml
@@ -1,0 +1,5 @@
+---
+# Fixture: unknown top-level property
+# Expected failure: additionalProperties is false
+osacAapLicenseFile: "/home/cloud-user/aap-license.zip"
+unknownField: this-should-fail

--- a/plugins/osac/test-fixtures/schemas/config/invalid/wrong-images-type.yaml
+++ b/plugins/osac/test-fixtures/schemas/config/invalid/wrong-images-type.yaml
@@ -1,0 +1,5 @@
+---
+# Fixture: osac_images must be an object, not a string
+# Expected failure: type validation
+osacAapLicenseFile: "/home/cloud-user/aap-license.zip"
+osac_images: "not-an-object"

--- a/plugins/osac/test-fixtures/schemas/config/valid/base.yaml
+++ b/plugins/osac/test-fixtures/schemas/config/valid/base.yaml
@@ -1,0 +1,8 @@
+---
+osacAapLicenseFile: "/home/cloud-user/aap-license.zip"
+osacProfilesList:
+  - caas
+  - vmaas
+osac_images:
+  osac_operator: "ghcr.io/osac-project/osac-operator:v0.0.4"
+  fulfillment_service: "ghcr.io/osac-project/fulfillment-service:v0.0.4"


### PR DESCRIPTION
## Summary

- Remove hardcoded `osac_images` from `defaults.yaml` — the chart's built-in image tags now take effect by default
- Wrap all image references in `values.yaml.j2` with Jinja2 conditionals so they are only injected when `osac_images` is explicitly set in `config/plugins/osac.yaml`
- Move `config-as-code-ig` secret creation from `post-operators.yaml` into the Helm chart by passing `configAsCode` values (`projectGitUri`, `projectGitBranch`, `eeImage`) through `values.yaml.j2` — the chart already has a template for this secret
- The `config-as-code-manifest-ig` secret (AAP license) stays in `post-operators.yaml` since the chart expects it pre-created (binary zip content can't be passed through Helm values)
- Move image override reference from `defaults.yaml` to `osac.example.yaml` — chart owns the defaults, the example config is where users discover available overrides

## Overridable keys

| Key | Chart value |
|-----|------------|
| `osac_operator` | `operator.image.repository` + `tag` |
| `fulfillment_service` | `service.images.service` |
| `envoy` | `service.images.envoy` |
| `aap_bootstrap` | `aap.bootstrap.image` + `configAsCode.eeImage` |
| `cli` | `aap.bootstrap.cliImage` |

## Test plan

- [ ] Deploy OSAC plugin without `osac_images` set — verify chart default tags are used
- [ ] Deploy with partial `osac_images` (e.g. only `osac_operator`) — verify only that image is overridden
- [ ] Deploy with all `osac_images` set — verify all images are overridden
- [ ] Verify `config-as-code-ig` secret is created by the chart (not by post-operators.yaml)
- [ ] Verify `config-as-code-manifest-ig` secret is still created by post-operators.yaml

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional configuration for overriding container image versions used by OSAC components.
  * Included an example configuration showing how to customize these image settings.

* **Bug Fixes**
  * Improved configuration validation so unexpected fields and invalid image settings are rejected.
  * Updated generated values to apply image settings only when they are provided.

* **Refactor**
  * Simplified OSAC defaults by removing hardcoded image overrides and related setup steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->