### PR TITLE
enable build-push-tarball for stable branch

### DIFF
--- a/.github/workflows/build-push-tarball.yml
+++ b/.github/workflows/build-push-tarball.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-      - 0-rc
+      - stable
     tags:
       - '*'
   pull_request:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to run from the `stable` branch instead of the previous release-candidate branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->