### PR TITLE
OSAC-2499: Add Network=host to metal3-bmo quadlet template

### DIFF
--- a/playbooks/templates/quadlets/metal3-bmo.container.j2
+++ b/playbooks/templates/quadlets/metal3-bmo.container.j2
@@ -4,6 +4,7 @@ After=metal3-ironic-api.service
 
 [Container]
 ContainerName=baremetal-operator
+Network=host
 Image={{ metal3_baremetal_operator_image }}
 Pull=never
 User=65532:65532


### PR DESCRIPTION
## Summary
- The `metal3-bmo.container.j2` quadlet template was missing `Network=host`, so the BMO container ran in an isolated network namespace and couldn't use the host's DNS resolver, breaking communication with Ironic and other cluster services.
- Adds `Network=host` to the `[Container]` section, matching the existing pattern used by `metal3-ironic.pod.j2` and other quadlets that need host-bound services.

Fixes OSAC-2499

## Test plan
- [ ] Deploy Phase 7 (discovery services configuration) and confirm the regenerated `metal3-bmo.container` quadlet includes `Network=host`
- [ ] Verify DNS resolution works from within the BMO container and it can reach the Ironic API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Metal3 Baremetal Operator container to use the host network, improving network connectivity and service integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->