### PR TITLE
[WIP] OSAC-3130: Fix Makefile workingDir override and DISCONNECTED boolean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,16 @@
         deploy-plugin mirror-plugin bootstrap sync
 
 # Configuration
-WORKING_DIR ?= $(HOME)
 DISCONNECTED ?= true
 PLUGIN ?=
 
 # Ansible
 AP = ansible-playbook
-AP_FLAGS = -e workingDir=$(WORKING_DIR) -e disconnected=$(DISCONNECTED)
+ifdef WORKING_DIR
+AP_FLAGS = -e workingDir=$(WORKING_DIR) --extra-vars '{"disconnected":$(DISCONNECTED)}'
+else
+AP_FLAGS = --extra-vars '{"disconnected":$(DISCONNECTED)}'
+endif
 
 # Default target
 help:
@@ -58,12 +61,12 @@ help:
 	@echo "  make python-types-test                - Run mypy type checks"
 	@echo ""
 	@echo "Configuration variables:"
-	@echo "  WORKING_DIR      - Working directory (default: $$HOME)"
+	@echo "  WORKING_DIR      - Working directory (default: from config/global.yaml)"
 	@echo "  DISCONNECTED     - Disconnected mode (default: true)"
 	@echo "  PLUGIN           - Plugin name for deploy-plugin target"
 	@echo ""
 	@echo "Current values:"
-	@echo "  WORKING_DIR=$(WORKING_DIR)"
+	@echo "  WORKING_DIR=$(WORKING_DIR) $(if $(WORKING_DIR),(user override),(from config/global.yaml))"
 	@echo "  DISCONNECTED=$(DISCONNECTED)"
 	@echo ""
 	@echo "Examples:"

--- a/playbooks/deploy-plugin.yaml
+++ b/playbooks/deploy-plugin.yaml
@@ -17,17 +17,19 @@
   environment:
     PATH: "{{ workingDir | default('') }}/bin:{{ lookup('env', 'HOME') }}/.local/bin:{{ lookup('env', 'PATH') }}"
   tasks:
+    - name: Load common variables
+      ansible.builtin.include_tasks:
+        file: common/load-vars.yaml
+        apply:
+          tags: always
+      tags: always
+
     - name: Validate workingDir is provided
       ansible.builtin.assert:
         that:
           - workingDir is defined
           - workingDir | length > 0
-        fail_msg: "workingDir must be provided (e.g., -e workingDir=/home/cloud-user)"
-      tags: always
-
-    - name: Load common variables
-      ansible.builtin.include_tasks:
-        file: common/load-vars.yaml
+        fail_msg: "workingDir must be provided (e.g., -e workingDir=/home/cloud-user or set in config/global.yaml)"
       tags: always
 
     - name: Deploy plugin


### PR DESCRIPTION
## Summary
- The LZ `Makefile` always passed `-e workingDir=$(HOME)` to ansible-playbook via `AP_FLAGS`, overriding `config/global.yaml` because Ansible extra vars have highest precedence
- This broke plugin mirroring on environments where `workingDir` is set to a non-default path (e.g. `/home/user/sessions/1`) — `pullSecretPath` resolved to a non-existent file, causing oc-mirror auth failures
- Fix: only pass `-e workingDir` when `WORKING_DIR` is explicitly set by the user, letting `config/global.yaml` provide the default via `include_vars`
- Additionally, `DISCONNECTED` was passed as a string via `-e key=value`, making `DISCONNECTED=false` truthy in Jinja2 (non-empty string). Now passed as a JSON boolean via `--extra-vars` so `false` is correctly falsy

## Test plan
- [ ] Run `make deploy-plugin PLUGIN=<name>` without setting `WORKING_DIR` — verify `workingDir` comes from `config/global.yaml`
- [ ] Run `WORKING_DIR=/custom/path make deploy-plugin PLUGIN=<name>` — verify the override still works
- [ ] Run `make deploy-cluster-connected` — verify `disconnected` is boolean `false` in playbook context
- [ ] Run `make help` — verify updated help text

Jira: [OSAC-3130](https://redhat.atlassian.net/browse/OSAC-3130)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployment commands now use an explicitly provided working directory when available, while otherwise relying on the configured project value.
  * Help output now explains configuration variables and indicates how the working directory value was determined.

* **Bug Fixes**
  * Improved deployment validation so configuration values are loaded before checking the working directory.
  * Expanded error guidance to include configuring the working directory in the global configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->