### PR TITLE
OSAC-1999: Make bmcSystemId optional - let Ironic auto-discover

### DIFF
--- a/config/cloud_infra.example.yaml
+++ b/config/cloud_infra.example.yaml
@@ -18,6 +18,7 @@ discovery_hosts:
     ipAddress: YOUR_IP_ADDRESS        # Should be in machineNetwork
     # interfaceName: eno1np0          # Optional: NIC name (default: eno1). Override for hardware with different naming
     redfish: YOUR_REDFISH_IP          # IPMI/Redfish management IP
+    # bmcSystemId: System.Embedded.1  # Optional. Redfish System ID. Only needed for multi-system BMCs
     rootDisk: YOUR_ROOT_DISK_PATH     # Example: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: YOUR_REDFISH_USER
     redfishPassword: YOUR_REDFISH_PASSWORD

--- a/config/global.example.yaml
+++ b/config/global.example.yaml
@@ -152,6 +152,7 @@ agent_hosts:
     rootDisk: YOUR_ROOT_DISK_PATH     # Example: /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
     redfishUser: YOUR_REDFISH_USER
     redfishPassword: YOUR_REDFISH_PASSWORD
+    # bmcSystemId: System.Embedded.1   # Optional. Redfish System ID. Only needed for multi-system BMCs
   # Add a total of 3 agent hosts, no more, no less
 
 # For complex network setups you can use mapInterfaces and networkConfig

--- a/defaults/deployment.yaml
+++ b/defaults/deployment.yaml
@@ -35,3 +35,7 @@ migrationTasksFilePath: "{{ workingDir }}/migrations/tasks.txt"
 # 'updateservice-registry' key from this ConfigMap to prevent UpdateService reconciliation failures.
 # See: https://github.com/gori-project/GoRI/issues/924
 quayRegistryCAConfigmapName: quay-registry-ca
+
+# Default network interface name for NMState configuration.
+# Override per host via discovery_hosts[].interfaceName.
+defaultInterfaceName: eno1

--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -373,7 +373,7 @@ agent_hosts:
 
 | Field | Description | Example |
 |-------|-------------|---------|
-| `bmcSystemId` | Redfish system ID path component (`/redfish/v1/Systems/<bmcSystemId>`). Defaults to `1` | `1` |
+| `bmcSystemId` | Redfish System ID. Only needed for multi-system BMCs; Ironic auto-discovers when omitted | `System.Embedded.1` |
 | `mapInterfaces` | List of interface-to-MAC mappings for advanced network configuration | See example below |
 | `networkConfig` | Full nmstate network configuration in YAML format | See example below |
 
@@ -1226,7 +1226,8 @@ discovery_hosts:
 
 | Field | Description | Example |
 |-------|-------------|---------|
-| `bmcSystemId` | Redfish system ID path component (`/redfish/v1/Systems/<bmcSystemId>`). Defaults to `1` | `1` |
+| `bmcSystemId` | Redfish System ID. Only needed for multi-system BMCs; auto-discovered when omitted | `System.Embedded.1` |
+| `interfaceName` | Network interface name. Defaults to `eno1` | `ens3f0` |
 
 **Notes**:
 - MAC addresses must be unique

--- a/playbooks/tasks/configure_hardware_ironic_boot.yaml
+++ b/playbooks/tasks/configure_hardware_ironic_boot.yaml
@@ -36,9 +36,9 @@
         redfish_address: "https://{{ agent_host.redfish }}"
         redfish_username: "{{ agent_host.redfishUser }}"
         redfish_password: "{{ agent_host.redfishPassword }}"
-        redfish_system_id: "/redfish/v1/Systems/{{ agent_host.bmcSystemId | default('1') }}"
         redfish_verify_ca: false
         force_persistent_boot_device: "Never"
+        redfish_system_id: "{{ '/redfish/v1/Systems/' + agent_host.bmcSystemId if agent_host.bmcSystemId is defined else omit }}"
       properties:
         capabilities: "boot_mode:uefi"
     headers:

