### PR TITLE
OSAC-2504: Optionally provision Keycloak realm users during OSAC plugin deployment

### DIFF
--- a/config/plugins/osac.example.yaml
+++ b/config/plugins/osac.example.yaml
@@ -19,6 +19,9 @@
 #   - vmaas
 #   - ...
 
+# Optional: create test users for initial UI/CLI access (default: false)
+# osacTestUsers: true
+
 # Optional: bring your own database
 # osacBYODatabase: true
 # osacDatabaseUrl: "postgres://user@host:5432/dbname?sslmode=require"

--- a/plugins/osac/defaults.yaml
+++ b/plugins/osac/defaults.yaml
@@ -10,6 +10,9 @@ osacProfilesList:
   - caas
   - vmaas
 
+# Test users (opt-in for dev/test environments)
+osacTestUsers: false
+
 # Netris network backend
 osacNetrisEnabled: false
 
@@ -28,6 +31,74 @@ osac_keycloak_client_id: osac-controller
 osac_keycloak_admin_client_id: osac-admin
 osac_keycloak_service_port: 8443
 osac_keycloak_validate_certs: true
+
+# Keycloak client scopes required for OSAC token claims
+osac_keycloak_client_scopes:
+  - name: groups
+    description: Group membership claim
+    protocolMappers:
+      - name: groups
+        protocol: openid-connect
+        protocolMapper: oidc-group-membership-mapper
+        consentRequired: false
+        config:
+          full.path: "false"
+          introspection.token.claim: "true"
+          multivalued: "true"
+          userinfo.token.claim: "true"
+          id.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: groups
+  - name: username
+    description: User name
+    protocolMappers:
+      - name: username
+        protocol: openid-connect
+        protocolMapper: oidc-usermodel-attribute-mapper
+        consentRequired: false
+        config:
+          user.attribute: username
+          claim.name: username
+          jsonType.label: String
+          id.token.claim: "true"
+          access.token.claim: "true"
+          userinfo.token.claim: "true"
+          introspection.token.claim: "true"
+          multivalued: "false"
+          aggregate.attrs: "false"
+  - name: osac-api
+    description: OSAC API
+    attributes:
+      include.in.token.scope: "false"
+      display.on.consent.screen: "false"
+      include.in.openid.provider.metadata: "false"
+    protocolMappers:
+      - name: osac-api-aud
+        protocol: openid-connect
+        protocolMapper: oidc-audience-mapper
+        consentRequired: false
+        config:
+          id.token.claim: "false"
+          access.token.claim: "true"
+          introspection.token.claim: "true"
+          included.custom.audience: osac-api
+
+# Keycloak test users (initial UI/CLI access when osacTestUsers is enabled)
+osac_keycloak_test_users:
+  - username: admin
+    firstName: Administrator
+    lastName: User
+    email: admin@example.com
+    password: foobar
+    groups:
+      - admins
+  - username: user
+    firstName: Test
+    lastName: User
+    email: user@example.com
+    password: foobar
+    groups:
+      - tenant1
 
 # Fulfillment database (built-in dev postgres)
 osacBYODatabase: false

--- a/plugins/osac/schemas/config.yaml
+++ b/plugins/osac/schemas/config.yaml
@@ -49,6 +49,9 @@ properties:
     description: >-
       Optional container image overrides. When unset, the Helm chart's
       built-in image references are used.
+  osacTestUsers:
+    type: boolean
+    description: "Create test users in the Keycloak osac realm for initial UI/CLI access"
   osacNetrisEnabled:
     type: boolean
     description: "Enable Netris network backend for cluster/network fulfillment"

--- a/plugins/osac/schemas/defaults.yaml
+++ b/plugins/osac/schemas/defaults.yaml
@@ -51,6 +51,52 @@ properties:
   osac_keycloak_validate_certs:
     type: boolean
     description: Whether to validate TLS certificates for Keycloak API calls.
