### PR TITLE
Fix ansible-core 2.19 boolean conditional errors in load-vars

### DIFF
--- a/playbooks/common/load-vars.yaml
+++ b/playbooks/common/load-vars.yaml
@@ -16,9 +16,9 @@
 
 - name: Resolve sslCACertificate from system trust store if not provided
   when:
-    - sslCACertificate is not defined or not sslCACertificate
-    - (sslAPICertificateFullChain is defined and sslAPICertificateFullChain) or
-      (sslIngressCertificateFullChain is defined and sslIngressCertificateFullChain)
+    - sslCACertificate is not defined or sslCACertificate | length == 0
+    - (sslAPICertificateFullChain is defined and sslAPICertificateFullChain | length > 0) or
+      (sslIngressCertificateFullChain is defined and sslIngressCertificateFullChain | length > 0)
   block:
     - name: Get root CA from system trust store since it is not provided in the config
       ansible.builtin.command:


### PR DESCRIPTION
ansible-core 2.19 rejects conditionals that resolve to a non-boolean type. The ssl*FullChain and sslCACertificate variables are PEM strings, so bare variable references in `when:` clauses triggered the error "Conditional result was derived from value of type 'str'". Replace with explicit `| length > 0` / `| length == 0` checks to produce boolean results while preserving identical semantics.