### PR TITLE
OSAC-2328: Deploy latest nightly OSAC chart version in CI

### DIFF
--- a/.github/actions/notify-slack/action.yml
+++ b/.github/actions/notify-slack/action.yml
@@ -31,6 +31,10 @@ inputs:
     description: 'URL to download artifacts (optional)'
     required: false
     default: ''
+  osac-chart-version:
+    description: 'OSAC Helm chart version (optional, shown in notification when set)'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -47,6 +51,7 @@ runs:
         INPUT_FAILED_STEP: ${{ inputs.failed-step }}
         INPUT_ARTIFACT_URL: ${{ inputs.artifact-url }}
         INPUT_SLACK_WEBHOOKS: ${{ inputs.slack-webhook-urls }}
+        INPUT_OSAC_CHART_VERSION: ${{ inputs.osac-chart-version }}
       run: |
         # Set status-specific values
         if [ "$INPUT_STATUS" = "success" ]; then
@@ -75,10 +80,11 @@ runs:
           --arg cluster "$INPUT_CLUSTER_NAME" \
           --arg branch "$INPUT_BRANCH_NAME" \
           --arg commit "${INPUT_COMMIT_SHA:0:7}" \
+          --arg chart "${INPUT_OSAC_CHART_VERSION}" \
           '[
             {"type": "mrkdwn", "text": ("*Cluster:* " + $cluster)},
             {"type": "mrkdwn", "text": ("*Branch:* " + $branch + " (" + $commit + ")")}
-          ]')
+          ] + (if $chart != "" then [{"type": "mrkdwn", "text": ("*OSAC Chart:* " + $chart)}] else [] end)')
 
         # Build action buttons
         if [ -n "$INPUT_ARTIFACT_URL" ]; then

--- a/.github/workflows/e2e-deployment.yml
+++ b/.github/workflows/e2e-deployment.yml
@@ -67,6 +67,11 @@ on:
         required: false
         type: string
         default: 'E2E Deployment'
+      osac-chart-version:
+        description: 'OSAC Helm chart version to deploy (overrides plugin default)'
+        required: false
+        type: string
+        default: ''
   workflow_call:
     inputs:
       run-connected:
@@ -93,6 +98,9 @@ on:
       workflow-display-name:
         type: string
         default: 'E2E Deployment'
+      osac-chart-version:
+        type: string
+        default: ''
   pull_request:
     types: [opened, synchronize, reopened]
   merge_group:
@@ -251,6 +259,7 @@ jobs:
       ENCLAVE_ENABLE_GPU_PASSTHROUGH: "false"
       LZ_OS_VARIANT: ${{ vars.LZ_OS_VARIANT }}
       AAP_LICENSE_FILE: ${{ inputs.aap-license-file }}
+      OSAC_CHART_VERSION: ${{ inputs.osac-chart-version }}
 
     steps:
       - name: Checkout code
@@ -664,6 +673,7 @@ jobs:
           commit-sha: ${{ github.sha }}
           failed-step: ${{ steps.failed_step.outputs.FAILED_STEP }}
           artifact-url: ${{ steps.artifact_url.outputs.ARTIFACT_URL }}
+          osac-chart-version: ${{ inputs.osac-chart-version }}
 
   # ---------------------------------------------------------------------------
   # Disconnected mode E2E deployment
@@ -697,6 +707,7 @@ jobs:
       ENCLAVE_ENABLE_GPU_PASSTHROUGH: "false"
       LZ_OS_VARIANT: ${{ vars.LZ_OS_VARIANT }}
       AAP_LICENSE_FILE: ${{ inputs.aap-license-file }}
+      OSAC_CHART_VERSION: ${{ inputs.osac-chart-version }}
 
     steps:
       - name: Checkout code
@@ -1119,3 +1130,4 @@ jobs:
           commit-sha: ${{ github.sha }}
           failed-step: ${{ steps.failed_step.outputs.FAILED_STEP }}
           artifact-url: ${{ steps.artifact_url.outputs.ARTIFACT_URL }}
+          osac-chart-version: ${{ inputs.osac-chart-version }}

