### PR TITLE
OSAC-2255: Embed enclave CLI calls into upgrade playbook

### DIFF
--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -46,20 +46,17 @@ Each Enclave tarball release includes:
     ```sh
     ./sync.sh
     ```
-7. **Execute upgrade script** - Run the upgrade automation to apply configuration migrations and updates. Currently executes the `playbooks/upgrade.yaml` playbook. Future versions will also automate steps 8 and 9 (cluster and operator upgrades):
+7. **Execute upgrade script** - Run the upgrade automation to apply configuration migrations, then upgrade the management cluster and operators to the versions pinned in the tarball. This executes the `playbooks/upgrade.yaml` playbook, which runs migrations followed by `enclave reconcile mgmt-cluster-version --use-defaults` and `enclave reconcile operator-versions --use-defaults`:
     ```sh
     ./upgrade.sh
     ```
-8. **Upgrade management cluster** - Update OpenShift to the version in the tarball:
+8. **(Optional) Run cluster/operator upgrades separately** - By default `upgrade.yaml` performs both the management cluster and operator upgrades. To skip either step (e.g. to control upgrade timing independently) pass `upgrade_mgmt_cluster=false` and/or `upgrade_operators=false`, then run the corresponding command manually when ready:
     ```sh
+    ansible-playbook playbooks/upgrade.yaml -e workingDir=<your global.yaml workingDir variable> -e upgrade_mgmt_cluster=false -e upgrade_operators=false
+
     WORKING_DIR=<your global.yaml workingDir variable>
     export KUBECONFIG=$WORKING_DIR/ocp-cluster/auth/kubeconfig
     enclave reconcile mgmt-cluster-version --use-defaults
-    ```
-9. **Upgrade operators** - Update operators to the versions in the tarball:
-    ```sh
-    WORKING_DIR=<your global.yaml workingDir variable>
-    export KUBECONFIG=$WORKING_DIR/ocp-cluster/auth/kubeconfig
     enclave reconcile operator-versions --use-defaults
     ```
 

--- a/playbooks/upgrade.yaml
+++ b/playbooks/upgrade.yaml
@@ -29,9 +29,6 @@
           - reconcile
           - mgmt-cluster-version
           - --use-defaults
-          - --no-dry-run
-      environment:
-        KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
       register: r_mgmt_cluster_upgrade
       when: upgrade_mgmt_cluster | default(true) | bool
 
@@ -47,9 +44,6 @@
           - reconcile
           - operator-versions
           - --use-defaults
-          - --no-dry-run
-      environment:
-        KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
       register: r_operator_versions_upgrade
       when: upgrade_operators | default(true) | bool
 

--- a/playbooks/upgrade.yaml
+++ b/playbooks/upgrade.yaml
@@ -21,3 +21,39 @@
     - name: Run migrations
       ansible.builtin.include_tasks:
         file: tasks/migrations.yaml
+
+    - name: Upgrade management cluster OpenShift version
+      ansible.builtin.command:
+        argv:
+          - enclave
+          - reconcile
+          - mgmt-cluster-version
+          - --use-defaults
+          - --no-dry-run
+      environment:
+        KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+      register: r_mgmt_cluster_upgrade
+      when: upgrade_mgmt_cluster | default(true) | bool
+
+    - name: Print management cluster upgrade output
+      ansible.builtin.debug:
+        var: r_mgmt_cluster_upgrade.stderr_lines
+      when: upgrade_mgmt_cluster | default(true) | bool
+
+    - name: Upgrade operator versions
+      ansible.builtin.command:
+        argv:
+          - enclave
+          - reconcile
+          - operator-versions
+          - --use-defaults
+          - --no-dry-run
+      environment:
+        KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+      register: r_operator_versions_upgrade
+      when: upgrade_operators | default(true) | bool
+
+    - name: Print operator versions upgrade output
+      ansible.builtin.debug:
+        var: r_operator_versions_upgrade.stderr_lines
+      when: upgrade_operators | default(true) | bool


### PR DESCRIPTION
## Summary
- Automate the management cluster and operator version upgrades (`enclave reconcile mgmt-cluster-version --use-defaults` / `enclave reconcile operator-versions --use-defaults`) as tasks in `playbooks/upgrade.yaml`, so `./upgrade.sh` fully covers steps 7-9 of the upgrade process instead of requiring separate manual commands
- Each upgrade step can be individually skipped via `-e upgrade_mgmt_cluster=false` / `-e upgrade_operators=false` for cases where timing needs to be controlled manually
- Update `docs/UPGRADE.md` to describe the automated flow and the opt-out flags

## Test plan
- [x] `ansible-lint playbooks/upgrade.yaml` passes
- [ ] Run `./upgrade.sh` against a real deployment to confirm the reconcile calls execute successfully end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streamlined upgrade flow now runs migrations and then reconciles both the management cluster version and operator versions as part of `./upgrade.sh`.
  * Added an option to run management cluster and/or operator upgrades separately by invoking `ansible-playbook` with flags (e.g., `upgrade_mgmt_cluster=false` and/or `upgrade_operators=false`).

* **Documentation**
  * Updated the upgrade guide to reframe and renumber steps, clarifying how each action is executed during the upgrade process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->