+  osac_keycloak_client_scopes:
+    type: array
+    description: >-
+      Keycloak client scopes to create in the osac realm. Each item defines
+      a scope with protocol mappers for OSAC token claims (groups, username, audience).
+    items:
+      type: object
+      required: [name, description, protocolMappers]
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        attributes:
+          type: object
+        protocolMappers:
+          type: array
+          items:
+            type: object
+  osac_keycloak_test_users:
+    type: array
+    description: >-
+      Test users to create in the osac realm for initial UI/CLI access.
+      Each user is created with the specified password and group memberships.
+    items:
+      type: object
+      required: [username, firstName, lastName, email, password, groups]
+      properties:
+        username:
+          type: string
+        firstName:
+          type: string
+        lastName:
+          type: string
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+        groups:
+          type: array
+          items:
+            type: string
+  osacTestUsers:
+    type: boolean
+    description: Create test users in the Keycloak osac realm for initial UI/CLI access.
   osacNetrisEnabled:
     type: boolean
     description: Enable Netris network backend for cluster/network fulfillment.

--- a/plugins/osac/tasks/keycloak_client_scope.yaml
+++ b/plugins/osac/tasks/keycloak_client_scope.yaml
@@ -1,0 +1,29 @@
+---
+# Reusable task: create a Keycloak client scope (idempotent).
+#
+# Required variables (set by caller via include_tasks vars):
+#   _kc_scope — dict with keys: name, description, protocolMappers, and
+#               optional attributes overrides
+#
+# Required variables (in scope from post-operators.yaml):
+#   _osac_keycloak_hostname, _osac_kc_token, osac_keycloak_realm,
+#   osac_keycloak_validate_certs, _osac_keycloak_ca_path
+
+- name: "{{ _kc_scope.name }} | Create client scope"
+  ansible.builtin.uri:
+    url: "https://{{ _osac_keycloak_hostname }}/admin/realms/{{ osac_keycloak_realm }}/client-scopes"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ _osac_kc_token }}"
+      Content-Type: application/json
+    body_format: json
+    body:
+      name: "{{ _kc_scope.name }}"
+      description: "{{ _kc_scope.description }}"
+      protocol: openid-connect
+      attributes: "{{ _kc_scope.attributes | default({'include.in.token.scope': 'false', 'display.on.consent.screen': 'true'}) }}"
+      protocolMappers: "{{ _kc_scope.protocolMappers }}"
+    validate_certs: "{{ osac_keycloak_validate_certs }}"
+    ca_path: "{{ _osac_keycloak_ca_path }}"
+    status_code: [201, 409]
+  no_log: true

--- a/plugins/osac/tasks/keycloak_client_scope.yaml
+++ b/plugins/osac/tasks/keycloak_client_scope.yaml
@@ -1,5 +1,5 @@
 ---
-# Reusable task: create a Keycloak client scope (idempotent).
+# Reusable task: create or update a Keycloak client scope (idempotent).
 #
 # Required variables (set by caller via include_tasks vars):
 #   _kc_scope — dict with keys: name, description, protocolMappers, and
@@ -8,6 +8,49 @@
 # Required variables (in scope from post-operators.yaml):
 #   _osac_keycloak_hostname, _osac_kc_token, osac_keycloak_realm,
 #   osac_keycloak_validate_certs, _osac_keycloak_ca_path
+
+- name: "{{ _kc_scope.name }} | Get client scopes"
+  ansible.builtin.uri:
+    url: "https://{{ _osac_keycloak_hostname }}/admin/realms/{{ osac_keycloak_realm }}/client-scopes"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ _osac_kc_token }}"
+    validate_certs: "{{ osac_keycloak_validate_certs }}"
+    ca_path: "{{ _osac_keycloak_ca_path }}"
+    status_code: 200
+  register: _kc_client_scopes
+  no_log: true
+
+- name: "{{ _kc_scope.name }} | Find client scope"
+  ansible.builtin.set_fact:
+    _kc_existing_scope: >-
+      {{
+        _kc_client_scopes.json
+        | selectattr('name', 'equalto', _kc_scope.name)
+        | first
+        | default({})
+      }}
+    _kc_desired_attributes: >-
+      {{
+        _kc_scope.attributes
+        | default({
+            'include.in.token.scope': 'false',
+            'display.on.consent.screen': 'true'
+          })
+      }}
+  no_log: true
+
+- name: "{{ _kc_scope.name }} | Check whether client scope needs update"
+  ansible.builtin.set_fact:
+    _kc_scope_update_required: >-
+      {{
+        _kc_existing_scope != {} and (
+          (_kc_existing_scope.description | default('')) != _kc_scope.description or
+          (_kc_existing_scope.attributes | default({})) != _kc_desired_attributes or
+          (_kc_existing_scope.protocol | default('')) != 'openid-connect'
+        )
+      }}
+  no_log: true
 
 - name: "{{ _kc_scope.name }} | Create client scope"
   ansible.builtin.uri:
