### PR TITLE
Block CI slash commands on fork PRs

### DIFF
--- a/.github/workflows/slash-command.yml
+++ b/.github/workflows/slash-command.yml
@@ -5,7 +5,6 @@ on:
     types: [created]
 
 permissions:
-  contents: write
   pull-requests: write
   actions: write
   checks: write
@@ -48,20 +47,15 @@ jobs:
         id: pr
         run: |
           PR_JSON=$(gh pr view "${PR_NUMBER}" -R "${REPO}" \
-            --json headRefName,headRefOid,headRepositoryOwner)
+            --json headRefName,headRefOid,isCrossRepository)
 
           HEAD_BRANCH=$(echo "${PR_JSON}" | jq -r '.headRefName')
           HEAD_SHA=$(echo "${PR_JSON}" | jq -r '.headRefOid')
-          HEAD_REPO_OWNER=$(echo "${PR_JSON}" | jq -r '.headRepositoryOwner.login')
+          IS_CROSS_REPO=$(echo "${PR_JSON}" | jq -r '.isCrossRepository')
 
           echo "head_branch=${HEAD_BRANCH}" >> "$GITHUB_OUTPUT"
           echo "head_sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
-
-          if [ "${HEAD_REPO_OWNER}" != "${{ github.repository_owner }}" ]; then
-            echo "is_fork=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "is_fork=false" >> "$GITHUB_OUTPUT"
-          fi
+          echo "is_fork=${IS_CROSS_REPO}" >> "$GITHUB_OUTPUT"
 
       - name: Block commands on fork PRs
         if: steps.pr.outputs.is_fork == 'true'

--- a/.github/workflows/slash-command.yml
+++ b/.github/workflows/slash-command.yml
@@ -63,6 +63,15 @@ jobs:
             echo "is_fork=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Block commands on fork PRs
+        if: steps.pr.outputs.is_fork == 'true'
+        run: |
+          gh pr comment "${PR_NUMBER}" -R "${REPO}" \
+            --body "CI commands (\`/test\`, \`/retest\`, \`/cancel\`) are not supported on pull requests from forks, since they would run fork-controlled code with access to CI secrets and infrastructure. Ask a maintainer to open this PR from a branch within this repository instead."
+          gh api "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" \
+            -f content='confused'
+          exit 1
+
       - name: React with eyes
         run: |
           gh api "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" \
@@ -115,32 +124,6 @@ jobs:
           gh api "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" \
             -f content='rocket'
 
-      - name: Create temp branch for fork PRs
-        id: ref
-        if: >-
-          steps.cmd.outputs.command != '?' &&
-          steps.cmd.outputs.command != 'help' &&
-          !startsWith(steps.cmd.outputs.command, 'cancel:')
-        env:
-          IS_FORK: ${{ steps.pr.outputs.is_fork }}
-          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
-        run: |
-          if [ "${IS_FORK}" = "true" ]; then
-            TEMP_BRANCH="test/pr-${PR_NUMBER}"
-            if gh api "repos/${REPO}/git/refs/heads/${TEMP_BRANCH}" \
-                 -X PATCH -f sha="${HEAD_SHA}" 2>/dev/null; then
-              echo "Updated existing temp branch ${TEMP_BRANCH}"
-            else
-              gh api "repos/${REPO}/git/refs" \
-                -f ref="refs/heads/${TEMP_BRANCH}" \
-                -f sha="${HEAD_SHA}"
-              echo "Created temp branch ${TEMP_BRANCH}"
-            fi
-            echo "dispatch_ref=${TEMP_BRANCH}" >> "$GITHUB_OUTPUT"
-          else
-            echo "dispatch_ref=" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Execute command
         if: >-
           steps.cmd.outputs.command != '?' &&
@@ -151,7 +134,6 @@ jobs:
           COMMAND: ${{ steps.cmd.outputs.command }}
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
           HEAD_BRANCH: ${{ steps.pr.outputs.head_branch }}
-          DISPATCH_REF: ${{ steps.ref.outputs.dispatch_ref }}
         run: |
           # Re-run a workflow's latest PR run for this commit.
           # The re-run stays associated with the PR in the Checks tab.
@@ -178,9 +160,8 @@ jobs:
           dispatch_workflow() {
             local workflow="$1"
             shift
-            local ref="${DISPATCH_REF:-${HEAD_BRANCH}}"
-            echo "Dispatching ${workflow} on ref ${ref}"
-            gh workflow run "${workflow}" --ref "${ref}" "$@" -R "${REPO}"
+            echo "Dispatching ${workflow} on ref ${HEAD_BRANCH}"
+            gh workflow run "${workflow}" --ref "${HEAD_BRANCH}" "$@" -R "${REPO}"
           }
 
           SUCCEEDED=""


### PR DESCRIPTION
## Summary
- `/test`, `/retest`, and `/cancel` previously created/updated a `test/pr-<N>` branch pointing at a fork PR's exact head SHA, then dispatched `e2e-deployment.yml` against that ref.
- `e2e-deployment.yml` checks out that ref and runs `Makefile.ci`/`scripts/**` from it directly on `self-hosted, enclave-large` runners with `PULL_SECRET`, `LZ_RHSM_ORG`, `LZ_RHSM_ACTIVATION_KEY`, and `SLACK_WEBHOOK_URLS` in scope.
- Net effect: a maintainer with write access running `/test e2e-connected` on a malicious fork PR would execute fork-controlled code with full CI secret access and self-hosted infra access, with no code review gate.
- Fix: reject all CI slash commands on fork PRs outright (comment explaining why + exit early) instead of trying to sandbox untrusted code. Removed the now-unused temp-branch/dispatch-ref plumbing.

## Test plan
- [ ] Open a PR from a fork and comment `/test validation` — verify the bot replies that fork PRs aren't supported and no workflow is triggered/dispatched.
- [ ] Comment `/test validation` on a same-repo branch PR — verify existing behavior (rerun of pr-validation.yml) still works.
- [ ] Comment `/test e2e-connected` on a same-repo branch PR — verify `e2e-deployment.yml` is dispatched on the PR's head branch as before.
- [ ] Comment `/retest` and `/cancel` on a same-repo branch PR — verify unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Blocked slash commands from running on forked pull requests.
  * Added a clear notification and failure response when a command is blocked.
  * Ensured workflow dispatches consistently use the pull request’s source branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->