### PR TITLE
Add connected_auto property to plugin operator schema

### DIFF
--- a/schemas/plugin.yaml
+++ b/schemas/plugin.yaml
@@ -42,6 +42,9 @@ definitions:
       global:
         type: boolean
         description: Configure operator to watch the entire cluster.
+      connected_auto:
+        type: boolean
+        description: Use automatic install plan approval when not disconnected.
     dependencies:
       csvMirror:
       - csvNames


### PR DESCRIPTION
## Summary
- `connected_auto` was added to core operators (`defaults/operators.yaml` / `schemas/operators.yaml`) in #471 to enable automatic install plan approval when the environment is not disconnected.
- Plugin operators (declared in `plugins/*/plugin.yaml`) already flow through the same `playbooks/tasks/configure_operator.yaml` logic (via `deploy_plugin.yaml`'s loop), so the `_use_automatic_approval` behavior already applies to them.
- However, `schemas/plugin.yaml`'s operator definition has `additionalProperties: false` and did not include `connected_auto`, so any plugin trying to set it would fail schema validation.
- This adds `connected_auto` to `schemas/plugin.yaml` to bring it in line with `schemas/operators.yaml`, unblocking plugin operators from opting into automatic approval when connected.

## Test plan
- [ ] `make -f Makefile.ci validate-plugins` passes
- [ ] `make -f Makefile.ci validate-yaml` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to automatically approve install plans when operating in connected mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->