### PR TITLE
OSAC-1153: Add disconnected deployment support for trust-manager plugin

### DIFF
--- a/plugins/trust-manager/plugin.yaml
+++ b/plugins/trust-manager/plugin.yaml
@@ -5,8 +5,12 @@ order: 100
 
 helm:
   - release: trust-manager
-    repo: https://charts.jetstack.io
-    chart: trust-manager
+    chart: "oci://quay.io/jetstack/charts/trust-manager"
     version: v0.20.0
     namespace: cert-manager
     createNamespace: false
+    extractImages: true
+
+registries:
+  - location: "quay.io/jetstack"
+    mirror: "jetstack"


### PR DESCRIPTION
## Summary
- Switch trust-manager Helm chart from legacy repository (`https://charts.jetstack.io`) to OCI reference (`oci://quay.io/jetstack/charts/trust-manager`)
- Enable `extractImages: true` to auto-discover container images for disconnected mirroring — images always match the pinned chart version
- Add `quay.io/jetstack` registry mirror entry for disconnected environments

Depends on #616 (OCI chart support for `extractImages`).

## Test plan
- [x] Verify CI schema validation passes
- [x] Deploy trust-manager in disconnected mode — confirm images are extracted and mirrored
- [x] Verify trust-manager pods start with mirrored images

Jira: [OSAC-1153](https://redhat.atlassian.net/browse/OSAC-1153)

🤖 Generated with [Claude Code](https://claude.com/claude-code)