### PR TITLE
Document config/schema sync requirement in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,12 @@ make -f Makefile.ci validate-plugins     # plugin descriptor validation
 - Optional lifecycle task files: `tasks/early-validate.yaml`, `tasks/deploy.yaml`, `tasks/post-validate.yaml`
 - Declarative operator and registry requirements in the descriptor
 
+### Config and schemas (`config/`, `defaults/`, `schemas/`)
+- Every property added to a file under `config/` or `defaults/` (including plugin example/default
+  configs) must also be added to its matching schema file under `schemas/` (same base filename,
+  e.g. `defaults/catalogs.yaml` → `schemas/catalogs.yaml`) in the same PR
+- Run `make -f Makefile.ci validate-json-schema` before opening a PR to catch missing schema entries
+
 ## Git workflow
 
 - **NEVER push commits directly to `main`** — all changes must go through pull requests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ make -f Makefile.ci validate-plugins     # plugin descriptor validation
 - Declarative operator and registry requirements in the descriptor
 
 ### Config and schemas (`config/`, `defaults/`, `schemas/`)
+
 - Every property added to a file under `config/` or `defaults/` (including plugin example/default
   configs) must also be added to its matching schema file under `schemas/` (same base filename,
   e.g. `defaults/catalogs.yaml` → `schemas/catalogs.yaml`) in the same PR


### PR DESCRIPTION
## Summary
- Add a "Config and schemas" subsection to `AGENTS.md` requiring that any new property added to `config/`, `defaults/`, or plugin example/default configs be added to its matching schema file under `schemas/` in the same PR
- Reference `make -f Makefile.ci validate-json-schema` as the pre-PR check

## Why
This exact gap was flagged by review twice, on separate PRs:
- #561 — `fleet_rh_operator_catalog` added to `defaults/catalogs.yaml` without a matching schema update
- #590 — `osacChartVersion` added to `config/plugins/osac.example.yaml` without a matching schema update

Documenting it in `AGENTS.md` means both human contributors and AI coding agents (which read this file automatically) check schema sync before opening a PR, instead of relying on review to catch it.

## Test plan
- [x] Docs-only change; no code paths affected
- [x] `AGENTS.md` renders correctly as markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance requiring configuration and default property changes to include corresponding schema updates.
  * Documented the schema validation command to run before submitting changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->