### PR TITLE
Fix missing osacNetrisEnabled in OSAC defaults schema

### DIFF
--- a/plugins/osac/schemas/defaults.yaml
+++ b/plugins/osac/schemas/defaults.yaml
@@ -47,6 +47,9 @@ properties:
   osac_keycloak_validate_certs:
     type: boolean
     description: Whether to validate TLS certificates for Keycloak API calls.
+  osacNetrisEnabled:
+    type: boolean
+    description: Enable Netris network backend for cluster/network fulfillment.
   osacBYODatabase:
     type: boolean
     description: Use an external database instead of the built-in dev postgres.

--- a/plugins/osac/test-fixtures/schemas/defaults/valid/base.yaml
+++ b/plugins/osac/test-fixtures/schemas/defaults/valid/base.yaml
@@ -17,6 +17,8 @@ osac_keycloak_admin_client_id: osac-admin
 osac_keycloak_service_port: 8443
 osac_keycloak_validate_certs: true
 
+osacNetrisEnabled: false
+
 osacBYODatabase: false
 osac_db_name: postgres
 osac_db_image: "registry.redhat.io/rhel10/postgresql-18:latest"


### PR DESCRIPTION
## Summary
- Add `osacNetrisEnabled` property to `plugins/osac/schemas/defaults.yaml`
- Update valid test fixture to include the property
- PR #500 added `osacNetrisEnabled` to `defaults.yaml` but did not update the defaults schema, causing validation failures with `additionalProperties: false` since github.com/rh-ecosystem-edge/enclave/pull/556 was merged

## Test plan
- [x] `make -f Makefile.ci validate-plugins` passes
- [x] `ansible-playbook playbooks/validation/validate-schema.yaml --tags test-fixtures` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)