--- a/playbooks/templates/baremetalhost.yaml.j2
+++ b/playbooks/templates/baremetalhost.yaml.j2
@@ -12,6 +12,6 @@ spec:
   automatedCleaningMode: disabled
   bootMACAddress: "{{ discovery_host.macAddress }}"
   bmc:
-    address: "redfish-virtualmedia+https://{{ discovery_host.redfish }}/redfish/v1/Systems/{{ discovery_host.bmcSystemId | default('1') }}"
+    address: "redfish-virtualmedia+https://{{ discovery_host.redfish }}{% if discovery_host.bmcSystemId is defined %}/redfish/v1/Systems/{{ discovery_host.bmcSystemId }}{% endif %}"
     credentialsName: {{ discovery_host.name }}-bmc-secret
     disableCertificateVerification: true

--- a/playbooks/templates/nmstateconfig.yaml.j2
+++ b/playbooks/templates/nmstateconfig.yaml.j2
@@ -14,7 +14,7 @@ spec:
 {% else %}
   config:
    interfaces:
-   - name: {{ discovery_host.interfaceName | default('eno1') }}
+   - name: {{ discovery_host.interfaceName | default(defaultInterfaceName) }}
      type: ethernet
      state: up
      mac-address:  {{ discovery_host.macAddress }}
@@ -26,13 +26,13 @@ spec:
    routes:
      config:
      - next-hop-address:  {{ defaultGateway }}
-       next-hop-interface: {{ discovery_host.interfaceName | default('eno1') }}
+       next-hop-interface: {{ discovery_host.interfaceName | default(defaultInterfaceName) }}
        destination: 0.0.0.0/0
    dns-resolver:
      config:
        server:
          -  {{ defaultDNS }}
   interfaces:
-   - name: {{ discovery_host.interfaceName | default('eno1') }}
+   - name: {{ discovery_host.interfaceName | default(defaultInterfaceName) }}
      macAddress: {{ discovery_host.macAddress }}
 {% endif %}

--- a/schemas/definitions.yaml
+++ b/schemas/definitions.yaml
@@ -85,10 +85,10 @@ definitions:
     properties:
       bmcSystemId:
         type: string
-        description: Redfish system ID path component, defaults to '1'
+        description: Redfish System ID. Only needed for multi-system BMCs; auto-discovered when omitted
       interfaceName:
         type: string
-        pattern: "^[a-zA-Z0-9]+$"
+        pattern: "^[a-zA-Z0-9_.-]+$"
         description: Network interface name (e.g., eno1, eno1np0). Defaults to 'eno1' if not specified.
       ipAddress:
         "$ref": "#/definitions/ipv4Address"

--- a/schemas/deployment.yaml
+++ b/schemas/deployment.yaml
@@ -54,3 +54,4 @@ required:
   - diskEncryption
   - ocMirrorLogLevel
   - pullSecretPath
+  - defaultInterfaceName

--- a/schemas/deployment.yaml
+++ b/schemas/deployment.yaml
@@ -41,6 +41,12 @@ properties:
       ConfigMap name for Quay registry CA certificates used by image.config and UpdateService.
       Partner overlays that replace image.config.spec.additionalTrustedCA must include the
       'updateservice-registry' key from this ConfigMap to prevent UpdateService reconciliation failures.
+  defaultInterfaceName:
+    type: string
+    pattern: "^[a-zA-Z0-9_.-]+$"
+    description: >-
+      Default network interface name for NMState configuration. Override per host via
+      discovery_hosts[].interfaceName.
 required:
   - disconnected
   - fresh

--- a/validations.sh
+++ b/validations.sh
@@ -317,12 +317,34 @@ for host in 0 1 2; do
     redfish=$(getValue .agent_hosts[$host].redfish)
     redfish_user=$(getValue .agent_hosts[$host].redfishUser)
     redfish_password=$(getValue .agent_hosts[$host].redfishPassword)
