### PR TITLE
feat(certs): move all certificate validation into enclave tools check-certificate-chains

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -193,8 +193,6 @@ step_validate() {
     echo "Validating Config .. "  | tee -a ${log}
     ANSIBLE_LOG_PATH=${log} ansible-playbook playbooks/validation/validate-schema.yaml $EXTRA_VARS --tags validate-config
     bash ./validations.sh 2>&1 | tee -a ${log}
-    enclave tools check-root-ca --config "${certs_vars}" 2>&1 | tee -a ${log}
-    enclave tools check-certificate-chains --config "${certs_vars}" 2>&1 | tee -a ${log}
     step_done
 }
 

--- a/src/enclave/cli.py
+++ b/src/enclave/cli.py
@@ -2,7 +2,7 @@ import click
 
 from enclave.reconcile.cli import cli as reconcile_cli
 from enclave.tools.cli import cli as tools_cli
-from enclave.utils import LOG_LEVELS, configure_logging
+from enclave.utils import LOG_FORMATS, LOG_LEVELS, configure_logging
 
 
 @click.group()
@@ -12,9 +12,20 @@ from enclave.utils import LOG_LEVELS, configure_logging
     type=click.Choice(LOG_LEVELS, case_sensitive=False),
     help="Set the logging level.",
 )
-def cli(log_level: str) -> None:
+@click.option(
+    "--log-format",
+    default="full",
+    type=click.Choice(LOG_FORMATS, case_sensitive=False),
+    help=(
+        "Log output format. "
+        "'full' prints timestamp, level, and message "
+        "(e.g. '2026-07-21T12:00:00 INFO     done'). "
+        "'plain' prints the message only (e.g. 'done')."
+    ),
+)
+def cli(log_level: str, log_format: str) -> None:
     """Enclave CLI."""
-    configure_logging(log_level)
+    configure_logging(log_level, log_format)
 
 
 # Add existing command groups as subcommands

--- a/src/enclave/tools/cert_utils.py
+++ b/src/enclave/tools/cert_utils.py
@@ -4,12 +4,13 @@ import logging
 import re
 import subprocess
 import tempfile
+from datetime import UTC, datetime
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-_OPENSSL_TIMEOUT_SECONDS = 10
-_PEM_BLOCK = re.compile(
+OPENSSL_TIMEOUT_SECONDS = 10
+PEM_BLOCK_RE = re.compile(
     r"-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----",
     re.DOTALL,
 )
@@ -42,7 +43,7 @@ def openssl_verify(ca_pem: str, cert_pem: str) -> bool:
                 capture_output=True,
                 text=True,
                 check=False,
-                timeout=_OPENSSL_TIMEOUT_SECONDS,
+                timeout=OPENSSL_TIMEOUT_SECONDS,
             )
         except subprocess.TimeoutExpired as exc:
             msg = "openssl verify timed out"
@@ -55,7 +56,7 @@ def openssl_verify(ca_pem: str, cert_pem: str) -> bool:
 
 def pem_blocks(pem_text: str) -> list[str]:
     """Return all PEM certificate blocks found in pem_text, in order."""
-    return _PEM_BLOCK.findall(pem_text or "")
+    return PEM_BLOCK_RE.findall(pem_text or "")
 
 
 def is_self_signed(cert_pem: str) -> bool:
@@ -73,7 +74,7 @@ def is_self_signed(cert_pem: str) -> bool:
             capture_output=True,
             text=True,
             check=False,
-            timeout=_OPENSSL_TIMEOUT_SECONDS,
+            timeout=OPENSSL_TIMEOUT_SECONDS,
         )
     except (subprocess.TimeoutExpired, OSError) as exc:
         logger.warning("openssl unavailable: %s", exc)
@@ -105,9 +106,125 @@ def is_self_signed(cert_pem: str) -> bool:
                 capture_output=True,
                 text=True,
                 check=False,
-                timeout=_OPENSSL_TIMEOUT_SECONDS,
+                timeout=OPENSSL_TIMEOUT_SECONDS,
             )
         except (subprocess.TimeoutExpired, OSError) as exc:
             logger.warning("openssl self-signature check unavailable: %s", exc)
             return False
     return verify.returncode == 0
