### PR TITLE
OSAC-2909: Add emergencyServiceAccounts to OSAC plugin Helm values

### DIFF
--- a/plugins/osac/templates/values.yaml.j2
+++ b/plugins/osac/templates/values.yaml.j2
@@ -55,6 +55,11 @@ service:
       name: default-ca
   auth:
     issuerUrl: "https://{{ _osac_keycloak_hostname }}/realms/{{ osac_keycloak_realm }}"
+    emergencyServiceAccounts:
+    - admin
+    - osac-operator
+    - osac-operator-controller-manager
+    - template-publisher
     controllerCredentials:
       - secret:
           name: fulfillment-controller-credentials


### PR DESCRIPTION
## Summary

- The enclave OSAC plugin's `values.yaml.j2` did not set `auth.emergencyServiceAccounts`, falling through to the fulfillment-service subchart default (`admin` only)
- This caused the `publish-templates` AAP job to get a **403 Forbidden** when calling `GET /api/private/v1/cluster_templates` because `template-publisher` was not in the emergency service accounts list
- Added the same four accounts used by the [osac-installer CI values files](https://github.com/osac-project/osac-installer/blob/main/values/vmaas-ci/values.yaml#L68-L72): `admin`, `osac-operator`, `osac-operator-controller-manager`, `template-publisher`

## Test plan

- [x] Deploy OSAC via enclave and verify the `publish-templates` job completes without 403
- [ ] Confirm `--emergency-service-accounts` flag on the gRPC server pod includes all four accounts

Jira: https://redhat.atlassian.net/browse/OSAC-2909

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added default emergency service account configuration for administrative and operator service accounts.
  * Included emergency access settings for the operator, controller manager, and template publisher.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->