### PR TITLE
Re-enable addon plugin day-0 deployment

### DIFF
--- a/docs/PLUGIN_ARCHITECTURE.md
+++ b/docs/PLUGIN_ARCHITECTURE.md
@@ -67,7 +67,7 @@ registries:
 | Field | What it does |
 |-------|-------------|
 | `name` | Plugin identifier. Must match the directory name. |
-| `type` | `foundation` -- deploys before core operators (storage, networking). `addon` -- deployed separately. |
+| `type` | `foundation` -- deploys before core operators (storage, networking). `addon` -- deploys after core operators and Quay mirroring. |
 | `order` | Deploy order among same-type plugins. Lower = first. LVMS is 10, ODF is 10. |
 | `catalog` | Operator catalog name (`redhat` or `certified`). Defaults to `redhat`. |
 | `operators` | List of OLM operators to install. Each entry is passed to `configure_operator.yaml`. |
@@ -348,10 +348,10 @@ A validation-only plugin can hook into any of these checkpoints:
 |------|---------------|----------------|-----------------|
 | `early-validate.yaml` | Phase 1 (Prepare) start | No | Yes -- any enabled plugin with `requires` |
 | `pre-install-validate.yaml` | Phase 3 (Deploy), before cluster install | No | Yes |
-| `pre-validate.yaml` | Phase 5 (Operators), inside `deploy_plugin.yaml` | Yes | Only `type: foundation` plugins |
-| `post-validate.yaml` | Phase 5 (Operators), inside `deploy_plugin.yaml` | Yes | Only `type: foundation` plugins |
+| `pre-validate.yaml` | Phase 5 (Operators), inside `deploy_plugin.yaml` | Yes | Yes -- all enabled plugins |
+| `post-validate.yaml` | Phase 5 (Operators), inside `deploy_plugin.yaml` | Yes | Yes -- all enabled plugins |
 
-`pre-validate.yaml` and `post-validate.yaml` run inside `deploy_plugin.yaml`, which is only triggered automatically for `type: foundation` plugins (via `deploy_plugins.yaml`). Use `type: foundation` with an `order` field for validation-only plugins that need cluster access.
+`pre-validate.yaml` and `post-validate.yaml` run inside `deploy_plugin.yaml`, which is triggered automatically for both `foundation` and `addon` plugins (via `deploy_plugins.yaml`).
 
 Example -- a plugin that validates network config before mirroring:
 

--- a/playbooks/02-mirror.yaml
+++ b/playbooks/02-mirror.yaml
@@ -68,6 +68,14 @@
             catalog_operators: "{{ {'core': {'operators': operators, 'catalog': 'redhat'}} | combine(_core_plugin_operators | default({})) }}"
           tags: mirror-registry
 
+        - name: Display catalog operators to mirror
+          ansible.builtin.debug:
+            msg: "operators: {{ item.value.operators | default([]) | map(attribute='name') | list }}"
+          loop: "{{ catalog_operators | dict2items }}"
+          loop_control:
+            label: "{{ item.key }}"
+          tags: mirror-registry
+
         - name: Include tasks for mirror-registry
           ansible.builtin.include_tasks:
             file: tasks/mirror_registry.yaml

--- a/playbooks/05-operators.yaml
+++ b/playbooks/05-operators.yaml
@@ -102,3 +102,16 @@
             apply:
               tags: operators
           tags: operators
+
+        - name: Auto-discover and deploy addon plugins
+          ansible.builtin.include_tasks:
+            file: tasks/deploy_plugins.yaml
+            apply:
+              tags:
+                - addon-plugins
+                - operators
+          vars:
+            plugin_type: addon
+          tags:
+            - addon-plugins
+            - operators

--- a/playbooks/tasks/collect_core_plugin_operators.yaml
+++ b/playbooks/tasks/collect_core_plugin_operators.yaml
@@ -22,18 +22,18 @@
 
 - name: Build combined plugin operators dictionary
   vars:
