### PR TITLE
OSAC-1602: add configurable CaaS inventory backend

### DIFF
--- a/config/plugins/osac.example.yaml
+++ b/config/plugins/osac.example.yaml
@@ -77,3 +77,12 @@
 #   -----BEGIN OPENSSH PRIVATE KEY-----
 #   ...
 #   -----END OPENSSH PRIVATE KEY-----
+# Optional: enable BCM (NVIDIA Base Command Manager) as an additional
+# bare metal inventory source. discovery_hosts in cloud_infra.yaml are
+# always used when the CaaS profile is active.
+# osacBcmEnabled: true
+# osacBcmApiUrl: "https://bcm-head:8081"
+# osacBcmClientCert: "<PEM-encoded client certificate>"
+# osacBcmClientKey: "<PEM-encoded client private key>"
+# osacBcmValidateCerts: true
+# osacBcmDisableBmcCertVerification: false

--- a/plugins/osac/defaults.yaml
+++ b/plugins/osac/defaults.yaml
@@ -111,3 +111,19 @@ osac_db_database: service
 # AAP bootstrap
 osac_aap_project_git_uri: "https://github.com/osac-project/osac-aap"
 osac_aap_project_git_branch: main
+
+# Container images
+osac_images:
+  osac_operator: "ghcr.io/osac-project/osac-operator:v0.0.12"
+  fulfillment_service: "ghcr.io/osac-project/fulfillment-service:v0.0.61"
+  envoy: "docker.io/envoyproxy/envoy:v1.33.0"
+  aap_bootstrap: "ghcr.io/osac-project/osac-aap:v0.0.13"
+  cli: "quay.io/openshift/origin-cli:4.20.0"
+
+# BCM inventory (NVIDIA Base Command Manager)
+osacBcmEnabled: false
+osacBcmApiUrl: ""
+osacBcmClientCert: ""
+osacBcmClientKey: ""
+osacBcmValidateCerts: true
+osacBcmDisableBmcCertVerification: false

--- a/plugins/osac/schemas/config.yaml
+++ b/plugins/osac/schemas/config.yaml
@@ -132,6 +132,35 @@ properties:
   osacNetrisSshBastionKey:
     type: string
     description: "SSH private key for bastion host access"
+  osacBcmEnabled:
+    type: boolean
+    title: "Enable BCM Inventory"
+    description: "Enable NVIDIA Base Command Manager as an additional bare metal inventory source"
+  osacBcmApiUrl:
+    type: string
+    minLength: 1
+    title: "BCM API URL"
+    description: "BCM head node API endpoint (e.g. https://bcm-head:8081)"
+  osacBcmClientCert:
+    type: string
+    minLength: 1
+    title: "BCM Client Certificate"
+    format: textarea
+    description: "PEM-encoded client certificate for BCM mTLS authentication"
+  osacBcmClientKey:
+    type: string
+    minLength: 1
+    title: "BCM Client Key"
+    format: textarea
+    description: "PEM-encoded client private key for BCM mTLS authentication"
+  osacBcmValidateCerts:
+    type: boolean
+    title: "BCM Validate Certificates"
+    description: "Verify BCM server TLS certificates"
+  osacBcmDisableBmcCertVerification:
+    type: boolean
+    title: "BCM Disable BMC Cert Verification"
+    description: "Skip BMC TLS certificate verification during BCM system discovery"
 required:
   - osacAapLicenseFile
 dependencies:
@@ -139,17 +168,29 @@ dependencies:
     - osacNetrisAwsSecretAccessKey
   osacNetrisAwsSecretAccessKey:
     - osacNetrisAwsAccessKeyId
-if:
-  required:
-    - osacNetrisEnabled
-  properties:
-    osacNetrisEnabled:
-      const: true
-then:
-  required:
-    - osacNetrisControllerUrl
-    - osacNetrisUsername
-    - osacNetrisPassword
-    - osacNetrisSiteId
-    - osacNetrisTenantId
-    - osacNetrisTenantName
+allOf:
+  - if:
+      required:
+        - osacNetrisEnabled
+      properties:
+        osacNetrisEnabled:
+          const: true
+    then:
+      required:
+        - osacNetrisControllerUrl
+        - osacNetrisUsername
+        - osacNetrisPassword
+        - osacNetrisSiteId
+        - osacNetrisTenantId
+        - osacNetrisTenantName
+  - if:
+      required:
+        - osacBcmEnabled
+      properties:
+        osacBcmEnabled:
+          const: true
+    then:
+      required:
+        - osacBcmApiUrl
+        - osacBcmClientCert
+        - osacBcmClientKey

--- a/plugins/osac/schemas/defaults.yaml
+++ b/plugins/osac/schemas/defaults.yaml
@@ -124,6 +124,44 @@ properties:
   osac_aap_project_git_branch:
     type: string
     description: Git branch for AAP config-as-code project.
