### PR TITLE
OSAC-272: Enable extractImages for OSAC Helm chart

### DIFF
--- a/plugins/osac/plugin.yaml
+++ b/plugins/osac/plugin.yaml
@@ -17,17 +17,19 @@ helm:
     createNamespace: true
     timeout: "45m"
     wait: false    # AAP takes 30+ minutes; deploy.yaml handles post-install waits
+    extractImages: true
+    extractPlaceholders:
+      __r_ingress_config:
+        resources:
+          - spec:
+              domain: "apps.placeholder.example.com"
+      _osac_keycloak_hostname: "keycloak.placeholder.example.com"
 
+# Images not referenced in the Helm chart templates (deployed by AAP operator, etc.)
 additionalImages:
-  - ghcr.io/osac-project/osac-operator:latest
-  - ghcr.io/osac-project/fulfillment-service:latest
-  - ghcr.io/osac-project/osac-aap:latest
-  - docker.io/envoyproxy/envoy:v1.33.0
-  - quay.io/openshift/origin-cli:4.20.0
   - quay.io/keycloak/keycloak:26.3
   - registry.redhat.io/rhel10/postgresql-18:latest
   - quay.io/prometheus/prometheus:v3.8.1
-  - docker.io/bitnami/kubectl:latest
 
 registries:
   - location: "ghcr.io/osac-project"


### PR DESCRIPTION
## Summary

- Enable `extractImages: true` on the OSAC OCI Helm chart so container images are auto-discovered via `helm template` instead of manually maintained in `additionalImages`
- Reduces the manual `additionalImages` list from 9 to 3 (only images not referenced in chart templates — deployed by AAP operator, etc.)
- Adds `extractPlaceholders` for runtime variables (`__r_ingress_config`, `_osac_keycloak_hostname`) that the values template requires but are only available at deploy time

## Dependencies

Depends on #616 (OCI chart extraction support)

## Test plan

- [ ] Verify `make -f Makefile.ci validate-plugins` passes
- [ ] Deploy OSAC plugin in disconnected mode — confirm all chart images are discovered and mirrored

Jira: [OSAC-272](https://redhat.atlassian.net/browse/OSAC-272)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled automatic extraction of container images from Helm charts.
  - Added placeholder extraction for ingress domains and Keycloak hostnames.
  - Added support for Keycloak 26.3, RHEL 10 PostgreSQL 18, and Prometheus 3.8.1 images.

- **Changes**
  - Updated the OSAC plugin’s configured image list to include only the currently supported images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->