--- a/.github/workflows/e2e-osac.yml
+++ b/.github/workflows/e2e-osac.yml
@@ -32,7 +32,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  get-latest-chart-version:
+    name: Get latest OSAC nightly chart version
+    if: github.event_name != 'pull_request'
+    runs-on: [self-hosted, pr-validation]
+    timeout-minutes: 5
+    permissions: {}
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Query latest nightly OSAC chart version from OCI registry
+        id: version
+        run: |
+          VERSION=$(skopeo list-tags --no-creds docker://ghcr.io/osac-project/charts/osac \
+            | jq -r '.Tags[]' | { grep 'nightly' || test $? = 1; } | sort -V | tail -1)
+          if [ -z "$VERSION" ]; then
+            echo "::error::No nightly chart version found"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Latest OSAC nightly chart version: $VERSION"
+
   e2e-osac:
+    needs: get-latest-chart-version
+    if: always() && needs.get-latest-chart-version.result != 'failure'
     permissions:
       contents: read
       checks: write  # required by e2e-deployment.yml for check-run updates
@@ -45,4 +68,5 @@ jobs:
       skip-cleanup: ${{ inputs.skip-cleanup || false }}
       send-slack-notification: ${{ inputs.send-slack-notification || false }}
       workflow-display-name: 'E2E OSAC'
+      osac-chart-version: ${{ needs.get-latest-chart-version.outputs.version || '' }}
     secrets: inherit

--- a/scripts/deployment/deploy_plugin.sh
+++ b/scripts/deployment/deploy_plugin.sh
@@ -149,10 +149,18 @@ if [ -n "${AAP_LICENSE_FILE:-}" ] && { [ "$PLUGIN_NAME" = "aap" ] || [ "$PLUGIN_
     # shellcheck disable=SC2086  # SSH_OPTS needs word splitting
     if ! ssh $SSH_OPTS "$LZ_SSH" "test -f $LZ_ENCLAVE_DIR/config/plugins/osac.yaml"; then
         info "Generating config/plugins/osac.yaml on Landing Zone"
+        if [ -n "${OSAC_CHART_VERSION:-}" ]; then
+            if [[ ! "$OSAC_CHART_VERSION" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+                error "Invalid OSAC_CHART_VERSION: '$OSAC_CHART_VERSION'"
+                error "Version must match: ^[A-Za-z0-9][A-Za-z0-9._-]*$"
+                exit 1
+            fi
+        fi
         # shellcheck disable=SC2086,SC2087  # SSH_OPTS needs word splitting, we want client-side expansion
         ssh $SSH_OPTS "$LZ_SSH" "mkdir -p $LZ_ENCLAVE_DIR/config/plugins && cat > $LZ_ENCLAVE_DIR/config/plugins/osac.yaml" <<OSAC_EOF
 ---
 osacAapLicenseFile: "${LZ_AAP_LICENSE}"
+${OSAC_CHART_VERSION:+osacChartVersion: "${OSAC_CHART_VERSION}"}
 osacProfilesList:
   - caas
 OSAC_EOF


### PR DESCRIPTION
## Summary
- Add `get-latest-chart-version` pipeline stage to `e2e-osac.yml` that queries ghcr.io/osac-project/charts/osac for the latest nightly chart version via skopeo
- Nightly lookup only runs on scheduled/manual triggers; PR runs use the default version from `defaults.yaml`
- Add `osac-chart-version` input to `e2e-deployment.yml` (both `workflow_dispatch` and `workflow_call`)
- Wire `OSAC_CHART_VERSION` env var through `deploy_plugin.sh` into `config/plugins/osac.yaml` on the LZ

Depends on PR #590 (OSAC-2321: configurable chart version).

Jira: https://redhat.atlassian.net/browse/OSAC-2328

## Test plan
- [x] Verify `skopeo list-tags --no-creds` returns nightly versions from ghcr.io/osac-project/charts/osac
- [x] Scheduled/manual run: confirm latest nightly version is resolved and deployed
- [x] PR run: confirm `get-latest-chart-version` is skipped and default from `defaults.yaml` is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added an optional `osac-chart-version` input for end-to-end deployments and surfaced it in Slack notifications.
  - Enhanced E2E OSAC runs to determine and use the latest available nightly OSAC chart version when applicable.
  - Propagated the resolved chart version through both connected and disconnected deployment modes, and into generated OSAC plugin configuration.
- **Bug Fixes**
  - Validated `OSAC_CHART_VERSION` against a strict character set to prevent invalid values from being used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->