### PR TITLE
PoC: acs plugin — install Advanced Cluster Security via autoshiftv2

### DIFF
--- a/.github/workflows/e2e-deployment.yml
+++ b/.github/workflows/e2e-deployment.yml
@@ -254,7 +254,8 @@ jobs:
       ENCLAVE_IRONIC_HTTPS: 'true'
       CLEANUP_AFTER: 'true'
       STORAGE_PLUGIN: ${{ matrix.storage-plugin }}
-      ENABLED_PLUGINS: ${{ inputs.enabled-plugins || matrix.storage-plugin }}
+      # TEMPORARY: appends acs for testing PR #602 (acs plugin PoC) only — revert before merge.
+      ENABLED_PLUGINS: ${{ inputs.enabled-plugins || format('{0},acs', matrix.storage-plugin) }}
       OPENSHIFT_CI: "true"
       ENCLAVE_ENABLE_GPU_PASSTHROUGH: "false"
       LZ_OS_VARIANT: ${{ vars.LZ_OS_VARIANT }}
@@ -438,6 +439,12 @@ jobs:
         if: contains(format(',{0},', env.ENABLED_PLUGINS), ',osac,')
         id: deploy_osac
         run: make -f Makefile.ci deploy-plugin PLUGIN=osac
+
+      # TEMPORARY: for testing PR #602 (acs plugin PoC) only — revert before merge.
+      - name: Deploy acs plugin
+        if: contains(format(',{0},', env.ENABLED_PLUGINS), ',acs,')
+        id: deploy_acs
+        run: make -f Makefile.ci deploy-plugin PLUGIN=acs
 
       - name: Verify cluster deployment
         if: success()
@@ -702,7 +709,8 @@ jobs:
       ENCLAVE_DEPLOYMENT_MODE: disconnected
       CLEANUP_AFTER: 'true'
       STORAGE_PLUGIN: ${{ matrix.storage-plugin }}
-      ENABLED_PLUGINS: ${{ inputs.enabled-plugins || matrix.storage-plugin }}
+      # TEMPORARY: appends acs for testing PR #602 (acs plugin PoC) only — revert before merge.
+      ENABLED_PLUGINS: ${{ inputs.enabled-plugins || format('{0},acs', matrix.storage-plugin) }}
       OPENSHIFT_CI: "true"
       ENCLAVE_ENABLE_GPU_PASSTHROUGH: "false"
       LZ_OS_VARIANT: ${{ vars.LZ_OS_VARIANT }}
@@ -886,6 +894,12 @@ jobs:
         if: contains(format(',{0},', env.ENABLED_PLUGINS), ',osac,')
         id: deploy_osac
         run: make -f Makefile.ci deploy-plugin PLUGIN=osac
+
+      # TEMPORARY: for testing PR #602 (acs plugin PoC) only — revert before merge.
+      - name: Deploy acs plugin
+        if: contains(format(',{0},', env.ENABLED_PLUGINS), ',acs,')
+        id: deploy_acs
+        run: make -f Makefile.ci deploy-plugin PLUGIN=acs
 
       - name: Verify cluster deployment
         if: success()

