### PR TITLE
docs: document bmcSystemId field for agent_hosts and discovery_hosts

### DIFF
--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -373,6 +373,7 @@ agent_hosts:
 
 | Field | Description | Example |
 |-------|-------------|---------|
+| `bmcSystemId` | Redfish system ID path component (`/redfish/v1/Systems/<bmcSystemId>`). Defaults to `1` | `1` |
 | `mapInterfaces` | List of interface-to-MAC mappings for advanced network configuration | See example below |
 | `networkConfig` | Full nmstate network configuration in YAML format | See example below |
 
@@ -1220,6 +1221,12 @@ discovery_hosts:
 | `rootDisk` | Physical disk path for root filesystem (use `/dev/disk/by-path/` paths) | `/dev/disk/by-path/pci-0000:0011.4-ata-1.0` |
 | `redfishUser` | Username for Redfish API authentication | `admin` |
 | `redfishPassword` | Password for Redfish API authentication | `YourSecurePassword` |
+
+**Optional fields for each host**:
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| `bmcSystemId` | Redfish system ID path component (`/redfish/v1/Systems/<bmcSystemId>`). Defaults to `1` | `1` |
 
 **Notes**:
 - MAC addresses must be unique


### PR DESCRIPTION
## Summary
- `bmcSystemId` is defined in `schemas/definitions.yaml` but was missing from `docs/CONFIGURATION_REFERENCE.md`, so it was easy to miss when a BMC exposes its Redfish system at a non-default path.
- Adds it to the optional fields tables for both `agent_hosts` and `discovery_hosts`.

Related: gori-project/GoRI#947

## Test plan
- [x] Doc-only change, no code affected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented the optional `bmcSystemId` configuration field for host and discovery host settings.
  * Clarified its Redfish system path usage and default value of `1`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->