### PR TITLE
bump quay-operator to 3.15.6

### DIFF
--- a/defaults/operators.yaml
+++ b/defaults/operators.yaml
@@ -2,7 +2,7 @@
 operators:
 
   - name: quay-operator
-    version: 3.15.5
+    version: 3.15.6
     channel: stable-3.15
     init_version: 3.15.0
     namespace: quay-enterprise


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the quay-operator version to 3.15.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->