### PR TITLE
OSAC-2313: Add workflow display name to Slack notifications

### DIFF
--- a/.github/workflows/e2e-deployment.yml
+++ b/.github/workflows/e2e-deployment.yml
@@ -62,6 +62,11 @@ on:
         required: false
         type: string
         default: ''
+      workflow-display-name:
+        description: 'Display name prefix for Slack notifications (e.g., "E2E OSAC")'
+        required: false
+        type: string
+        default: 'E2E Deployment'
   workflow_call:
     inputs:
       run-connected:
@@ -85,6 +90,9 @@ on:
       aap-license-file:
         type: string
         default: ''
+      workflow-display-name:
+        type: string
+        default: 'E2E Deployment'
   pull_request:
     types: [opened, synchronize, reopened]
   merge_group:
@@ -648,7 +656,7 @@ jobs:
         uses: ./.github/actions/notify-slack
         with:
           status: ${{ job.status }}
-          workflow-name: E2E Deployment - Connected
+          workflow-name: ${{ inputs.workflow-display-name || 'E2E Deployment' }} - Connected
           cluster-name: ${{ env.ENCLAVE_CLUSTER_NAME }}
           slack-webhook-urls: ${{ secrets.SLACK_WEBHOOK_URLS }}
           workflow-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -1103,7 +1111,7 @@ jobs:
         uses: ./.github/actions/notify-slack
         with:
           status: ${{ job.status }}
-          workflow-name: E2E Deployment - Disconnected
+          workflow-name: ${{ inputs.workflow-display-name || 'E2E Deployment' }} - Disconnected
           cluster-name: ${{ env.ENCLAVE_CLUSTER_NAME }}
           slack-webhook-urls: ${{ secrets.SLACK_WEBHOOK_URLS }}
           workflow-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/e2e-odf-schedule.yml
+++ b/.github/workflows/e2e-odf-schedule.yml
@@ -27,5 +27,6 @@ jobs:
             -f run-disconnected=true \
             -f storage-plugin=odf \
             -f send-slack-notification=true \
+            -f workflow-display-name="E2E ODF" \
             -R "${{ github.repository }}"
           echo "Dispatched E2E Disconnected with ODF storage plugin" | tee -a $GITHUB_STEP_SUMMARY

--- a/.github/workflows/e2e-osac.yml
+++ b/.github/workflows/e2e-osac.yml
@@ -44,4 +44,5 @@ jobs:
       aap-license-file: '/etc/enclave-ci/aap-license.zip'
       skip-cleanup: ${{ inputs.skip-cleanup || false }}
       send-slack-notification: ${{ inputs.send-slack-notification || false }}
+      workflow-display-name: 'E2E OSAC'
     secrets: inherit


### PR DESCRIPTION
## Summary

- Add `workflow-display-name` input to the reusable `e2e-deployment.yml` workflow (defaults to "E2E Deployment" for backward compatibility)
- Pass `workflow-display-name: "E2E OSAC"` from `e2e-osac.yml` so Slack notifications show "E2E OSAC - Connected" instead of "E2E Deployment - Connected"
- Pass `workflow-display-name: "E2E ODF"` from `e2e-odf-schedule.yml` for the same reason

## Test plan

- [x] Trigger `e2e-osac` manually with `send-slack-notification=true` and verify Slack message shows "E2E OSAC - Connected"
- [x] Verify default `e2e-deployment` runs still show "E2E Deployment - Connected/Disconnected"

Jira: https://redhat.atlassian.net/browse/OSAC-2313

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for customizable display names in E2E deployment notifications.
  * Scheduled and reusable E2E workflows now show clearer, workflow-specific names in alerts.

* **Bug Fixes**
  * Updated Slack notifications to use consistent connected/disconnected labels with the correct workflow name.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->