### PR TITLE
OSAC-3237: Support OCI charts in Helm image extraction for mirroring

### DIFF
--- a/docs/PLUGIN_ARCHITECTURE.md
+++ b/docs/PLUGIN_ARCHITECTURE.md
@@ -78,7 +78,7 @@ registries:
 | `additionalImages` | Extra images to include in the plugin's oc-mirror image set. |
 | `blockedImages` | Images to exclude from mirroring (by tag, digest, or pattern). |
 | `requires` | Declarative requirements validated at load time, before any deployment work begins. See [Load-Time Validation](#load-time-validation). |
-| `helm` | List of Helm charts to install after operators, before `tasks/deploy.yaml`. Supports local charts and remote repos. Each entry specifies `release`, `namespace`, and optional `repo`, `version`, values template, and `extractImages`. When `extractImages: true` is set on a local chart, `helm template` is run before mirroring to discover container image references and merge them into `additionalImages` automatically. |
+| `helm` | List of Helm charts to install after operators, before `tasks/deploy.yaml`. Supports local charts, OCI charts (`oci://`), and remote repos. Each entry specifies `release`, `namespace`, and optional `chart`, `repo`, `version`, values template, and `extractImages`. When `extractImages: true` is set on a chart (local or OCI), `helm template` is run before mirroring to discover container image references and merge them into `additionalImages` automatically. |
 
 The plugin descriptor is validated by JSON Schema (`schemas/plugin.yaml`) during `make validate`. The validator (`make validate-plugins`) also checks directory structure.
 
@@ -105,7 +105,7 @@ Here's what runs and in what order:
 
 Steps 3-4 are the load-time validation gate. If any declared requirement is missing or the early-validate script fails, the plugin fails immediately -- before mirroring, operator installation, or deployment. Note that `early-validate.yaml` runs before the cluster exists, so it cannot use KUBECONFIG. Use it for config format checks, external connectivity validation, or other pre-flight logic.
 
-Step 6 runs `helm template` (with chart defaults, no custom values) on local charts that have `extractImages: true`. The discovered image references are merged into `additionalImages` before mirroring. This is opt-in because `helm template` can fail if sub-chart dependencies aren't populated. Remote charts (with `repo` set) are skipped.
+Step 6 runs `helm template` on charts that have `extractImages: true`. Both local charts and OCI charts (`oci://`) are supported. When a `valuesTemplate` is defined on the chart entry, it is rendered (Jinja2) and passed to `helm template` to satisfy required values. A `valuesFile` is copied unchanged and passed with `-f`. Since extraction runs before operators and post-operators, some runtime variables may not exist yet. Use `extractPlaceholders` in the helm entry to provide stub values for variables that are only set at deploy time — the actual values don't matter for image discovery. The discovered image references are merged into `additionalImages` before mirroring. This is opt-in because `helm template` can fail if sub-chart dependencies aren't populated or required values are missing. Remote charts (with `repo` set) are skipped.
 
 Step 9 (`post-operators.yaml`) is useful for plugins that need to set up infrastructure after operators are installed but before Helm charts or deploy tasks run. For example, a plugin might use this hook to create a CR instance and extract credentials that the Helm values template depends on. Facts set in `post-operators.yaml` are available to later steps because all hooks run in the same Ansible play via `include_tasks`.
 
@@ -385,7 +385,7 @@ requires:
 1. Add `requires` to declare variables or files that must exist at load time
 1. Add `tasks/early-validate.yaml` for custom pre-flight checks that don't need cluster access (optional)
 1. Add `tasks/post-operators.yaml` for setup needed after operators but before Helm or deploy (optional)
-1. Add `helm` list if you need Helm chart deployments, with chart sources under `charts/` or from a remote `repo`. Set `extractImages: true` on local charts to auto-discover container images for mirroring
+1. Add `helm` list if you need Helm chart deployments, with chart sources under `charts/`, OCI references (`oci://`), or from a remote `repo`. Set `extractImages: true` on charts to auto-discover container images for mirroring
 1. Add `tasks/deploy.yaml` with your post-operator (or post-Helm) setup logic
 1. Add `tasks/quay.yaml` if your plugin provides storage for Quay
 1. Run `make validate-plugins` to verify

--- a/playbooks/tasks/helm_deploy.yaml
+++ b/playbooks/tasks/helm_deploy.yaml
@@ -115,7 +115,7 @@
   ansible.builtin.set_fact:
     _helm_log: "{{ workingDir }}/logs/helm-{{ plugin_name }}-{{ helm_chart.release }}.{{ lookup('pipe', 'date +%s') }}.log"
 
-- name: "Helm | Install {{ helm_chart.release }}{{ ' v' ~ (helm_chart.version | default('')) if helm_chart.version is defined else '' }}"
+- name: "Helm | Install {{ helm_chart.release }}{{ ' ' ~ helm_chart.version if helm_chart.version is defined else '' }}"
   ansible.builtin.shell: |
     set -o pipefail
     {{ workingDir }}/bin/helm upgrade --install \

--- a/playbooks/tasks/helm_extract_images.yaml
+++ b/playbooks/tasks/helm_extract_images.yaml
@@ -34,7 +34,7 @@
          }) }}
   when: _helm_all_extracted_images | default([]) | length > 0
 
