### PR TITLE
OSAC-3218: Batch IDMS/ITMS applies in mirror_plugin to trigger single MCO rollout

### DIFF
--- a/operators/quay-operator/quay_disconnected_mirrors.yaml
+++ b/operators/quay-operator/quay_disconnected_mirrors.yaml
@@ -1,10 +1,15 @@
 ---
-# Quay disconnected: apply IDMS/ITMS from oc-mirror and trust Quay registry CA for image pulls.
-# Included from quay_disconnected.yaml.
+# Quay disconnected: prepare and optionally apply IDMS/ITMS from oc-mirror,
+# then trust Quay registry CA for image pulls.
+# Included from quay_disconnected_finish.yaml and mirror_plugin.yaml.
+#
 # Copy to a target manifest name based on mode:
 # - default: idms-<slice>-internal (core); plugin mode: quay_mirror_suffix is plugin-<plugin>-internal
 #   → idms-<slice>-plugin-<plugin>-internal (oc-mirror may emit multiple slices per file; keep \2 in the name).
 # LZ plugin manifests use idms-<slice>-plugin-<plugin> (mirror_plugin.yaml).
+#
+# Set quay_mirror_skip_apply: true to prepare manifests without applying them (mirror_plugin.yaml
+# batches all applies to trigger a single MCO rollout).
 
 - name: Set target mirror suffix and base directory
   ansible.builtin.set_fact:
@@ -80,7 +85,9 @@
       - "{{ quay_idms_apply_manifest }}"
   environment:
     KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
-  when: quay_idms_src_stat.stat.exists
+  when:
+    - quay_idms_src_stat.stat.exists
+    - not (quay_mirror_skip_apply | default(false) | bool)
 
 - name: Apply Quay ITMS to cluster (fallback mirrors to internal Quay)
   ansible.builtin.command:
@@ -91,7 +98,9 @@
       - "{{ quay_itms_apply_manifest }}"
   environment:
     KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
-  when: quay_itms_src_stat.stat.exists
+  when:
+    - quay_itms_src_stat.stat.exists
+    - not (quay_mirror_skip_apply | default(false) | bool)
 
 - name: Trust Quay registry CA in image.config for image pulls
   ansible.builtin.include_tasks: ../../playbooks/tasks/trust_quay_registry_ca_for_image_config.yaml

--- a/playbooks/tasks/mirror_plugin.yaml
+++ b/playbooks/tasks/mirror_plugin.yaml
@@ -70,7 +70,7 @@
 
           Full log: {{ _oc_mirror_plugin_log }}
 
-- name: Apply updated mirror manifests to cluster
+- name: Prepare LZ mirror manifests
   block:
     - name: Set landing-zone cluster resources directory
       ansible.builtin.set_fact:
@@ -128,42 +128,6 @@
         path: "{{ lz_cluster_resources_dir }}/itms-oc-mirror.yaml"
         state: absent
       when: lz_itms_src_stat.stat.exists
-
-    - name: Apply updated mirror manifests to cluster
-      ansible.builtin.shell: |
-        {{ workingDir }}/bin/oc apply \
-          -f {{ lz_cluster_resources_dir }}/ \
-          --server-side --force-conflicts
-      environment:
-        KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
-  when:
-    - plugin.installOperators | default(true)
-    - r_plugin_mirror is defined
-    - r_plugin_mirror is success
-
-- name: Wait for MachineConfigPool to finish updating after LZ mirrors
-  ansible.builtin.include_tasks: wait_mcp.yaml
-  when:
-    - plugin.installOperators | default(true)
-    - r_plugin_mirror is defined
-    - r_plugin_mirror is success
-
-- name: Wait for updated CatalogSource to be ready
-  kubernetes.core.k8s_info:
-    api_version: operators.coreos.com/v1alpha1
-    kind: CatalogSource
-    namespace: openshift-marketplace
-  environment:
-    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
-  register: r_catalog_sources
-  retries: 24
-  delay: 10
-  until: >-
-    r_catalog_sources.resources | default([])
-    | selectattr('status', 'defined')
-    | selectattr('status.connectionState', 'defined')
-    | selectattr('status.connectionState.lastObservedState', 'equalto', 'READY')
-    | list | length >= (r_catalog_sources.resources | length)
   when:
     - plugin.installOperators | default(true)
     - r_plugin_mirror is defined
@@ -279,20 +243,97 @@
     - r_plugin_mirror is defined
     - r_plugin_mirror is success
 
-- name: Apply Quay Enterprise mirrors for plugin
+- name: Prepare Quay Enterprise mirrors for plugin
   ansible.builtin.include_tasks:
     file: "../../operators/quay-operator/quay_disconnected_mirrors.yaml"
     apply:
       environment:
         KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  vars:
