### PR TITLE
Fix example certificates.yaml: comment out empty ironic HTTPS cert fields

### DIFF
--- a/config/certificates.example.yaml
+++ b/config/certificates.example.yaml
@@ -70,6 +70,15 @@ sslCACertificate: |
 # The SAN on this certificate must cover lzBmcHostname (DNS SAN, for Let's Encrypt certs)
 # or lzBmcIP (IP SAN, for private CA certs). Set lzBmcHostname in global.yaml when using
 # a publicly trusted certificate such as Let's Encrypt.
-ironicHTTPSCertificate: ""
-
-ironicHTTPSKey: ""
+#
+# Leave these commented out (not set to an empty string) when not serving boot ISOs
+# over HTTPS: the schema requires a non-empty value if the key is present at all.
+# ironicHTTPSCertificate: |
+#   -----BEGIN CERTIFICATE-----
+#   YOUR_IRONIC_HTTPS_CERTIFICATE
+#   -----END CERTIFICATE-----
+#
+# ironicHTTPSKey: |
+#   -----BEGIN PRIVATE KEY-----
+#   YOUR_IRONIC_HTTPS_PRIVATE_KEY
+#   -----END PRIVATE KEY-----

--- a/config/certificates.example.yaml
+++ b/config/certificates.example.yaml
@@ -71,8 +71,9 @@ sslCACertificate: |
 # or lzBmcIP (IP SAN, for private CA certs). Set lzBmcHostname in global.yaml when using
 # a publicly trusted certificate such as Let's Encrypt.
 #
-# Leave these commented out (not set to an empty string) when not serving boot ISOs
-# over HTTPS: the schema requires a non-empty value if the key is present at all.
+# Leave both fields commented out (not set to an empty string) unless HTTPS
+# serving is enabled: ironicHTTPSCertificate must always be non-empty when
+# present, and setting only one of the two fields is rejected.
 # ironicHTTPSCertificate: |
 #   -----BEGIN CERTIFICATE-----
 #   YOUR_IRONIC_HTTPS_CERTIFICATE


### PR DESCRIPTION
## Summary
- `config/certificates.example.yaml` set `ironicHTTPSCertificate`/`ironicHTTPSKey` to empty strings (`""`) by default
- `schemas/certificates.yaml` enforces `minLength: 1` on both fields whenever they're present — so the example, if copied as-is, fails schema validation with `'' should be non-empty`
- This caused a real deployment failure reported in Slack (bare-metal deploy of `main-sovcloud-1784177656-46fdd18.tar.gz`), where the confirmed workaround was to omit the keys entirely rather than leave them empty
- Fixed by commenting the fields out by default (as placeholders), with a note that they must be omitted — not set to `""` — when Ironic HTTPS boot ISOs aren't in use

## Test plan
- [x] `make -f Makefile.ci validate-json-schema` passes
- [x] Manually confirmed `config/certificates.example.yaml` with these fields omitted validates cleanly against `schemas/certificates.yaml`

Related Slack threads:
- https://redhat-internal.slack.com/archives/C09G9BS83T9/p1784713443034469
- https://redhat-internal.slack.com/archives/C09MHJM91LG/p1784283912536639

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the example certificate configuration to leave optional HTTPS certificate and key settings unset by default.
  * Added guidance to configure these fields only when serving boot ISOs over HTTPS.
  * Clarified that a certificate must be provided when HTTPS boot-ISO serving is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->