-- name: "HelmExtract | Show extracted images"
+- name: "HelmExtract | Show extracted images ({{ _helm_all_extracted_images | default([]) | length }})"
   ansible.builtin.debug:
-    msg: "Extracted {{ _helm_all_extracted_images | default([]) | length }} image(s) from Helm charts: {{ _helm_all_extracted_images | default([]) }}"
+    msg: "{{ _helm_all_extracted_images | default([]) }}"
   when: _helm_all_extracted_images | default([]) | length > 0

--- a/playbooks/tasks/helm_extract_single.yaml
+++ b/playbooks/tasks/helm_extract_single.yaml
@@ -1,50 +1,206 @@
 ---
-# Extract container images from a single local Helm chart via helm template.
+# Extract container images from a single Helm chart via helm template.
+#
+# Supports local charts and OCI charts (oci://), with optional valuesTemplate.
 #
 # Required loop_var: _extract_chart (helm entry with extractImages: true)
-# Required variables: plugin_dir, workingDir
+# Required variables: plugin_dir, plugin_name, workingDir
 
-- name: "HelmExtract | Set chart path for {{ _extract_chart.release }}"
+# --- Log setup (early, so all steps can reference it) ---
+
+- name: "HelmExtract | Ensure log directory exists"
+  ansible.builtin.file:
+    path: "{{ workingDir }}/logs/"
+    state: directory
+
+- name: "HelmExtract | Set log path: {{ _extract_chart.release }}"
   ansible.builtin.set_fact:
-    _extract_chart_path: >-
-      {{ plugin_dir ~ '/' ~ (_extract_chart.chart | default('charts/' ~ _extract_chart.release)) }}
+    _extract_log: "{{ workingDir }}/logs/helm-extract-{{ plugin_name }}-{{ _extract_chart.release }}.{{ lookup('pipe', 'date +%s') }}.log"
 
-- name: "HelmExtract | Verify chart exists: {{ _extract_chart.release }}"
+# --- Determine chart type ---
+
+- name: "HelmExtract | Detect OCI chart: {{ _extract_chart.release }}"
+  ansible.builtin.set_fact:
+    _extract_is_oci: "{{ _extract_chart.chart is defined and _extract_chart.chart is match('^oci://') }}"
+
+# --- Set chart source (local path or oci:// URL) ---
+
+- name: "HelmExtract | Set chart source for {{ _extract_chart.release }}"
+  ansible.builtin.set_fact:
+    _extract_chart_src: >-
+      {{ _extract_chart.chart
+         if (_extract_is_oci | bool)
+         else (plugin_dir ~ '/' ~ (_extract_chart.chart | default('charts/' ~ _extract_chart.release))) }}
+
+- name: "HelmExtract | Show chart source: {{ _extract_chart.release }}"
+  ansible.builtin.debug:
+    msg: |
+      Chart: {{ _extract_chart_src }}
+      OCI: {{ _extract_is_oci }}
+      Version: {{ _extract_chart.version | default('latest') }}
+      Log: {{ _extract_log }}
+
+# --- Local chart: verify exists ---
+
+- name: "HelmExtract | Verify local chart exists: {{ _extract_chart.release }}"
   ansible.builtin.stat:
