### PR TITLE
OSAC-3005: Add timeout and retries to control binary downloads

### DIFF
--- a/defaults/download.yaml
+++ b/defaults/download.yaml
@@ -1,6 +1,6 @@
 ---
 # Retry settings for binary download (get_url) tasks.
 # These are internal defaults and are not meant to be overridden by the user.
-download_timeout: 600
+download_timeout: 120
 download_retries: 3
 download_delay: 10

--- a/defaults/download.yaml
+++ b/defaults/download.yaml
@@ -1,0 +1,6 @@
+---
+# Retry settings for binary download (get_url) tasks.
+# These are internal defaults and are not meant to be overridden by the user.
+download_timeout: 600
+download_retries: 3
+download_delay: 10

--- a/playbooks/common/load-vars.yaml
+++ b/playbooks/common/load-vars.yaml
@@ -59,6 +59,7 @@
   ansible.builtin.include_vars: "../../defaults/{{ config_file }}"
   loop:
     - control_binaries.yaml
+    - download.yaml
     - operators.yaml
     - platforms.yaml
     - catalogs.yaml

--- a/playbooks/tasks/download_control_binaries.yaml
+++ b/playbooks/tasks/download_control_binaries.yaml
@@ -24,6 +24,11 @@
     url: "{{ control_binaries.openshift_client.url }}"
     dest: "{{ workingDir }}/dist/openshift-client-linux.tar.gz"
     checksum: "{{ control_binaries.openshift_client.checksum }}"
+    timeout: "{{ download_timeout }}"
+  register: _download_oc
+  retries: "{{ download_retries }}"
+  delay: "{{ download_delay }}"
+  until: _download_oc is success
 
 - name: Unarchive openshift-client-linux.tar.gz to {{ workingDir }}/bin/
   ansible.builtin.unarchive:
@@ -37,12 +42,22 @@
     dest: "{{ workingDir }}/bin/helm"
     checksum: "{{ control_binaries.helm.checksum }}"
     mode: "0750"
+    timeout: "{{ download_timeout }}"
+  register: _download_helm
+  retries: "{{ download_retries }}"
+  delay: "{{ download_delay }}"
+  until: _download_helm is success
 
 - name: Download latest mirror registry available
   ansible.builtin.get_url:
     url: "{{ control_binaries.mirror_registry.url }}"
     dest: "{{ workingDir }}/dist/mirror-registry-amd64.tar.gz"
     checksum: "{{ control_binaries.mirror_registry.checksum }}"
+    timeout: "{{ download_timeout }}"
+  register: _download_mirror_registry
+  retries: "{{ download_retries }}"
+  delay: "{{ download_delay }}"
+  until: _download_mirror_registry is success
 
 - name: Unarchive mirror-registry-amd64.tar.gz to {{ workingDir }}/bin/
   ansible.builtin.unarchive:
@@ -55,6 +70,11 @@
     url: "{{ control_binaries.oc_mirror.url }}"
     dest: "{{ workingDir }}/dist/oc-mirror.tar.gz"
     checksum: "{{ control_binaries.oc_mirror.checksum }}"
+    timeout: "{{ download_timeout }}"
+  register: _download_oc_mirror
+  retries: "{{ download_retries }}"
+  delay: "{{ download_delay }}"
+  until: _download_oc_mirror is success
 
 - name: Unarchive oc-mirror.tar.gz to {{ workingDir }}/bin/
   ansible.builtin.unarchive:

--- a/playbooks/validation/tasks/defaults_schema_validation.yaml
+++ b/playbooks/validation/tasks/defaults_schema_validation.yaml
@@ -56,6 +56,12 @@
     criteria: "{{ lookup('ansible.builtin.file', '../../schemas/k8s.yaml') | from_yaml | combine(schema_definitions, recursive=True) | to_json }}"
     engine: ansible.utils.jsonschema
 
+- name: validate defaults/download.yaml schema
+  ansible.utils.validate:
+    data: "{{ lookup('ansible.builtin.file', '../../defaults/download.yaml') | from_yaml | to_json }}"
+    criteria: "{{ lookup('ansible.builtin.file', '../../schemas/download.yaml') | from_yaml | combine(schema_definitions, recursive=True) | to_json }}"
+    engine: ansible.utils.jsonschema
+
 - name: Find all plugin.yaml files
   ansible.builtin.find:
     paths: "{{ playbook_dir }}/../../plugins"

--- a/schemas/download.yaml
+++ b/schemas/download.yaml
@@ -1,0 +1,24 @@
+---
+"$schema": "http://json-schema.org/draft-07/schema"
+version: "1.0"
+type: object
+
+additionalProperties: false
+properties:
+  download_timeout:
+    type: integer
+    minimum: 1
+    description: Timeout in seconds for binary download (get_url) tasks
+  download_retries:
+    type: integer
+    minimum: 1
+    description: Number of retries for binary download tasks
+  download_delay:
+    type: integer
+    minimum: 1
+    description: Delay in seconds between binary download retries
+
+required:
+  - download_timeout
+  - download_retries
+  - download_delay


### PR DESCRIPTION
get_url tasks in download_control_binaries.yaml used the default 10s timeout, causing mirror-registry (~696 MB) and other large binary downloads to fail on connected deployments.

Add download_timeout (600s), download_retries (3), and download_delay (10s) variables in defaults/download.yaml following the k8s.yaml pattern, with matching schema and validation.

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved reliability of critical binary downloads by adding configurable timeout, retry, and delay behavior with automatic “retry until success” handling.

* **Chores**
  * Introduced internal default download settings and added schema validation to ensure download configuration is consistent and correctly structured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->