--- a/docs/design/acs-plugin-poc-via-autoshiftv2.md
+++ b/docs/design/acs-plugin-poc-via-autoshiftv2.md
@@ -1,0 +1,267 @@
+# Design doc: ACS plugin PoC via autoshiftv2
+
+## Author/date
+
+mafriedm / 2026-07-15
+
+## Tracking JIRA
+
+TBD
+
+## Problem Statement
+
+We want to evaluate [autoshiftv2](https://github.com/auto-shift/autoshiftv2) as a tool for
+fleet-wide day-2 configuration of clusters managed by enclave. autoshiftv2 is a Helm+GitOps+ACM
+policy framework: it ships ~50 self-contained Helm charts under
+`policies/{stable,certified,community}/<feature>`, each rendering ACM
+`Policy`/`ConfigurationPolicy`/`OperatorPolicy`/`Placement`/`PlacementBinding` objects that ACM's
+governance-policy framework enforces on whichever clusters match, selected via labels
+(`autoshift.io/<feature>: 'true'`) on ACM `ManagedCluster`/`ManagedClusterSet` objects.
+
+Before committing to a broader integration, we want a **small, focused PoC**: reuse one
+autoshiftv2 policy chart as the implementation behind a normal enclave plugin, proving out the
+pattern end to end. **autoshiftv2 is the tool, not the plugin** — the plugin is `acs`
+(Advanced Cluster Security), which happens to use autoshiftv2's vendored `advanced-cluster-security`
+chart the same way another plugin might use any other upstream Helm chart.
+
+The explicit goal (per direction from the requester) is to use autoshiftv2 primarily for
+**fleet management**: install and configure things on spoke/managed clusters via ACM policy,
+not via enclave's own Ansible-driven local install path. ACS is a good first component for this
+because it has a natural hub/spoke split: `Central` (the singleton management/data-plane
+backend) runs once, and `SecuredCluster` (the lightweight per-cluster agent: sensor, admission
+controller, collector) runs on every cluster that should be secured — including the hub itself
+(self-monitoring) and any number of spokes.
+
+## Background: why autoshiftv2 fits enclave's plugin model well
+
+- Enclave's core already installs both of autoshiftv2's hard prerequisites: ACM 2.15.3
+  (`defaults/operators.yaml:18`) and OpenShift GitOps 1.19.2 (`defaults/operators.yaml:33`).
+  No need to install autoshiftv2's own bootstrap charts
+  (`openshift-gitops/`, `advanced-cluster-management/` from the autoshiftv2 repo).
+- For one fixed component, autoshiftv2's ArgoCD `ApplicationSet` git-discovery layer (the
+  `autoshift/` chart, which auto-discovers all ~50 policy folders from a git repo and
+  continuously syncs them) is unneeded complexity. Deploying the vendored ACS chart directly
+  via enclave's existing `plugin.helm` mechanism keeps the same ACM Policy self-healing
+  behavior — that property comes from ACM's policy controller, not from ArgoCD — with far
+  fewer moving parts. Revisit GitOps/ApplicationSet mode if/when we manage many autoshiftv2
+  components at once.
+- ACS's operator install is expressed **inside the vendored chart** as an ACM `OperatorPolicy`
+  (`policy-acs-operator-install.yaml`), not a plain OLM `Subscription` created by Ansible.
+  Enclave already has a purpose-built mechanism for exactly this split between "make the
+  operator catalog available" and "actually install the operator", described below.
+
+## Goals
+
+- Prove that an enclave plugin can reuse an autoshiftv2 policy chart as its implementation,
+  referencing it remotely (no vendoring into the enclave repo).
+- Install ACS `Central` on the enclave-managed hub cluster and `SecuredCluster` on any cluster
+  (hub included) opted in via a single ACM label — all installed and enforced via ACM policy.
+- Keep enclave's own responsibility limited to what nothing else already does at the right
+  scope: mirroring the operator's images/catalog for disconnected environments, and making
+  that catalog available on opted-in clusters.
+
+## Non-goals (explicitly out of scope for this PoC)
+
+- ArgoCD `ApplicationSet`/GitOps auto-discovery of policies.
+- Any autoshiftv2 component beyond ACS.
+- Actually provisioning or labeling real spoke clusters — the mechanism is wired up generically,
+  but exercising it needs a live fleet, which isn't available while designing this.
+- Full end-to-end functional test against a live disconnected cluster (ACM Policy reaching
+  `Compliant`, Central/SecuredCluster actually coming up) — deferred until a test
+  cluster/fleet is available.
+
+## Proposal
+
+New addon plugin: `plugins/acs/`
+
+```
+plugins/acs/
+  plugin.yaml
+  templates/values.yaml.j2
+  tasks/deploy.yaml
+```
+
+### Reference the chart remotely (no vendoring)
+
+autoshiftv2 publishes each policy chart to OCI at release time
+(`quay.io/autoshift/policies/<name>`, per its `make release` flow). Rather than copying the
+chart into the enclave repo, the plugin's `helm:` entry points straight at the published OCI
+artifact — the same pattern the existing `osac` plugin already uses for
+`oci://ghcr.io/osac-project/charts/osac` (`plugins/osac/plugin.yaml`). No local `charts/`
+directory, no template edits, no vendoring/sync step: enclave pulls
+`oci://quay.io/autoshift/policies/advanced-cluster-security` at deploy time, pinned to
+`0.0.4` — the latest published release tag as of this writing.
+
+### `plugin.yaml`
+
+```yaml
+name: acs
+type: addon
+order: 130
+
+catalog: redhat
+operators:
+  - name: rhacs-operator
+    version: 4.11.1
+    channel: stable
+    namespace: rhacs-operator
+    global: true
+
+installOperators: false        # no Ansible-driven OLM install on the management cluster
+installOperatorsFleet: false   # push CatalogSource only; the vendored OperatorPolicy installs the operator via ACM policy
+clusterSelector:
+  matchLabels:
+    autoshift.io/acs: "true"
+
+helm:
+  - release: acs
+    namespace: open-cluster-policies
+    chart: "oci://quay.io/autoshift/policies/advanced-cluster-security"
+    version: "0.0.4"
+    valuesTemplate: templates/values.yaml.j2
+    createNamespace: true
+
+registries:
+  - location: "registry.redhat.io/advanced-cluster-security"
+    mirror: "advanced-cluster-security"
+```
+
+`registries` covers RHACS's operand images (Central, Scanner, Sensor, Collector, Admission
+Controller), which are published separately from the operator bundle/catalog — this feeds
+MCE's custom-registries patch so fleet/spoke clusters can also resolve them.
+
+#### Why `installOperators: false` + `clusterSelector` + `installOperatorsFleet: false`
+
+Confirmed by reading `playbooks/tasks/configure_operators_fleet.yaml` and
+`playbooks/tasks/deploy_plugin.yaml`:
+
+- `installOperators: false` skips enclave's local/hub Ansible-driven `Subscription` creation
+  entirely (`deploy_plugin.yaml`'s "Install plugin operators" step is gated on
+  `plugin.installOperators | default(true)`).
+- `clusterSelector: {...}` — independent of `installOperators` — triggers
+  `configure_operators_fleet.yaml`, which always creates an ACM `Policy`
+  (`{{ plugin.name }}-catalogsource`, i.e. `acs-catalogsource`) that enforces a `CatalogSource`
+  named exactly `{{ catalog_mirror }}` (`redhat-operator-index-acs`) in
+  `openshift-marketplace` on every `ManagedCluster` matching the selector, with `spec.image`
+  pointing at the hub's internal Quay mirror route.
+- `installOperatorsFleet: false` skips the *second* ACM policy that would otherwise also push
+  a `Namespace`/`OperatorGroup`/`Subscription` to matched clusters — leaving the actual
+  operator install to autoshiftv2's own `OperatorPolicy` in the vendored chart.
+- Mirroring itself (the oc-mirror run that populates the internal Quay with `rhacs-operator`'s
+  package/images) is **not** gated by `installOperators`, so this still happens normally.
+
+Net effect: enclave's job is just "get the mirrored operator catalog onto every cluster that
+opts in"; the vendored autoshiftv2 policy fully owns installing/configuring the operator and
+the ACS custom resources. This is the same pattern already used by `odf`/`lvms`
+(`installOperatorsFleet: false`, broadcast catalog to spokes, manual/external operator
+install), taken one step further by letting an external policy (the vendored chart, instead of
+a human) own the install step too.
+
+### `templates/values.yaml.j2`
+
+```jinja
+policy_namespace: open-cluster-policies
+hubClusterSets:
+  hub: {}
+managedClusterSets:
+  managed: {}
+acs:
+  source: >-
+    {{ 'redhat-operators' if not (disconnected | default(true) | bool) else catalog_mirror }}
+```
+
+`catalog_mirror` (`redhat-operator-index-acs`) is already a global fact set by
+`deploy_plugin.yaml` before the Helm deploy step runs, and is exactly the `CatalogSource` name
+the fleet policy enforces — so the vendored chart's `OperatorPolicy` and enclave's fleet
+`CatalogSource` policy agree on the source name with zero extra plumbing. All other `acs.*`
+values are left at upstream chart defaults.
+
+### Hub vs. spoke resource gating in the vendored chart
+
+- `Central`, the hub's own `SecuredCluster`, and the init-bundle job are gated on a non-empty
+  `.Values.hubClusterSets` map. Their `Placement.spec.clusterSets` names an ACM
+  `ManagedClusterSet`, further filtered by an `autoshift.io/acs: 'true'` `ManagedCluster`
+  label predicate baked into the chart's own templates.
+- The spoke-facing `SecuredCluster` (`policy-acs-secured-cluster.yaml`) is the mirror image:
+  gated on `.Values.managedClusterSets`, same label predicate, and depends on a
+  `policy-acs-sync-bundle` policy that relays the Central-issued init-bundle down to spokes.
+- Reusing autoshiftv2's own `autoshift.io/acs: 'true'` label as the plugin's `clusterSelector`
+  match key means **one label** on a `ManagedCluster` simultaneously (a) makes it a target of
+  enclave's fleet `CatalogSource` push, and (b) makes it a target of the vendored chart's own
+  `OperatorPolicy`/`SecuredCluster` policies. No bespoke enclave-specific label is needed.
+
+### Do we need any tasks at all?
+
+Only one, and only for plumbing autoshiftv2 itself doesn't provide at the right scope.
+
+It's named `tasks/deploy.yaml`, **not** `tasks/post-operators.yaml`. `post-operators.yaml` is
+enclave's lifecycle hook for "runs right after *this plugin's own* operator install step" (see
+`deploy_plugin.yaml`'s "Run post-operators" step) — misleading here, since
+`installOperators: false` means no local/hub Ansible-driven operator install ever runs for
+this plugin. `tasks/deploy.yaml` (the generic "CR creation / supporting logic around the
+Helm-deployed chart" hook, documented in `docs/PLUGIN_ARCHITECTURE.md`) is the correct fit,
+and runs after the Helm chart deploy — which is fine functionally, since ACM Policy/Placement
+reconciliation is eventually consistent: the vendored chart's Placements will simply show "no
+matching clusters" until this task's `ManagedClusterSet`/label setup lands, then pick them up
+on the next reconcile.
+
+`tasks/deploy.yaml` does the minimum needed for the vendored chart's Placements to have
+something to match:
+
+- Ensure namespace `open-cluster-policies` exists.
+- Create `ManagedClusterSet` `hub` and `ManagedClusterSet` `managed`
+  (`cluster.open-cluster-management.io/v1beta2`, `selectorType: ExclusiveClusterSetLabel`) and
+  a `ManagedClusterSetBinding` for each in `open-cluster-policies`.
+- Patch `ManagedCluster/local-cluster` with labels `autoshift.io/acs: "true"` and
+  `cluster.open-cluster-management.io/clusterset: hub`.
+
+Actual spoke/fleet clusters are **not** created or labeled by this plugin — enabling ACS on a
+spoke going forward is just: label that `ManagedCluster` with `autoshift.io/acs: "true"` and
+`cluster.open-cluster-management.io/clusterset: managed`. No plugin change needed. That's the
+fleet-management story this PoC demonstrates, even without live spoke clusters to test against
+during design.
+
+`tasks/pre-validate.yaml`/`tasks/post-validate.yaml` are dropped for this PoC — ACM's own
+Policy compliance reporting (`oc get policy -n open-cluster-policies`, or the ACM console) is
+the natural place to check post-deploy status, and duplicating that as Ansible assertions
+doesn't add much value here. Cheap to add back later if we want CI-time structural checks.
+
+## Alternatives considered
+
+**Reusing autoshiftv2's own `advanced-cluster-management`/`cluster-labels` charts instead of a
+plain `tasks/deploy.yaml` task**, for the `ManagedClusterSet`/`ManagedClusterSetBinding` and
+local-cluster labeling:
+
+- `policies/stable/advanced-cluster-management` does render `ManagedClusterSet`/
+  `ManagedClusterSetBinding`, but that's a small fraction of what it does — it also installs
+  and configures ACM itself (operator install, `MultiClusterHub`, observability, provisioning,
+  search storage, addon tuning), which would directly conflict with enclave's own
+  already-configured ACM core install.
+- `policies/stable/cluster-labels` handles cluster labeling, but it's a fleet-wide
+  label-reconciliation engine using `mustonlyhave` semantics — it takes over **all**
+  `autoshift.io/*` labels on **every** `ManagedCluster` in the fleet, driven by a separate
+  `ConfigMap`-based config system (`autoshift.io/cluster-labels` ConfigMaps, itself produced
+  by the `cluster-config-maps` policy). Adopting it just to set two labels on one cluster is
+  disproportionate blast radius for a PoC.
+- Conclusion: a small, obviously-scoped Ansible task is the better trade-off here than pulling
+  in either of those charts.
+
+**Vendoring the ACS chart into the enclave repo** instead of referencing it via OCI: rejected
+in favor of the `osac` plugin's existing remote-OCI-chart precedent — avoids a sync/drift
+problem between the vendored copy and upstream, at the cost of a runtime dependency on
+`quay.io/autoshift` availability (same trade-off `osac` already accepts for `ghcr.io`).
+
+**Full ArgoCD `ApplicationSet`/GitOps mode** (autoshiftv2's native deployment path): deferred.
+Adds a git-repo dependency (or OCI policy-list mode) and continuous ArgoCD sync on top of what
+a single-component PoC needs; revisit once/if enclave manages several autoshiftv2 components
+and the dynamic-discovery benefit outweighs the added moving parts.
+
+## Open questions / follow-ups
+
+- `rhacs-operator` pinned to `4.11.1` and the autoshiftv2 `advanced-cluster-security` chart
+  pinned to `0.0.4` — both confirmed as latest as of this writing.
+- Live-cluster verification (ACM Policy reaching `Compliant`, Central/SecuredCluster actually
+  running, fleet `CatalogSource` landing on a real spoke) requires a test cluster/fleet not
+  available during design — to be done as a follow-up.
+- Decide whether/how to expose user-facing configuration (e.g. `config/plugins/acs.yaml`) once
+  the PoC proves out — no config surface is planned for the initial version.

--- a/plugins/acs/plugin.yaml
+++ b/plugins/acs/plugin.yaml
@@ -1,0 +1,42 @@
+---
+name: acs
+type: addon
+order: 130
+
+# Advanced Cluster Security is installed via ACM policy (the vendored autoshiftv2 Helm chart
+# below renders an OperatorPolicy), not via enclave's own Ansible-driven OLM install. See
+# docs/design/acs-plugin-poc-via-autoshiftv2.md for the full rationale.
+#
+# installOperators: false => skip the local/hub Subscription creation enclave would normally do.
+# clusterSelector + installOperatorsFleet: false => only push the mirrored CatalogSource to
+# clusters matching the selector (hub included, once labeled); the actual operator install and
+# ACS custom resources are owned entirely by the autoshiftv2 chart's own ACM policies.
+catalog: redhat
+operators:
+  - name: rhacs-operator
+    version: 4.11.1
+    channel: stable
+    init_version: 4.11.1
+    namespace: rhacs-operator
+    global: true
+
+installOperators: false
+installOperatorsFleet: false
+clusterSelector:
+  matchLabels:
+    autoshift.io/acs: "true"
+
+helm:
+  - release: acs
+    namespace: open-cluster-policies
+    chart: "oci://quay.io/autoshift/policies/advanced-cluster-security"
+    version: "0.0.4"
+    valuesTemplate: templates/values.yaml.j2
+    createNamespace: true
+
+# RHACS operand images (Central, Scanner, Sensor, Collector, Admission Controller, etc.) are
+# published under this registry path, separate from the operator bundle/catalog itself. This
+# feeds MCE's custom-registries patch so fleet/spoke clusters can resolve them too.
+registries:
+  - location: "registry.redhat.io/advanced-cluster-security"
+    mirror: "advanced-cluster-security"

--- a/plugins/acs/tasks/deploy.yaml
+++ b/plugins/acs/tasks/deploy.yaml
@@ -1,0 +1,63 @@
+---
+# Supporting ACM plumbing the vendored autoshiftv2 chart needs but doesn't provide at the
+# right scope. See docs/design/acs-plugin-poc-via-autoshiftv2.md ("Do we need any tasks at all?") for why
+# this lives here instead of tasks/post-operators.yaml, and why it doesn't reuse
+# autoshiftv2's own advanced-cluster-management/cluster-labels charts.
+#
+# Runs after the Helm chart deploy (createNamespace: true on the helm entry already ensures
+# open-cluster-policies exists by this point). ACM Policy/Placement reconciliation is
+# eventually consistent, so ordering relative to the Helm deploy doesn't matter functionally.
+
+- name: Create ManagedClusterSets for ACS hub/managed placement
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: cluster.open-cluster-management.io/v1beta2
+      kind: ManagedClusterSet
+      metadata:
+        name: "{{ item }}"
+      spec:
+        clusterSelector:
+          selectorType: ExclusiveClusterSetLabel
+  loop:
+    - hub
+    - managed
+  register: r_acs_clusterset
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_acs_clusterset is success
+
+- name: Bind ManagedClusterSets in the ACS policy namespace
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: cluster.open-cluster-management.io/v1beta2
+      kind: ManagedClusterSetBinding
+      metadata:
+        name: "{{ item }}"
+        namespace: open-cluster-policies
+      spec:
+        clusterSet: "{{ item }}"
+  loop:
+    - hub
+    - managed
+  register: r_acs_csb
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_acs_csb is success
+
+- name: Opt local-cluster into ACS via ACM labels
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: cluster.open-cluster-management.io/v1
+      kind: ManagedCluster
+      metadata:
+        name: local-cluster
+        labels:
+          autoshift.io/acs: "true"
+          cluster.open-cluster-management.io/clusterset: hub
+  register: r_acs_local_cluster_label
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_acs_local_cluster_label is success

--- a/plugins/acs/templates/values.yaml.j2
+++ b/plugins/acs/templates/values.yaml.j2
@@ -1,0 +1,21 @@
+---
+# Values for autoshiftv2's advanced-cluster-security policy chart.
+# See docs/design/acs-plugin-poc-via-autoshiftv2.md for why these are the only overrides needed.
+
+policy_namespace: open-cluster-policies
+
+# Non-empty hubClusterSets/managedClusterSets gate the chart's hub-only (Central, hub's own
+# SecuredCluster) and spoke-facing (SecuredCluster) resources respectively. Cluster set names
+# must match the ManagedClusterSets created by tasks/deploy.yaml.
+hubClusterSets:
+  hub: {}
+managedClusterSets:
+  managed: {}
+
+acs:
+  # Must match the CatalogSource name enclave's fleet mechanism enforces on clusters matching
+  # this plugin's clusterSelector (see tasks/configure_operators_fleet.yaml: the CatalogSource
+  # is always named "{{ catalog_mirror }}"), so the chart's own OperatorPolicy resolves to the
+  # same, already-mirrored catalog.
+  source: >-
+    {{ 'redhat-operators' if not (disconnected | default(true) | bool) else catalog_mirror }}


### PR DESCRIPTION
## Summary
- Adds a new addon plugin, `acs`, that installs Red Hat Advanced Cluster Security by referencing autoshiftv2's `advanced-cluster-security` policy chart remotely via OCI (`oci://quay.io/autoshift/policies/advanced-cluster-security`), no vendoring — same pattern as the existing `osac` plugin.
- `installOperators: false` + `clusterSelector` (`autoshift.io/acs: "true"`) + `installOperatorsFleet: false`: enclave only mirrors the `rhacs-operator` catalog and pushes the `CatalogSource` to opted-in clusters (fleet-wide, hub included); the operator install and ACS custom resources (`Central`, `SecuredCluster`) are owned entirely by ACM policies rendered by the vendored autoshiftv2 chart.
- ACS `Central` runs on the hub cluster; `SecuredCluster` is pushed to any cluster (hub and spokes) labeled `autoshift.io/acs: "true"` — demonstrating autoshiftv2 as a fleet-management tool, per design direction.
- `tasks/deploy.yaml` creates the supporting `ManagedClusterSet`/`ManagedClusterSetBinding` objects and opts the hub (`local-cluster`) in via ACM labels.
- Full design rationale and alternatives considered: `docs/design/acs-plugin-poc-via-autoshiftv2.md`.

Out of scope for this PoC: ArgoCD ApplicationSet/GitOps auto-discovery, other autoshiftv2 components, live end-to-end cluster verification (no test cluster/fleet available during development).

Jira: ticket creation via `jira` CLI is in flight (OSAC project, Enclave component) — will update this PR description with the ticket link once it completes.

## Test plan
- [x] `./scripts/verification/validate_plugins.sh` — passes
- [x] `yamllint -c .yamllint.yml plugins/acs` — clean
- [x] `ansible-lint plugins/acs/tasks/deploy.yaml` — passes (production profile)
- [ ] Live-cluster verification (ACM Policy reaching `Compliant`, Central/SecuredCluster coming up, fleet `CatalogSource` landing on a real spoke) — follow-up once a test cluster/fleet is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Advanced Cluster Security (ACS) addon plugin for selected clusters.
  * Enabled Helm-based ACS deployment with support for disconnected catalog mirroring.
  * Added image registry mirroring for ACS operand images to improve fleet resolution.
  * Automatically prepares required ACM cluster sets and bindings, and applies ACS membership labels.
* **Documentation**
  * Added a design document covering the ACS proof of concept, configuration approach, and open follow-ups.
* **Tests**
  * Updated e2e deployment to enable and deploy the ACS plugin in both connected and disconnected scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->