-    path: "{{ _extract_chart_path }}"
+    path: "{{ _extract_chart_src }}"
   register: _r_extract_chart_stat
+  when: not (_extract_is_oci | bool)
 
-- name: "HelmExtract | Assert chart exists: {{ _extract_chart.release }}"
+- name: "HelmExtract | Assert local chart exists: {{ _extract_chart.release }}"
   ansible.builtin.assert:
     that: _r_extract_chart_stat.stat.exists
     fail_msg: >-
-      Helm chart not found at {{ _extract_chart_path }}.
+      Helm chart not found at {{ _extract_chart_src }}.
       Cannot extract images for release '{{ _extract_chart.release }}'.
+      Plugin directory: {{ plugin_dir }}
+  when: not (_extract_is_oci | bool)
+
+# --- Local chart: dependency build (if chart has dependencies) ---
+
+- name: "HelmExtract | Read Chart.yaml: {{ _extract_chart.release }}"
+  ansible.builtin.slurp:
+    src: "{{ _extract_chart_src }}/Chart.yaml"
+  register: _r_extract_chart_yaml
+  when: not (_extract_is_oci | bool)
+
+- name: "HelmExtract | Build dependencies: {{ _extract_chart.release }}"
+  block:
+    - name: "HelmExtract | Run helm dependency build: {{ _extract_chart.release }}"
+      ansible.builtin.command:
+        argv:
+          - "{{ workingDir }}/bin/helm"
+          - dependency
+          - build
+          - "{{ _extract_chart_src }}"
+      register: _r_dep_build
+      changed_when: false
+    - name: "HelmExtract | Log dependency build output: {{ _extract_chart.release }}"
+      ansible.builtin.copy:
+        content: |
+          --- helm dependency build stdout ---
+          {{ _r_dep_build.stdout | default('') }}
+          --- helm dependency build stderr ---
+          {{ _r_dep_build.stderr | default('') }}
+        dest: "{{ _extract_log }}"
+  rescue:
+    - name: "HelmExtract | Dependency build failed: {{ _extract_chart.release }}"
+      ansible.builtin.fail:
+        msg: >-
+          helm dependency build failed for chart '{{ _extract_chart.release }}' at {{ _extract_chart_src }}.
+          Error: {{ _r_dep_build.stderr | default('unknown') }}
+  when:
+    - not (_extract_is_oci | bool)
+    - (_r_extract_chart_yaml.content | b64decode | from_yaml).dependencies is defined
+
+# --- Render values template (if defined) ---
+# The extract phase runs before operators and post-operators (step 6 vs 8-9),
+# so runtime variables like __r_ingress_config may not exist yet. We only need
+# the template to render without errors — actual values don't matter because
+# we're only parsing image references from the helm template output.
+
+- name: "HelmExtract | Set placeholder variables for extraction: {{ _extract_chart.release }}"
+  ansible.builtin.set_fact:
+    "{{ item.key }}": "{{ item.value }}"
+  loop: "{{ _extract_chart.extractPlaceholders | default({}) | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+  when:
+    - _extract_chart.extractPlaceholders is defined
+    - item.key not in vars
+
+- name: "HelmExtract | Render values template: {{ _extract_chart.release }}"
+  block:
+    - name: "HelmExtract | Template values: {{ _extract_chart.release }}"
+      ansible.builtin.template:
+        src: "{{ plugin_dir }}/{{ _extract_chart.valuesTemplate }}"
+        dest: "{{ workingDir }}/helm-values-{{ plugin_name }}-{{ _extract_chart.release }}.yaml"
+  rescue:
+    - name: "HelmExtract | Values template rendering failed: {{ _extract_chart.release }}"
+      ansible.builtin.fail:
+        msg: >-
+          Failed to render values template '{{ _extract_chart.valuesTemplate }}' for chart '{{ _extract_chart.release }}'.
+          Template: {{ plugin_dir }}/{{ _extract_chart.valuesTemplate }}
+          This template requires Ansible variables that may not be available during the extract phase.
+          If a variable is only needed at deploy time (not for image discovery), add it to
+          extractPlaceholders in the helm entry of plugin.yaml.
+  when: _extract_chart.valuesTemplate is defined
+
+- name: "HelmExtract | Copy static values file: {{ _extract_chart.release }}"
+  ansible.builtin.copy:
+    src: "{{ plugin_dir }}/{{ _extract_chart.valuesFile }}"
+    dest: "{{ workingDir }}/helm-values-{{ plugin_name }}-{{ _extract_chart.release }}.yaml"
+  when:
+    - _extract_chart.valuesFile is defined
+    - _extract_chart.valuesTemplate is not defined
+
+- name: "HelmExtract | Build values path: {{ _extract_chart.release }}"
+  ansible.builtin.set_fact:
+    _extract_values_path: "{{ workingDir }}/helm-values-{{ plugin_name }}-{{ _extract_chart.release }}.yaml"
+  when: _extract_chart.valuesTemplate is defined or _extract_chart.valuesFile is defined
+
+# --- Run helm template ---
+
+- name: "HelmExtract | Build helm template argv: {{ _extract_chart.release }}"
+  ansible.builtin.set_fact:
+    _extract_helm_argv: >-
+      {{ [workingDir ~ '/bin/helm', 'template', 'extract', _extract_chart_src,
+          '--namespace', _extract_chart.namespace]
+         + (['--version', _extract_chart.version] if (_extract_is_oci | bool) and _extract_chart.version is defined else [])
+         + (['-f', _extract_values_path] if (_extract_chart.valuesTemplate is defined or _extract_chart.valuesFile is defined) else []) }}
 
 - name: "HelmExtract | Run helm template: {{ _extract_chart.release }}"
   ansible.builtin.command:
