### PR TITLE
docs: note RHCOS ISO extraction can be skipped by pre-placing a file

### DIFF
--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -1356,6 +1356,12 @@ RHCOS ISOs are automatically extracted from OpenShift release images during the 
 3. Determines the ISO volume ID using `blkid`
 4. Stores the ISO at `/var/www/html/rhcos-<version>-x86_64-live-iso.x86_64.iso`
 
+**Note**: If an ISO already exists at the destination path above for a given
+version, extraction is skipped for that version. To provide your own ISO
+instead of extracting it from the release image, pre-place it at
+`/var/www/html/rhcos-<version>-x86_64-live-iso.x86_64.iso` before running the
+prepare phase.
+
 ## Complete Example
 
 Configuration is split across multiple files. Here are complete examples for each.


### PR DESCRIPTION
## Summary
- Documents the existing skip-if-exists behavior for RHCOS ISO extraction: if a file already exists at the expected destination path for a given version, the prepare phase skips extracting it from the release image
- Clarifies that this allows users to supply their own ISO by pre-placing it at that path

Code reference: https://github.com/rh-ecosystem-edge/enclave/blob/6cf151e0fe91fdcbfe04bf2a77b4c3a73b56f4f6/playbooks/tasks/download_content_single_version.yaml#L2-L5

## Test plan
- [x] Docs-only change, no code affected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified RHCOS ISO handling during preparation.
  * Documented that existing ISOs are reused, and custom ISOs should be placed at the expected destination before preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->