### PR TITLE
bump default ocp version to 4.20.29

### DIFF
--- a/defaults/control_binaries.yaml
+++ b/defaults/control_binaries.yaml
@@ -1,8 +1,8 @@
 ---
 control_binaries:
   openshift_client:
-    url: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.20.21/openshift-client-linux.tar.gz"
-    checksum: "sha256:bc49d2bcc26812668ceed77e703aca247a48b81440da022bd14870600a33e6e8"
+    url: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.20.29/openshift-client-linux.tar.gz"
+    checksum: "sha256:a8cb9187c000b4744cf87546045dbab8bf35eb4f4950b5238f7a94f2f4b63460"
   helm:
     url: "https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/helm/3.17.1/helm-linux-amd64"
     checksum: "sha256:ef6c04f6a748d0f1d624a94a56dc0db83f8d70a65e3dbb19e94107126efcc5fd"

--- a/defaults/platforms.yaml
+++ b/defaults/platforms.yaml
@@ -2,4 +2,5 @@
 openshift_versions:
 - version: 4.20.8
 - version: 4.20.21
+- version: 4.20.29
   default: true

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -166,7 +166,7 @@ def test_mgmt_cluster_version_use_defaults(mocker: MockerFixture) -> None:
         cli, ["mgmt-cluster-version", "--use-defaults", "--dry-run"], env=_KC
     )
     assert result.exit_code == 0, result.output
-    mock_reconcile.assert_called_once_with("4.20.21", dry_run, 180, 60)
+    mock_reconcile.assert_called_once_with("4.20.29", dry_run, 180, 60)
 
 
 def test_mgmt_cluster_version_use_defaults_mutual_exclusive_version() -> None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated the OpenShift client binary to version 4.20.29.
  * Added OpenShift 4.20.29 to the supported platform versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->