-    cmd: >-
-      {{ workingDir }}/bin/helm template _extract {{ _extract_chart_path }}
+    argv: "{{ _extract_helm_argv }}"
   register: _r_helm_template
   failed_when: false
   changed_when: false
 
+- name: "HelmExtract | Log helm template output: {{ _extract_chart.release }}"
+  ansible.builtin.blockinfile:
+    path: "{{ _extract_log }}"
+    create: true
+    marker: "# {mark} helm template output"
+    block: "{{ _r_helm_template.stdout | default('') }}"
+
+- name: "HelmExtract | Log helm template stderr: {{ _extract_chart.release }}"
+  ansible.builtin.blockinfile:
+    path: "{{ _extract_log }}"
+    marker: "# {mark} helm template stderr"
+    block: "{{ _r_helm_template.stderr | default('') }}"
+  when: _r_helm_template.stderr | default('') | length > 0
+
 - name: "HelmExtract | Fail on template error: {{ _extract_chart.release }}"
   ansible.builtin.fail:
-    msg: >-
-      helm template failed for chart '{{ _extract_chart.release }}' at {{ _extract_chart_path }}.
-      If the chart has sub-chart dependencies, run 'helm dependency build' first.
+    msg: |
+      helm template failed for chart '{{ _extract_chart.release }}'.
+      Chart source: {{ _extract_chart_src }}
       Error: {{ _r_helm_template.stderr | default('unknown') }}
+      Log: {{ _extract_log }}
   when: _r_helm_template.rc != 0
+
+# --- Parse images ---
 
 - name: "HelmExtract | Parse images from template output: {{ _extract_chart.release }}"
   ansible.builtin.set_fact:
     _chart_images: >-
       {{ _r_helm_template.stdout_lines
-         | select('match', '^\s*image:\s*')
+         | select('match', '^\s*image:\s*\S+')
          | map('regex_replace', '^\s*image:\s*["'']?([^"''\s]+)["'']?\s*$', '\1')
          | reject('match', '^\s*$')
          | unique | sort | list }}