-    _foundation: >-
+    _enabled: >-
       {{ r_cp_slurp.results
          | map(attribute='content')
          | map('b64decode')
          | map('from_yaml')
-         | selectattr('type', 'equalto', 'foundation')
+         | selectattr('name', 'defined')
          | selectattr('name', 'in', enabled_plugins)
          | list }}
   ansible.builtin.set_fact:
     _core_plugin_operators: |-
       {% set tmp = {} %}
-      {% for p in _foundation if p.operators is defined %}
+      {% for p in _enabled if p.operators is defined %}
       {% set _ = tmp.update({p.name: {'operators': p.operators, 'catalog': p.catalog | default('redhat')}}) %}
       {% endfor %}
       {{ tmp }}

--- a/playbooks/tasks/collect_plugin_registries.yaml
+++ b/playbooks/tasks/collect_plugin_registries.yaml
@@ -22,17 +22,16 @@
 
 - name: Build combined plugin registries list
   vars:
-    _foundation: >-
+    _enabled: >-
       {{ r_pr_slurp.results
          | map(attribute='content')
          | map('b64decode')
          | map('from_yaml')
-         | selectattr('type', 'equalto', 'foundation')
          | selectattr('name', 'in', enabled_plugins)
          | list }}
   ansible.builtin.set_fact:
     _core_plugin_registries: >-
