### PR TITLE
Add enclave reconcile ironic-version subcommand

### DIFF
--- a/src/enclave/reconcile/cli.py
+++ b/src/enclave/reconcile/cli.py
@@ -8,6 +8,10 @@ from enclave.reconcile.cluster_upgrade import (
     ClusterUpgradeError,
     reconcile as cluster_upgrade_reconcile,
 )
+from enclave.reconcile.ironic_version import (
+    IronicVersionError,
+    reconcile as ironic_version_reconcile,
+)
 from enclave.reconcile.operator_versions import reconcile as operator_versions_reconcile
 from enclave.utils import (
     LOG_LEVELS,
@@ -24,6 +28,59 @@ def defaults_path(filename: str) -> Path:
     if not path.exists():
         path = enclave_pkg.parent.parent / "defaults" / filename
     return path
+
+
+def resolve_platform_version(version: str | None, use_defaults: bool) -> str:
+    """Resolve OpenShift version from either direct input or defaults.
+
+    Args:
+        version: Direct version string (e.g., "4.20.21")
+        use_defaults: If True, load default from platforms.yaml
+
+    Returns:
+        Resolved version string
+
+    Raises:
+        click.UsageError: If arguments are mutually exclusive or missing
+        click.ClickException: If defaults file issues or missing version key
+    """
+    if use_defaults and version:
+        raise click.UsageError("--use-defaults is mutually exclusive with --version")
+
+    if not use_defaults and not version:
+        raise click.UsageError("Either --version or --use-defaults must be provided")
+
+    if use_defaults:
+        defaults_file = defaults_path("platforms.yaml")
+        try:
+            with defaults_file.open(encoding="utf-8") as fh:
+                platforms = yaml.safe_load(fh)
+        except FileNotFoundError as exc:
+            raise click.ClickException(
+                f"{defaults_file} not found; run from the repo root"
+            ) from exc
+        except yaml.YAMLError as exc:
+            raise click.ClickException(
+                f"Failed to parse {defaults_file}: {exc}"
+            ) from exc
+
+        openshift_versions: list[dict[str, object]] = platforms.get(
+            "openshift_versions", []
+        )
+        default_entry = next(
+            (v for v in openshift_versions if v.get("default") is True), None
+        )
+        if default_entry is None:
+            raise click.ClickException(
+                "No default version found in defaults/platforms.yaml; "
+                "set 'default: true' on one entry"
+            )
+        if "version" not in default_entry:
+            raise click.ClickException(
+                "Default OpenShift entry in defaults/platforms.yaml is missing 'version'"
+            )
+        return str(default_entry["version"])
+    return cast("str", version)
 
 
 @click.group(cls=KubeconfigGroup)
@@ -132,46 +189,54 @@ def mgmt_cluster_version(
     timeout_minutes: int,
     sleep_interval: int,
 ) -> None:
-    if use_defaults and version:
-        raise click.UsageError("--use-defaults is mutually exclusive with --version")
-
-    if not use_defaults and not version:
-        raise click.UsageError("Either --version or --use-defaults must be provided")
-
-    if use_defaults:
-        defaults_file = defaults_path("platforms.yaml")
-        try:
-            with defaults_file.open(encoding="utf-8") as fh:
-                platforms = yaml.safe_load(fh)
-        except FileNotFoundError as exc:
-            raise click.ClickException(
-                f"{defaults_file} not found; run from the repo root"
-            ) from exc
-        except yaml.YAMLError as exc:
-            raise click.ClickException(
-                f"Failed to parse {defaults_file}: {exc}"
-            ) from exc
-
-        openshift_versions: list[dict[str, object]] = platforms.get(
-            "openshift_versions", []
-        )
-        default_entry = next(
-            (v for v in openshift_versions if v.get("default") is True), None
-        )
-        if default_entry is None:
-            raise click.ClickException(
-                "No default version found in defaults/platforms.yaml; "
-                "set 'default: true' on one entry"
-            )
-        resolved_version: str = str(default_entry["version"])
-    else:
-        resolved_version = cast("str", version)
+    resolved_version = resolve_platform_version(version, use_defaults)
 
     try:
         cluster_upgrade_reconcile(
             resolved_version, dry_run, timeout_minutes, sleep_interval
         )
     except (ClusterUpgradeError, RuntimeError, TimeoutError) as e:
+        raise click.ClickException(str(e)) from e
+
+
+@cli.command(no_args_is_help=True)
+@click.option(
+    "--version", "version", default=None, help="OpenShift version to get ironic from"
+)
+@click.option(
+    "--use-defaults",
+    is_flag=True,
+    default=False,
+    help="Load the default OpenShift version from defaults/platforms.yaml (mutually exclusive with --version)",
+)
+@click.option("--dry-run/--no-dry-run", default=False)
+@click.option(
+    "--timeout-minutes",
+    default=10,
+    type=click.IntRange(min=1),
+    help="Timeout for waiting operations in minutes (default: 10)",
+)
+@click.option(
+    "--sleep-interval",
+    default=5,
+    type=click.IntRange(min=1),
+    help="Sleep interval between polling attempts in seconds (default: 5)",
+)
+def ironic_version(
+    version: str | None,
+    use_defaults: bool,
+    dry_run: bool,
+    timeout_minutes: int,
+    sleep_interval: int,
+) -> None:
+    """Update ironic to the version bundled with the specified OpenShift release."""
+    resolved_version = resolve_platform_version(version, use_defaults)
+
+    try:
+        ironic_version_reconcile(
+            resolved_version, dry_run, timeout_minutes, sleep_interval
+        )
+    except (IronicVersionError, RuntimeError, TimeoutError) as e:
         raise click.ClickException(str(e)) from e
 
 

--- a/src/enclave/reconcile/ironic_version.py
+++ b/src/enclave/reconcile/ironic_version.py
@@ -1,0 +1,506 @@
+import contextlib
+import json
+import logging
+import os
+import re
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from enclave.utils import (
+    log_subprocess_output,
+    run_oc_command,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class IronicVersionError(Exception):
+    """Base exception for ironic version operations."""
+
+
+class IronicNotFoundError(IronicVersionError):
+    """Raised when ironic containers are not found."""
+
+    def __init__(self) -> None:
+        super().__init__("Ironic containers not found. Is ironic deployed?")
+
+
+class IronicImageNotFoundError(IronicVersionError):
+    """Raised when the specified ironic image cannot be found."""
+
+    def __init__(self, openshift_version: str) -> None:
+        self.openshift_version = openshift_version
+        super().__init__(
+            f"Cannot extract ironic image from OpenShift release {openshift_version}"
+        )
+
+
+def load_pull_secret_from_config() -> dict[str, Any] | None:
+    """Load pull secret from config/global.yaml."""
+    config_path = Path("config/global.yaml")
+    if not config_path.is_file():
+        logger.warning("config/global.yaml not found, skipping authentication")
+        return None
+
+    try:
+        with config_path.open(encoding="utf-8") as f:
+            config: dict[str, Any] = yaml.safe_load(f) or {}
+    except (OSError, yaml.YAMLError) as e:
+        logger.warning("Failed to read config/global.yaml: %s", e)
+        return None
+
+    pull_secret = config.get("pullSecret")
+    if pull_secret is None:
+        logger.warning("pullSecret not found in config/global.yaml")
+        return None
+
+    # Handle different pull secret formats
+    result = None
+    if isinstance(pull_secret, str):
+        # Parse string-encoded JSON
+        try:
+            result = json.loads(pull_secret)
+        except json.JSONDecodeError:
+            logger.exception("Invalid JSON in pullSecret field")
+    elif isinstance(pull_secret, dict):
+        result = pull_secret
+    else:
+        logger.error("pullSecret field has unexpected type: %s", type(pull_secret))
+
+    return result
+
+
+def get_current_ironic_image() -> str:
+    """Get the currently running ironic container image (systemd quadlet deployment)."""
+    # Get all containers and look for ironic
+    result = subprocess.run(
+        ["sudo", "podman", "ps", "--format", "json"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    logger.debug("podman ps command returned: returncode=%d", result.returncode)
+
+    if result.returncode != 0:
+        logger.error("podman ps command failed: %s", result.stderr)
+        raise IronicNotFoundError
+
+    try:
+        containers = json.loads(result.stdout)
+        logger.debug("Found %d total containers", len(containers))
+
+        # Look for the ironic container specifically
+        for container in containers:
+            container_names = container.get("Names", [])
+            image = container.get("Image", "")  # This is the full registry reference
+
+            # Log all containers for debugging
+            logger.debug("Container: names=%s, image=%s", container_names, image)
+
+            # Check if any name is exactly "ironic" or contains "ironic" but not "infra"
+            for name in container_names:
+                if name == "ironic" or (
+                    "ironic" in name.lower() and "infra" not in name.lower()
+                ):
+                    logger.debug(
+                        "Found ironic container '%s' with image: %s", name, image
+                    )
+                    if image:  # Make sure we have a non-empty image
+                        return image
+
+        logger.debug("No ironic container found matching criteria")
+        raise IronicNotFoundError
+    except (json.JSONDecodeError, KeyError, IndexError) as e:
+        logger.exception("Failed to parse container list")
+        logger.debug("Raw stdout was: %s", result.stdout)
+        raise IronicNotFoundError from e
+
+
+def _validate_openshift_version(version: str) -> None:
+    """Validate OpenShift version format to prevent malformed input."""
+    if not re.match(r"^\d+\.\d+\.\d+$", version):
+        raise ValueError(f"Invalid OpenShift version format: {version}. Expected format: X.Y.Z")
+
+
+def get_ironic_image_from_openshift_release(openshift_version: str) -> str:
+    """Extract ironic image from OpenShift release (matches deploy_ironic.yaml logic)."""
+    _validate_openshift_version(openshift_version)
+    logger.info("Extracting ironic image from OpenShift release %s", openshift_version)
+
+    # Load pull secret for authentication
+    pull_secret = load_pull_secret_from_config()
+
+    if pull_secret is None:
+        # Try without authentication first
+        result = run_oc_command([
+            "oc",
+            "adm",
+            "release",
+            "info",
+            "--image-for",
+            "ironic",
+            f"quay.io/openshift-release-dev/ocp-release:{openshift_version}-x86_64",
+        ])
+    else:
+        # Use authentication with temporary file
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False, encoding="utf-8"
+        ) as auth_file:
+            try:
+                json.dump(pull_secret, auth_file)
+                auth_file.flush()
+
+                # Use the auth file with oc command via REGISTRY_AUTH_FILE environment variable
+                env = os.environ.copy()
+                env["REGISTRY_AUTH_FILE"] = auth_file.name
+
+                try:
+                    result = subprocess.run(
+                        [
+                            "oc",
+                            "adm",
+                            "release",
+                            "info",
+                            "--image-for",
+                            "ironic",
+                            f"quay.io/openshift-release-dev/ocp-release:{openshift_version}-x86_64",
+                        ],
+                        capture_output=True,
+                        text=True,
+                        timeout=60,
+                        check=False,
+                        env=env,
+                    )
+                except subprocess.TimeoutExpired as exc:
+                    cmd_str = f"oc adm release info --image-for ironic quay.io/openshift-release-dev/ocp-release:{openshift_version}-x86_64"
+                    raise TimeoutError(
+                        f"Command timed out after 60 seconds: {cmd_str}"
+                    ) from exc
+
+            finally:
+                # Clean up temporary auth file
+                with contextlib.suppress(OSError):
+                    Path(auth_file.name).unlink()
+
+    if result.returncode != 0:
+        header = (
+            f"Failed to get ironic image from OpenShift release {openshift_version}"
+        )
+        if result.stderr:
+            log_subprocess_output(f"{header} [stderr]", result.stderr, logging.ERROR)
+        if result.stdout:
+            log_subprocess_output(f"{header} [stdout]", result.stdout, logging.ERROR)
+        raise IronicImageNotFoundError(openshift_version)
+
+    ironic_image = result.stdout.strip()
+    logger.info("Extracted ironic image: %s", ironic_image)
+    return ironic_image
+
+
+def validate_ironic_image_exists(image: str) -> bool:
+    """Check if the specified ironic image exists and is accessible (systemd quadlet deployment)."""
+    logger.debug("Validating ironic image exists: %s", image)
+
+    # Check if image exists locally
+    result = subprocess.run(
+        ["sudo", "podman", "image", "exists", image],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    if result.returncode == 0:
+        logger.debug("Image exists locally: %s", image)
+        return True
+
+    # Try to pull the image if it doesn't exist locally
+    logger.info("Pulling ironic image: %s", image)
+
+    # Load pull secret for authentication
+    pull_secret = load_pull_secret_from_config()
+
+    if pull_secret is None:
+        # Try without authentication
+        result = subprocess.run(
+            ["sudo", "podman", "pull", image],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            logger.info("Successfully pulled image without authentication: %s", image)
+            return True
+
+        logger.error(
+            "Failed to pull image %s (no authentication available): %s",
+            image,
+            result.stderr,
+        )
+        return False
+
+    # Use authentication with temporary file
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".json", delete=False, encoding="utf-8"
+    ) as auth_file:
+        try:
+            json.dump(pull_secret, auth_file)
+            auth_file.flush()
+
+            result = subprocess.run(
+                ["sudo", "podman", "pull", "--authfile", auth_file.name, image],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            if result.returncode == 0:
+                logger.info("Successfully pulled image with authentication: %s", image)
+                return True
+
+            logger.error(
+                "Failed to pull image %s with authentication: %s", image, result.stderr
+            )
+            return False
+
+        finally:
+            # Clean up temporary auth file
+            with contextlib.suppress(OSError):
+                Path(auth_file.name).unlink()
+
+
+def update_ironic_systemd(new_image: str) -> None:
+    """Update ironic systemd quadlet configuration with new image."""
+    logger.info("Updating systemd quadlet configuration with image: %s", new_image)
+
+    def update_quadlet_file(quadlet_path: str) -> None:
+        """Update a single quadlet file with the new image."""
+        # Check if file exists
+        result = subprocess.run(
+            ["sudo", "test", "-f", quadlet_path],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            logger.warning("Quadlet file not found: %s", quadlet_path)
+            return
+
+        # Read current content
+        result = subprocess.run(
+            ["sudo", "cat", quadlet_path],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise IronicVersionError(f"Failed to read {quadlet_path}: {result.stderr}")
+
+        content = result.stdout
+
+        # Update the Image line
+        lines = content.splitlines()
+        updated_lines = []
+        image_updated = False
+
+        for line in lines:
+            if line.startswith("Image="):
+                updated_lines.append(f"Image={new_image}")
+                image_updated = True
+                logger.info(
+                    "Updated Image line in %s: %s", quadlet_path, f"Image={new_image}"
+                )
+            else:
+                updated_lines.append(line)
+
+        if not image_updated:
+            logger.warning("Could not find Image= line in %s", quadlet_path)
+            return
+
+        # Write back the updated content using sudo tee
+        updated_content = "\n".join(updated_lines) + "\n"
+
+        result = subprocess.run(
+            ["sudo", "tee", quadlet_path],
+            input=updated_content,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise IronicVersionError(f"Failed to write {quadlet_path}: {result.stderr}")
+
+    # Update the ironic API container quadlet
+    update_quadlet_file("/etc/containers/systemd/metal3-ironic-api.container")
+
+    # Also update httpd container quadlet (both use same image)
+    update_quadlet_file("/etc/containers/systemd/metal3-httpd.container")
+
+    logger.info("Updated systemd quadlet files")
+
+
+def restart_ironic_systemd() -> None:
+    """Restart ironic systemd services."""
+    logger.info("Restarting ironic systemd services")
+
+    # Reload systemd daemon to pick up changes
+    result = subprocess.run(
+        ["sudo", "systemctl", "daemon-reload"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        logger.warning("systemctl daemon-reload failed: %s", result.stderr)
+
+    # Stop and start services in correct order
+    services = [
+        "metal3-ironic-api.service",
+        "metal3-httpd.service",
+        "metal3-ironic-pod.service",
+    ]
+
+    # Stop services
+    for service in services:
+        logger.info("Stopping %s", service)
+        subprocess.run(
+            ["sudo", "systemctl", "stop", service],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    # Start services
+    for service in reversed(services):  # Start in reverse order
+        logger.info("Starting %s", service)
+        result = subprocess.run(
+            ["sudo", "systemctl", "start", service],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            logger.error("Failed to start %s: %s", service, result.stderr)
+
+
+def wait_for_ironic_ready(timeout_minutes: int = 10, sleep_interval: int = 5) -> None:
+    """Wait for ironic API to be ready after restart."""
+    logger.info("Waiting for ironic to be ready...")
+    deadline = time.time() + (timeout_minutes * 60)
+
+    while time.time() < deadline:
+        try:
+            # Check if ironic API is responding (matches deploy_ironic.yaml:167-178)
+            result = subprocess.run(
+                [
+                    "curl",
+                    "-s",
+                    "-o",
+                    "/dev/null",
+                    "-w",
+                    "%{http_code}",
+                    "http://localhost:6385/v1/",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=5,
+            )
+
+            if result.stdout.strip() in {"200", "401"}:  # 401 is OK (auth required)
+                logger.info("Ironic API is responding")
+                return
+
+        except subprocess.SubprocessError as e:
+            logger.debug("Ironic health check failed: %s", e)
+
+        logger.debug("Ironic not ready yet, waiting %d seconds...", sleep_interval)
+        time.sleep(sleep_interval)
+
+    raise TimeoutError(f"Ironic did not become ready within {timeout_minutes} minutes")
+
+
+def restart_ironic_with_new_image(new_image: str) -> None:
+    """Update ironic systemd quadlet deployment to use the new image."""
+    update_ironic_systemd(new_image)
+    restart_ironic_systemd()
+
+
+def reconcile(
+    openshift_version: str,
+    dry_run: bool,
+    timeout_minutes: int = 10,
+    sleep_interval: int = 5,
+) -> None:
+    """Reconcile ironic to the version matching the specified OpenShift version.
+
+    Args:
+        openshift_version: OpenShift version to extract ironic from (e.g., "4.20.21")
+        dry_run: If True, only show what would be done
+        timeout_minutes: Max time to wait for ironic to be ready
+        sleep_interval: Polling interval for readiness checks
+    """
+    logger.info(
+        "Reconciling ironic version for OpenShift %s (dry_run=%s)",
+        openshift_version,
+        dry_run,
+    )
+
+    # Extract ironic image from the OpenShift release
+    target_image = get_ironic_image_from_openshift_release(openshift_version)
+
+    try:
+        current_image = get_current_ironic_image()
+        logger.info("Current ironic image: %s", current_image)
+
+        if current_image == target_image:
+            logger.info(
+                "✅ Ironic is already using the target image from OpenShift %s",
+                openshift_version,
+            )
+            logger.info("No action needed - versions match")
+            if dry_run:
+                logger.info(
+                    "DRY RUN: No changes would be made (versions already match)"
+                )
+            return
+        logger.info(
+            "Ironic needs to be updated from %s to %s", current_image, target_image
+        )
+        current_image_found = True
+
+    except IronicNotFoundError:
+        logger.info("Ironic not currently running, deployment needed")
+        current_image_found = False
+
+    if dry_run:
+        if current_image_found:
+            logger.info(
+                "DRY RUN: Would update ironic systemd quadlets to image %s",
+                target_image,
+            )
+        else:
+            logger.info(
+                "DRY RUN: Would deploy ironic systemd quadlets with image %s",
+                target_image,
+            )
+        return
+
+    # Validate the target image is accessible
+    if not validate_ironic_image_exists(target_image):
+        raise IronicImageNotFoundError(openshift_version)
+
+    # Update ironic deployment
+    restart_ironic_with_new_image(target_image)
+
+    # Wait for ironic to be ready
+    wait_for_ironic_ready(timeout_minutes, sleep_interval)
+
+    logger.info(
+        "Successfully updated ironic to version from OpenShift %s", openshift_version
+    )


### PR DESCRIPTION
This command updates ironic to the version bundled with a specified OpenShift release, specifically targeting systemd quadlet deployments running as root.

Features:
- Extract ironic image from OpenShift releases using oc adm release info
- Compare current running ironic image with target version
- Update systemd quadlet configuration files when versions differ
- Support both --version and --use-defaults (from platforms.yaml) options
- Comprehensive dry-run mode for safe testing

Authentication improvements:
- Extract pull secret from config/global.yaml for authenticated image pulls
- Support both string and dict format pull secrets
- Use REGISTRY_AUTH_FILE for oc command authentication
- Use temporary auth files with podman pull operations

Root deployment support:
- All podman operations use sudo since ironic runs as root
- Systemd quadlet file updates use sudo for proper permissions
- Container inspection works with root-owned containers

Code quality:
- Comprehensive error handling with custom exception hierarchy
- Debug logging for troubleshooting container detection
- Simplified codebase focused on systemd quadlet deployment only
- Type annotations and strict mypy compliance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `ironic_version` command to update an existing Ironic deployment to the image matching a specified OpenShift release.
  * Supports default version selection, dry runs, configurable timeouts, and polling intervals.
  * Automatically validates or pulls the required image, updates services, restarts them, and waits for readiness.

* **Bug Fixes**
  * Improved validation and user-facing error handling for version reconciliation commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->