+    quay_mirror_skip_apply: true
   when:
     - plugin.installOperators | default(true)
     - r_plugin_mirror_quay is defined
     - r_plugin_mirror_quay is success
 
-- name: Wait for MachineConfigPool to finish updating after Quay Enterprise mirrors
-  ansible.builtin.include_tasks: wait_mcp.yaml
+# --- Apply all mirror manifests at once to trigger a single MCO rollout ---
+# Both oc-mirror runs (LZ and Quay Enterprise) complete without needing IDMS/ITMS
+# on the cluster. Applying all manifests here triggers one MCO rollout instead of two.
+
+- name: Show mirror manifests to apply
+  ansible.builtin.debug:
+    msg:
+      lz_cluster_resources_dir: "{{ lz_cluster_resources_dir | default('n/a') }}"
+      quay_idms_manifest: "{{ quay_idms_apply_manifest | default('n/a') }}"
+      quay_itms_manifest: "{{ quay_itms_apply_manifest | default('n/a') }}"
+  when: plugin.installOperators | default(true)
+
+- name: Apply LZ mirror manifests to cluster
+  ansible.builtin.shell: |
+    {{ workingDir }}/bin/oc apply \
+      -f {{ lz_cluster_resources_dir }}/ \
+      --server-side --force-conflicts
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  when:
+    - plugin.installOperators | default(true)
+    - r_plugin_mirror is defined
+    - r_plugin_mirror is success
+
+- name: Apply Quay IDMS to cluster
+  ansible.builtin.command:
+    argv:
+      - "{{ workingDir }}/bin/oc"
+      - apply
+      - -f
+      - "{{ quay_idms_apply_manifest }}"
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
   when:
     - plugin.installOperators | default(true)
     - r_plugin_mirror_quay is defined
     - r_plugin_mirror_quay is success
+    - quay_idms_apply_manifest is defined
+
+- name: Apply Quay ITMS to cluster
+  ansible.builtin.command:
+    argv:
+      - "{{ workingDir }}/bin/oc"
+      - apply
+      - -f
+      - "{{ quay_itms_apply_manifest }}"
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  when:
+    - plugin.installOperators | default(true)
+    - r_plugin_mirror_quay is defined
+    - r_plugin_mirror_quay is success
+    - quay_itms_apply_manifest is defined
+
+- name: Wait for MachineConfigPool to finish updating
+  ansible.builtin.include_tasks: wait_mcp.yaml
+  when:
+    - plugin.installOperators | default(true)
+    - (r_plugin_mirror is defined and r_plugin_mirror is success) or
+      (r_plugin_mirror_quay is defined and r_plugin_mirror_quay is success)
+
+- name: Wait for updated CatalogSource to be ready
+  kubernetes.core.k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: CatalogSource
+    namespace: openshift-marketplace
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+  register: r_catalog_sources
+  retries: 24
+  delay: 10
+  until: >-
+    r_catalog_sources.resources | default([])
+    | selectattr('status', 'defined')
+    | selectattr('status.connectionState', 'defined')
+    | selectattr('status.connectionState.lastObservedState', 'equalto', 'READY')
+    | list | length >= (r_catalog_sources.resources | length)
+  when:
+    - plugin.installOperators | default(true)
+    - r_plugin_mirror is defined
+    - r_plugin_mirror is success


### PR DESCRIPTION
## Summary

- Defer all IDMS/ITMS applies to after both oc-mirror runs (LZ and Quay Enterprise) complete, then apply once and wait once
- Cuts worst case from two MCO rollouts (~60 min) to one (~30 min)
- Add `quay_mirror_skip_apply` flag to `quay_disconnected_mirrors.yaml` so `mirror_plugin.yaml` can prepare manifests without applying them — existing callers are unaffected

Depends on #617.

Jira: [OSAC-3218](https://redhat.atlassian.net/browse/OSAC-3218)

## Test plan

- [ ] Deploy an addon plugin (e.g. rhbk) in disconnected mode — verify single MCO rollout instead of two
- [ ] Verify `quay_disconnected_finish.yaml` (core flow) still applies IDMS/ITMS as before
- [ ] Verify CatalogSource becomes ready after combined apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to prepare disconnected mirroring manifests without automatically applying them.
  * Consolidated application of Landing Zone and Quay Enterprise mirror manifests into a single workflow.
  * Added clearer guidance for generating and applying IDMS/ITMS manifests.

* **Bug Fixes**
  * Prevented mirror resources from being applied when skip-apply mode is enabled.
  * Improved synchronization by waiting for the MachineConfigPool after mirror configuration is applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->