@@ -21,9 +64,34 @@
       name: "{{ _kc_scope.name }}"
       description: "{{ _kc_scope.description }}"
       protocol: openid-connect
-      attributes: "{{ _kc_scope.attributes | default({'include.in.token.scope': 'false', 'display.on.consent.screen': 'true'}) }}"
-      protocolMappers: "{{ _kc_scope.protocolMappers }}"
+      attributes: "{{ _kc_desired_attributes }}"
+      protocolMappers: "{{ _kc_scope.protocolMappers | default([]) }}"
     validate_certs: "{{ osac_keycloak_validate_certs }}"
     ca_path: "{{ _osac_keycloak_ca_path }}"
-    status_code: [201, 409]
+    status_code: 201
+  when: _kc_existing_scope == {}
+  no_log: true
+
+- name: "{{ _kc_scope.name }} | Update client scope"
+  ansible.builtin.uri:
+    url: "https://{{ _osac_keycloak_hostname }}/admin/realms/{{ osac_keycloak_realm }}/client-scopes/{{ _kc_existing_scope.id }}"
+    method: PUT
+    headers:
+      Authorization: "Bearer {{ _osac_kc_token }}"
+      Content-Type: application/json
+    body_format: json
+    body: >-
+      {{
+        _kc_existing_scope | combine({
+          'name': _kc_scope.name,
+          'description': _kc_scope.description,
+          'protocol': 'openid-connect',
+          'attributes': _kc_desired_attributes,
+          'protocolMappers': _kc_scope.protocolMappers | default([])
+        }, recursive=True)
+      }}
+    validate_certs: "{{ osac_keycloak_validate_certs }}"
+    ca_path: "{{ _osac_keycloak_ca_path }}"
+    status_code: 200
+  when: _kc_scope_update_required
   no_log: true

--- a/plugins/osac/tasks/keycloak_user.yaml
+++ b/plugins/osac/tasks/keycloak_user.yaml
@@ -1,0 +1,48 @@
+---
+# Reusable task: create a Keycloak user with group membership (idempotent).
+#
+# Required variables (set by caller via include_tasks vars):
+#   _kc_user — dict with keys: username, firstName, lastName, email,
+#              password, groups
+#
+# Required variables (in scope from post-operators.yaml):
+#   _osac_keycloak_hostname, _osac_kc_token, osac_keycloak_realm,
+#   osac_keycloak_validate_certs, _osac_keycloak_ca_path
+
+- name: "{{ _kc_user.username }} | Check if user exists"
+  ansible.builtin.uri:
+    url: "https://{{ _osac_keycloak_hostname }}/admin/realms/{{ osac_keycloak_realm }}/users?username={{ _kc_user.username }}&exact=true"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ _osac_kc_token }}"
+    validate_certs: "{{ osac_keycloak_validate_certs }}"
+    ca_path: "{{ _osac_keycloak_ca_path }}"
+    status_code: 200
+  register: __r_kc_user_check
+  no_log: true
+
+- name: "{{ _kc_user.username }} | Create user"
+  ansible.builtin.uri:
+    url: "https://{{ _osac_keycloak_hostname }}/admin/realms/{{ osac_keycloak_realm }}/users"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ _osac_kc_token }}"
+      Content-Type: application/json
+    body_format: json
+    body:
+      username: "{{ _kc_user.username }}"
+      firstName: "{{ _kc_user.firstName }}"
+      lastName: "{{ _kc_user.lastName }}"
+      email: "{{ _kc_user.email }}"
+      emailVerified: true
+      enabled: true
+      groups: "{{ _kc_user.groups }}"
+      credentials:
+        - type: password
+          value: "{{ _kc_user.password }}"
+          temporary: true
+    validate_certs: "{{ osac_keycloak_validate_certs }}"
+    ca_path: "{{ _osac_keycloak_ca_path }}"
+    status_code: [201]
+  when: __r_kc_user_check.json | length == 0
+  no_log: true

--- a/plugins/osac/tasks/keycloak_user.yaml
+++ b/plugins/osac/tasks/keycloak_user.yaml
@@ -1,5 +1,6 @@
 ---
-# Reusable task: create a Keycloak user with group membership (idempotent).
+# Reusable task: create or update a Keycloak user with group membership
+# (idempotent).
 #
 # Required variables (set by caller via include_tasks vars):
 #   _kc_user — dict with keys: username, firstName, lastName, email,