-      {{ _foundation
+      {{ _enabled
          | selectattr('registries', 'defined')
          | map(attribute='registries')
          | flatten

--- a/playbooks/tasks/deploy_plugin.yaml
+++ b/playbooks/tasks/deploy_plugin.yaml
@@ -17,41 +17,41 @@
     fail_msg: "plugin_name must be a valid name (alphanumeric, dots, hyphens, underscores; no path separators)"
   tags: always
 
-- name: Set plugin directory
+- name: "{{ plugin_name }} | Set plugin directory"
   ansible.builtin.set_fact:
     plugin_dir: "{{ playbook_dir }}/../plugins/{{ plugin_name }}"
   tags: always
 
-- name: Verify plugin.yaml exists
+- name: "{{ plugin_name }} | Verify plugin.yaml exists"
   ansible.builtin.stat:
     path: "{{ plugin_dir }}/plugin.yaml"
   register: r_plugin_yaml
   tags: always
 
-- name: Fail if plugin.yaml is missing
+- name: "{{ plugin_name }} | Fail if plugin.yaml is missing"
   ansible.builtin.assert:
     that: r_plugin_yaml.stat.exists
     fail_msg: "Plugin descriptor not found: {{ plugin_dir }}/plugin.yaml"
   tags: always
 
-- name: Load plugin descriptor
+- name: "{{ plugin_name }} | Load plugin descriptor"
   ansible.builtin.include_vars:
     file: "{{ plugin_dir }}/plugin.yaml"
     name: plugin
   tags: always
 
-- name: Display plugin info
+- name: "{{ plugin_name }} | Display plugin info"
   ansible.builtin.debug:
     msg: "Deploying plugin '{{ plugin.name }}' (type={{ plugin.type }}, order={{ plugin.order | default('unset') }}, mirror={{ plugin_mirror | default(false) | bool }})"
   tags: always
 
-- name: Stat plugin defaults.yaml
+- name: "{{ plugin_name }} | Stat plugin defaults.yaml"
   ansible.builtin.stat:
     path: "{{ plugin_dir }}/defaults.yaml"
   register: r_plugin_defaults_yaml
   tags: always
 
-- name: Fail if both defaults.yaml and defaults field are defined
+- name: "{{ plugin_name }} | Fail if both defaults.yaml and defaults field are defined"
   ansible.builtin.fail:
     msg: "Plugin '{{ plugin.name }}' has both defaults.yaml and a defaults: field in plugin.yaml. Only one is allowed."
   when:
@@ -59,7 +59,7 @@
     - plugin.defaults is defined
   tags: always
 
-- name: Load plugin defaults from defaults.yaml
+- name: "{{ plugin_name }} | Load plugin defaults from defaults.yaml"
   ansible.builtin.include_vars:
     file: "{{ plugin_dir }}/defaults.yaml"
   when: r_plugin_defaults_yaml.stat.exists
@@ -67,7 +67,7 @@
 
 # noqa: var-naming[no-jinja] — Jinja2 in the variable name is the only way
 # to set dynamic fact names from a dict.
-- name: Load plugin defaults from plugin.yaml  # noqa: var-naming[no-jinja]
+- name: "{{ plugin_name }} | Load plugin defaults from plugin.yaml"  # noqa: var-naming[no-jinja]
   ansible.builtin.set_fact:
     "{{ item.key }}": "{{ item.value }}"
   loop: "{{ plugin.defaults | dict2items }}"
@@ -81,19 +81,19 @@
 # Load user config for this plugin (config/plugins/<name>.yaml) if it exists.
 # The load-vars.yaml only loads config files for plugins in enabled_plugins,
 # but day-2 plugins deployed via deploy-plugin.yaml may not be in that list.
-- name: Stat plugin user config file
+- name: "{{ plugin_name }} | Stat plugin user config file"
   ansible.builtin.stat:
     path: "{{ playbook_dir }}/../config/plugins/{{ plugin_name }}.yaml"
   register: r_plugin_user_config
   tags: always
 
-- name: Load plugin user config
+- name: "{{ plugin_name }} | Load plugin user config"
   ansible.builtin.include_vars:
     file: "{{ r_plugin_user_config.stat.path }}"
   when: r_plugin_user_config.stat.exists
   tags: always
 
-- name: Validate plugin requirements (vars)
+- name: "{{ plugin_name }} | Validate plugin requirements (vars)"
   ansible.builtin.assert:
     that: "item.name in vars"
     fail_msg: >-
@@ -108,7 +108,7 @@
     - item.when | default(true) | bool
   tags: always
 
-- name: Stat plugin required files
+- name: "{{ plugin_name }} | Stat plugin required files"
   ansible.builtin.stat:
     path: "{{ plugin_dir }}/{{ item.path }}"
   loop: "{{ plugin.requires.files | default([]) }}"
@@ -120,7 +120,7 @@
     - plugin.requires.files is defined
   tags: always
 
-- name: Validate plugin requirements (files)
+- name: "{{ plugin_name }} | Validate plugin requirements (files)"
   ansible.builtin.assert:
     that: r_required_files.results[ansible_loop.index0].stat.exists
     fail_msg: >-
@@ -137,7 +137,7 @@
     - item.when | default(true) | bool
   tags: always
 
-- name: Run pre-validate
+- name: "{{ plugin_name }} | Run pre-validate"
   ansible.builtin.include_tasks:
     file: "{{ plugin_dir }}/tasks/pre-validate.yaml"
     apply:
@@ -147,7 +147,7 @@
   when: lookup('ansible.builtin.fileglob', plugin_dir ~ '/tasks/pre-validate.yaml') | length > 0
   tags: pre-validate
 
-- name: Extract images from Helm charts for mirroring
+- name: "{{ plugin_name }} | Extract images from Helm charts for mirroring"
   ansible.builtin.include_tasks:
     file: tasks/helm_extract_images.yaml
     apply:
@@ -161,14 +161,14 @@
       | list | length > 0
   tags: mirror
 
-- name: Set catalog image and mirror defaults
+- name: "{{ plugin_name }} | Set catalog image and mirror defaults"
   ansible.builtin.set_fact:
     catalog_image: "{{ rh_operator_catalog }}"
     catalog_mirror: "{{ mirror_rh_operator_catalog }}-{{ plugin.name }}"
     catalog_version: "{{ rh_operator_catalog_version }}"
   tags: always
 
-- name: Override variables for certified catalog
+- name: "{{ plugin_name }} | Override variables for certified catalog"
   ansible.builtin.set_fact:
     catalog_image: "{{ certified_operator_catalog }}"
     catalog_mirror: "{{ mirror_certified_rh_operator_catalog }}-{{ plugin.name }}"
@@ -177,7 +177,7 @@
     - plugin.catalog | default("") == "certified"
   tags: always
 
-- name: Mirror plugin
+- name: "{{ plugin_name }} | Mirror plugin"
   ansible.builtin.include_tasks:
     file: mirror_plugin.yaml
   when:
@@ -186,7 +186,7 @@
     - disconnected | default(true) | bool
   tags: mirror
 
-- name: Patch MCE custom-registries with plugin entries
+- name: "{{ plugin_name }} | Patch MCE custom-registries with plugin entries"
   ansible.builtin.include_tasks:
     file: tasks/patch_mce_registries.yaml
     apply:
@@ -197,11 +197,10 @@
     plugin_registries_entries: "{{ plugin.registries }}"
   when:
     - plugin.registries is defined
-    - plugin_mirror | default(false) | bool
     - disconnected | default(true) | bool
   tags: mirror
 
-- name: Install plugin operators
+- name: "{{ plugin_name }} | Install plugin operators"
   vars:
     default_operator_source: "cs-{{ catalog_mirror }}-v4-20"
   ansible.builtin.include_tasks:
@@ -218,7 +217,7 @@
     - plugin.installOperators | default(true)
   tags: operators
 
-- name: Install plugin operators to fleet
+- name: "{{ plugin_name }} | Install plugin operators to fleet"
   ansible.builtin.include_tasks:
     file: tasks/configure_operators_fleet.yaml
     apply:
@@ -231,7 +230,7 @@
     - plugin.clusterSelector | length > 0
   tags: operators
 
-- name: Run post-operators
+- name: "{{ plugin_name }} | Run post-operators"
   ansible.builtin.include_tasks:
     file: "{{ plugin_dir }}/tasks/post-operators.yaml"
     apply:
@@ -241,7 +240,7 @@
   when: lookup('ansible.builtin.fileglob', plugin_dir ~ '/tasks/post-operators.yaml') | length > 0
   tags: post-operators
 
-- name: Deploy Helm charts
+- name: "{{ plugin_name }} | Deploy Helm charts"
   ansible.builtin.include_tasks:
     file: tasks/helm_deploy.yaml
     apply:
@@ -257,7 +256,7 @@
     - plugin.helm | length > 0
   tags: helm
 
-- name: Run deploy
+- name: "{{ plugin_name }} | Run deploy"
   ansible.builtin.include_tasks:
     file: "{{ plugin_dir }}/tasks/deploy.yaml"
     apply:
@@ -267,7 +266,7 @@
   when: lookup('ansible.builtin.fileglob', plugin_dir ~ '/tasks/deploy.yaml') | length > 0
   tags: deploy
 
-- name: Run post-validate
+- name: "{{ plugin_name }} | Run post-validate"
   ansible.builtin.include_tasks:
     file: "{{ plugin_dir }}/tasks/post-validate.yaml"
     apply:


### PR DESCRIPTION
## Summary

Re-enables addon plugins (type: addon) in the day-0 bootstrap flow so they are deployed automatically alongside foundation plugins during phase 5. The day-0 addon plugin support was disabled in #476.

### Changes

- **05-operators.yaml**: add addon plugin auto-discovery and deployment after core operators and Quay mirroring complete
- **collect_core_plugin_operators.yaml**: include all enabled plugins in the core imageset (not just foundation) so addon operator images are mirrored during phase 2
- **collect_plugin_registries.yaml**: include all enabled plugin registries in the base `registries.conf` (not just foundation) so the Quay Enterprise oc-mirror resolves addon images from the LZ registry instead of going upstream
- **deploy_plugin.yaml**: decouple MCE custom-registries patching from the `plugin_mirror` flag so it runs during day-0 when spoke clusters need the registry redirects
- **deploy_plugin.yaml**: prefix all task names with `plugin_name` for clearer log output
- **02-mirror.yaml**: add debug task to display catalog operators being mirrored

## Test plan

- [ ] Disconnected deployment with addon plugins in `enabled_plugins` (e.g. `lvms, nvidia-gpu`)
- [ ] Verify addon operators are included in the base oc-mirror imageset (phase 2)
- [ ] Verify addon registries appear in `registries.conf` for Quay Enterprise mirror
- [ ] Verify MCE custom-registries ConfigMap is patched with addon plugin entries
- [ ] Verify `--tags addon-plugins` can target just the addon deployment block