+
+- name: "HelmExtract | Show extracted images: {{ _extract_chart.release }}"
+  ansible.builtin.debug:
+    msg: "{{ _chart_images }}"
+
+- name: "HelmExtract | Warn if no images found: {{ _extract_chart.release }}"
+  ansible.builtin.debug:
+    msg: >-
+      WARNING: No images extracted from chart '{{ _extract_chart.release }}'.
+      Check {{ _extract_log }} for the full helm template output.
+  when: _chart_images | length == 0
 
 - name: "HelmExtract | Accumulate images from {{ _extract_chart.release }}"
   ansible.builtin.set_fact:

--- a/playbooks/tasks/mirror_plugin.yaml
+++ b/playbooks/tasks/mirror_plugin.yaml
@@ -129,7 +129,6 @@
         state: absent
       when: lz_itms_src_stat.stat.exists
   when:
-    - plugin.installOperators | default(true)
     - r_plugin_mirror is defined
     - r_plugin_mirror is success
 
@@ -252,7 +251,6 @@
   vars:
     quay_mirror_skip_apply: true
   when:
-    - plugin.installOperators | default(true)
     - r_plugin_mirror_quay is defined
     - r_plugin_mirror_quay is success
 
@@ -266,7 +264,9 @@
       lz_cluster_resources_dir: "{{ lz_cluster_resources_dir | default('n/a') }}"
       quay_idms_manifest: "{{ quay_idms_apply_manifest | default('n/a') }}"
       quay_itms_manifest: "{{ quay_itms_apply_manifest | default('n/a') }}"
-  when: plugin.installOperators | default(true)
+  when:
+    - (r_plugin_mirror is defined and r_plugin_mirror is success) or
+      (r_plugin_mirror_quay is defined and r_plugin_mirror_quay is success)
 
 - name: Apply LZ mirror manifests to cluster
   ansible.builtin.shell: |
@@ -276,7 +276,6 @@
   environment:
     KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
   when:
-    - plugin.installOperators | default(true)
     - r_plugin_mirror is defined
     - r_plugin_mirror is success
 
@@ -290,7 +289,6 @@
   environment:
     KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
   when:
-    - plugin.installOperators | default(true)
     - r_plugin_mirror_quay is defined
     - r_plugin_mirror_quay is success
     - quay_idms_apply_manifest is defined
@@ -305,7 +303,6 @@
   environment:
     KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
   when:
-    - plugin.installOperators | default(true)
     - r_plugin_mirror_quay is defined
     - r_plugin_mirror_quay is success
     - quay_itms_apply_manifest is defined
@@ -313,7 +310,6 @@
 - name: Wait for MachineConfigPool to finish updating
   ansible.builtin.include_tasks: wait_mcp.yaml
   when:
-    - plugin.installOperators | default(true)
     - (r_plugin_mirror is defined and r_plugin_mirror is success) or
       (r_plugin_mirror_quay is defined and r_plugin_mirror_quay is success)
 

--- a/schemas/plugin.yaml
+++ b/schemas/plugin.yaml
@@ -164,6 +164,15 @@ definitions:
       required: [repo]
     then:
       required: [chart]
+    allOf:
+      - if:
+          required: [chart]
+          properties:
+            chart:
+              pattern: '^oci://'
+        then:
+          not:
+            required: [repo]
     properties:
       chart:
         type: string
@@ -203,10 +212,20 @@ definitions:
       extractImages:
         type: boolean
         description: >-