@@ -19,6 +20,24 @@
     ca_path: "{{ _osac_keycloak_ca_path }}"
     status_code: 200
   register: __r_kc_user_check
+  no_log: true
+
+- name: "{{ _kc_user.username }} | Set existing user facts"
+  ansible.builtin.set_fact:
+    _kc_existing_user: "{{ __r_kc_user_check.json | first | default({}) }}"
+  no_log: true
+
+- name: "{{ _kc_user.username }} | Check whether user needs update"
+  ansible.builtin.set_fact:
+    _kc_user_update_required: >-
+      {{
+        _kc_existing_user != {} and (
+          (_kc_existing_user.firstName | default('')) != _kc_user.firstName or
+          (_kc_existing_user.lastName | default('')) != _kc_user.lastName or
+          (_kc_existing_user.email | default('')) != _kc_user.email or
+          not (_kc_existing_user.enabled | default(false))
+        )
+      }}
   no_log: true
 
 - name: "{{ _kc_user.username }} | Create user"
@@ -44,5 +63,29 @@
     validate_certs: "{{ osac_keycloak_validate_certs }}"
     ca_path: "{{ _osac_keycloak_ca_path }}"
     status_code: [201]
-  when: __r_kc_user_check.json | length == 0
+  when: _kc_existing_user == {}
+  no_log: true
+
+- name: "{{ _kc_user.username }} | Update user"
+  ansible.builtin.uri:
+    url: "https://{{ _osac_keycloak_hostname }}/admin/realms/{{ osac_keycloak_realm }}/users/{{ _kc_existing_user.id }}"
+    method: PUT
+    headers:
+      Authorization: "Bearer {{ _osac_kc_token }}"
+      Content-Type: application/json
+    body_format: json
+    body: >-
+      {{
+        _kc_existing_user | combine({
+          'firstName': _kc_user.firstName,
+          'lastName': _kc_user.lastName,
+          'email': _kc_user.email,
+          'emailVerified': true,
+          'enabled': true
+        })
+      }}
+    validate_certs: "{{ osac_keycloak_validate_certs }}"
+    ca_path: "{{ _osac_keycloak_ca_path }}"
+    status_code: 204
+  when: _kc_user_update_required
   no_log: true

--- a/plugins/osac/tasks/post-operators.yaml
+++ b/plugins/osac/tasks/post-operators.yaml
@@ -231,7 +231,7 @@
       enabled: true
       publicClient: true
       standardFlowEnabled: true
-      directAccessGrantsEnabled: true
+      directAccessGrantsEnabled: false
       serviceAccountsEnabled: false
       protocol: openid-connect
       defaultClientScopes:
@@ -325,10 +325,42 @@
   no_log: true
   when: osacTestUsers | bool
 
+- name: Build expected group map from test users
+  ansible.builtin.set_fact:
+    _expected_groups_by_user: >-
+      {{
+        dict(
+          osac_keycloak_test_users
+          | map(attribute='username')
+          | zip(
+              osac_keycloak_test_users
+              | map(attribute='groups')
+              | map('default', [])
+            )
+        )
+      }}
+  when: osacTestUsers | bool
+
 - name: Assert test user group membership
+  vars:
+    _username: "{{ item.item.json[0].username }}"
+    _actual_groups: >-
+      {{
+        item.json
+        | default([])
+        | map(attribute='name')
+        | list
+        | sort
+      }}
+    _expected_groups: >-
+      {{
+        _expected_groups_by_user[_username]
+        | default([])
+        | sort
+      }}
   ansible.builtin.assert:
     that:
-      - (item.json | map(attribute='name') | sort) == (item.item.item.groups | sort)
+      - _actual_groups == _expected_groups
   loop: "{{ __r_verify_groups.results }}"
   no_log: true
   when: osacTestUsers | bool

--- a/plugins/osac/tasks/post-operators.yaml
+++ b/plugins/osac/tasks/post-operators.yaml
@@ -193,6 +193,185 @@
   no_log: true
 
 # =====================================================================
