### PR TITLE
[stable] Add trust quay ca in update service migration (backport #549)

### DIFF
--- a/playbooks/tasks/migrations.yaml
+++ b/playbooks/tasks/migrations.yaml
@@ -23,3 +23,7 @@
   when:
     - sslCACertificate is defined
     - sslCACertificate | length > 0
+
+- name: Trust quay registry CA for image config
+  ansible.builtin.include_tasks:
+    file: trust_quay_registry_ca_for_image_config.yaml


### PR DESCRIPTION
it is needed to make sure that update service works fine by adding the needed root CA to the trust store configmap it mounts