### PR TITLE
Add /cherry-pick slash command for backporting merged PRs

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -1,0 +1,239 @@
+name: Cherry Pick
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  cherry-pick:
+    if: >-
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/cherry-pick')
+    runs-on: [self-hosted, pr-validation]
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.issue.number }}
+      COMMENT_ID: ${{ github.event.comment.id }}
+    steps:
+      - name: Check permissions
+        env:
+          COMMENTER: ${{ github.event.comment.user.login }}
+        run: |
+          PERM=$(gh api "repos/${REPO}/collaborators/${COMMENTER}/permission" \
+            --jq '.permission' 2>/dev/null) || true
+          if [ -z "${PERM}" ]; then
+            gh pr comment "${PR_NUMBER}" -R "${REPO}" \
+              --body "@${COMMENTER} you don't have permission to trigger cherry-picks. Required: write access or above."
+            exit 1
+          fi
+          case "${PERM}" in
+            admin|maintain|write) echo "User ${COMMENTER} has ${PERM} permission" ;;
+            *)
+              gh pr comment "${PR_NUMBER}" -R "${REPO}" \
+                --body "@${COMMENTER} you don't have permission to trigger cherry-picks. Required: write access or above."
+              exit 1
+              ;;
+          esac
+
+      - name: React with eyes
+        run: |
+          gh api "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" \
+            -f content='eyes'
+
+      - name: Parse target branch
+        id: cmd
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          FIRST_LINE=$(echo "${COMMENT_BODY}" | head -n1 | xargs)
+
+          if [[ "${FIRST_LINE}" =~ ^/cherry-pick[[:space:]]+([^[:space:]]+) ]]; then
+            echo "target=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+          else
+            echo "target=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Validate command
+        if: steps.cmd.outputs.target == ''
+        run: |
+          gh pr comment "${PR_NUMBER}" -R "${REPO}" \
+            --body 'Usage: `/cherry-pick <branch-name>`'
+          gh api "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" \
+            -f content='confused'
+          exit 1
+
+      - name: Get PR details
+        id: pr
+        if: steps.cmd.outputs.target != ''
+        env:
+          TARGET: ${{ steps.cmd.outputs.target }}
+        run: |
+          PR_JSON=$(gh pr view "${PR_NUMBER}" -R "${REPO}" \
+            --json title,body,url,baseRefName,mergedAt,mergeCommit)
+
+          MERGED_AT=$(echo "${PR_JSON}" | jq -r '.mergedAt')
+          BASE_REF=$(echo "${PR_JSON}" | jq -r '.baseRefName')
+
+          if [ "${MERGED_AT}" = "null" ]; then
+            gh pr comment "${PR_NUMBER}" -R "${REPO}" \
+              --body "This PR must be merged before it can be cherry-picked."
+            gh api "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" \
+              -f content='confused'
+            exit 1
+          fi
+
+          if [ "${BASE_REF}" = "${TARGET}" ]; then
+            gh pr comment "${PR_NUMBER}" -R "${REPO}" \
+              --body "This PR already targets \`${TARGET}\`."
+            gh api "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" \
+              -f content='confused'
+            exit 1
+          fi
+
+          {
+            echo "merge_sha=$(echo "${PR_JSON}" | jq -r '.mergeCommit.oid')"
+            echo "title=$(echo "${PR_JSON}" | jq -r '.title')"
+            echo "url=$(echo "${PR_JSON}" | jq -r '.url')"
+          } >> "$GITHUB_OUTPUT"
+
+          # Body can be multiline; use a delimiter safe from PR body content.
+          {
+            echo "body<<CHERRY_PICK_PR_BODY_EOF"
+            echo "${PR_JSON}" | jq -r '.body'
+            echo "CHERRY_PICK_PR_BODY_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Validate target branch exists
+        if: steps.cmd.outputs.target != ''
+        env:
+          TARGET: ${{ steps.cmd.outputs.target }}
+        run: |
+          if ! gh api "repos/${REPO}/branches/${TARGET}" >/dev/null 2>&1; then
+            gh pr comment "${PR_NUMBER}" -R "${REPO}" \
+              --body "Branch \`${TARGET}\` does not exist."
+            gh api "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" \
+              -f content='confused'
+            exit 1
+          fi
+
+      - name: Checkout target branch
+        if: steps.cmd.outputs.target != ''
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.cmd.outputs.target }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cherry-pick commit
+        id: pick
+        if: steps.cmd.outputs.target != ''
+        env:
+          TARGET: ${{ steps.cmd.outputs.target }}
+          MERGE_SHA: ${{ steps.pr.outputs.merge_sha }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+          BRANCH="cherry-pick/${TARGET}/pr-${PR_NUMBER}"
+          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+
+          git push origin --delete "${BRANCH}" 2>/dev/null || true
+          git checkout -b "${BRANCH}"
+
+          if ! git cherry-pick -x "${MERGE_SHA}"; then
+            CONFLICT_FILES=$(git diff --name-only --diff-filter=U)
+            git cherry-pick --abort
+
+            gh pr comment "${PR_NUMBER}" -R "${REPO}" \
+              --body "$(cat <<EOF
+          Cherry-pick to \`${TARGET}\` failed due to conflicts in:
+
+          \`\`\`
+          ${CONFLICT_FILES}
+          \`\`\`
+
+          Please resolve manually:
+          \`\`\`
+          git fetch origin ${TARGET}
+          git checkout -b cherry-pick/${TARGET}/pr-${PR_NUMBER} origin/${TARGET}
+          git cherry-pick -x ${MERGE_SHA}
+          \`\`\`
+          EOF
+          )"
+            gh api "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" \
+              -f content='confused'
+            exit 1
+          fi
+
+      - name: Push branch
+        if: steps.cmd.outputs.target != ''
+        env:
+          BRANCH: ${{ steps.pick.outputs.branch }}
+        run: |
+          git push --force origin "HEAD:refs/heads/${BRANCH}"
+
+      - name: Check for existing backport PR
+        id: existing
+        if: steps.cmd.outputs.target != ''
+        env:
+          TARGET: ${{ steps.cmd.outputs.target }}
+          BRANCH: ${{ steps.pick.outputs.branch }}
+        run: |
+          EXISTING_URL=$(gh pr list -R "${REPO}" \
+            --head "${BRANCH}" --base "${TARGET}" \
+            --json url --jq '.[0].url // empty')
+          echo "url=${EXISTING_URL}" >> "$GITHUB_OUTPUT"
+
+      - name: Comment existing PR link
+        if: steps.cmd.outputs.target != '' && steps.existing.outputs.url != ''
+        env:
+          EXISTING_URL: ${{ steps.existing.outputs.url }}
+        run: |
+          gh pr comment "${PR_NUMBER}" -R "${REPO}" \
+            --body "Backport already open: ${EXISTING_URL}"
+          gh api "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" \
+            -f content='rocket'
+
+      - name: Create backport PR
+        if: steps.cmd.outputs.target != '' && steps.existing.outputs.url == ''
+        id: newpr
+        env:
+          TARGET: ${{ steps.cmd.outputs.target }}
+          BRANCH: ${{ steps.pick.outputs.branch }}
+          TITLE: ${{ steps.pr.outputs.title }}
+          ORIGINAL_URL: ${{ steps.pr.outputs.url }}
+          ORIGINAL_BODY: ${{ steps.pr.outputs.body }}
+        run: |
+          BODY="$(cat <<EOF
+          Automated cherry-pick of #${PR_NUMBER} to \`${TARGET}\`.
+
+          Original PR: ${ORIGINAL_URL}
+
+          ---
+
+          ${ORIGINAL_BODY}
+          EOF
+          )"
+
+          NEW_URL=$(gh pr create -R "${REPO}" \
+            --base "${TARGET}" \
+            --head "${BRANCH}" \
+            --title "[${TARGET}] ${TITLE} (backport #${PR_NUMBER})" \
+            --body "${BODY}")
+
+          echo "url=${NEW_URL}" >> "$GITHUB_OUTPUT"
+
+      - name: Comment new PR link
+        if: steps.cmd.outputs.target != '' && steps.existing.outputs.url == ''
+        env:
+          NEW_URL: ${{ steps.newpr.outputs.url }}
+        run: |
+          gh pr comment "${PR_NUMBER}" -R "${REPO}" \
+            --body "Opened backport PR: ${NEW_URL}"
+          gh api "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" \
+            -f content='rocket'

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -4,15 +4,19 @@ on:
   issue_comment:
     types: [created]
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   cherry-pick:
+    permissions:
+      contents: write # push the backport branch
+      pull-requests: write # create/comment backport PRs
     if: >-
       github.event.issue.pull_request &&
       startsWith(github.event.comment.body, '/cherry-pick')
+    concurrency:
+      group: cherry-pick-${{ github.repository }}-${{ github.event.issue.number }}
+      cancel-in-progress: false
     runs-on: [self-hosted, pr-validation]
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -101,19 +105,18 @@ jobs:
             echo "url=$(echo "${PR_JSON}" | jq -r '.url')"
           } >> "$GITHUB_OUTPUT"
 
-          # Body can be multiline; use a delimiter safe from PR body content.
-          {
-            echo "body<<CHERRY_PICK_PR_BODY_EOF"
-            echo "${PR_JSON}" | jq -r '.body'
-            echo "CHERRY_PICK_PR_BODY_EOF"
-          } >> "$GITHUB_OUTPUT"
+          # Body is untrusted and multiline; base64-encode it so it can't
+          # inject extra $GITHUB_OUTPUT entries.
+          BODY_B64=$(echo "${PR_JSON}" | jq -r '.body // ""' | base64 -w 0)
+          echo "body_b64=${BODY_B64}" >> "$GITHUB_OUTPUT"
 
       - name: Validate target branch exists
         if: steps.cmd.outputs.target != ''
         env:
           TARGET: ${{ steps.cmd.outputs.target }}
         run: |
-          if ! gh api "repos/${REPO}/branches/${TARGET}" >/dev/null 2>&1; then
+          ENCODED_TARGET=$(jq -rn --arg target "${TARGET}" '$target | @uri')
+          if ! gh api "repos/${REPO}/branches/${ENCODED_TARGET}" >/dev/null 2>&1; then
             gh pr comment "${PR_NUMBER}" -R "${REPO}" \
               --body "Branch \`${TARGET}\` does not exist."
             gh api "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" \
@@ -123,7 +126,7 @@ jobs:
 
       - name: Checkout target branch
         if: steps.cmd.outputs.target != ''
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ steps.cmd.outputs.target }}
           fetch-depth: 0
@@ -142,8 +145,8 @@ jobs:
           BRANCH="cherry-pick/${TARGET}/pr-${PR_NUMBER}"
           echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
 
-          git push origin --delete "${BRANCH}" 2>/dev/null || true
-          git checkout -b "${BRANCH}"
+          git fetch origin "${BRANCH}:refs/remotes/origin/${BRANCH}" 2>/dev/null || true
+          git checkout -B "${BRANCH}"
 
           if ! git cherry-pick -x "${MERGE_SHA}"; then
             CONFLICT_FILES=$(git diff --name-only --diff-filter=U)
@@ -175,7 +178,7 @@ jobs:
         env:
           BRANCH: ${{ steps.pick.outputs.branch }}
         run: |
-          git push --force origin "HEAD:refs/heads/${BRANCH}"
+          git push --force-with-lease origin "HEAD:refs/heads/${BRANCH}"
 
       - name: Check for existing backport PR
         id: existing
@@ -207,8 +210,9 @@ jobs:
           BRANCH: ${{ steps.pick.outputs.branch }}
           TITLE: ${{ steps.pr.outputs.title }}
           ORIGINAL_URL: ${{ steps.pr.outputs.url }}
-          ORIGINAL_BODY: ${{ steps.pr.outputs.body }}
+          ORIGINAL_BODY_B64: ${{ steps.pr.outputs.body_b64 }}
         run: |
+          ORIGINAL_BODY=$(printf '%s' "${ORIGINAL_BODY_B64}" | base64 -d)
           BODY="$(cat <<EOF
           Automated cherry-pick of #${PR_NUMBER} to \`${TARGET}\`.
 

--- a/.github/workflows/slash-command.yml
+++ b/.github/workflows/slash-command.yml
@@ -108,6 +108,7 @@ jobs:
           | `/retest` | Re-run all failed checks on this PR | — |
           | `/cancel <name>` | Cancel a running check (e.g. `/cancel e2e-connected`) | — |
           | `/cancel` | Cancel all running checks on this PR | — |
+          | `/cherry-pick <branch>` | Cherry-pick this merged PR onto `<branch>` and open a backport PR | pr-validation |
           EOF
           )"
 


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/cherry-pick.yml`: comment `/cherry-pick <branch>` on a merged PR to cherry-pick its squash-merge commit onto `<branch>` and open a backport PR
- Validates permissions (write+), that the PR is merged, and that the target branch exists before acting
- Conflicts abort cleanly (no partial/conflicted branch pushed) and are reported on the original PR with the conflicting file list and manual-resolution instructions
- Idempotent reruns: reuses an existing backport branch/PR instead of erroring or duplicating
- Documents the new command in the `/test ?` help table in `slash-command.yml`

## Test plan
- [x] YAML parses and all embedded bash steps pass `bash -n`
- [x] `yamllint` clean (only cosmetic line-length warnings, consistent with existing workflows)
- [ ] Live test: merge a throwaway PR and comment `/cherry-pick stable` on it to confirm a backport PR is opened correctly (needs the self-hosted `pr-validation` runner, can't be exercised locally)

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `/cherry-pick <branch>` comment command to create backport/cherry-pick branches from merged pull requests.
  * The workflow now validates command usage, checks permissions, and handles existing backport PRs automatically.
  * If a cherry-pick fails due to conflicts, it reports the affected files and next steps in a comment.

* **Documentation**
  * Updated the `/test` help text to include the new cherry-pick command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->