+  osac_images:
+    type: object
+    additionalProperties: false
+    properties:
+      osac_operator:
+        type: string
+        description: Default osac-operator container image.
+      fulfillment_service:
+        type: string
+        description: Default fulfillment-service container image.
+      envoy:
+        type: string
+        description: Default envoy sidecar container image.
+      aap_bootstrap:
+        type: string
+        description: Default AAP bootstrap container image.
+      cli:
+        type: string
+        description: Default OpenShift CLI container image.
+    description: Default container image references.
+  osacBcmEnabled:
+    type: boolean
+    description: Enable NVIDIA Base Command Manager as an additional bare metal inventory source.
+  osacBcmApiUrl:
+    type: string
+    description: BCM head node API endpoint.
+  osacBcmClientCert:
+    type: string
+    description: PEM-encoded client certificate for BCM mTLS authentication.
+  osacBcmClientKey:
+    type: string
+    description: PEM-encoded client private key for BCM mTLS authentication.
+  osacBcmValidateCerts:
+    type: boolean
+    description: Verify BCM server TLS certificates.
+  osacBcmDisableBmcCertVerification:
+    type: boolean
+    description: Skip BMC TLS certificate verification during BCM system discovery.
 required:
   - osacProfilesList
   - osac_aap_name

--- a/plugins/osac/templates/values.yaml.j2
+++ b/plugins/osac/templates/values.yaml.j2
@@ -114,15 +114,45 @@ aap:
     image: "{{ osac_images.aap_bootstrap }}"
 {% endif %}
 
-configAsCode:
-  projectGitUri: "{{ osac_aap_project_git_uri }}"
-  projectGitBranch: "{{ osac_aap_project_git_branch }}"
+    configAsCode:
+      projectGitUri: "{{ osac_aap_project_git_uri }}"
+      projectGitBranch: "{{ osac_aap_project_git_branch }}"
 {% if osac_images is defined and osac_images.aap_bootstrap is defined %}
-  eeImage: "{{ osac_images.aap_bootstrap }}"
+      eeImage: "{{ osac_images.aap_bootstrap }}"
 {% endif %}
-
-bmf:
-  enabled: false
+{% set _has_discovery = discovery_hosts | default([]) | length > 0 and 'caas' in (osacProfilesList | default([])) %}
+{% set _has_bcm = osacBcmEnabled | default(false) %}
+{% if _has_discovery %}
+      importAgentsEnabled: true
+{% endif %}
+{% if _has_bcm %}
+      importBcmAgentsEnabled: true
+{% endif %}
+{% if _has_discovery %}
+    importAgents:
+      servers:
+{% for host in discovery_hosts %}
+        - name: {{ host.name | to_json }}
+          bmc_url: {{ ("redfish-virtualmedia+https://" ~ host.redfish ~ ":443/redfish/v1/Systems/1") | to_json }}
+          bmc_username: {{ host.redfishUser | to_json }}
+          bmc_password: {{ host.redfishPassword | to_json }}
+          boot_mac: {{ host.macAddress | to_json }}
+          netris_server_name: {{ host.name | to_json }}
+          resource_class: {{ host.resource_class | default('default') | to_json }}
+{% endfor %}
+{% endif %}
+{% if _has_bcm %}
+    importBcmAgents:
+      url: "{{ osacBcmApiUrl }}"
+      validateCerts: {{ osacBcmValidateCerts | default(true) | lower }}
+      disableBmcCertVerification: {{ osacBcmDisableBmcCertVerification | default(false) | lower }}
+      cert: |
+{{ osacBcmClientCert | indent(8, true) }}
+      key: |
+{{ osacBcmClientKey | indent(8, true) }}
+{% endif %}
+    bmf:
+      enabled: false
 
 dbMigrate:
   enabled: false


### PR DESCRIPTION
Add BCM (NVIDIA Base Command Manager) as an optional bare metal inventory source alongside the existing discovery_hosts.

- Schema: osacBcmEnabled toggle, API URL, mTLS client cert/key, cert validation settings. Uses title/format/enumLabels for schema-driven UI rendering.
- Defaults: BCM disabled, safe defaults for all fields.
- Template: derives ConfigMap import-agents from discovery_hosts when CaaS profile is active. Enables BCM import when osacBcmEnabled is set. Both can run simultaneously.

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional NVIDIA Base Command Manager inventory integration with configurable API access, client certificates, and certificate validation.
  - Added default container image settings for core platform services and command-line tooling.
  - Enhanced automated bootstrap configuration with project source details and optional execution environment images.
  - Added support for importing discovery and BCM agents and providing host hardware and network metadata.
  - Added configuration validation to ensure required BCM connection details are supplied when integration is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->