+# 7b. Create OSAC-specific client scopes (groups, username, osac-api)
+# =====================================================================
+
+- name: Create OSAC client scopes
+  ansible.builtin.include_tasks: keycloak_client_scope.yaml
+  vars:
+    _kc_scope: "{{ item }}"
+  loop: "{{ osac_keycloak_client_scopes }}"
+
+# =====================================================================
+# 7c. Create osac-cli public client for UI/CLI login
+# =====================================================================
+
+- name: Check if osac-cli client exists
+  ansible.builtin.uri:
+    url: "https://{{ _osac_keycloak_hostname }}/admin/realms/{{ osac_keycloak_realm }}/clients?clientId=osac-cli"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ _osac_kc_token }}"
+    validate_certs: "{{ osac_keycloak_validate_certs }}"
+    ca_path: "{{ _osac_keycloak_ca_path }}"
+    status_code: 200
+  register: __r_osac_cli_check
+  no_log: true
+
+- name: Create osac-cli public client
+  ansible.builtin.uri:
+    url: "https://{{ _osac_keycloak_hostname }}/admin/realms/{{ osac_keycloak_realm }}/clients"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ _osac_kc_token }}"
+      Content-Type: application/json
+    body_format: json
+    body:
+      clientId: osac-cli
+      enabled: true
+      publicClient: true
+      standardFlowEnabled: true
+      directAccessGrantsEnabled: true
+      serviceAccountsEnabled: false
+      protocol: openid-connect
+      defaultClientScopes:
+        - groups
+        - basic
+        - username
+        - roles
+        - osac-api
+      optionalClientScopes: []
+      redirectUris:
+        - http://localhost
+    validate_certs: "{{ osac_keycloak_validate_certs }}"
+    ca_path: "{{ _osac_keycloak_ca_path }}"
+    status_code: [201]
+  when: __r_osac_cli_check.json | length == 0
+  no_log: true
+
+# =====================================================================
+# 7d. Create groups and test users
+# =====================================================================
+
+- name: Create Keycloak groups for test users
+  ansible.builtin.uri:
+    url: "https://{{ _osac_keycloak_hostname }}/admin/realms/{{ osac_keycloak_realm }}/groups"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ _osac_kc_token }}"
+      Content-Type: application/json
+    body_format: json
+    body:
+      name: "{{ item }}"
+    validate_certs: "{{ osac_keycloak_validate_certs }}"
+    ca_path: "{{ _osac_keycloak_ca_path }}"
+    status_code: [201, 409]
+  loop: "{{ osac_keycloak_test_users | map(attribute='groups') | flatten | unique }}"
+  no_log: true
+  when: osacTestUsers | bool
+
+- name: Create test users
+  ansible.builtin.include_tasks: keycloak_user.yaml
+  vars:
+    _kc_user: "{{ item }}"
+  loop: "{{ osac_keycloak_test_users }}"
+  loop_control:
+    label: "{{ item.username }}"
+  when: osacTestUsers | bool
+
+# =====================================================================
+# 7e. Verify test users exist with correct attributes and groups
+# =====================================================================
+
+- name: Fetch test user from Keycloak
+  ansible.builtin.uri:
+    url: "https://{{ _osac_keycloak_hostname }}/admin/realms/{{ osac_keycloak_realm }}/users?username={{ item.username }}&exact=true"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ _osac_kc_token }}"
+    validate_certs: "{{ osac_keycloak_validate_certs }}"
+    ca_path: "{{ _osac_keycloak_ca_path }}"
+    status_code: 200
+  register: __r_verify_users
+  loop: "{{ osac_keycloak_test_users }}"
+  no_log: true
+  when: osacTestUsers | bool
+
+- name: Assert test user attributes
+  ansible.builtin.assert:
+    that:
+      - item.json | length == 1
+      - item.json[0].username == item.item.username
+      - item.json[0].firstName == item.item.firstName
+      - item.json[0].lastName == item.item.lastName
+      - item.json[0].email == item.item.email
+      - item.json[0].enabled
+      - item.json[0].emailVerified
+  loop: "{{ __r_verify_users.results }}"
+  no_log: true
+  when: osacTestUsers | bool
+
+- name: Fetch test user group membership
+  ansible.builtin.uri:
+    url: "https://{{ _osac_keycloak_hostname }}/admin/realms/{{ osac_keycloak_realm }}/users/{{ item.json[0].id }}/groups"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ _osac_kc_token }}"
+    validate_certs: "{{ osac_keycloak_validate_certs }}"
+    ca_path: "{{ _osac_keycloak_ca_path }}"
+    status_code: 200
+  register: __r_verify_groups
+  loop: "{{ __r_verify_users.results }}"
+  no_log: true
+  when: osacTestUsers | bool
+
+- name: Assert test user group membership
+  ansible.builtin.assert:
+    that:
+      - (item.json | map(attribute='name') | sort) == (item.item.item.groups | sort)
+  loop: "{{ __r_verify_groups.results }}"
+  no_log: true
+  when: osacTestUsers | bool
+
+# =====================================================================
+# 7f. Verify osac-cli client has expected default scopes
+# =====================================================================
+
+- name: Fetch osac-cli client details
+  ansible.builtin.uri:
+    url: "https://{{ _osac_keycloak_hostname }}/admin/realms/{{ osac_keycloak_realm }}/clients?clientId=osac-cli"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ _osac_kc_token }}"
+    validate_certs: "{{ osac_keycloak_validate_certs }}"
+    ca_path: "{{ _osac_keycloak_ca_path }}"
+    status_code: 200
+  register: __r_osac_cli_details
+  no_log: true
+
+- name: Fetch osac-cli default scopes
+  ansible.builtin.uri:
+    url: "https://{{ _osac_keycloak_hostname }}/admin/realms/{{ osac_keycloak_realm }}/clients/{{ __r_osac_cli_details.json[0].id }}/default-client-scopes"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ _osac_kc_token }}"
+    validate_certs: "{{ osac_keycloak_validate_certs }}"
+    ca_path: "{{ _osac_keycloak_ca_path }}"
+    status_code: 200
+  register: __r_osac_cli_scopes
+  no_log: true
+
+- name: Assert osac-cli client scopes include OSAC-specific scopes
+  vars:
+    _scope_names: "{{ __r_osac_cli_scopes.json | map(attribute='name') | list }}"
+  ansible.builtin.assert:
+    that:
+      - "'groups' in _scope_names"
+      - "'username' in _scope_names"
+      - "'osac-api' in _scope_names"
+  no_log: true
+
+# =====================================================================
 # 8. Create and configure osac-controller client (idempotent)
 # =====================================================================
 

