### PR TITLE
run Generate SSH keypair if doesn't exist twice

### DIFF
--- a/playbooks/tasks/configure_ocp_abi.yaml
+++ b/playbooks/tasks/configure_ocp_abi.yaml
@@ -13,6 +13,14 @@
     backend: cryptography
     private_key_format: ssh
 
+- name: Generate SSH keypair if doesn't exist
+  community.crypto.openssh_keypair:
+    path: "{{ sshPubPath | replace('.pub','') }}"
+    type: ed25519
+    regenerate: never
+    backend: cryptography
+    private_key_format: ssh
+
 - name: Extract openshift-install binary
   ansible.builtin.command: |
     {{ workingDir }}/bin/oc adm release extract --registry-config={{ pullSecretPath }} --command=openshift-install --to {{ workingDir }}/bin/


### PR DESCRIPTION
test regeneration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected an SSH key generation task so its settings are applied properly, improving reliability during setup.
  * Fixed a configuration issue that could prevent the task from running as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->