-    redfish_curl_return=$(curl -o /dev/null -s -w '%{http_code}' -u "${redfish_user}:${redfish_password}" -k https://${redfish}/redfish/v1/Systems)
+    redfish_response=$(mktemp)
+    redfish_curl_return=$(curl -s -w '%{http_code}' -o "$redfish_response" -u "${redfish_user}:${redfish_password}" -k "https://${redfish}/redfish/v1/Systems")
     if [[ $redfish_curl_return != 200 ]]; then
+        rm -f "$redfish_response"
         validation fail $host_name "Connection to $host_name ($redfish) is not healthy. Return code: $redfish_curl_return"
     else
         validation pass $host_name "Redfish connection to $host_name ($redfish) successful"
     fi
+
+    bmc_system_id=$(getValue ".agent_hosts[$host].bmcSystemId")
+    system_count=$(jq -r '."Members@odata.count" // (.Members | length)' "$redfish_response" 2>/dev/null)
+    if [[ -z "$bmc_system_id" || "$bmc_system_id" == "null" ]]; then
+        if [[ "$system_count" =~ ^[0-9]+$ && "$system_count" -gt 1 ]]; then
+            rm -f "$redfish_response"
+            validation fail "${host_name}_system_id" "BMC on $host_name ($redfish) manages $system_count systems but bmcSystemId is not set. Set bmcSystemId in agent_hosts config"
+        else
+            validation pass "${host_name}_system_id" "BMC on $host_name ($redfish) has a single system, bmcSystemId not required"
+        fi
+    else
+        if jq -e --arg id "/redfish/v1/Systems/${bmc_system_id}" '.Members[]? | select(."@odata.id" == $id)' "$redfish_response" > /dev/null 2>&1; then
+            validation pass "${host_name}_system_id" "bmcSystemId '${bmc_system_id}' found on $host_name ($redfish)"
+        else
+            available_systems=$(jq -r '.Members[]?."@odata.id" // empty' "$redfish_response" 2>/dev/null | sed 's|/redfish/v1/Systems/||' | paste -sd ', ')
+            rm -f "$redfish_response"
+            validation fail "${host_name}_system_id" "bmcSystemId '${bmc_system_id}' not found on $host_name ($redfish). Available systems: ${available_systems}"
+        fi
+    fi
+    rm -f "$redfish_response"
 done
 
 ## Validate S3 configuration (only for RadosGWStorage backend)

--- a/validations.sh
+++ b/validations.sh
@@ -324,27 +324,30 @@ for host in 0 1 2; do
         validation fail $host_name "Connection to $host_name ($redfish) is not healthy. Return code: $redfish_curl_return"
     else
         validation pass $host_name "Redfish connection to $host_name ($redfish) successful"
-    fi
 
-    bmc_system_id=$(getValue ".agent_hosts[$host].bmcSystemId")
-    system_count=$(jq -r '."Members@odata.count" // (.Members | length)' "$redfish_response" 2>/dev/null)
-    if [[ -z "$bmc_system_id" || "$bmc_system_id" == "null" ]]; then
-        if [[ "$system_count" =~ ^[0-9]+$ && "$system_count" -gt 1 ]]; then
-            rm -f "$redfish_response"
-            validation fail "${host_name}_system_id" "BMC on $host_name ($redfish) manages $system_count systems but bmcSystemId is not set. Set bmcSystemId in agent_hosts config"
+        bmc_system_id=$(getValue ".agent_hosts[$host].bmcSystemId")
+        system_count=$(jq -r '."Members@odata.count" // (.Members | length)' "$redfish_response" 2>/dev/null)
+        if [[ -z "$bmc_system_id" || "$bmc_system_id" == "null" ]]; then
+            if [[ ! "$system_count" =~ ^[0-9]+$ ]]; then
+                rm -f "$redfish_response"
+                validation fail "${host_name}_system_id" "Could not determine system count from BMC on $host_name ($redfish). Set bmcSystemId explicitly"
+            elif [[ "$system_count" -gt 1 ]]; then
+                rm -f "$redfish_response"
+                validation fail "${host_name}_system_id" "BMC on $host_name ($redfish) manages $system_count systems but bmcSystemId is not set. Set bmcSystemId in agent_hosts config"
+            else
+                validation pass "${host_name}_system_id" "BMC on $host_name ($redfish) has a single system, bmcSystemId not required"
+            fi
         else
-            validation pass "${host_name}_system_id" "BMC on $host_name ($redfish) has a single system, bmcSystemId not required"
+            if jq -e --arg id "/redfish/v1/Systems/${bmc_system_id}" '.Members[]? | select(."@odata.id" == $id)' "$redfish_response" > /dev/null 2>&1; then
+                validation pass "${host_name}_system_id" "bmcSystemId '${bmc_system_id}' found on $host_name ($redfish)"
+            else
+                available_systems=$(jq -r '.Members[]?."@odata.id" // empty' "$redfish_response" 2>/dev/null | sed 's|/redfish/v1/Systems/||' | paste -sd ', ')
+                rm -f "$redfish_response"
+                validation fail "${host_name}_system_id" "bmcSystemId '${bmc_system_id}' not found on $host_name ($redfish). Available systems: ${available_systems}"
+            fi
         fi
-    else
-        if jq -e --arg id "/redfish/v1/Systems/${bmc_system_id}" '.Members[]? | select(."@odata.id" == $id)' "$redfish_response" > /dev/null 2>&1; then
-            validation pass "${host_name}_system_id" "bmcSystemId '${bmc_system_id}' found on $host_name ($redfish)"
-        else
-            available_systems=$(jq -r '.Members[]?."@odata.id" // empty' "$redfish_response" 2>/dev/null | sed 's|/redfish/v1/Systems/||' | paste -sd ', ')
-            rm -f "$redfish_response"
-            validation fail "${host_name}_system_id" "bmcSystemId '${bmc_system_id}' not found on $host_name ($redfish). Available systems: ${available_systems}"
-        fi
+        rm -f "$redfish_response"
     fi
-    rm -f "$redfish_response"
 done
 
 ## Validate S3 configuration (only for RadosGWStorage backend)


### PR DESCRIPTION
## Summary

- Make `bmcSystemId` optional — let Ironic/BMO auto-discover the system when not set (common case for single-system BMCs)
- Remove the hardcoded default of `'1'` so users don't need to find non-trivial system ID values
- Add BMC system count validation in `validations.sh`
- Centralize `defaultInterfaceName` in deployment defaults (required in schema)

## Details

### bmcSystemId handling
- `redfish_system_id` is only included in Ironic `driver_info` when `bmcSystemId` is explicitly set
- BareMetalHost BMC address conditionally appends the system ID
- Schema description updated to clarify the field is optional and auto-discovered

### Validation (validations.sh)
When connecting to the BMC, the script now:
1. Queries `/redfish/v1/Systems` and captures the response
2. If `bmcSystemId` is **not set**: fails if the BMC manages multiple systems, fails if system count cannot be parsed, passes on single system
3. If `bmcSystemId` **is set**: validates it exists in the BMC's available systems list

System count validation only runs after a successful Redfish connection.

### defaultInterfaceName
- Moved hardcoded `eno1` default from Jinja2 templates to `defaults/deployment.yaml`
- Added schema validation for the new default (required field)
- Templates now use `default(defaultInterfaceName)` instead of `default('eno1')`

## Test plan

- [ ] Verify `validations.sh` correctly detects single-system BMC (no `bmcSystemId` needed)
- [ ] Verify `validations.sh` fails on multi-system BMC without `bmcSystemId`
- [ ] Verify `validations.sh` fails when BMC system count cannot be parsed
- [ ] Verify `validations.sh` validates explicit `bmcSystemId` against BMC systems list
- [ ] Verify Ironic enrollment works without `bmcSystemId` on single-system BMC
- [ ] Verify BareMetalHost creation works without system ID path in BMC address
- [ ] Verify `defaultInterfaceName` is used when `interfaceName` is not set per host

Closes: [OSAC-1999](https://issues.redhat.com/browse/OSAC-1999)

🤖 Generated with [Claude Code](https://claude.com/claude-code)