### PR TITLE
Add cert chain, expiry, and intermediate CA test coverage

### DIFF
--- a/src/enclave/tools/cert_utils.py
+++ b/src/enclave/tools/cert_utils.py
@@ -96,6 +96,7 @@ def is_self_signed(cert_pem: str) -> bool:
                     "verify",
                     "-no-CAfile",
                     "-no-CApath",
+                    "-no_check_time",
                     "-check_ss_sig",
                     "-CAfile",
                     str(cert_path),

--- a/src/enclave/tools/check_certificate_chains.py
+++ b/src/enclave/tools/check_certificate_chains.py
@@ -18,18 +18,25 @@ class CertificateValidationError(Exception):
     """Raised when certificate chain validation fails."""
 
 
+def _check_self_signed_root(field: str, cert_pem: str, ca_pem: str) -> str | None:
+    """Return an issue string when the chain ends with a self-signed root, else None."""
+    if not openssl_verify(cert_pem, cert_pem):
+        return f"{field}: chain ends with a self-signed root that has expired."
+    if ca_pem and not openssl_verify(ca_pem, cert_pem):
+        return (
+            f"{field}: chain ends with a self-signed root but sslCACertificate "
+            f"does not verify it — they may belong to different CA hierarchies."
+        )
+    return None
+
+
 def _check_chain(field: str, chain_pem: str, ca_pem: str) -> str | None:
     """Return an issue string if the chain has a completeness or consistency problem, else None."""
     certs = pem_blocks(chain_pem)
     if not certs:
         return f"{field}: configured but contains no PEM certificate blocks — check the value"
     if is_self_signed(certs[-1]):
-        return (
-            f"{field}: chain ends with a self-signed root but sslCACertificate "
-            f"does not verify it — they may belong to different CA hierarchies."
-            if ca_pem and not openssl_verify(ca_pem, certs[-1])
-            else None
-        )
+        return _check_self_signed_root(field, certs[-1], ca_pem)
     if not ca_pem:
         try:
             system_ca = find_system_ca_for_chain(chain_pem)

--- a/src/tests/cert_helpers.py
+++ b/src/tests/cert_helpers.py
@@ -1,6 +1,7 @@
 """Shared openssl helper functions for certificate generation in tests."""
 
 import subprocess
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 
@@ -36,9 +37,17 @@ def generate_ca(tmp_path: Path, cn: str) -> tuple[str, Path, Path]:
 
 
 def generate_signed_leaf(
-    tmp_path: Path, ca_cert_path: Path, ca_key_path: Path, cn: str
+    tmp_path: Path,
+    ca_cert_path: Path,
+    ca_key_path: Path,
+    cn: str,
+    sans: list[str] | None = None,
 ) -> str:
