### PR TITLE
fix: skip check_leftovers when validations.sh is called from sync.sh

### DIFF
--- a/sync.sh
+++ b/sync.sh
@@ -78,7 +78,7 @@ step_done
 
 echo "Validating Config .. " | tee -a ${log}
     ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/validation/validate-schema.yaml -e fresh=false --tags validate-config
-    bash ./validations.sh 2>&1 | tee -a ${log}
+    bash ./validations.sh --skip-check-leftovers 2>&1 | tee -a ${log}
 step_done
 
 echo "Building local cache .. " | tee -a ${log}

--- a/sync.sh
+++ b/sync.sh
@@ -78,7 +78,7 @@ step_done
 
 echo "Validating Config .. " | tee -a ${log}
     ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/validation/validate-schema.yaml -e fresh=false --tags validate-config
-    bash ./validations.sh --skip-check-leftovers 2>&1 | tee -a ${log}
+    bash ./validations.sh --skip-check-leftovers 2>&1 | tee -a "${log}"
 step_done
 
 echo "Building local cache .. " | tee -a ${log}

--- a/validations.sh
+++ b/validations.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+SKIP_CHECK_LEFTOVERS=false
+for arg in "$@"; do
+  case "$arg" in
+    --skip-check-leftovers) SKIP_CHECK_LEFTOVERS=true ;;
+  esac
+done
+
 # Config file paths — single source of truth matching load-vars.yaml
 global_vars=config/global.yaml
 certs_vars=config/certificates.yaml
@@ -179,52 +186,54 @@ machine_network=$(getValue .machineNetwork)
 rendezvous_ip=$(getValue .rendezvousIP)
 
 ## Leftover resources check
-validation_section "check_leftovers"
+if [[ "$SKIP_CHECK_LEFTOVERS" == "false" ]]; then
+    validation_section "check_leftovers"
 
-# Check for metal3 systemd units left from a previous bootstrap
-metal3_units=$(systemctl list-unit-files 'metal3-*.service' --no-legend 2>/dev/null || true)
-if [[ -n "$metal3_units" ]]; then
-    validation fail metal3_systemd "Metal3 systemd units detected from a previous installation" "$metal3_units"
-fi
-validation pass metal3_systemd "No metal3 systemd units found"
+    # Check for metal3 systemd units left from a previous bootstrap
+    metal3_units=$(systemctl list-unit-files 'metal3-*.service' --no-legend 2>/dev/null || true)
+    if [[ -n "$metal3_units" ]]; then
+        validation fail metal3_systemd "Metal3 systemd units detected from a previous installation" "$metal3_units"
+    fi
+    validation pass metal3_systemd "No metal3 systemd units found"
 
-# Check root podman context
-root_pods=$(sudo podman pod ls --format "{{.Name}}" 2>/dev/null | grep -E 'metal3|quay' || true)
-if [[ -n "$root_pods" ]]; then
-    validation fail root_podman_pods "Root podman pods with metal3/quay detected" "$root_pods"
-fi
-validation pass root_podman_pods "No metal3/quay root podman pods"
+    # Check root podman context
+    root_pods=$(sudo podman pod ls --format "{{.Name}}" 2>/dev/null | grep -E 'metal3|quay' || true)
+    if [[ -n "$root_pods" ]]; then
+        validation fail root_podman_pods "Root podman pods with metal3/quay detected" "$root_pods"
+    fi
+    validation pass root_podman_pods "No metal3/quay root podman pods"
 
-root_containers=$(sudo podman ps -a --format "{{.Names}}" 2>/dev/null | grep -E 'metal3|ironic|httpd|baremetal-operator' || true)
-if [[ -n "$root_containers" ]]; then
-    validation fail root_podman_containers "Root podman containers detected" "$root_containers"
-fi
-validation pass root_podman_containers "No leftover root podman containers"
+    root_containers=$(sudo podman ps -a --format "{{.Names}}" 2>/dev/null | grep -E 'metal3|ironic|httpd|baremetal-operator' || true)
+    if [[ -n "$root_containers" ]]; then
+        validation fail root_podman_containers "Root podman containers detected" "$root_containers"
+    fi
+    validation pass root_podman_containers "No leftover root podman containers"
 
-root_volumes=$(sudo podman volume ls --format "{{.Name}}" 2>/dev/null | grep -E 'metal3|quay' || true)
-if [[ -n "$root_volumes" ]]; then
-    validation fail root_podman_volumes "Root podman volumes with metal3/quay detected" "$root_volumes"
-fi
-validation pass root_podman_volumes "No leftover root podman volumes"
+    root_volumes=$(sudo podman volume ls --format "{{.Name}}" 2>/dev/null | grep -E 'metal3|quay' || true)
+    if [[ -n "$root_volumes" ]]; then
+        validation fail root_podman_volumes "Root podman volumes with metal3/quay detected" "$root_volumes"
+    fi
+    validation pass root_podman_volumes "No leftover root podman volumes"
 
-# Check user podman context
-user_pods=$(podman pod ls --format "{{.Name}}" 2>/dev/null | grep -E 'metal3|quay' || true)
-if [[ -n "$user_pods" ]]; then
-    validation fail user_podman_pods "User podman pods with metal3/quay detected" "$user_pods"
-fi
-validation pass user_podman_pods "No metal3/quay user podman pods"
+    # Check user podman context
+    user_pods=$(podman pod ls --format "{{.Name}}" 2>/dev/null | grep -E 'metal3|quay' || true)
+    if [[ -n "$user_pods" ]]; then
+        validation fail user_podman_pods "User podman pods with metal3/quay detected" "$user_pods"
+    fi
+    validation pass user_podman_pods "No metal3/quay user podman pods"
 
-user_containers=$(podman ps -a --format "{{.Names}}" 2>/dev/null | grep -E 'metal3|ironic|httpd|baremetal-operator' || true)
-if [[ -n "$user_containers" ]]; then
-    validation fail user_podman_containers "User podman containers detected" "$user_containers"
-fi
-validation pass user_podman_containers "No leftover user podman containers"
+    user_containers=$(podman ps -a --format "{{.Names}}" 2>/dev/null | grep -E 'metal3|ironic|httpd|baremetal-operator' || true)
+    if [[ -n "$user_containers" ]]; then
+        validation fail user_podman_containers "User podman containers detected" "$user_containers"
+    fi
+    validation pass user_podman_containers "No leftover user podman containers"
 
-user_volumes=$(podman volume ls --format "{{.Name}}" 2>/dev/null | grep -E 'metal3|quay' || true)
-if [[ -n "$user_volumes" ]]; then
-    validation fail user_podman_volumes "User podman volumes with metal3/quay detected" "$user_volumes"
+    user_volumes=$(podman volume ls --format "{{.Name}}" 2>/dev/null | grep -E 'metal3|quay' || true)
+    if [[ -n "$user_volumes" ]]; then
+        validation fail user_podman_volumes "User podman volumes with metal3/quay detected" "$user_volumes"
+    fi
+    validation pass user_podman_volumes "No leftover user podman volumes"
 fi
-validation pass user_podman_volumes "No leftover user podman volumes"
 
 ## IP Validations
 validation_section "ip_address"


### PR DESCRIPTION
The check_leftovers section checks for stale podman pods and metal3 units from a previous bootstrap, which is only meaningful before a fresh deployment. Running it during sync fails on live clusters where those resources are expected to be present.

Add --skip-check-leftovers flag to validations.sh (off by default) and pass it from sync.sh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to skip leftover resource checks during validation.

* **Bug Fixes**
  * Synchronization now uses the skip-leftovers option to avoid unnecessary leftover resource validation during its validation phase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->