### PR TITLE
Reintroduce Clair postgres config Secret validation

### DIFF
--- a/operators/quay-operator/clair_validations.yaml
+++ b/operators/quay-operator/clair_validations.yaml
@@ -30,17 +30,28 @@
     msg: "Required CPE mapping files are missing from /data in pod {{ clair_pod_name }}"
   when: cpe_file_check.rc != 0 or repo_map_check.rc != 0
 
-- name: Validate that Clair postgres config Secret exists
+- name: Get Secrets owned by the Quay registry
   kubernetes.core.k8s_info:
     kind: Secret
     namespace: quay-enterprise
     label_selectors:
-      - quay-component=clairpostgres
-  register: clair_postgres_config_secret
+      - quay-operator/quayregistry=registry
+  register: quay_registry_secrets
 
-- name: Fail if Secret is missing
+- name: Find the Clair postgres config Secret
+  ansible.builtin.set_fact:
+    clair_postgres_config_secret: "{{ quay_registry_secrets.resources | selectattr('metadata.name', 'match', 'registry-clairpostgres-config-secret') | list }}"
+
+- name: Fail if Clair postgres config Secret is missing
   ansible.builtin.assert:
     that:
-      - clair_postgres_config_secret.resources | length > 0
-    fail_msg: "Validation Failed: no Secret with label quay-component=clairpostgres was found in namespace quay-enterprise."
-    success_msg: "Validation Passed: Clair postgres config Secret ({{ clair_postgres_config_secret.resources[0].metadata.name }}) is present in namespace quay-enterprise."
+      - clair_postgres_config_secret | length > 0
+    fail_msg: >-
+      Validation Failed: no Secret with label quay-operator/quayregistry=registry
+      and a name starting with 'registry-clairpostgres-config-secret' was found
+      in namespace quay-enterprise.
+    success_msg: >-
+      Validation Passed: Clair postgres config Secret
+      ({{ clair_postgres_config_secret[0].metadata.name
+      if clair_postgres_config_secret | length > 0 else 'unknown' }})
+      is present in namespace quay-enterprise.

--- a/operators/quay-operator/clair_validations.yaml
+++ b/operators/quay-operator/clair_validations.yaml
@@ -29,3 +29,18 @@
   fail:
     msg: "Required CPE mapping files are missing from /data in pod {{ clair_pod_name }}"
   when: cpe_file_check.rc != 0 or repo_map_check.rc != 0
+
+- name: Validate that Clair postgres config Secret exists
+  kubernetes.core.k8s_info:
+    kind: Secret
+    namespace: quay-enterprise
+    label_selectors:
+      - quay-component=clairpostgres
+  register: clair_postgres_config_secret
+
+- name: Fail if Secret is missing
+  ansible.builtin.assert:
+    that:
+      - clair_postgres_config_secret.resources | length > 0
+    fail_msg: "Validation Failed: no Secret with label quay-component=clairpostgres was found in namespace quay-enterprise."
+    success_msg: "Validation Passed: Clair postgres config Secret ({{ clair_postgres_config_secret.resources[0].metadata.name }}) is present in namespace quay-enterprise."


### PR DESCRIPTION
## Summary
- Reintroduces the "Clair postgres config Secret exists" check in `operators/quay-operator/clair_validations.yaml`, which was removed in f2b0066 because it hardcoded the Secret name (`clairpostgres-config-secret`).
- The quay-operator now generates this Secret's name dynamically, so the check now finds it via the `quay-component=clairpostgres` label instead, matching the pattern already used for the `clair-app` pod lookup in this same file.

## History
- Added in dbe4a51 ("bump quay to 3.15.5") alongside the CPE mapping file checks.
- Removed in f2b0066 ("remove Clair postgres config Secret validation") once the fixed Secret name stopped matching reality.
- This PR restores the intent of the original check with a label-based lookup that tolerates the generated name.

## Test plan
- [ ] `make -f Makefile.ci validate-ansible`
- [ ] Run the validation playbook against a cluster with the quay-operator deployed and confirm it passes when the Secret exists and fails clearly when it doesn't

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added an additional validation check to confirm the Clair Postgres configuration Secret exists before reporting the environment as healthy.
  * Improved validation feedback by clearly indicating when the Secret is missing or successfully detected, including which Secret was matched.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->