-    """Generate a cert signed by the given CA. Returns cert_pem (stripped)."""
+    """Generate a cert signed by the given CA. Returns cert_pem (stripped).
+
+    Pass sans to embed a subjectAltName extension (e.g. ["foo.example.com", "*.example.com"]).
+    When None, no SAN extension is added and the cert is CN-only.
+    """
     leaf_key = tmp_path / "leaf.key"
     # Generate a P-256 EC private key for the leaf certificate.
     subprocess.run(
@@ -75,27 +84,33 @@ def generate_signed_leaf(
     leaf_cert = tmp_path / "leaf.crt"
     # Sign the CSR with the CA's certificate and key, producing the leaf cert.
     # -set_serial supplies a fixed serial number (required when not using a CA database).
-    subprocess.run(
-        [
-            "openssl",
-            "x509",
-            "-req",
-            "-in",
-            str(leaf_csr),
-            "-CA",
-            str(ca_cert_path),
-            "-CAkey",
-            str(ca_key_path),
-            "-out",
-            str(leaf_cert),
-            "-days",
-            "1",
-            "-set_serial",
-            "01",
-        ],
-        check=True,
-        capture_output=True,
-    )
+    cmd = [
+        "openssl",
+        "x509",
+        "-req",
+        "-in",
+        str(leaf_csr),
+        "-CA",
+        str(ca_cert_path),
+        "-CAkey",
+        str(ca_key_path),
+        "-out",
+        str(leaf_cert),
+        "-days",
+        "1",
+        "-set_serial",
+        "01",
+    ]
+    if sans:
+        # Write a minimal extensions config with the requested SANs. openssl x509 -req
+        # does not support -addext, so an extfile is required to inject extensions.
+        ext_file = tmp_path / "leaf.ext"
+        ext_file.write_text(
+            "[ext]\nsubjectAltName=" + ",".join(f"DNS:{s}" for s in sans) + "\n",
+            encoding="utf-8",
+        )
+        cmd += ["-extfile", str(ext_file), "-extensions", "ext"]
+    subprocess.run(cmd, check=True, capture_output=True)
     return leaf_cert.read_text(encoding="utf-8").strip()
 
 
@@ -195,3 +210,203 @@ def generate_self_issued_not_self_signed_cert(tmp_path: Path) -> str:
         capture_output=True,
     )
     return cross_cert.read_text(encoding="utf-8").strip()
+
+
+def generate_intermediate_ca(
+    tmp_path: Path,
+    cn: str,
+    parent_cert_path: Path,
+    parent_key_path: Path,
+) -> tuple[str, Path, Path]:
+    """Generate an intermediate CA cert signed by parent. Returns (cert_pem, cert_path, key_path)."""
+    key_path = tmp_path / f"{cn}.key"
+    csr_path = tmp_path / f"{cn}.csr"
+    cert_path = tmp_path / f"{cn}.crt"
+    # Generate a P-256 EC private key for the intermediate CA.
+    subprocess.run(
+        [
+            "openssl",
+            "genpkey",
+            "-algorithm",
+            "EC",
+            "-pkeyopt",
+            "ec_paramgen_curve:P-256",
+            "-out",
+            str(key_path),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    # Create a Certificate Signing Request (CSR) for the intermediate CA.
+    subprocess.run(
+        [
+            "openssl",
+            "req",
+            "-new",
+            "-key",
+            str(key_path),
+            "-out",
+            str(csr_path),
+            "-subj",
+            f"/CN={cn}",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    # Write an extensions config that marks the cert as a CA (basicConstraints=CA:TRUE)
+    # and restricts its usage to signing certs and CRLs. openssl x509 -req does not
+    # support -addext, so an extfile is required to inject extensions.
+    ext_file = tmp_path / f"{cn}.ext"
+    ext_file.write_text(
+        "[ext]\nbasicConstraints=CA:TRUE,pathlen:0\nkeyUsage=keyCertSign,cRLSign\n",
+        encoding="utf-8",
+    )
+    # Sign the CSR with the parent CA's key, embedding the CA extensions via -extfile.
+    # -set_serial supplies a fixed serial number (required when not using a CA database).
+    subprocess.run(
+        [
+            "openssl",
+            "x509",
+            "-req",
+            "-in",
+            str(csr_path),
+            "-CA",
+            str(parent_cert_path),
+            "-CAkey",
+            str(parent_key_path),
+            "-out",
+            str(cert_path),
+            "-days",
+            "1",
+            "-set_serial",
+            "10",
+            "-extfile",
+            str(ext_file),
+            "-extensions",
+            "ext",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return cert_path.read_text(encoding="utf-8").strip(), cert_path, key_path
+
+
+def generate_expired_cert(
+    tmp_path: Path,
+    ca_cert_path: Path,
+    ca_key_path: Path,
+    cn: str,
+) -> str:
+    """Generate a cert with validity dates in the past, signed by the CA. Returns cert_pem.
+
+    The validity window is set to the two-day period ending yesterday so the cert is
+    expired by the time the test runs. Requires OpenSSL 3.x in PATH (available on
+    RHEL 9/10 CI and macOS with Homebrew openssl@3).
+    """
+    key_path = tmp_path / f"expired_{cn}.key"
+    csr_path = tmp_path / f"expired_{cn}.csr"
+    cert_path = tmp_path / f"expired_{cn}.crt"
+    # Generate a P-256 EC private key for the expired certificate.
+    subprocess.run(
+        [
+            "openssl",
+            "genpkey",
+            "-algorithm",
+            "EC",
+            "-pkeyopt",
+            "ec_paramgen_curve:P-256",
+            "-out",
+            str(key_path),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    # Create a Certificate Signing Request (CSR) for the soon-to-be-expired cert.
+    subprocess.run(
+        [
+            "openssl",
+            "req",
+            "-new",
+            "-key",
+            str(key_path),
+            "-out",
+            str(csr_path),
+            "-subj",
+            f"/CN={cn}",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    # Compute a validity window that ends yesterday so the cert is already expired.
+    yesterday = datetime.now(UTC).date() - timedelta(days=1)
+    day_before = datetime.now(UTC).date() - timedelta(days=2)
+    not_before = day_before.strftime("%Y%m%d000000Z")
+    not_after = yesterday.strftime("%Y%m%d000000Z")
+    # Sign the CSR with a past validity window. The CA's signature is valid; only the
+    # notBefore/notAfter dates place the cert outside its usable period.
+    subprocess.run(
+        [
+            "openssl",
+            "x509",
+            "-req",
+            "-in",
+            str(csr_path),
+            "-CA",
+            str(ca_cert_path),
+            "-CAkey",
+            str(ca_key_path),
+            "-out",
+            str(cert_path),
+            "-not_before",
+            not_before,
+            "-not_after",
+            not_after,
+            "-set_serial",
+            "99",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return cert_path.read_text(encoding="utf-8").strip()
+
+
+def generate_expired_self_signed(tmp_path: Path, cn: str) -> str:
+    """Generate a self-signed cert with validity dates in the past. Returns cert_pem.
+
+    The validity window is set to the two-day period ending yesterday so the cert is
+    expired by the time the test runs. Requires OpenSSL 3.x in PATH (available on
+    RHEL 9/10 CI and macOS with Homebrew openssl@3).
+    """
+    key_path = tmp_path / f"expired_ss_{cn}.key"
+    cert_path = tmp_path / f"expired_ss_{cn}.crt"
+    # Compute a validity window that ended yesterday so the cert is already expired.
+    yesterday = datetime.now(UTC).date() - timedelta(days=1)
+    day_before = datetime.now(UTC).date() - timedelta(days=2)
+    # Generate a self-signed cert in one step (-x509 produces a cert rather than a CSR).
+    # -newkey ec creates and uses a fresh P-256 key; -nodes skips key encryption.
+    # -not_before/-not_after set the validity window in the past.
+    subprocess.run(
+        [
+            "openssl",
+            "req",
+            "-x509",
+            "-newkey",
+            "ec",
+            "-pkeyopt",
+            "ec_paramgen_curve:P-256",
+            "-keyout",
+            str(key_path),
+            "-out",
+            str(cert_path),
+            "-nodes",
+            "-subj",
+            f"/CN={cn}",
+            "-not_before",
+            day_before.strftime("%Y%m%d000000Z"),
+            "-not_after",
+            yesterday.strftime("%Y%m%d000000Z"),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return cert_path.read_text(encoding="utf-8").strip()

--- a/src/tests/cert_helpers.py
+++ b/src/tests/cert_helpers.py
@@ -300,8 +300,8 @@ def generate_expired_cert(
     """Generate a cert with validity dates in the past, signed by the CA. Returns cert_pem.
 
     The validity window is set to the two-day period ending yesterday so the cert is
-    expired by the time the test runs. Requires OpenSSL 3.x in PATH (available on
-    RHEL 9/10 CI and macOS with Homebrew openssl@3).
+    expired by the time the test runs. Requires OpenSSL 3.4+ (-not_before/-not_after
+    were introduced in 3.4).
     """
     key_path = tmp_path / f"expired_{cn}.key"
     csr_path = tmp_path / f"expired_{cn}.csr"
@@ -370,12 +370,101 @@ def generate_expired_cert(
     return cert_path.read_text(encoding="utf-8").strip()
 
 
+def generate_expired_intermediate_ca(
+    tmp_path: Path,
+    cn: str,
+    parent_cert_path: Path,
+    parent_key_path: Path,
+) -> tuple[str, Path, Path]:
+    """Generate an expired intermediate CA cert signed by parent. Returns (cert_pem, cert_path, key_path).
+
+    Combines CA extensions (basicConstraints=CA:TRUE) with a past validity window so the
+    cert is both structurally a CA and already expired when the test runs.
+    Requires OpenSSL 3.4+ (-not_before/-not_after were introduced in 3.4).
+    """
+    key_path = tmp_path / f"expired_inter_{cn}.key"
+    csr_path = tmp_path / f"expired_inter_{cn}.csr"
+    cert_path = tmp_path / f"expired_inter_{cn}.crt"
+    # Generate a P-256 EC private key for the expired intermediate CA.
+    subprocess.run(
+        [
+            "openssl",
+            "genpkey",
+            "-algorithm",
+            "EC",
+            "-pkeyopt",
+            "ec_paramgen_curve:P-256",
+            "-out",
+            str(key_path),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    # Create a Certificate Signing Request (CSR) for the expired intermediate CA.
+    subprocess.run(
+        [
+            "openssl",
+            "req",
+            "-new",
+            "-key",
+            str(key_path),
+            "-out",
+            str(csr_path),
+            "-subj",
+            f"/CN={cn}",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    # Write a CA extensions config so the cert carries basicConstraints=CA:TRUE.
+    # openssl x509 -req does not support -addext, so an extfile is required.
+    ext_file = tmp_path / f"expired_inter_{cn}.ext"
+    ext_file.write_text(
+        "[ext]\nbasicConstraints=CA:TRUE,pathlen:0\nkeyUsage=keyCertSign,cRLSign\n",
+        encoding="utf-8",
+    )
+    # Compute a validity window that ends yesterday so the cert is already expired.
+    yesterday = datetime.now(UTC).date() - timedelta(days=1)
+    day_before = datetime.now(UTC).date() - timedelta(days=2)
+    not_before = day_before.strftime("%Y%m%d000000Z")
+    not_after = yesterday.strftime("%Y%m%d000000Z")
+    # Sign the CSR with the parent CA, embedding CA extensions and a past validity window.
+    subprocess.run(
+        [
+            "openssl",
+            "x509",
+            "-req",
+            "-in",
+            str(csr_path),
+            "-CA",
+            str(parent_cert_path),
+            "-CAkey",
+            str(parent_key_path),
+            "-out",
+            str(cert_path),
+            "-not_before",
+            not_before,
+            "-not_after",
+            not_after,
+            "-set_serial",
+            "98",
+            "-extfile",
+            str(ext_file),
+            "-extensions",
+            "ext",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return cert_path.read_text(encoding="utf-8").strip(), cert_path, key_path
+
+
 def generate_expired_self_signed(tmp_path: Path, cn: str) -> str:
     """Generate a self-signed cert with validity dates in the past. Returns cert_pem.
 
     The validity window is set to the two-day period ending yesterday so the cert is
-    expired by the time the test runs. Requires OpenSSL 3.x in PATH (available on
-    RHEL 9/10 CI and macOS with Homebrew openssl@3).
+    expired by the time the test runs. Requires OpenSSL 3.4+ (-not_before/-not_after
+    were introduced in 3.4).
     """
     key_path = tmp_path / f"expired_ss_{cn}.key"
     cert_path = tmp_path / f"expired_ss_{cn}.crt"

--- a/src/tests/test_cert_utils.py
+++ b/src/tests/test_cert_utils.py
@@ -12,7 +12,12 @@ from pathlib import Path
 import pytest
 
 from enclave.tools.cert_utils import is_self_signed, openssl_verify, pem_blocks
-from tests.cert_helpers import generate_ca, generate_self_issued_not_self_signed_cert
+from tests.cert_helpers import (
+    generate_ca,
+    generate_expired_cert,
+    generate_expired_self_signed,
+    generate_self_issued_not_self_signed_cert,
+)
 
 
 def test_pem_blocks_splits_multiple_certificates(
@@ -78,3 +83,21 @@ def test_is_self_signed_returns_false_for_self_issued_but_not_self_signed(
     """A cert with issuer==subject but signed by a different key is not self-signed."""
     cross_pem = generate_self_issued_not_self_signed_cert(tmp_path)
     assert is_self_signed(cross_pem) is False
+
+
+def test_is_self_signed_returns_true_for_expired_self_signed(tmp_path: Path) -> None:
+    """Return True for a self-signed cert whose validity window has passed.
+
+    is_self_signed is a structural check: it verifies that the cert's signature was
+    made by its own key, regardless of whether the cert is currently within its
+    validity period.
+    """
+    expired_ss_pem = generate_expired_self_signed(tmp_path, "Expired CA")
+    assert is_self_signed(expired_ss_pem) is True
+
+
+def test_openssl_verify_expired_cert_returns_false(tmp_path: Path) -> None:
+    """openssl_verify returns False when the cert is expired."""
+    ca_pem, ca_cert_path, ca_key_path = generate_ca(tmp_path, "Test CA")
+    expired_pem = generate_expired_cert(tmp_path, ca_cert_path, ca_key_path, "Leaf")
+    assert openssl_verify(ca_pem, expired_pem) is False

--- a/src/tests/test_check_certificate_chains.py
+++ b/src/tests/test_check_certificate_chains.py
@@ -13,6 +13,8 @@ from enclave.tools.check_certificate_chains import (
 from tests.cert_helpers import (
     generate_ca,
     generate_expired_cert,
+    generate_expired_intermediate_ca,
+    generate_expired_self_signed,
     generate_intermediate_ca,
     generate_signed_leaf,
 )
@@ -33,6 +35,9 @@ def test_check_passes_when_chain_ends_with_self_signed_root(
     """Pass when the chain ends with a self-signed root."""
     mocker.patch(
         "enclave.tools.check_certificate_chains.is_self_signed", return_value=True
+    )
+    mocker.patch(
+        "enclave.tools.check_certificate_chains.openssl_verify", return_value=True
     )
     path = _write_certs(
         tmp_path,
@@ -58,7 +63,7 @@ def test_check_passes_when_ca_matches_self_signed_root(
     )
     check_certificate_chains(path)
     mock_is_self_signed.assert_called_once_with(root_pem)
-    mock_openssl_verify.assert_called_once_with(root_pem, root_pem)
+    mock_openssl_verify.assert_called_with(root_pem, root_pem)
 
 
 def test_check_raises_when_ca_does_not_match_self_signed_root(
@@ -364,6 +369,19 @@ def test_real_chain_missing_intermediate_fails(tmp_path: Path) -> None:
         check_certificate_chains(path)
 
 
+def test_expired_self_signed_root_chain_fails(tmp_path: Path) -> None:
+    """Fail when the chain ends with an expired self-signed root and no CA is provided.
+
+    is_self_signed uses -no_check_time to detect structural self-signing regardless
+    of validity dates. This test ensures that the expiry check after that structural
+    check still rejects the chain.
+    """
+    expired_root_pem = generate_expired_self_signed(tmp_path, "Expired Root CA")
+    path = _write_certs(tmp_path, sslAPICertificateFullChain=expired_root_pem)
+    with pytest.raises(CertificateValidationError):
+        check_certificate_chains(path)
+
+
 def test_expired_leaf_fails(tmp_path: Path) -> None:
     """Fail when the leaf cert is expired.
 
@@ -384,17 +402,22 @@ def test_expired_leaf_fails(tmp_path: Path) -> None:
 
 
 def test_expired_intermediate_fails(tmp_path: Path) -> None:
-    """Fail when an intermediate cert in the chain is expired.
+    """Fail when an intermediate CA in the chain is expired.
 
-    The chain ends with the expired intermediate (non-self-signed). The root CA
-    issued it, but openssl_verify(root, expired_intermediate) returns False because
-    the cert has expired.
+    The expired intermediate has basicConstraints=CA:TRUE and was issued by the root.
+    The leaf is signed by the expired intermediate's key. The chain ends with the
+    expired intermediate (non-self-signed), and openssl_verify(root, expired_inter)
+    returns False because the cert has expired.
     """
     root_pem, root_cert_path, root_key_path = generate_ca(tmp_path, "Root CA")
-    expired_inter_pem = generate_expired_cert(
-        tmp_path, root_cert_path, root_key_path, "Intermediate CA"
+    expired_inter_pem, expired_inter_cert_path, expired_inter_key_path = (
+        generate_expired_intermediate_ca(
+            tmp_path, "Intermediate CA", root_cert_path, root_key_path
+        )
     )
-    leaf_pem = generate_signed_leaf(tmp_path, root_cert_path, root_key_path, "Leaf")
+    leaf_pem = generate_signed_leaf(
+        tmp_path, expired_inter_cert_path, expired_inter_key_path, "Leaf"
+    )
     path = _write_certs(
         tmp_path,
         sslAPICertificateFullChain=f"{leaf_pem}\n{expired_inter_pem}",

--- a/src/tests/test_check_certificate_chains.py
+++ b/src/tests/test_check_certificate_chains.py
@@ -10,6 +10,12 @@ from enclave.tools.check_certificate_chains import (
     check_certificate_chains,
     main,
 )
+from tests.cert_helpers import (
+    generate_ca,
+    generate_expired_cert,
+    generate_intermediate_ca,
+    generate_signed_leaf,
+)
 
 
 def _write_certs(tmp_path: Path, **kwargs: str) -> str:
@@ -314,3 +320,85 @@ def test_main_propagates_validation_error(
     with pytest.raises(CertificateValidationError, match="chain incomplete"):
         main(str(tmp_path / "certs.yaml"))
     assert capsys.readouterr().out == ""
+
+
+def test_real_three_hop_chain_passes(tmp_path: Path) -> None:
+    """check_certificate_chains passes for a genuine three-certificate chain.
+
+    Builds a self-signed root CA, an intermediate CA signed by the root (with
+    basicConstraints=CA:TRUE), and a leaf cert signed by the intermediate. The
+    full chain leaf→intermediate→root is written to sslAPICertificateFullChain.
+    No mocks: is_self_signed and openssl_verify run real openssl subprocess calls,
+    so this test exercises the complete validation path with genuine certificates.
+    """
+    root_pem, root_cert_path, root_key_path = generate_ca(tmp_path, "Root CA")
+    inter_pem, inter_cert_path, inter_key_path = generate_intermediate_ca(
+        tmp_path, "Intermediate CA", root_cert_path, root_key_path
+    )
+    leaf_pem = generate_signed_leaf(tmp_path, inter_cert_path, inter_key_path, "Leaf")
+    path = _write_certs(
+        tmp_path,
+        sslAPICertificateFullChain=f"{leaf_pem}\n{inter_pem}\n{root_pem}",
+    )
+    check_certificate_chains(path)
+
+
+def test_real_chain_missing_intermediate_fails(tmp_path: Path) -> None:
+    """Fail when the leaf is not directly signed by the provided CA (no mocks).
+
+    The root CA signs the intermediate, not the leaf directly. Presenting the leaf
+    alone with sslCACertificate=root causes openssl_verify(root, leaf) to return
+    False, which is the path we want to exercise without any mocking.
+    """
+    root_pem, root_cert_path, root_key_path = generate_ca(tmp_path, "Root CA")
+    _, inter_cert_path, inter_key_path = generate_intermediate_ca(
+        tmp_path, "Intermediate CA", root_cert_path, root_key_path
+    )
+    leaf_pem = generate_signed_leaf(tmp_path, inter_cert_path, inter_key_path, "Leaf")
+    path = _write_certs(
+        tmp_path,
+        sslAPICertificateFullChain=leaf_pem,
+        sslCACertificate=root_pem,
+    )
+    with pytest.raises(CertificateValidationError):
+        check_certificate_chains(path)
+
+
+def test_expired_leaf_fails(tmp_path: Path) -> None:
+    """Fail when the leaf cert is expired.
+
+    openssl verify rejects expired certs by default, so openssl_verify(ca, expired_leaf)
+    returns False even though the CA did issue the cert.
+    """
+    root_pem, root_cert_path, root_key_path = generate_ca(tmp_path, "Root CA")
+    expired_leaf_pem = generate_expired_cert(
+        tmp_path, root_cert_path, root_key_path, "Leaf"
+    )
+    path = _write_certs(
+        tmp_path,
+        sslAPICertificateFullChain=expired_leaf_pem,
+        sslCACertificate=root_pem,
+    )
+    with pytest.raises(CertificateValidationError):
+        check_certificate_chains(path)
+
+
+def test_expired_intermediate_fails(tmp_path: Path) -> None:
+    """Fail when an intermediate cert in the chain is expired.
+
+    The chain ends with the expired intermediate (non-self-signed). The root CA
+    issued it, but openssl_verify(root, expired_intermediate) returns False because
+    the cert has expired.
+    """
+    root_pem, root_cert_path, root_key_path = generate_ca(tmp_path, "Root CA")
+    expired_inter_pem = generate_expired_cert(
+        tmp_path, root_cert_path, root_key_path, "Intermediate CA"
+    )
+    leaf_pem = generate_signed_leaf(tmp_path, root_cert_path, root_key_path, "Leaf")
+    path = _write_certs(
+        tmp_path,
+        sslAPICertificateFullChain=f"{leaf_pem}\n{expired_inter_pem}",
+        sslCACertificate=root_pem,
+    )
+    with pytest.raises(CertificateValidationError):
+        check_certificate_chains(path)


### PR DESCRIPTION
cert_helpers.py — new test helpers:
- generate_intermediate_ca: intermediate CA cert with basicConstraints=CA:TRUE,
  signed by a parent CA; uses -extfile since openssl x509 -req lacks -addext
- generate_expired_cert: CA-signed end-entity cert with a past validity window
  (-not_before/-not_after, requires OpenSSL 3.4+)
- generate_expired_self_signed: same but self-signed in one openssl req -x509 step
- generate_expired_intermediate_ca: expired CA cert with CA:TRUE extensions and
  past validity window; returns (pem, cert_path, key_path) so callers can sign
  a leaf with the expired CA's key and produce a semantically correct chain
- generate_signed_leaf: add optional sans parameter; injects SANs via -extfile
  (openssl x509 -req does not support -addext)

cert_utils.py — fix is_self_signed date coupling:
- Add -no_check_time to the openssl verify -check_ss_sig call so the structural
  self-signed check (signature by own key) is independent of validity dates;
  without this flag, expired self-signed CAs were misclassified as not self-signed

check_certificate_chains.py — fix expired self-signed root accepted without CA:
- Extract _check_self_signed_root from _check_chain
- When no sslCACertificate is provided, call openssl_verify(root, root) with
  normal time checking after the structural is_self_signed gate; an expired
  self-signed root now correctly fails instead of passing silently

test_cert_utils.py — two new tests:
- test_is_self_signed_returns_true_for_expired_self_signed: confirms structural
  check ignores validity dates
- test_openssl_verify_expired_cert_returns_false: confirms expiry is rejected

test_check_certificate_chains.py — five new no-mock tests:
- test_real_three_hop_chain_passes: genuine root→intermediate→leaf chain
- test_real_chain_missing_intermediate_fails: leaf not directly signed by CA
- test_expired_leaf_fails: CA rejects its own expired leaf
- test_expired_intermediate_fails: uses generate_expired_intermediate_ca so the
  leaf is signed by the expired CA's key (not by the root directly)
- test_expired_self_signed_root_chain_fails: regression for the _check_self_signed_root fix



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Self-signed certificates are now recognized correctly even when expired, while certificate chain validation continues to reject expired certificates.
  * Certificate validation now reliably handles missing intermediates and expired certificates in multi-level chains.

* **Tests**
  * Added coverage for valid three-level certificate chains, missing intermediates, expired leaf certificates, and expired intermediate certificates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->