+
+
+def cert_key_pair_matches(cert_pem: str, key_pem: str) -> bool:
+    """Return True if key_pem is the private key for cert_pem.
+
+    Extracts the public key from each side via stdin and compares them.
+    Neither the cert nor the key is written to disk.
+    Returns False on any openssl error, mismatch, or missing binary.
+    """
+    try:
+        # Extract public key from the certificate via stdin.
+        cert_pub = subprocess.run(
+            ["openssl", "x509", "-noout", "-pubkey"],
+            input=cert_pem,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=OPENSSL_TIMEOUT_SECONDS,
+        )
+        # Extract public key from the private key via stdin.
+        key_pub = subprocess.run(
+            ["openssl", "pkey", "-pubout"],
+            input=key_pem,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=OPENSSL_TIMEOUT_SECONDS,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.warning("openssl unavailable: %s", exc)
+        return False
+    if cert_pub.returncode != 0 or key_pub.returncode != 0:
+        return False
+    return cert_pub.stdout.strip() == key_pub.stdout.strip()
+
+
+def cert_validity_window_ok(cert_pem: str) -> bool:
+    """Return True if the current UTC time is within the cert's notBefore..notAfter window.
+
+    Returns False when the cert is not yet valid, has expired, or cannot be parsed.
+    """
+    try:
+        result = subprocess.run(
+            ["openssl", "x509", "-noout", "-startdate", "-enddate"],
+            input=cert_pem,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=OPENSSL_TIMEOUT_SECONDS,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.warning("openssl unavailable: %s", exc)
+        return False
+    if result.returncode != 0:
+        return False
+    not_before_match = re.search(r"^notBefore=(.+)$", result.stdout, re.MULTILINE)
+    not_after_match = re.search(r"^notAfter=(.+)$", result.stdout, re.MULTILINE)
+    if not not_before_match or not not_after_match:
+        return False
+    fmt = "%b %d %H:%M:%S %Y %Z"
+    try:
+        not_before = datetime.strptime(not_before_match.group(1).strip(), fmt).replace(
+            tzinfo=UTC
+        )
+        not_after = datetime.strptime(not_after_match.group(1).strip(), fmt).replace(
+            tzinfo=UTC
+        )
+    except ValueError:
+        logger.warning(
+            "cert_validity_window_ok: could not parse date strings %r / %r using format %r",
+            not_before_match.group(1).strip(),
+            not_after_match.group(1).strip(),
+            fmt,
+        )
+        return False
+    now = datetime.now(UTC)
+    return not_before <= now <= not_after
+
+
+def cert_covers_hostname(cert_pem: str, hostname: str) -> bool:
+    """Return True if any SAN in cert_pem covers hostname.
+
+    Supports exact DNS names (case-insensitive) and wildcards (*.example.com matches
+    foo.example.com but not example.com or foo.bar.example.com). Returns False when
+    no SAN extension is present, or when no SAN matches.
+    """
+    try:
+        result = subprocess.run(
+            ["openssl", "x509", "-noout", "-ext", "subjectAltName"],
+            input=cert_pem,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=OPENSSL_TIMEOUT_SECONDS,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.warning("openssl unavailable: %s", exc)
+        return False
+    if result.returncode != 0 or not result.stdout.strip():
+        return False
+    # Parse "DNS:foo.example.com, DNS:*.example.com, IP Address:1.2.3.4" lines.
+    dns_names = re.findall(r"DNS:([^\s,]+)", result.stdout)
+    hostname_lower = hostname.lower()
+    for san in dns_names:
+        san_lower = san.lower()
+        if san_lower.startswith("*."):
+            # Wildcard: exactly one label to the left, no glob metacharacter interpretation.
+            # *.example.com covers foo.example.com but not example.com or foo.bar.example.com.
+            san_suffix = san_lower[1:]  # ".example.com"
+            if hostname_lower.endswith(san_suffix) and hostname.count(".") == san.count(
+                "."
+            ):
+                return True
+        elif san_lower == hostname_lower:
+            return True
+    return False

--- a/src/enclave/tools/cert_utils.py
+++ b/src/enclave/tools/cert_utils.py
@@ -15,6 +15,36 @@ PEM_BLOCK_RE = re.compile(
     re.DOTALL,
 )
 
+# OpenSSL always outputs English month abbreviations in notBefore/notAfter regardless
+# of the system locale. Python's %b in strptime follows LC_TIME, so it would reject
+# "Jan" on a French or German system. We map month names explicitly instead.
+OPENSSL_MONTHS = {
+    "Jan": 1,
+    "Feb": 2,
+    "Mar": 3,
+    "Apr": 4,
+    "May": 5,
+    "Jun": 6,
+    "Jul": 7,
+    "Aug": 8,
+    "Sep": 9,
+    "Oct": 10,
+    "Nov": 11,
+    "Dec": 12,
+}
+
+
+def _parse_openssl_date(date_str: str) -> datetime:
+    """Parse an OpenSSL notBefore/notAfter string into a UTC-aware datetime."""
+    parts = date_str.strip().split()
+    if len(parts) < 4:  # noqa: PLR2004 — month, day, HH:MM:SS, year
+        raise ValueError(f"unexpected OpenSSL date string: {date_str!r}")
+    month = OPENSSL_MONTHS.get(parts[0])
+    if month is None:
+        raise ValueError(f"unknown month abbreviation {parts[0]!r} in: {date_str!r}")
+    normalized = f"{month:02d} {parts[1]} {parts[2]} {parts[3]}"
+    return datetime.strptime(normalized, "%m %d %H:%M:%S %Y").replace(tzinfo=UTC)
+
 
 def openssl_verify(ca_pem: str, cert_pem: str) -> bool:
     """Return True if ca_pem signs cert_pem according to openssl verify.
@@ -171,20 +201,14 @@ def cert_validity_window_ok(cert_pem: str) -> bool:
     not_after_match = re.search(r"^notAfter=(.+)$", result.stdout, re.MULTILINE)
     if not not_before_match or not not_after_match:
         return False
-    fmt = "%b %d %H:%M:%S %Y %Z"
     try:
-        not_before = datetime.strptime(not_before_match.group(1).strip(), fmt).replace(
-            tzinfo=UTC
-        )
-        not_after = datetime.strptime(not_after_match.group(1).strip(), fmt).replace(
-            tzinfo=UTC
-        )
+        not_before = _parse_openssl_date(not_before_match.group(1))
+        not_after = _parse_openssl_date(not_after_match.group(1))
     except ValueError:
         logger.warning(
-            "cert_validity_window_ok: could not parse date strings %r / %r using format %r",
+            "cert_validity_window_ok: could not parse date strings %r / %r",
             not_before_match.group(1).strip(),
             not_after_match.group(1).strip(),
-            fmt,
         )
         return False
     now = datetime.now(UTC)

--- a/src/enclave/tools/check_certificate_chains.py
+++ b/src/enclave/tools/check_certificate_chains.py
@@ -1,21 +1,61 @@
 """Certificate chain completeness and CA consistency checks."""
 
 import logging
-import sys
 from pathlib import Path
+from typing import Any
 
 import yaml
 
-from enclave.tools.cert_utils import is_self_signed, openssl_verify, pem_blocks
+from enclave.tools.cert_utils import (
+    cert_covers_hostname,
+    cert_key_pair_matches,
+    cert_validity_window_ok,
+    is_self_signed,
+    openssl_verify,
+    pem_blocks,
+)
 from enclave.tools.system_ca import find_system_ca_for_chain
 
 logger = logging.getLogger(__name__)
 
-_CHAIN_FIELDS = ("sslAPICertificateFullChain", "sslIngressCertificateFullChain")
+# Maps cert_type argument to its config field name in certificates.yaml.
+CERT_TYPE_TO_FIELD: dict[str, str] = {
+    "api": "sslAPICertificateFullChain",
+    "ingress": "sslIngressCertificateFullChain",
+    "ironic": "ironicHTTPSCertificate",
+}
+
+# Maps cert_type to the private key field that accompanies the cert in certificates.yaml.
+CERT_TYPE_TO_KEY_FIELD: dict[str, str] = {
+    "api": "sslAPICertificateKey",
+    "ingress": "sslIngressCertificateKey",
+    "ironic": "ironicHTTPSKey",
+}
+
+# Types that carry a full chain and require completeness + CA consistency checks.
+# "ironic" is excluded: ironicHTTPSCertificate is a single cert with no CA counterpart.
+CHAIN_CERT_TYPES: frozenset[str] = frozenset({"api", "ingress"})
 
 
 class CertificateValidationError(Exception):
     """Raised when certificate chain validation fails."""
+
+
+def _load_config(config_path: str) -> dict[str, Any]:
+    """Read and parse a YAML config file, raising CertificateValidationError on any failure."""
+    try:
+        text = Path(config_path).read_text(encoding="utf-8")
+    except OSError as exc:
+        raise CertificateValidationError(f"cannot read {config_path}: {exc}") from exc
+    try:
+        raw = yaml.safe_load(text) or {}
+    except yaml.YAMLError as exc:
+        raise CertificateValidationError(f"cannot parse {config_path}: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise CertificateValidationError(
+            f"{config_path}: expected a YAML mapping, got {type(raw).__name__}"
+        )
+    return raw
 
 
 def _check_self_signed_root(field: str, cert_pem: str, ca_pem: str) -> str | None:
@@ -59,47 +99,89 @@ def _check_chain(field: str, chain_pem: str, ca_pem: str) -> str | None:
     )
 
 
-def check_certificate_chains(config_path: str) -> None:
-    """Check that certificate chains are complete and the CA is consistent.
+def _check_leaf(
+    field: str,
+    leaf_pem: str,
+    hostnames: list[str],
+    key_pem: str,
+) -> list[str]:
+    """Return issue strings for leaf-cert checks: expiry, SANs, and key match."""
+    issues: list[str] = []
+    if not cert_validity_window_ok(leaf_pem):
+        issues.append(f"{field}: leaf certificate has expired or is not yet valid.")
+    issues.extend(
+        f"{field}: leaf certificate SAN does not cover '{hostname}'."
+        for hostname in hostnames
+        if not cert_covers_hostname(leaf_pem, hostname)
+    )
+    if not cert_key_pair_matches(leaf_pem, key_pem):
+        issues.append(f"{field}: private key does not match the leaf certificate.")
+    return issues
 
-    Raises CertificateValidationError when a chain ends with a non-self-signed
-    certificate and either sslCACertificate is not set, or the provided CA does not
-    sign the last certificate in the chain. Also raises when a complete chain (ending
-    with a self-signed root) is inconsistent with the provided sslCACertificate.
+
+def check_certificate_chains(
+    config_path: str,
+    cert_type: str,
+    hostnames: list[str],
+) -> None:
+    """Check that a certificate is valid, complete, and consistent.
+
+    cert_type selects which config field to validate:
+      "api"     → sslAPICertificateFullChain    (full chain + leaf checks)
+      "ingress" → sslIngressCertificateFullChain (full chain + leaf checks)
+      "ironic"  → ironicHTTPSCertificate        (leaf checks only)
+
+    For api/ingress: chain completeness is verified against sslCACertificate or the
+    system trust store.
+    For ironic: no chain check.
+
+    The private key is always read from the config (sslAPICertificateKey,
+    sslIngressCertificateKey, or ironicHTTPSKey) and is required whenever the
+    corresponding cert field is set.
+
+    Leaf cert expiry is always checked when the cert field is present and non-empty.
+    Each hostname in hostnames is checked against the cert's SANs.
+
+    Raises CertificateValidationError on any validation failure.
     """
     try:
-        text = Path(config_path).read_text(encoding="utf-8")
-    except OSError as exc:
-        msg = f"cannot read {config_path}: {exc}"
+        field = CERT_TYPE_TO_FIELD[cert_type]
+        key_field = CERT_TYPE_TO_KEY_FIELD[cert_type]
+    except KeyError as exc:
+        msg = f"unknown certificate type: {cert_type!r}"
         raise CertificateValidationError(msg) from exc
 
-    try:
-        raw = yaml.safe_load(text) or {}
-    except yaml.YAMLError as exc:
-        msg = f"cannot parse {config_path}: {exc}"
-        raise CertificateValidationError(msg) from exc
+    raw = _load_config(config_path)
 
-    if not isinstance(raw, dict):
-        msg = f"{config_path}: expected a YAML mapping, got {type(raw).__name__}"
+    cert_pem: str = (raw.get(field) or "").strip()
+    if not cert_pem:
+        logger.debug("%s: no certificate configured; skipping", cert_type)
+        return
+
+    if not hostnames:
+        msg = f"{cert_type}: at least one hostname is required"
         raise CertificateValidationError(msg)
 
-    ca_pem: str = raw.get("sslCACertificate") or ""
+    key_pem: str = (raw.get(key_field) or "").strip()
+    if not key_pem:
+        msg = f"{key_field} is required when {field} is configured"
+        raise CertificateValidationError(msg)
+
     issues: list[str] = []
 
-    for field in _CHAIN_FIELDS:
-        chain_pem: str = raw.get(field) or ""
-        if not chain_pem:
-            continue
-        issue = _check_chain(field, chain_pem, ca_pem)
+    if cert_type in CHAIN_CERT_TYPES:
+        ca_pem: str = (raw.get("sslCACertificate") or "").strip()
+        issue = _check_chain(field, cert_pem, ca_pem)
         if issue:
             issues.append(issue)
+
+        certs = pem_blocks(cert_pem)
+        if certs:
+            issues.extend(_check_leaf(field, certs[0], hostnames, key_pem))
+    else:
+        issues.extend(_check_leaf(field, cert_pem, hostnames, key_pem))
 
     if issues:
         raise CertificateValidationError("\n".join(issues))
 
-    logger.debug("certificate chain check passed")
-
-
-def main(config_path: str) -> None:
-    check_certificate_chains(config_path)
-    sys.stdout.write("Certificate chain check passed.\n")
+    logger.info("certificate chain check passed for %s", cert_type)

--- a/src/enclave/tools/check_certificate_chains.py
+++ b/src/enclave/tools/check_certificate_chains.py
@@ -41,6 +41,22 @@ class CertificateValidationError(Exception):
     """Raised when certificate chain validation fails."""
 
 
+def _get_config_str(raw: dict[str, Any], field: str) -> str:
+    """Return raw[field] as a stripped string, or "" if absent or None.
+
+    Raises CertificateValidationError if the field is present but not a string,
+    so a misconfigured YAML value (list, int, bool) never leaks an AttributeError.
+    """
+    value = raw.get(field)
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise CertificateValidationError(
+            f"{field}: expected a string value, got {type(value).__name__}"
+        )
+    return value.strip()
+
+
 def _load_config(config_path: str) -> dict[str, Any]:
     """Read and parse a YAML config file, raising CertificateValidationError on any failure."""
     try:
@@ -153,7 +169,7 @@ def check_certificate_chains(
 
     raw = _load_config(config_path)
 
-    cert_pem: str = (raw.get(field) or "").strip()
+    cert_pem: str = _get_config_str(raw, field)
     if not cert_pem:
         logger.debug("%s: no certificate configured; skipping", cert_type)
         return
@@ -162,7 +178,7 @@ def check_certificate_chains(
         msg = f"{cert_type}: at least one hostname is required"
         raise CertificateValidationError(msg)
 
-    key_pem: str = (raw.get(key_field) or "").strip()
+    key_pem: str = _get_config_str(raw, key_field)
     if not key_pem:
         msg = f"{key_field} is required when {field} is configured"
         raise CertificateValidationError(msg)
@@ -170,7 +186,7 @@ def check_certificate_chains(
     issues: list[str] = []
 
     if cert_type in CHAIN_CERT_TYPES:
-        ca_pem: str = (raw.get("sslCACertificate") or "").strip()
+        ca_pem: str = _get_config_str(raw, "sslCACertificate")
         issue = _check_chain(field, cert_pem, ca_pem)
         if issue:
             issues.append(issue)

--- a/src/enclave/tools/cli.py
+++ b/src/enclave/tools/cli.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -8,7 +9,7 @@ import yaml
 from enclave.tools.cert_utils import pem_blocks
 from enclave.tools.check_certificate_chains import (
     CertificateValidationError,
-    main as check_certificate_chains_main,
+    check_certificate_chains as check_certificate_chains_helper,
 )
 from enclave.tools.node_image_digests import main as collect_node_image_digests_main
 from enclave.tools.quay_registry_ca import main as quay_registry_ca_main
@@ -114,18 +115,33 @@ def collect_node_image_digests(
 
 
 @cli.command("check-certificate-chains")
+@click.argument("cert_type", type=click.Choice(["api", "ingress", "ironic"]))
 @click.option(
     "--config",
     required=True,
     type=click.Path(exists=True, dir_okay=False),
     help="Path to certificates.yaml.",
 )
-def check_certificate_chains(config: str) -> None:
-    """Check certificate chain completeness and CA consistency."""
+@click.option(
+    "--hostname",
+    "hostnames",
+    multiple=True,
+    required=True,
+    help="Hostname the cert must cover (exact or wildcard). Repeat for multiple names.",
+)
+def check_certificate_chains(
+    cert_type: str,
+    config: str,
+    hostnames: tuple[str, ...],
+) -> None:
+    """Check certificate expiry, SAN coverage, and (for api/ingress) chain completeness."""
     try:
-        check_certificate_chains_main(config)
+        check_certificate_chains_helper(
+            config, cert_type=cert_type, hostnames=list(hostnames)
+        )
     except CertificateValidationError as exc:
-        raise click.ClickException(str(exc)) from exc
+        logger.error("%s", exc)  # noqa: TRY400 — traceback is unwanted for user-facing errors
+        sys.exit(1)
 
 
 @cli.command("get-root-ca")

--- a/src/enclave/utils.py
+++ b/src/enclave/utils.py
@@ -11,19 +11,25 @@ import click
 logger = logging.getLogger(__name__)
 
 LOG_LEVELS = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+LOG_FORMATS = ["full", "plain"]
 
 
-def configure_logging(log_level: str) -> None:
-    """Configure logging with the specified level if not already configured.
+def configure_logging(log_level: str, log_format: str = "full") -> None:
+    """Configure logging with the specified level and format if not already configured.
 
     This helper is shared across all CLI entry points to avoid duplication.
     Logging is only configured if the root logger has no handlers yet, so parent
     CLIs can set up logging once and subcommands will skip reconfiguration.
     """
     if not logging.getLogger().handlers:
+        fmt = (
+            "%(message)s"
+            if log_format == "plain"
+            else "%(asctime)s %(levelname)-8s %(message)s"
+        )
         logging.basicConfig(
             level=getattr(logging, log_level.upper()),
-            format="%(asctime)s %(levelname)-8s %(message)s",
+            format=fmt,
             datefmt="%Y-%m-%dT%H:%M:%S",
             stream=sys.stderr,
         )

--- a/src/tests/test_cert_utils.py
+++ b/src/tests/test_cert_utils.py
@@ -11,12 +11,20 @@ from pathlib import Path
 
 import pytest
 
-from enclave.tools.cert_utils import is_self_signed, openssl_verify, pem_blocks
+from enclave.tools.cert_utils import (
+    cert_covers_hostname,
+    cert_key_pair_matches,
+    cert_validity_window_ok,
+    is_self_signed,
+    openssl_verify,
+    pem_blocks,
+)
 from tests.cert_helpers import (
     generate_ca,
     generate_expired_cert,
     generate_expired_self_signed,
     generate_self_issued_not_self_signed_cert,
+    generate_signed_leaf,
 )
 
 
@@ -101,3 +109,92 @@ def test_openssl_verify_expired_cert_returns_false(tmp_path: Path) -> None:
     ca_pem, ca_cert_path, ca_key_path = generate_ca(tmp_path, "Test CA")
     expired_pem = generate_expired_cert(tmp_path, ca_cert_path, ca_key_path, "Leaf")
     assert openssl_verify(ca_pem, expired_pem) is False
+
+
+def test_cert_key_pair_matches_returns_true(tmp_path: Path) -> None:
+    """cert_key_pair_matches returns True when the key was used to generate the cert.
+
+    generate_signed_leaf writes the leaf key to tmp_path/leaf.key; read it back
+    and verify it matches the returned cert PEM.
+    """
+    _, ca_cert_path, ca_key_path = generate_ca(tmp_path, "CA")
+    leaf_pem = generate_signed_leaf(tmp_path, ca_cert_path, ca_key_path, "Leaf")
+    leaf_key_pem = (tmp_path / "leaf.key").read_text(encoding="utf-8")
+    assert cert_key_pair_matches(leaf_pem, leaf_key_pem) is True
+
+
+def test_cert_key_pair_matches_returns_false(tmp_path: Path) -> None:
+    """cert_key_pair_matches returns False when the key belongs to a different pair."""
+    _, ca_cert_path, ca_key_path = generate_ca(tmp_path, "CA")
+    leaf_pem = generate_signed_leaf(tmp_path, ca_cert_path, ca_key_path, "Leaf")
+    # The CA key is unrelated to the leaf cert's key.
+    assert (
+        cert_key_pair_matches(leaf_pem, ca_key_path.read_text(encoding="utf-8"))
+        is False
+    )
+
+
+def test_cert_validity_window_ok_returns_true(module_ca_pem: str) -> None:
+    """cert_validity_window_ok returns True for a freshly generated cert."""
+    assert cert_validity_window_ok(module_ca_pem) is True
+
+
+def test_cert_validity_window_ok_returns_false_for_expired(tmp_path: Path) -> None:
+    """cert_validity_window_ok returns False for a cert with a past validity window."""
+    _, ca_cert_path, ca_key_path = generate_ca(tmp_path, "CA")
+    expired_pem = generate_expired_cert(tmp_path, ca_cert_path, ca_key_path, "Leaf")
+    assert cert_validity_window_ok(expired_pem) is False
+
+
+def test_cert_covers_hostname_exact_match(tmp_path: Path) -> None:
+    """cert_covers_hostname returns True for an exact DNS SAN match."""
+    _, ca_cert_path, ca_key_path = generate_ca(tmp_path, "CA")
+    leaf_pem = generate_signed_leaf(
+        tmp_path, ca_cert_path, ca_key_path, "Leaf", sans=["foo.example.com"]
+    )
+    assert cert_covers_hostname(leaf_pem, "foo.example.com") is True
+
+
+def test_cert_covers_hostname_wildcard_match(tmp_path: Path) -> None:
+    """cert_covers_hostname returns True when a wildcard SAN covers the hostname."""
+    _, ca_cert_path, ca_key_path = generate_ca(tmp_path, "CA")
+    leaf_pem = generate_signed_leaf(
+        tmp_path, ca_cert_path, ca_key_path, "Leaf", sans=["*.example.com"]
+    )
+    assert cert_covers_hostname(leaf_pem, "foo.example.com") is True
+
+
+def test_cert_covers_hostname_wildcard_does_not_match_parent(tmp_path: Path) -> None:
+    """cert_covers_hostname returns False when the wildcard does not cover the apex domain."""
+    _, ca_cert_path, ca_key_path = generate_ca(tmp_path, "CA")
+    leaf_pem = generate_signed_leaf(
+        tmp_path, ca_cert_path, ca_key_path, "Leaf", sans=["*.example.com"]
+    )
+    assert cert_covers_hostname(leaf_pem, "example.com") is False
+
+
+def test_cert_covers_hostname_wildcard_does_not_match_subdomain(tmp_path: Path) -> None:
+    """cert_covers_hostname returns False when the wildcard does not span multiple labels."""
+    _, ca_cert_path, ca_key_path = generate_ca(tmp_path, "CA")
+    leaf_pem = generate_signed_leaf(
+        tmp_path, ca_cert_path, ca_key_path, "Leaf", sans=["*.example.com"]
+    )
+    assert cert_covers_hostname(leaf_pem, "foo.bar.example.com") is False
+
+
+def test_cert_covers_hostname_returns_false_when_no_san(tmp_path: Path) -> None:
+    """cert_covers_hostname returns False when the cert has no SAN extension."""
+    _, ca_cert_path, ca_key_path = generate_ca(tmp_path, "CA")
+    leaf_pem = generate_signed_leaf(
+        tmp_path, ca_cert_path, ca_key_path, "foo.example.com"
+    )
+    assert cert_covers_hostname(leaf_pem, "foo.example.com") is False
+
+
+def test_cert_covers_hostname_mismatch(tmp_path: Path) -> None:
+    """cert_covers_hostname returns False when no SAN covers the requested hostname."""
+    _, ca_cert_path, ca_key_path = generate_ca(tmp_path, "CA")
+    leaf_pem = generate_signed_leaf(
+        tmp_path, ca_cert_path, ca_key_path, "Leaf", sans=["bar.example.com"]
+    )
+    assert cert_covers_hostname(leaf_pem, "foo.example.com") is False

--- a/src/tests/test_check_certificate_chains.py
+++ b/src/tests/test_check_certificate_chains.py
@@ -8,7 +8,6 @@ from pytest_mock import MockerFixture
 from enclave.tools.check_certificate_chains import (
     CertificateValidationError,
     check_certificate_chains,
-    main,
 )
 from tests.cert_helpers import (
     generate_ca,
@@ -39,11 +38,24 @@ def test_check_passes_when_chain_ends_with_self_signed_root(
     mocker.patch(
         "enclave.tools.check_certificate_chains.openssl_verify", return_value=True
     )
+    mocker.patch(
+        "enclave.tools.check_certificate_chains.cert_validity_window_ok",
+        return_value=True,
+    )
+    mocker.patch(
+        "enclave.tools.check_certificate_chains.cert_covers_hostname",
+        return_value=True,
+    )
+    mocker.patch(
+        "enclave.tools.check_certificate_chains.cert_key_pair_matches",
+        return_value=True,
+    )
     path = _write_certs(
         tmp_path,
         sslAPICertificateFullChain=f"{leaf_pem}\n{root_pem}",
+        sslAPICertificateKey="fake-key",
     )
-    check_certificate_chains(path)
+    check_certificate_chains(path, "api", ["api.cluster.example.com"])
 
 
 def test_check_passes_when_ca_matches_self_signed_root(
@@ -56,24 +68,37 @@ def test_check_passes_when_ca_matches_self_signed_root(
     mock_openssl_verify = mocker.patch(
         "enclave.tools.check_certificate_chains.openssl_verify", return_value=True
     )
+    mocker.patch(
+        "enclave.tools.check_certificate_chains.cert_validity_window_ok",
+        return_value=True,
+    )
+    mocker.patch(
+        "enclave.tools.check_certificate_chains.cert_covers_hostname",
+        return_value=True,
+    )
+    mocker.patch(
+        "enclave.tools.check_certificate_chains.cert_key_pair_matches",
+        return_value=True,
+    )
     path = _write_certs(
         tmp_path,
         sslAPICertificateFullChain=f"{leaf_pem}\n{root_pem}",
         sslCACertificate=root_pem,
+        sslAPICertificateKey="fake-key",
     )
-    check_certificate_chains(path)
+    check_certificate_chains(path, "api", ["api.cluster.example.com"])
     mock_is_self_signed.assert_called_once_with(root_pem)
-    mock_openssl_verify.assert_called_with(root_pem, root_pem)
+    assert mock_openssl_verify.call_count == 2
 
 
-def test_check_raises_when_ca_does_not_match_self_signed_root(
+def test_check_raises_when_self_signed_root_fails_self_verification(
     mocker: MockerFixture,
     tmp_path: Path,
     leaf_pem: str,
     root_pem: str,
     intermediate_pem: str,
 ) -> None:
-    """Raise when sslCACertificate does not verify the self-signed root."""
+    """Raise when openssl cannot verify the self-signed root against itself (e.g. expired key)."""
     mocker.patch(
         "enclave.tools.check_certificate_chains.is_self_signed", return_value=True
     )
@@ -84,9 +109,50 @@ def test_check_raises_when_ca_does_not_match_self_signed_root(
         tmp_path,
         sslAPICertificateFullChain=f"{leaf_pem}\n{root_pem}",
         sslCACertificate=intermediate_pem,
+        sslAPICertificateKey="fake-key",
     )
-    with pytest.raises(CertificateValidationError, match="sslAPICertificateFullChain"):
-        check_certificate_chains(path)
+    with pytest.raises(
+        CertificateValidationError, match="self-signed root that has expired"
+    ):
+        check_certificate_chains(path, "api", ["api.cluster.example.com"])
+
+
+def test_check_raises_when_ca_does_not_match_self_signed_root(
+    mocker: MockerFixture,
+    tmp_path: Path,
+    leaf_pem: str,
+    root_pem: str,
+    intermediate_pem: str,
+) -> None:
+    """Raise when sslCACertificate does not verify a self-signed root that is otherwise valid."""
+    mocker.patch(
+        "enclave.tools.check_certificate_chains.is_self_signed", return_value=True
+    )
+    # First call: root verifies itself (True). Second call: CA does not verify root (False).
+    mocker.patch(
+        "enclave.tools.check_certificate_chains.openssl_verify",
+        side_effect=[True, False],
+    )
+    mocker.patch(
+        "enclave.tools.check_certificate_chains.cert_validity_window_ok",
+        return_value=True,
+    )
+    mocker.patch(
+        "enclave.tools.check_certificate_chains.cert_covers_hostname",
+        return_value=True,
+    )
+    mocker.patch(
+        "enclave.tools.check_certificate_chains.cert_key_pair_matches",
+        return_value=True,
+    )
+    path = _write_certs(
+        tmp_path,
+        sslAPICertificateFullChain=f"{leaf_pem}\n{root_pem}",
+        sslCACertificate=intermediate_pem,
+        sslAPICertificateKey="fake-key",
+    )
+    with pytest.raises(CertificateValidationError, match="does not verify it"):
+        check_certificate_chains(path, "api", ["api.cluster.example.com"])
 
 
 def test_check_passes_when_chain_incomplete_but_ca_pem_set(
@@ -103,12 +169,25 @@ def test_check_passes_when_chain_incomplete_but_ca_pem_set(
     mocker.patch(
         "enclave.tools.check_certificate_chains.openssl_verify", return_value=True
     )
+    mocker.patch(
+        "enclave.tools.check_certificate_chains.cert_validity_window_ok",
+        return_value=True,
+    )
+    mocker.patch(
+        "enclave.tools.check_certificate_chains.cert_covers_hostname",
+        return_value=True,
+    )
+    mocker.patch(
+        "enclave.tools.check_certificate_chains.cert_key_pair_matches",
+        return_value=True,
+    )
     path = _write_certs(
         tmp_path,
         sslAPICertificateFullChain=f"{leaf_pem}\n{intermediate_pem}",
         sslCACertificate=root_pem,
+        sslAPICertificateKey="fake-key",
     )
-    check_certificate_chains(path)
+    check_certificate_chains(path, "api", ["api.cluster.example.com"])
 
 
 def test_check_raises_when_ca_does_not_sign_last_chain_cert(
@@ -129,9 +208,12 @@ def test_check_raises_when_ca_does_not_sign_last_chain_cert(
         tmp_path,
         sslAPICertificateFullChain=f"{leaf_pem}\n{intermediate_pem}",
         sslCACertificate=root_pem,
+        sslAPICertificateKey="fake-key",
     )
-    with pytest.raises(CertificateValidationError, match="sslAPICertificateFullChain"):
-        check_certificate_chains(path)
+    with pytest.raises(
+        CertificateValidationError, match="does not sign its last certificate"
+    ):
+        check_certificate_chains(path, "api", ["api.cluster.example.com"])
 
 
 def test_check_raises_when_api_chain_incomplete_without_ca(
@@ -144,9 +226,12 @@ def test_check_raises_when_api_chain_incomplete_without_ca(
     path = _write_certs(
         tmp_path,
         sslAPICertificateFullChain=f"{leaf_pem}\n{intermediate_pem}",
+        sslAPICertificateKey="fake-key",
     )
-    with pytest.raises(CertificateValidationError, match="sslAPICertificateFullChain"):
-        check_certificate_chains(path)
+    with pytest.raises(
+        CertificateValidationError, match="no sslCACertificate was provided"
+    ):
+        check_certificate_chains(path, "api", ["api.cluster.example.com"])
 
 
 def test_check_raises_when_ingress_chain_incomplete_without_ca(
@@ -159,37 +244,19 @@ def test_check_raises_when_ingress_chain_incomplete_without_ca(
     path = _write_certs(
         tmp_path,
         sslIngressCertificateFullChain=f"{leaf_pem}\n{intermediate_pem}",
+        sslIngressCertificateKey="fake-key",
     )
     with pytest.raises(
-        CertificateValidationError, match="sslIngressCertificateFullChain"
+        CertificateValidationError, match="no sslCACertificate was provided"
     ):
-        check_certificate_chains(path)
+        check_certificate_chains(path, "ingress", ["apps.cluster.example.com"])
 
 
-def test_check_reports_both_fields_when_both_incomplete(
-    mocker: MockerFixture, tmp_path: Path, leaf_pem: str, intermediate_pem: str
-) -> None:
-    """Report both field names when both chains are incomplete."""
-    mocker.patch(
-        "enclave.tools.check_certificate_chains.is_self_signed", return_value=False
-    )
-    path = _write_certs(
-        tmp_path,
-        sslAPICertificateFullChain=f"{leaf_pem}\n{intermediate_pem}",
-        sslIngressCertificateFullChain=f"{leaf_pem}\n{intermediate_pem}",
-    )
-    with pytest.raises(CertificateValidationError) as exc_info:
-        check_certificate_chains(path)
-    msg = str(exc_info.value)
-    assert "sslAPICertificateFullChain" in msg
-    assert "sslIngressCertificateFullChain" in msg
-
-
-def test_check_skips_absent_chain_fields(tmp_path: Path) -> None:
-    """Skip fields that are absent or empty in the config."""
+def test_check_skips_absent_cert_field(tmp_path: Path) -> None:
+    """Skip gracefully when the configured cert field is absent or empty."""
     path = tmp_path / "certificates.yaml"
     path.write_text("ironicHTTPSCertificate: ''\n", encoding="utf-8")
-    check_certificate_chains(str(path))
+    check_certificate_chains(str(path), "ironic", [])
 
 
 def test_check_raises_leaf_only_chain_without_ca(
@@ -199,9 +266,15 @@ def test_check_raises_leaf_only_chain_without_ca(
     mocker.patch(
         "enclave.tools.check_certificate_chains.is_self_signed", return_value=False
     )
-    path = _write_certs(tmp_path, sslAPICertificateFullChain=leaf_pem)
-    with pytest.raises(CertificateValidationError, match="sslAPICertificateFullChain"):
-        check_certificate_chains(str(path))
+    path = _write_certs(
+        tmp_path,
+        sslAPICertificateFullChain=leaf_pem,
+        sslAPICertificateKey="fake-key",
+    )
+    with pytest.raises(
+        CertificateValidationError, match="no sslCACertificate was provided"
+    ):
+        check_certificate_chains(str(path), "api", ["api.cluster.example.com"])
 
 
 def test_check_passes_leaf_only_chain_when_ca_set(
@@ -214,27 +287,44 @@ def test_check_passes_leaf_only_chain_when_ca_set(
     mocker.patch(
         "enclave.tools.check_certificate_chains.openssl_verify", return_value=True
     )
+    mocker.patch(
+        "enclave.tools.check_certificate_chains.cert_validity_window_ok",
+        return_value=True,
+    )
+    mocker.patch(
+        "enclave.tools.check_certificate_chains.cert_covers_hostname",
+        return_value=True,
+    )
+    mocker.patch(
+        "enclave.tools.check_certificate_chains.cert_key_pair_matches",
+        return_value=True,
+    )
     path = _write_certs(
         tmp_path,
         sslAPICertificateFullChain=leaf_pem,
         sslCACertificate=root_pem,
+        sslAPICertificateKey="fake-key",
     )
-    check_certificate_chains(str(path))
+    check_certificate_chains(str(path), "api", ["api.cluster.example.com"])
 
 
 def test_check_raises_when_chain_has_content_but_no_pem_blocks(
     tmp_path: Path,
 ) -> None:
     """Raise when a chain field is set to text that contains no PEM certificate blocks."""
-    path = _write_certs(tmp_path, sslAPICertificateFullChain="not a certificate")
+    path = _write_certs(
+        tmp_path,
+        sslAPICertificateFullChain="not a certificate",
+        sslAPICertificateKey="fake-key",
+    )
     with pytest.raises(CertificateValidationError, match="no PEM certificate blocks"):
-        check_certificate_chains(str(path))
+        check_certificate_chains(str(path), "api", ["api.cluster.example.com"])
 
 
 def test_check_raises_on_missing_file() -> None:
     """Raise when the config file does not exist."""
     with pytest.raises(CertificateValidationError, match="cannot read"):
-        check_certificate_chains("/nonexistent/path/certificates.yaml")
+        check_certificate_chains("/nonexistent/path/certificates.yaml", "api", [])
 
 
 def test_check_raises_on_invalid_yaml(tmp_path: Path) -> None:
@@ -242,7 +332,7 @@ def test_check_raises_on_invalid_yaml(tmp_path: Path) -> None:
     path = tmp_path / "certificates.yaml"
     path.write_text("key: [\nbad yaml", encoding="utf-8")
     with pytest.raises(CertificateValidationError, match="cannot parse"):
-        check_certificate_chains(str(path))
+        check_certificate_chains(str(path), "api", [])
 
 
 def test_check_raises_on_non_mapping_yaml(tmp_path: Path) -> None:
@@ -250,7 +340,7 @@ def test_check_raises_on_non_mapping_yaml(tmp_path: Path) -> None:
     path = tmp_path / "certificates.yaml"
     path.write_text("- item1\n- item2\n", encoding="utf-8")
     with pytest.raises(CertificateValidationError, match="expected a YAML mapping"):
-        check_certificate_chains(str(path))
+        check_certificate_chains(str(path), "api", [])
 
 
 def test_check_passes_via_system_store_when_no_ca_set(
@@ -271,12 +361,25 @@ def test_check_passes_via_system_store_when_no_ca_set(
     mock_openssl_verify = mocker.patch(
         "enclave.tools.check_certificate_chains.openssl_verify", return_value=True
     )
+    mocker.patch(
+        "enclave.tools.check_certificate_chains.cert_validity_window_ok",
+        return_value=True,
+    )
+    mocker.patch(
+        "enclave.tools.check_certificate_chains.cert_covers_hostname",
+        return_value=True,
+    )
+    mocker.patch(
+        "enclave.tools.check_certificate_chains.cert_key_pair_matches",
+        return_value=True,
+    )
     full_chain = f"{leaf_pem}\n{intermediate_pem}"
     path = _write_certs(
         tmp_path,
         sslAPICertificateFullChain=full_chain,
+        sslAPICertificateKey="fake-key",
     )
-    check_certificate_chains(path)
+    check_certificate_chains(path, "api", ["api.cluster.example.com"])
     mock_is_self_signed.assert_called_once_with(intermediate_pem)
     mock_find_system_ca.assert_called_once_with(full_chain)
     mock_openssl_verify.assert_not_called()
@@ -296,35 +399,10 @@ def test_check_raises_when_system_store_also_has_no_match(
     path = _write_certs(
         tmp_path,
         sslAPICertificateFullChain=f"{leaf_pem}\n{intermediate_pem}",
+        sslAPICertificateKey="fake-key",
     )
-    with pytest.raises(CertificateValidationError, match="sslAPICertificateFullChain"):
-        check_certificate_chains(path)
-
-
-def test_main_writes_success_message_to_stdout(
-    mocker: MockerFixture,
-    tmp_path: Path,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    """Write 'Certificate chain check passed.' to stdout on success."""
-    mocker.patch("enclave.tools.check_certificate_chains.check_certificate_chains")
-    main(str(tmp_path / "certs.yaml"))
-    assert capsys.readouterr().out == "Certificate chain check passed.\n"
-
-
-def test_main_propagates_validation_error(
-    mocker: MockerFixture,
-    tmp_path: Path,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    """Propagate CertificateValidationError without writing to stdout."""
-    mocker.patch(
-        "enclave.tools.check_certificate_chains.check_certificate_chains",
-        side_effect=CertificateValidationError("chain incomplete"),
-    )
-    with pytest.raises(CertificateValidationError, match="chain incomplete"):
-        main(str(tmp_path / "certs.yaml"))
-    assert capsys.readouterr().out == ""
+    with pytest.raises(CertificateValidationError, match="no matching CA was found"):
+        check_certificate_chains(path, "api", ["api.cluster.example.com"])
 
 
 def test_real_three_hop_chain_passes(tmp_path: Path) -> None:
@@ -340,12 +418,20 @@ def test_real_three_hop_chain_passes(tmp_path: Path) -> None:
     inter_pem, inter_cert_path, inter_key_path = generate_intermediate_ca(
         tmp_path, "Intermediate CA", root_cert_path, root_key_path
     )
-    leaf_pem = generate_signed_leaf(tmp_path, inter_cert_path, inter_key_path, "Leaf")
+    leaf_pem = generate_signed_leaf(
+        tmp_path,
+        inter_cert_path,
+        inter_key_path,
+        "Leaf",
+        sans=["api.cluster.example.com"],
+    )
+    leaf_key_pem = (tmp_path / "leaf.key").read_text(encoding="utf-8")
     path = _write_certs(
         tmp_path,
         sslAPICertificateFullChain=f"{leaf_pem}\n{inter_pem}\n{root_pem}",
+        sslAPICertificateKey=leaf_key_pem,
     )
-    check_certificate_chains(path)
+    check_certificate_chains(path, "api", ["api.cluster.example.com"])
 
 
 def test_real_chain_missing_intermediate_fails(tmp_path: Path) -> None:
@@ -360,13 +446,17 @@ def test_real_chain_missing_intermediate_fails(tmp_path: Path) -> None:
         tmp_path, "Intermediate CA", root_cert_path, root_key_path
     )
     leaf_pem = generate_signed_leaf(tmp_path, inter_cert_path, inter_key_path, "Leaf")
+    leaf_key_pem = (tmp_path / "leaf.key").read_text(encoding="utf-8")
     path = _write_certs(
         tmp_path,
         sslAPICertificateFullChain=leaf_pem,
         sslCACertificate=root_pem,
+        sslAPICertificateKey=leaf_key_pem,
     )
-    with pytest.raises(CertificateValidationError):
-        check_certificate_chains(path)
+    with pytest.raises(
+        CertificateValidationError, match="does not sign its last certificate"
+    ):
+        check_certificate_chains(path, "api", ["api.cluster.example.com"])
 
 
 def test_expired_self_signed_root_chain_fails(tmp_path: Path) -> None:
@@ -377,9 +467,16 @@ def test_expired_self_signed_root_chain_fails(tmp_path: Path) -> None:
     check still rejects the chain.
     """
     expired_root_pem = generate_expired_self_signed(tmp_path, "Expired Root CA")
-    path = _write_certs(tmp_path, sslAPICertificateFullChain=expired_root_pem)
-    with pytest.raises(CertificateValidationError):
-        check_certificate_chains(path)
+    key_pem = (tmp_path / "expired_ss_Expired Root CA.key").read_text(encoding="utf-8")
+    path = _write_certs(
+        tmp_path,
+        sslAPICertificateFullChain=expired_root_pem,
+        sslAPICertificateKey=key_pem,
+    )
+    with pytest.raises(
+        CertificateValidationError, match="self-signed root that has expired"
+    ):
+        check_certificate_chains(path, "api", ["api.cluster.example.com"])
 
 
 def test_expired_leaf_fails(tmp_path: Path) -> None:
@@ -392,13 +489,15 @@ def test_expired_leaf_fails(tmp_path: Path) -> None:
     expired_leaf_pem = generate_expired_cert(
         tmp_path, root_cert_path, root_key_path, "Leaf"
     )
+    expired_leaf_key_pem = (tmp_path / "expired_Leaf.key").read_text(encoding="utf-8")
     path = _write_certs(
         tmp_path,
         sslAPICertificateFullChain=expired_leaf_pem,
         sslCACertificate=root_pem,
+        sslAPICertificateKey=expired_leaf_key_pem,
     )
-    with pytest.raises(CertificateValidationError):
-        check_certificate_chains(path)
+    with pytest.raises(CertificateValidationError, match="expired or is not yet valid"):
+        check_certificate_chains(path, "api", ["api.cluster.example.com"])
 
 
 def test_expired_intermediate_fails(tmp_path: Path) -> None:
@@ -418,10 +517,214 @@ def test_expired_intermediate_fails(tmp_path: Path) -> None:
     leaf_pem = generate_signed_leaf(
         tmp_path, expired_inter_cert_path, expired_inter_key_path, "Leaf"
     )
+    leaf_key_pem = (tmp_path / "leaf.key").read_text(encoding="utf-8")
     path = _write_certs(
         tmp_path,
         sslAPICertificateFullChain=f"{leaf_pem}\n{expired_inter_pem}",
         sslCACertificate=root_pem,
+        sslAPICertificateKey=leaf_key_pem,
     )
-    with pytest.raises(CertificateValidationError):
-        check_certificate_chains(path)
+    with pytest.raises(
+        CertificateValidationError, match="does not sign its last certificate"
+    ):
+        check_certificate_chains(path, "api", ["api.cluster.example.com"])
+
+
+def test_hostname_matching_exact(tmp_path: Path) -> None:
+    """Pass when the leaf cert has an exact DNS SAN matching the requested hostname."""
+    root_pem, root_cert_path, root_key_path = generate_ca(tmp_path, "Root CA")
+    leaf_pem = generate_signed_leaf(
+        tmp_path,
+        root_cert_path,
+        root_key_path,
+        "Leaf",
+        sans=["api.cluster.example.com"],
+    )
+    leaf_key_pem = (tmp_path / "leaf.key").read_text(encoding="utf-8")
+    path = _write_certs(
+        tmp_path,
+        sslAPICertificateFullChain=leaf_pem,
+        sslCACertificate=root_pem,
+        sslAPICertificateKey=leaf_key_pem,
+    )
+    check_certificate_chains(path, "api", hostnames=["api.cluster.example.com"])
+
+
+def test_hostname_matching_wildcard(tmp_path: Path) -> None:
+    """Pass when a wildcard SAN in the leaf cert covers the requested hostname."""
+    root_pem, root_cert_path, root_key_path = generate_ca(tmp_path, "Root CA")
+    leaf_pem = generate_signed_leaf(
+        tmp_path,
+        root_cert_path,
+        root_key_path,
+        "Leaf",
+        sans=["*.apps.cluster.example.com"],
+    )
+    leaf_key_pem = (tmp_path / "leaf.key").read_text(encoding="utf-8")
+    path = _write_certs(
+        tmp_path,
+        sslIngressCertificateFullChain=leaf_pem,
+        sslCACertificate=root_pem,
+        sslIngressCertificateKey=leaf_key_pem,
+    )
+    check_certificate_chains(
+        path, "ingress", hostnames=["foo.apps.cluster.example.com"]
+    )
+
+
+def test_hostname_wildcard_does_not_match_parent(tmp_path: Path) -> None:
+    """Fail when the requested hostname is the apex domain of a wildcard SAN."""
+    root_pem, root_cert_path, root_key_path = generate_ca(tmp_path, "Root CA")
+    leaf_pem = generate_signed_leaf(
+        tmp_path,
+        root_cert_path,
+        root_key_path,
+        "Leaf",
+        sans=["*.apps.cluster.example.com"],
+    )
+    leaf_key_pem = (tmp_path / "leaf.key").read_text(encoding="utf-8")
+    path = _write_certs(
+        tmp_path,
+        sslAPICertificateFullChain=leaf_pem,
+        sslCACertificate=root_pem,
+        sslAPICertificateKey=leaf_key_pem,
+    )
+    with pytest.raises(CertificateValidationError, match="SAN does not cover"):
+        check_certificate_chains(path, "api", hostnames=["apps.cluster.example.com"])
+
+
+def test_hostname_missing_san_fails(tmp_path: Path) -> None:
+    """Fail when the leaf cert has no SAN extension."""
+    root_pem, root_cert_path, root_key_path = generate_ca(tmp_path, "Root CA")
+    leaf_pem = generate_signed_leaf(tmp_path, root_cert_path, root_key_path, "Leaf")
+    leaf_key_pem = (tmp_path / "leaf.key").read_text(encoding="utf-8")
+    path = _write_certs(
+        tmp_path,
+        sslAPICertificateFullChain=leaf_pem,
+        sslCACertificate=root_pem,
+        sslAPICertificateKey=leaf_key_pem,
+    )
+    with pytest.raises(CertificateValidationError, match="SAN does not cover"):
+        check_certificate_chains(path, "api", hostnames=["api.cluster.example.com"])
+
+
+def test_hostname_mismatch_fails(tmp_path: Path) -> None:
+    """Fail when the leaf cert SAN does not include the requested hostname."""
+    root_pem, root_cert_path, root_key_path = generate_ca(tmp_path, "Root CA")
+    leaf_pem = generate_signed_leaf(
+        tmp_path, root_cert_path, root_key_path, "Leaf", sans=["other.example.com"]
+    )
+    leaf_key_pem = (tmp_path / "leaf.key").read_text(encoding="utf-8")
+    path = _write_certs(
+        tmp_path,
+        sslAPICertificateFullChain=leaf_pem,
+        sslCACertificate=root_pem,
+        sslAPICertificateKey=leaf_key_pem,
+    )
+    with pytest.raises(CertificateValidationError, match="SAN does not cover"):
+        check_certificate_chains(path, "api", hostnames=["api.cluster.example.com"])
+
+
+def test_key_mismatch_fails(tmp_path: Path) -> None:
+    """Fail when the provided private key does not match the leaf cert."""
+    root_pem, root_cert_path, root_key_path = generate_ca(tmp_path, "Root CA")
+    leaf_pem = generate_signed_leaf(
+        tmp_path,
+        root_cert_path,
+        root_key_path,
+        "Leaf",
+        sans=["api.cluster.example.com"],
+    )
+    wrong_key_pem = root_key_path.read_text(encoding="utf-8")
+    path = _write_certs(
+        tmp_path,
+        sslAPICertificateFullChain=leaf_pem,
+        sslCACertificate=root_pem,
+        sslAPICertificateKey=wrong_key_pem,
+    )
+    with pytest.raises(CertificateValidationError, match="private key does not match"):
+        check_certificate_chains(path, "api", hostnames=["api.cluster.example.com"])
+
+
+def test_expired_chain_is_rejected(tmp_path: Path) -> None:
+    """Fail when the leaf cert is expired, regardless of hostname or CA validity."""
+    root_pem, root_cert_path, root_key_path = generate_ca(tmp_path, "Root CA")
+    expired_leaf_pem = generate_expired_cert(
+        tmp_path, root_cert_path, root_key_path, "Leaf"
+    )
+    expired_leaf_key_pem = (tmp_path / "expired_Leaf.key").read_text(encoding="utf-8")
+    path = _write_certs(
+        tmp_path,
+        sslAPICertificateFullChain=expired_leaf_pem,
+        sslCACertificate=root_pem,
+        sslAPICertificateKey=expired_leaf_key_pem,
+    )
+    with pytest.raises(CertificateValidationError, match="expired or is not yet valid"):
+        check_certificate_chains(path, "api", hostnames=["api.cluster.example.com"])
+
+
+def test_ironic_cert_skipped_when_absent(tmp_path: Path) -> None:
+    """Pass without error when ironicHTTPSCertificate is absent from the config."""
+    path = tmp_path / "certificates.yaml"
+    path.write_text("{}\n", encoding="utf-8")
+    check_certificate_chains(str(path), "ironic", ["bmc.example.com"])
+
+
+def test_ironic_cert_passes_when_valid(tmp_path: Path) -> None:
+    """Pass when ironicHTTPSCertificate is valid, key matches, and SAN covers hostname."""
+    _, ca_cert_path, ca_key_path = generate_ca(tmp_path, "CA")
+    leaf_pem = generate_signed_leaf(
+        tmp_path, ca_cert_path, ca_key_path, "Leaf", sans=["bmc.example.com"]
+    )
+    leaf_key_pem = (tmp_path / "leaf.key").read_text(encoding="utf-8")
+    path = _write_certs(
+        tmp_path,
+        ironicHTTPSCertificate=leaf_pem,
+        ironicHTTPSKey=leaf_key_pem,
+    )
+    check_certificate_chains(str(path), "ironic", hostnames=["bmc.example.com"])
+
+
+def test_ironic_cert_expiry_rejected(tmp_path: Path) -> None:
+    """Fail when ironicHTTPSCertificate is expired."""
+    _, ca_cert_path, ca_key_path = generate_ca(tmp_path, "CA")
+    expired_pem = generate_expired_cert(tmp_path, ca_cert_path, ca_key_path, "Leaf")
+    expired_key_pem = (tmp_path / "expired_Leaf.key").read_text(encoding="utf-8")
+    path = _write_certs(
+        tmp_path,
+        ironicHTTPSCertificate=expired_pem,
+        ironicHTTPSKey=expired_key_pem,
+    )
+    with pytest.raises(CertificateValidationError, match="expired or is not yet valid"):
+        check_certificate_chains(str(path), "ironic", ["bmc.example.com"])
+
+
+def test_ironic_cert_key_mismatch_rejected(tmp_path: Path) -> None:
+    """Fail when ironicHTTPSKey does not match ironicHTTPSCertificate."""
+    ca_pem, ca_cert_path, ca_key_path = generate_ca(tmp_path, "CA")
+    leaf_pem = generate_signed_leaf(
+        tmp_path, ca_cert_path, ca_key_path, "Leaf", sans=["bmc.example.com"]
+    )
+    path = _write_certs(
+        tmp_path,
+        ironicHTTPSCertificate=leaf_pem,
+        ironicHTTPSKey=ca_pem,
+    )
+    with pytest.raises(CertificateValidationError, match="private key does not match"):
+        check_certificate_chains(str(path), "ironic", hostnames=["bmc.example.com"])
+
+
+def test_ironic_cert_san_mismatch_rejected(tmp_path: Path) -> None:
+    """Fail when the ironic cert SAN does not cover the requested hostname."""
+    _, ca_cert_path, ca_key_path = generate_ca(tmp_path, "CA")
+    leaf_pem = generate_signed_leaf(
+        tmp_path, ca_cert_path, ca_key_path, "Leaf", sans=["other.example.com"]
+    )
+    leaf_key_pem = (tmp_path / "leaf.key").read_text(encoding="utf-8")
+    path = _write_certs(
+        tmp_path,
+        ironicHTTPSCertificate=leaf_pem,
+        ironicHTTPSKey=leaf_key_pem,
+    )
+    with pytest.raises(CertificateValidationError, match="SAN does not cover"):
+        check_certificate_chains(str(path), "ironic", hostnames=["bmc.example.com"])

--- a/src/tests/test_tools_cli.py
+++ b/src/tests/test_tools_cli.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+import pytest
 from click.testing import CliRunner
 from pytest_mock import MockerFixture
 
@@ -270,24 +271,35 @@ def test_check_certificate_chains_help() -> None:
 def test_check_certificate_chains_forwards_config(
     mocker: MockerFixture, tmp_path: Path
 ) -> None:
-    """Forward --config path to check_certificate_chains_main."""
-    mock_main = mocker.patch("enclave.tools.cli.check_certificate_chains_main")
+    """Forward cert_type, --config path, and --hostname values to check_certificate_chains_helper."""
+    mock_main = mocker.patch("enclave.tools.cli.check_certificate_chains_helper")
     config_file = tmp_path / "certificates.yaml"
     config_file.write_text("", encoding="utf-8")
     result = CliRunner().invoke(
         cli,
-        ["check-certificate-chains", "--config", str(config_file)],
+        [
+            "check-certificate-chains",
+            "api",
+            "--config",
+            str(config_file),
+            "--hostname",
+            "api.cluster.example.com",
+        ],
     )
     assert result.exit_code == 0
-    mock_main.assert_called_once_with(str(config_file))
+    mock_main.assert_called_once_with(
+        str(config_file),
+        cert_type="api",
+        hostnames=["api.cluster.example.com"],
+    )
 
 
 def test_check_certificate_chains_reports_runtime_error(
-    mocker: MockerFixture, tmp_path: Path
+    mocker: MockerFixture, tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Surface a CertificateValidationError as a non-zero exit with field name."""
+    """Surface a CertificateValidationError as a logger.error call and exit code 1."""
     mocker.patch(
-        "enclave.tools.cli.check_certificate_chains_main",
+        "enclave.tools.cli.check_certificate_chains_helper",
         side_effect=CertificateValidationError(
             "sslAPICertificateFullChain: chain ends with a non-self-signed certificate"
         ),
@@ -296,19 +308,74 @@ def test_check_certificate_chains_reports_runtime_error(
     config_file.write_text("", encoding="utf-8")
     result = CliRunner().invoke(
         cli,
-        ["check-certificate-chains", "--config", str(config_file)],
+        [
+            "check-certificate-chains",
+            "api",
+            "--config",
+            str(config_file),
+            "--hostname",
+            "api.cluster.example.com",
+        ],
     )
-    assert result.exit_code != 0
-    assert "sslAPICertificateFullChain" in result.output
+    assert result.exit_code == 1
+    assert "sslAPICertificateFullChain" in caplog.text
 
 
 def test_check_certificate_chains_rejects_missing_file() -> None:
     """Reject a non-existent --config path."""
     result = CliRunner().invoke(
         cli,
-        ["check-certificate-chains", "--config", "/nonexistent/certificates.yaml"],
+        [
+            "check-certificate-chains",
+            "api",
+            "--config",
+            "/nonexistent/certificates.yaml",
+            "--hostname",
+            "api.example.com",
+        ],
     )
     assert result.exit_code != 0
+
+
+def test_check_certificate_chains_ironic_type(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    """Forward ironic cert_type with --hostname to check_certificate_chains_helper."""
+    mock_main = mocker.patch("enclave.tools.cli.check_certificate_chains_helper")
+    config_file = tmp_path / "certificates.yaml"
+    config_file.write_text("", encoding="utf-8")
+    result = CliRunner().invoke(
+        cli,
+        [
+            "check-certificate-chains",
+            "ironic",
+            "--config",
+            str(config_file),
+            "--hostname",
+            "bmc.example.com",
+        ],
+    )
+    assert result.exit_code == 0
+    mock_main.assert_called_once_with(
+        str(config_file),
+        cert_type="ironic",
+        hostnames=["bmc.example.com"],
+    )
+
+
+@pytest.mark.parametrize("cert_type", ["api", "ingress", "ironic"])
+def test_check_certificate_chains_requires_hostname(
+    tmp_path: Path, cert_type: str
+) -> None:
+    """Reject any cert_type when --hostname is omitted."""
+    config_file = tmp_path / "certificates.yaml"
+    config_file.write_text("", encoding="utf-8")
+    result = CliRunner().invoke(
+        cli,
+        ["check-certificate-chains", cert_type, "--config", str(config_file)],
+    )
+    assert result.exit_code != 0
+    assert "--hostname" in result.output
 
 
 def test_collect_node_image_digests_help() -> None:

--- a/validations.sh
+++ b/validations.sh
@@ -77,71 +77,6 @@ checkDNS(){
     validation pass $check_name "$name points to $value"
 }
 
-checkCerts(){
-    local check_name=$1
-    local cert_name=$2
-    local key=$3
-    local cert=$4
-    local now_ts not_before not_after
-
-    # Check that key matches certificate
-    if [[ $(getValue $key | openssl pkey -pubout) != $(getValue $cert | openssl x509 -noout -pubkey) ]]; then
-        validation fail $check_name "Key $key does not match $cert"
-    fi
-
-    # Check that certificate is valid now
-    now_ts=$(date +%s)
-    not_before=$(getValue $cert | openssl x509 -noout -startdate | cut -d= -f2)
-    not_after=$(getValue $cert | openssl x509 -noout -enddate | cut -d= -f2)
-    not_before_ts=$(date -d "$not_before" +%s)
-    not_after_ts=$(date -d "$not_after" +%s)
-
-    if [[ $now_ts -lt $not_before_ts ]]; then
-        validation fail $check_name "Certificate $cert not valid yet (starts on $not_before)"
-    fi
-
-    if [[ $now_ts -gt $not_after_ts ]]; then
-        validation fail $check_name "Certificate $cert is expired (expired on $not_after)"
-    fi
-
-    cert_alt_names=$(getValue $cert | openssl x509 -noout -ext subjectAltName | tail -n +2 | tr -d ,| xargs -n1 | cut -d : -f 2)
-    if ! echo "$cert_alt_names" | grep -qx "$cert_name"; then
-        message="Valid names for certificate:
-$cert_alt_names"
-        validation fail $check_name "Certificate is not valid for name $cert_name" "$message"
-    fi
-
-    validation pass $check_name "Certificate $cert is valid"
-
-}
-
-checkCACert(){
-    local check_name=$1
-    local cert_jq=$2
-    local ca_pem now_ts not_before not_after not_before_ts not_after_ts
-
-    ca_pem=$(getValue "$cert_jq")
-
-    if ! echo "$ca_pem" | openssl x509 -noout 2>/dev/null; then
-        validation fail "$check_name" "sslCACertificate is not a valid PEM certificate"
-    fi
-
-    now_ts=$(date +%s)
-    not_before=$(echo "$ca_pem" | openssl x509 -noout -startdate | cut -d= -f2)
-    not_after=$(echo "$ca_pem" | openssl x509 -noout -enddate | cut -d= -f2)
-    not_before_ts=$(date -d "$not_before" +%s)
-    not_after_ts=$(date -d "$not_after" +%s)
-
-    if [[ $now_ts -lt $not_before_ts ]]; then
-        validation fail "$check_name" "CA certificate not valid yet (starts on $not_before)"
-    fi
-    if [[ $now_ts -gt $not_after_ts ]]; then
-        validation fail "$check_name" "CA certificate is expired (expired on $not_after)"
-    fi
-
-    validation pass "$check_name" "CA certificate is valid"
-}
-
 checkIP(){
     local check_subnet_net ip_net prefix
     local check_name="$1"
@@ -390,28 +325,43 @@ fi
 ## SSL Certificates
 validation_section ssl_certificates
 
-# Check SSL certificate validity
-checkCerts api api.$cluster_fqdn .sslAPICertificateKey .sslAPICertificateFullChain
-checkCerts ingress "*.apps.$cluster_fqdn" .sslIngressCertificateKey .sslIngressCertificateFullChain
-
-# Check CA certificate (optional)
-ca_cert=$(getValue .sslCACertificate)
-if [[ -n "$ca_cert" && "$ca_cert" != "null" ]]; then
-    checkCACert ssl_ca_certificate .sslCACertificate
+if output=$(enclave --log-format plain tools check-root-ca --config "${certs_vars}" 2>&1); then
+    validation pass root_ca "Root CA check passed"
 else
-    validation pass ssl_ca_certificate_skipped "sslCACertificate not configured. Skipping validation"
+    validation fail root_ca "Root CA check failed" "$output"
 fi
 
-# Check Ironic HTTPS certificate (optional)
-lz_bmc_ip=$(getValue .lzBmcIP)
-lz_bmc_hostname=$(getValue .lzBmcHostname)
-[[ "$lz_bmc_hostname" == "null" ]] && lz_bmc_hostname=""
-ironic_cert_name="${lz_bmc_hostname:-$lz_bmc_ip}"
-ironic_https_cert=$(getValue .ironicHTTPSCertificate)
-if [[ -n "$ironic_https_cert" && "$ironic_https_cert" != "null" ]]; then
-    checkCerts ironic_https "$ironic_cert_name" .ironicHTTPSKey .ironicHTTPSCertificate
+if output=$(enclave --log-format plain tools check-certificate-chains api \
+    --config "${certs_vars}" \
+    --hostname "api.${cluster_fqdn}" 2>&1); then
+    validation pass cert_api "API certificate chain check passed"
 else
-    validation pass ironic_https_skipped "Ironic HTTPS certificate not configured. Skipping validation"
+    validation fail cert_api "API certificate chain check failed" "$output"
+fi
+
+# Pass the wildcard pattern as the hostname so cert_covers_hostname confirms the
+# cert's SAN is exactly "*.apps.<cluster_fqdn>", matching what OpenShift ingress requires.
+if output=$(enclave --log-format plain tools check-certificate-chains ingress \
+    --config "${certs_vars}" \
+    --hostname "*.apps.${cluster_fqdn}" 2>&1); then
+    validation pass cert_ingress "Ingress certificate chain check passed"
+else
+    validation fail cert_ingress "Ingress certificate chain check failed" "$output"
+fi
+
+lz_bmc_hostname=$(getValue .lzBmcHostname 2>/dev/null || true)
+lz_bmc_ip=$(getValue .lzBmcIP 2>/dev/null || true)
+[[ "$lz_bmc_hostname" == "null" ]] && lz_bmc_hostname=""
+[[ "$lz_bmc_ip" == "null" ]] && lz_bmc_ip=""
+ironic_cert_name="${lz_bmc_hostname:-$lz_bmc_ip}"
+if [[ -n "${ironic_cert_name}" ]]; then
+    if output=$(enclave --log-format plain tools check-certificate-chains ironic \
+        --config "${certs_vars}" \
+        --hostname "${ironic_cert_name}" 2>&1); then
+        validation pass cert_ironic "Ironic certificate check passed"
+    else
+        validation fail cert_ironic "Ironic certificate check failed" "$output"
+    fi
 fi
 
 ## Check nmstate config (if defined)


### PR DESCRIPTION
Related-to: https://github.com/gori-project/GoRI/issues/943
Continuation of: https://github.com/rh-ecosystem-edge/enclave/pull/609

The previous approach split certificate checking between Bash (validations.sh,
bootstrap.sh) and a Python tool that only handled chain completeness, with no unit
tests covering expiry, SAN coverage, or key-pair matching.

All checks — expiry, SAN coverage, chain completeness, key-pair matching, and CA
consistency — are now consolidated in src/enclave/tools/check_certificate_chains.py
and covered by a pytest suite, enabling validation logic to be tested in isolation
without a running cluster.

A cert_type positional argument (api | ingress | ironic) determines which config
fields are read and which checks apply: api/ingress carry full chains and go through
completeness and CA consistency checks; ironic carries a single leaf cert and skips
chain verification. Private keys are read directly from certificates.yaml and are
mandatory when the corresponding cert is configured.

All tool output goes through Python logging for a consistent format. A --log-format
option (full | plain) on the top-level enclave CLI controls whether output includes a
timestamp and level prefix or emits only the message. This lets validations.sh
capture clean text into its YAML message fields. bootstrap.sh no longer calls these
tools directly; the ssl_certificates section in validations.sh now runs all four
checks (check-root-ca, api, ingress, and a conditional ironic check) so they appear
in the same structured validation output format as every other config check.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

- **New Features**
  - Improved TLS certificate-chain validation: endpoint-specific checks for API, ingress, and optional Ironic, including certificate/key matching, validity-window checks (UTC), and stricter DNS SAN wildcard behavior.
  - Updated the `check-certificate-chains` CLI to require `cert_type` plus one or more `--hostname` values.
  - Enclave CLI now supports `--log-format` (full/plain).

- **Bug Fixes**
  - Certificate validation is now consistently driven by the certificate-chain tool during `validations.sh`, improving end-to-end result accuracy.

- **Tests**
  - Expanded unit and CLI coverage for the new validation rules and argument requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->