-          Extract container image references from the chart's default values
-          via helm template and merge into additionalImages for mirroring.
-          Only works for local charts (repo and oci:// must not be set).
+          Extract container image references from the chart via helm template
+          and merge into additionalImages for mirroring. Supports local charts
+          and OCI charts (oci://). When a valuesTemplate or valuesFile is
+          defined, it is used during templating to satisfy required values.
           Default: false.
+      extractPlaceholders:
+        type: object
+        description: >-
+          Placeholder values for Ansible variables that the valuesTemplate
+          references but are only available at deploy time (e.g. from
+          post-operators.yaml). These are set as facts during the extract
+          phase only if the variable is not already defined. The actual
+          values don't matter — they just prevent template rendering failures
+          during image extraction.
     required:
       - release
       - namespace

--- a/templates/plugin-imageset.yaml.j2
+++ b/templates/plugin-imageset.yaml.j2
@@ -2,11 +2,12 @@
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1
 mirror:
+{% if plugin.operators | default([]) | length > 0 %}
   operators:
     - catalog: {{ catalog_image }}:{{ catalog_version }}
       targetCatalog: redhat/{{ catalog_mirror }}
       packages:
-{% for operator in plugin.operators | default([]) %}
+{% for operator in plugin.operators %}
 {% set additional_operator_names = operator.csvNames if (operator.csvMirror | default(false) | bool) else [] %}
 {% for operator_name in [operator.name] + additional_operator_names %}
         - name: {{ operator_name }}
@@ -20,6 +21,7 @@ mirror:
         - name: {{ pkg }}
 {% endfor %}
 {% endfor %}
+{% endif %}
 {% if plugin.additionalImages | default([]) | length > 0 %}
   additionalImages:
 {% for img in plugin.additionalImages %}


### PR DESCRIPTION
## Summary

- Extend `extractImages: true` to support OCI charts (`oci://`), enabling automatic container image discovery from Helm charts for disconnected mirroring
- Render `valuesTemplate`/`valuesFile` before `helm template` to satisfy charts using Go's `required()` function
- Add `extractPlaceholders` schema field for stub values needed only during extraction
- Add comprehensive logging, block/rescue error handling, and debug output for extraction failures

## Changes

| File | Change |
|------|--------|
| `playbooks/tasks/helm_extract_single.yaml` | Rewritten: OCI detection, values rendering, log capture via `blockinfile`, block/rescue error handling |
| `playbooks/tasks/helm_extract_images.yaml` | List-format debug output for extracted images |
| `schemas/plugin.yaml` | Update `extractImages` description for OCI support, add `extractPlaceholders`, add `allOf` rule rejecting `repo` on OCI charts |
| `docs/PLUGIN_ARCHITECTURE.md` | Document OCI chart support, `valuesTemplate`/`extractPlaceholders` usage in extraction |
| `templates/plugin-imageset.yaml.j2` | Conditionally render operators section (supports plugins with only `additionalImages`) |
| `playbooks/tasks/mirror_plugin.yaml` | Remove `installOperators` gate from mirror manifest apply |
| `playbooks/tasks/helm_deploy.yaml` | Fix version display in task name |

## How it works

1. Detect chart type: OCI (`oci://`) vs local path
2. For local charts: verify path exists, run `helm dependency build` if needed
3. Render `valuesTemplate` (Jinja2) or copy `valuesFile` if defined on the chart entry
4. Set `extractPlaceholders` as Ansible facts for variables not yet available at extraction time
5. Run `helm template` with values file, capturing stdout/stderr to a timestamped log via `blockinfile`
6. Parse `image:` lines from template output, deduplicate, merge into `additionalImages`
7. On failure: clear error message with log path for post-mortem

## Test plan

- [x] `make -f Makefile.ci validate` passes (schema, ansible-lint, shellcheck)
- [x] OCI chart extraction tested end-to-end in disconnected deployment — images discovered and mirrored successfully
- [x] Schema validation: `allOf` rule rejects `repo` when `chart` starts with `oci://`
- [ ] Test failure scenarios: missing values template vars, unreachable OCI registry

Jira: [OSAC-3237](https://redhat.atlassian.net/browse/OSAC-3237)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Helm image extraction now supports local and OCI-based charts.
  - Chart rendering can use values files or templates, including deploy-time placeholders.
  - Deployment artifacts now include broader Landing Zone pipeline logs.

- **Bug Fixes**
  - Improved handling and reporting of missing chart dependencies, rendering failures, and charts with no discoverable images.
  - Mirror preparation and application steps now run when either supported mirroring path succeeds.
  - Empty operator sections are omitted from generated image sets.

- **Documentation**
  - Expanded Helm configuration and lifecycle guidance, including OCI sources and image extraction requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->