--- a/plugins/osac/test-fixtures/schemas/defaults/valid/base.yaml
+++ b/plugins/osac/test-fixtures/schemas/defaults/valid/base.yaml
@@ -19,6 +19,7 @@ osac_keycloak_admin_client_id: osac-admin
 osac_keycloak_service_port: 8443
 osac_keycloak_validate_certs: true
 
+osacTestUsers: false
 osacNetrisEnabled: false
 
 osacBYODatabase: false

--- a/scripts/deployment/deploy_plugin.sh
+++ b/scripts/deployment/deploy_plugin.sh
@@ -163,6 +163,7 @@ osacAapLicenseFile: "${LZ_AAP_LICENSE}"
 ${OSAC_CHART_VERSION:+osacChartVersion: "${OSAC_CHART_VERSION}"}
 osacProfilesList:
   - caas
+osacTestUsers: true
 OSAC_EOF
     fi
 fi


### PR DESCRIPTION
## Summary

- The OSAC plugin creates the `osac` Keycloak realm but provisions no users, client scopes, or public client — making UI/CLI login impossible after deployment
- Adds three OSAC-specific client scopes (`groups`, `username`, `osac-api`) for proper token claims
- Creates the `osac-cli` public client for UI/CLI authentication
- Adds `osacTestUsers` flag (default `false`) — production deployments skip user creation entirely
- When enabled, provisions test users with temporary passwords (forced rotation on first login)
- Verifies test users via admin API (attributes and group membership)
- CI deploy script sets `osacTestUsers: true` for e2e testing

## Test plan

- [ ] Deploy OSAC with `osacTestUsers: false` (default) — verify no users are created
- [ ] Deploy OSAC with `osacTestUsers: true` — verify `admin` and `user` are created
- [ ] Verify admin API smoke test passes (user attributes + group membership)
- [ ] Log in to OSAC UI with `admin`/`foobar` — verify password change is required on first login
- [ ] Re-run deployment to verify idempotency (no errors on second run)

Fixes: https://redhat.atlassian.net/browse/OSAC-2504

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in creation of OSAC Keycloak test users for initial UI and CLI access.
  * Introduced default `admin` and `user` accounts with preset group memberships.
  * Added OSAC Keycloak client scopes for groups, username, and API audience/claim handling.
  * Added automated provisioning and verification of the `osac-cli` client (including default scopes).

* **Configuration**
  * Added the `osacTestUsers` setting (default: disabled); enabled in generated CI deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->