### PR TITLE
OSAC-2321: Make OSAC Helm chart version configurable via user config

### DIFF
--- a/config/plugins/osac.example.yaml
+++ b/config/plugins/osac.example.yaml
@@ -9,6 +9,9 @@
 # Obtain from: https://access.redhat.com/management/subscription_allocations
 # osacAapLicenseFile: "/path/to/aap-license.zip"
 
+# Optional: override OSAC Helm chart version (default from plugin defaults.yaml)
+# osacChartVersion: "0.0.6"
+
 # Optional: enabled service profiles (default: [caas, vmaas])
 # See docs/OSAC_DEPLOYMENT.md for valid profiles and prerequisites.
 # osacProfilesList:

--- a/docs/OSAC_DEPLOYMENT.md
+++ b/docs/OSAC_DEPLOYMENT.md
@@ -78,6 +78,7 @@ osacAapLicenseFile: "/home/<user>/aap-license.zip"
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `osacAapLicenseFile` | string | Yes | — | Path to AAP license manifest.zip on the Landing Zone |
+| `osacChartVersion` | string | No | `0.0.6` | OSAC Helm chart version to deploy |
 | `osacProfilesList` | list | No | `[caas, vmaas]` | Enabled service profiles: `vmaas`, `caas`, `bmaas` |
 | `osacBYODatabase` | boolean | No | `false` | Use an external database instead of the built-in dev postgres |
 | `osacDatabaseUrl` | string | No | — | Connection URL for external database (requires `osacBYODatabase: true`) |

--- a/plugins/osac/defaults.yaml
+++ b/plugins/osac/defaults.yaml
@@ -4,6 +4,8 @@
 # which is loaded into Ansible scope as-is. The defaults below use the same
 # camelCase convention to match. Ansible variables from defaults.yaml and
 # config/plugins/osac.yaml are merged into the same scope.
+osacChartVersion: "0.0.6"
+
 osacProfilesList:
   - caas
   - vmaas

--- a/plugins/osac/plugin.yaml
+++ b/plugins/osac/plugin.yaml
@@ -12,7 +12,7 @@ helm:
   - release: osac
     namespace: osac
     chart: "oci://ghcr.io/osac-project/charts/osac"
-    version: "0.0.6"
+    version: "{{ osacChartVersion }}"
     valuesTemplate: templates/values.yaml.j2
     createNamespace: true
     timeout: "45m"

--- a/plugins/osac/schemas/config.yaml
+++ b/plugins/osac/schemas/config.yaml
@@ -14,6 +14,10 @@ properties:
       type: string
       enum: [vmaas, caas, bmaas]
     description: "List of enabled service profiles: vmaas, caas, bmaas"
+  osacChartVersion:
+    type: string
+    minLength: 1
+    description: "OSAC Helm chart version to deploy (overrides default from defaults.yaml)"
   osacBYODatabase:
     type: boolean
     description: "Set to true to use an external database instead of the built-in dev postgres"

--- a/plugins/osac/schemas/defaults.yaml
+++ b/plugins/osac/schemas/defaults.yaml
@@ -3,6 +3,10 @@
 type: object
 additionalProperties: false
 properties:
+  osacChartVersion:
+    type: string
+    minLength: 1
+    description: OSAC Helm chart version to deploy.
   osacProfilesList:
     type: array
     minItems: 1

--- a/plugins/osac/test-fixtures/schemas/defaults/valid/base.yaml
+++ b/plugins/osac/test-fixtures/schemas/defaults/valid/base.yaml
@@ -1,4 +1,6 @@
 ---
+osacChartVersion: "0.0.6"
+
 osacProfilesList:
   - caas
   - vmaas


### PR DESCRIPTION
## Summary
- Move OSAC chart version from hardcoded `plugin.yaml` to configurable `osacChartVersion` variable
- Default in `defaults.yaml`, overridable in `config/plugins/osac.yaml` — same pattern as `osacProfilesList`
- Update deployment docs config reference table
- Add `osacChartVersion` to both config and defaults JSON schemas with `minLength: 1` validation
- Update defaults test fixture to include `osacChartVersion`

Jira: https://redhat.atlassian.net/browse/OSAC-2321

## Test plan
- [x] Plugin schema validation passes (`make -f Makefile.ci validate-plugins`)
- [x] Defaults schema test-fixtures validation passes (`ansible-playbook playbooks/validation/validate-schema.yaml --tags test-fixtures`)
- [ ] Deploy OSAC with default version (no user config override)
- [ ] Deploy OSAC with `osacChartVersion` set in user config

🤖 Generated with [Claude Code](https://claude.com/claude-code)