### PR TITLE
Revert "Fix virtual media detach timing to prevent ISO reboot loop (#554)"

### DIFF
--- a/playbooks/03-deploy.yaml
+++ b/playbooks/03-deploy.yaml
@@ -80,17 +80,6 @@
               tags: hardware
           tags: hardware
 
-        - name: Detach virtual media from hosts
-          loop: "{{ agent_hosts_to_provision }}"
-          loop_control:
-            loop_var: agent_host
-            label: "{{ agent_host.name }}"
-          ansible.builtin.include_tasks:
-            file: tasks/configure_hardware_ironic_detach_vmedia.yaml
-            apply:
-              tags: hardware
-          tags: hardware
-
         - name: Pre-install validate plugins
           ansible.builtin.include_tasks:
             file: tasks/pre_install_validate_plugins.yaml

--- a/playbooks/tasks/configure_hardware_ironic_detach_vmedia.yaml
+++ b/playbooks/tasks/configure_hardware_ironic_detach_vmedia.yaml
@@ -51,7 +51,5 @@
     user: "{{ metal3_ironic_username }}"
     password: "{{ metal3_ironic_password }}"
     force_basic_auth: true
-    status_code: [204, 404]
-  register: detach_result
-  failed_when:
-    - detach_result.status | default(0) not in [204, 404]
+    status_code: [204]
+  ignore_errors: true

--- a/playbooks/tasks/configure_hardware_ironic_detach_vmedia.yaml
+++ b/playbooks/tasks/configure_hardware_ironic_detach_vmedia.yaml
@@ -51,5 +51,7 @@
     user: "{{ metal3_ironic_username }}"
     password: "{{ metal3_ironic_password }}"
     force_basic_auth: true
-    status_code: [204]
-  ignore_errors: true
+    status_code: [204, 404]
+  register: detach_result
+  failed_when:
+    - detach_result.status | default(0) not in [204, 404]

--- a/playbooks/tasks/wait_for_deployment.yaml
+++ b/playbooks/tasks/wait_for_deployment.yaml
@@ -11,10 +11,18 @@
   ansible.builtin.command: |
     {{ workingDir }}/bin/openshift-install --dir {{ workingDir }}/ocp-cluster/ agent wait-for install-complete  --log-level=debug
 
+# Virtual media detach must stay here, after install-complete. Moving it earlier
+# (e.g. right after Ironic 'active') breaks hardware where coreos-installer reads
+# the RHCOS disk image directly from the mounted ISO in streaming mode: detaching
+# mid-stream causes an I/O error and aborts the disk write. A future improvement
+# should detach per-node as soon as each host's disk write completes (Assisted
+# Service host status 'rebooting') to also prevent UEFI firmware boot-loops on
+# hardware that ignores the one-shot boot order when virtual media is still attached.
 - name: Detach virtual media from hosts
   loop: "{{ agent_hosts }}"
   loop_control:
     loop_var: agent_host
+    label: "{{ agent_host.name }}"
   ansible.builtin.include_tasks:
     file: tasks/configure_hardware_ironic_detach_vmedia.yaml
 

--- a/playbooks/tasks/wait_for_deployment.yaml
+++ b/playbooks/tasks/wait_for_deployment.yaml
@@ -11,6 +11,13 @@
   ansible.builtin.command: |
     {{ workingDir }}/bin/openshift-install --dir {{ workingDir }}/ocp-cluster/ agent wait-for install-complete  --log-level=debug
 
+- name: Detach virtual media from hosts
+  loop: "{{ agent_hosts }}"
+  loop_control:
+    loop_var: agent_host
+  ansible.builtin.include_tasks:
+    file: tasks/configure_hardware_ironic_detach_vmedia.yaml
+
 - name: Cleanup Ironic
   ansible.builtin.include_tasks:
     file: tasks/configure_hardware_ironic_cleanup.yaml


### PR DESCRIPTION
## Why we are reverting

PR #554 moved virtual media detach to immediately after Ironic reports nodes `active` (i.e. as soon as the ABI ISO boots), intending to prevent UEFI firmware from booting nodes back into the ISO on their first post-install reboot ([GoRI#937](https://github.com/gori-project/GoRI/issues/937)).

This breaks on hardware where `coreos-installer` reads the RHCOS disk image **directly from the mounted ISO block device (`/dev/sr0`) in streaming mode** during the disk write phase. The ISO is not cached — it is streamed from virtual media across the BMC connection for the entire duration of the write. On RHDP physical servers this takes 20–40 minutes. Detaching the ISO at Ironic `active` — which fires minutes after power-on, before `coreos-installer` has even started — pulls the block device mid-stream and causes an I/O error that aborts the write and puts hosts into error state.

## The underlying conflict

The two hardware environments have contradictory requirements:

| | Requirement |
|---|---|
| **RHDP** | Do not detach ISO until streaming is complete (after disk write finishes) |
| **GoRI** | Detach ISO before the first post-disk-write reboot, so UEFI firmware doesn't boot from virtual media again |

These point at opposite sides of the same event. There is no single cluster-level gate that satisfies both.

## What the correct fix looks like

Detach virtual media **per node**, triggered when each individual node's disk write completes — Assisted Service host status `rebooting`. At that point the ISO stream is finished for that node, but the reboot has not yet happened, satisfying both requirements. This is tracked as a follow-up.

## What this PR does

- **Commit 1**: clean revert of #554 — restores virtual media detach to after `install-complete` in `wait_for_deployment.yaml`, which is safe for all known hardware
- **Commit 2**: keeps the correctness improvements introduced alongside #554's timing change — accept HTTP 404 (already detached) as success instead of `ignore_errors: true`, add a loop label to prevent host credentials from appearing in logs, and add a comment explaining the timing constraint and the intended future fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment reliability by moving virtual media detachment until installation completes.
  * Helps prevent disk I/O errors and hardware or firmware boot loops during host provisioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->