### PR TITLE
OSAC-4486: Add enclave-cert-gen and enable real-CA e2e on demand

### DIFF
--- a/.github/workflows/Dockerfile.ci
+++ b/.github/workflows/Dockerfile.ci
@@ -47,7 +47,7 @@ COPY pyproject.toml uv.lock .python-version README.md /workspace/
 # of the deps resolution layer leading to faster builds.
 RUN uv sync --all-groups --no-install-project
 COPY src/ /workspace/src/
-RUN uv sync --no-editable
+RUN uv sync --all-groups --no-editable
 
 # Put venv on PATH so all commands are available
 ENV PATH="/workspace/.venv/bin:$PATH"

--- a/.github/workflows/e2e-deployment.yml
+++ b/.github/workflows/e2e-deployment.yml
@@ -72,6 +72,19 @@ on:
         required: false
         type: string
         default: ''
+      cert-type:
+        description: 'TLS certificate type for API/ingress/ironic (self-signed = local CA, auto = day-of-week rotation)'
+        required: false
+        type: choice
+        default: self-signed
+        options:
+          - self-signed
+          - auto
+          - le-rsa
+          - le-ecdsa-long
+          - le-ecdsa-short
+          - zerossl-rsa
+          - zerossl-ecdsa
   workflow_call:
     inputs:
       run-connected:
@@ -99,6 +112,9 @@ on:
         type: string
         default: 'E2E Deployment'
       osac-chart-version:
+        type: string
+        default: ''
+      cert-type:
         type: string
         default: ''
   pull_request:
@@ -252,7 +268,6 @@ jobs:
       BASE_WORKING_DIR: ${{ vars.BASE_WORKING_DIR }}
       PULL_SECRET: ${{ secrets.PULL_SECRET }}
       ENCLAVE_DEPLOYMENT_MODE: connected
-      ENCLAVE_IRONIC_HTTPS: 'true'
       CLEANUP_AFTER: 'true'
       STORAGE_PLUGIN: ${{ matrix.storage-plugin }}
       ENABLED_PLUGINS: ${{ inputs.enabled-plugins || matrix.storage-plugin }}
@@ -711,6 +726,7 @@ jobs:
       LZ_OS_VARIANT: ${{ vars.LZ_OS_VARIANT }}
       AAP_LICENSE_FILE: ${{ inputs.aap-license-file }}
       OSAC_CHART_VERSION: ${{ inputs.osac-chart-version }}
+      ENCLAVE_IRONIC_HTTPS: 'true'
 
     steps:
       - name: Checkout code
@@ -727,6 +743,32 @@ jobs:
         run: |
           make -f Makefile.ci setup-working-dir
           echo "WORKING_DIR=$(cat /tmp/working_dir)" >> $GITHUB_ENV
+
+      - name: Determine certificate type
+        env:
+          INPUT_CERT_TYPE: ${{ inputs.cert-type }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          CERT_TYPE="${INPUT_CERT_TYPE}"
+          if [ "${CERT_TYPE}" = "self-signed" ]; then
+              CERT_TYPE=""
+          fi
+          if [ "${EVENT_NAME}" = "schedule" ] && [ -z "${CERT_TYPE}" ]; then
+              CERT_TYPE="auto"
+          fi
+          if [ "${CERT_TYPE}" = "auto" ]; then
+              TYPES=(le-rsa le-ecdsa-long le-ecdsa-short zerossl-rsa zerossl-ecdsa)
+              CERT_TYPE="${TYPES[$(( ($(date +%u) - 1) % 5 ))]}"
+          fi
+          if [ -n "${CERT_TYPE}" ]; then
+              case "${CERT_TYPE}" in
+                le-rsa|le-ecdsa-long|le-ecdsa-short|zerossl-rsa|zerossl-ecdsa) ;;
+                *) echo "Invalid cert type: ${CERT_TYPE}" >&2; exit 1 ;;
+              esac
+              echo "ENCLAVE_CERT_TYPE=${CERT_TYPE}" >> "$GITHUB_ENV"
+              echo "ENCLAVE_BASE_DOMAIN=nodns.in" >> "$GITHUB_ENV"
+              echo "Certificate type for this run: ${CERT_TYPE}"
+          fi
 
       - name: Workflow information
         run: |
@@ -777,6 +819,11 @@ jobs:
           echo "Landing Zone provisioned" >> $GITHUB_STEP_SUMMARY
 
       - name: Install Enclave Lab
+        env:
+          HETZNER_API_TOKEN: ${{ secrets.HETZNER_API_TOKEN }}
+          ACME_EMAIL: ${{ vars.ACME_EMAIL }}
+          ZEROSSL_EAB_KID: ${{ secrets.ZEROSSL_EAB_KID }}
+          ZEROSSL_EAB_HMAC_KEY: ${{ secrets.ZEROSSL_EAB_HMAC_KEY }}
         run: |
           echo "## Installing Enclave Lab" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -787,6 +834,11 @@ jobs:
       - name: Generate Ironic ISO server TLS certificate
         id: generate_ironic_cert
         if: env.ENCLAVE_IRONIC_HTTPS == 'true'
+        env:
+          HETZNER_API_TOKEN: ${{ secrets.HETZNER_API_TOKEN }}
+          ACME_EMAIL: ${{ vars.ACME_EMAIL }}
+          ZEROSSL_EAB_KID: ${{ secrets.ZEROSSL_EAB_KID }}
+          ZEROSSL_EAB_HMAC_KEY: ${{ secrets.ZEROSSL_EAB_HMAC_KEY }}
         run: make -f Makefile.ci generate-ironic-cert
 
       - name: Setup Ceph on Landing Zone

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ make -f Makefile.ci validate-makefile     # Validate Makefile syntax
 make -f Makefile.ci environment                     # Create test infrastructure
 make -f Makefile.ci provision-landing-zone          # Provision Landing Zone VM
 make -f Makefile.ci install-enclave                 # Install Enclave Lab
+make -f Makefile.ci generate-ironic-cert            # Generate Ironic TLS cert (real CA when ENCLAVE_CERT_TYPE is set)
 make -f Makefile.ci clean                           # Clean up all infrastructure
 
 # Verification

--- a/operators/quay-operator/clair_validations.yaml
+++ b/operators/quay-operator/clair_validations.yaml
@@ -11,24 +11,12 @@
   ansible.builtin.set_fact:
     clair_pod_name: "{{ clair_pods.resources[0].metadata.name }}"
 
-- name: Check for repository-to-cpe.json in the pod
-  kubernetes.core.k8s_exec:
-    namespace: quay-enterprise
-    pod: "{{ clair_pod_name }}"
-    command: ls /data/repository-to-cpe.json
-  register: cpe_file_check
-
-- name: Check for container-name-repos-map.json in the pod
-  kubernetes.core.k8s_exec:
-    namespace: quay-enterprise
-    pod: "{{ clair_pod_name }}"
-    command: ls /data/container-name-repos-map.json
-  register: repo_map_check
-
-- name: Fail if files are missing
-  fail:
-    msg: "Required CPE mapping files are missing from /data in pod {{ clair_pod_name }}"
-  when: cpe_file_check.rc != 0 or repo_map_check.rc != 0
+- name: Check for CPE mapping files in the Clair pod
+  ansible.builtin.shell: >-
+    {{ workingDir }}/bin/oc exec -n quay-enterprise {{ clair_pod_name }} --
+    sh -c 'test -f /data/repository-to-cpe.json && test -f /data/container-name-repos-map.json'
+  environment:
+    KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
 
 - name: Get Secrets owned by the Quay registry
   kubernetes.core.k8s_info:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
 
 [project.scripts]
 enclave = "enclave.cli:cli"
+enclave-cert-gen = "enclave.cert_gen.main:cli"
 
 [dependency-groups]
 dev = [
@@ -37,6 +38,10 @@ dev = [
     "pytest-mock ==3.15.1",
     "ruff ==0.16.4",
     "yamllint ==1.38.0",
+]
+cert-gen = [
+    "certbot ==5.7.0",
+    "certbot-dns-hetzner ==4.0.0",
 ]
 
 [build-system]

--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,7 @@
     {
       "customType": "regex",
       "description": "Update uv version in setup_ansible.sh",
-      "managerFilePatterns": ["setup_ansible.sh"],
+      "managerFilePatterns": ["setup_ansible.sh", "scripts/deployment/install_enclave.sh"],
       "matchStrings": ["UV_VERSION=\"(?<currentValue>[^\"]+)\""],
       "depNameTemplate": "astral-sh/uv",
       "datasourceTemplate": "github-releases",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -109,6 +109,7 @@ Scripts for deploying OpenShift clusters on the provisioned infrastructure.
 | `install_enclave.sh` | Install Enclave Lab on Landing Zone VM and generate configuration |
 | `deploy_cluster.sh` | Deploy full OpenShift cluster (connected or disconnected mode) |
 | `deploy_phase.sh` | Deploy specific phase of deployment (for phased workflows) |
+| `generate_ironic_cert.sh` | Generate TLS certificate for the Ironic ISO server; self-signed (local CA) by default, or a real DNS-01 certificate from a public CA when `ENCLAVE_CERT_TYPE` is set |
 
 **Deployment Modes:**
 - **Connected**: Pull images directly from quay.io/registry.redhat.io (~55 min)
@@ -245,6 +246,9 @@ Common environment variables used across scripts:
 | `ENCLAVE_SUBNET_ID` | Allocated subnet ID (for parallel CI) |
 | `ENCLAVE_BMC_NETWORK` | BMC network CIDR (e.g., `100.64.3.0/24`) |
 | `ENCLAVE_CLUSTER_NETWORK` | Cluster network CIDR (e.g., `192.168.3.0/24`) |
+| `ENCLAVE_CERT_TYPE` | TLS certificate type; unset = self-signed, `zerossl-ecdsa` = real cert via DNS-01 |
+| `ENCLAVE_BASE_DOMAIN` | Public DNS domain for SAN generation when `ENCLAVE_CERT_TYPE` is set |
+| `ENCLAVE_IRONIC_HTTPS` | Enable HTTPS on the Ironic ISO server; always `true` in disconnected mode |
 
 ### Error Handling
 

--- a/scripts/deployment/generate_ironic_cert.sh
+++ b/scripts/deployment/generate_ironic_cert.sh
@@ -2,8 +2,14 @@
 # Generate a TLS certificate for the Ironic ISO server, signed by the CA
 # produced by generate_ironic_ca.sh
 #
-# Reads lzBmcIP from config/global.yaml on the Landing Zone to set the
-# certificate SAN. Key and CSR are generated locally on the CI runner and
+# When ENCLAVE_CERT_TYPE is set, requests a real certificate from a public CA
+# via enclave-cert-gen using a DNS-01 challenge (dns-hetzner) and exits early
+# without needing SSH or local CA files. The only SAN issued is the DNS name
+# ironic.<cluster>.<domain>; public CAs cannot issue IP SANs. lzBmcHostname in
+# config/global.yaml must match that DNS name exactly for TLS validation to pass.
+#
+# Otherwise, reads lzBmcIP from config/global.yaml on the Landing Zone to set
+# the certificate SAN. Key and CSR are generated locally on the CI runner and
 # the CSR is signed with the CA key present in the ironic-ca working directory.
 #
 # Exports ENCLAVE_IRONIC_CERT and ENCLAVE_IRONIC_KEY to GITHUB_ENV for
@@ -28,6 +34,41 @@ source "${ENCLAVE_DIR}/scripts/lib/ssh.sh"
 require_env_var "DEV_SCRIPTS_PATH"
 require_env_var "WORKING_DIR"
 
+# Determine cluster name before the real-CA early-exit path below.
+ENCLAVE_CLUSTER_NAME="${ENCLAVE_CLUSTER_NAME:-enclave-test}"
+
+# Real-CA path (DNS-01 via dns-hetzner): exits early without needing SSH or the
+# local self-signed CA files. The only SAN requested is the DNS name
+# ironic.<cluster>.<domain>; public CAs cannot issue IP SANs. lzBmcHostname in
+# config/global.yaml must match that DNS name exactly.
+if [ -n "${ENCLAVE_CERT_TYPE:-}" ]; then
+    require_env_var "ENCLAVE_BASE_DOMAIN"
+    info "Requesting real ironic TLS certificate (${ENCLAVE_CERT_TYPE}) via enclave-cert-gen..."
+    IRONIC_YAML=$(uv run --group cert-gen enclave-cert-gen ironic \
+        --san "ironic.${ENCLAVE_CLUSTER_NAME}.${ENCLAVE_BASE_DOMAIN}" \
+        --type "${ENCLAVE_CERT_TYPE}")
+    if [ -n "${GITHUB_ENV:-}" ]; then
+        # Parse into variables first; a failure here aborts before any write to
+        # GITHUB_ENV, preventing a truncated heredoc delimiter in that file.
+        IRONIC_CERT=$(echo "${IRONIC_YAML}" | uv run python -c \
+            "import sys,yaml; d=yaml.safe_load(sys.stdin); print(d['ironicHTTPSCertificate'].strip())")
+        IRONIC_KEY=$(echo "${IRONIC_YAML}" | uv run python -c \
+            "import sys,yaml; d=yaml.safe_load(sys.stdin); print(d['ironicHTTPSKey'].strip())")
+        {
+            echo "ENCLAVE_IRONIC_CERT<<EOF"
+            echo "${IRONIC_CERT}"
+            echo "EOF"
+            echo "ENCLAVE_IRONIC_KEY<<EOF"
+            echo "${IRONIC_KEY}"
+            echo "EOF"
+        } >> "$GITHUB_ENV"
+        success "Ironic real CA certificate exported to GITHUB_ENV"
+    else
+        echo "$IRONIC_YAML"
+    fi
+    exit 0
+fi
+
 IRONIC_CA_DIR="${WORKING_DIR}/ironic-ca"
 CA_KEY="${IRONIC_CA_DIR}/ca.key"
 CA_CRT="${IRONIC_CA_DIR}/ca.crt"
@@ -37,9 +78,6 @@ if [ ! -f "$CA_KEY" ] || [ ! -f "$CA_CRT" ]; then
     error "Run generate_ironic_ca.sh before this script"
     exit 1
 fi
-
-# Determine cluster name for SSH access
-ENCLAVE_CLUSTER_NAME="${ENCLAVE_CLUSTER_NAME:-enclave-test}"
 
 # Source dev-scripts configuration
 load_devscripts_config

--- a/scripts/deployment/install_enclave.sh
+++ b/scripts/deployment/install_enclave.sh
@@ -120,6 +120,21 @@ success "Dependencies installed"
 # Step 5: Generate config/global.yaml, config/certificates.yaml and config/cloud_infra.yaml configuration
 info "Step 5: Generating Enclave Lab configuration (config/global.yaml, config/certificates.yaml and config/cloud_infra.yaml)..."
 
+# Ensure uv is available locally (runner side) at the expected version.
+# setup_ansible.sh installs uv on the Landing Zone VM; here we ensure the
+# runner also has uv so generate_enclave_vars.sh and generate_ironic_cert.sh
+# can call 'uv run --group cert-gen enclave-cert-gen' without SSH.
+UV_VERSION="0.12.5"
+current_uv_version=$(uv --version 2>/dev/null | awk '{print $2}' || true)
+if [ "${current_uv_version}" != "${UV_VERSION}" ]; then
+    info "Installing uv ${UV_VERSION} locally..."
+    UV_INSTALLER=$(mktemp)
+    curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" -o "$UV_INSTALLER"
+    UV_UNMANAGED_INSTALL="$HOME/.local/bin" sh "$UV_INSTALLER"
+    rm -f "$UV_INSTALLER"
+    export PATH="$HOME/.local/bin:$PATH"
+fi
+
 # Generate config files using helper script
 "${ENCLAVE_DIR}/scripts/infrastructure/generate_enclave_vars.sh"
 

--- a/scripts/docs/CI_RUNNER_SETUP.md
+++ b/scripts/docs/CI_RUNNER_SETUP.md
@@ -138,6 +138,13 @@ Required secrets:
 - `WORKING_DIR`: `/opt/dev-scripts`
 - `PULL_SECRET`: Your OpenShift pull secret (JSON format)
 
+Additional secrets required for real TLS certificate runs (`cert-type` dispatch input):
+- `HETZNER_API_TOKEN`: Hetzner DNS API token (used for DNS-01 challenge record creation)
+- `ZEROSSL_EAB_KID`: ZeroSSL External Account Binding key ID
+- `ZEROSSL_EAB_HMAC_KEY`: ZeroSSL External Account Binding HMAC key
+- `ACME_EMAIL`: Email address registered with ZeroSSL
+- `ENCLAVE_BASE_DOMAIN`: Public DNS domain used for SAN generation (e.g. `example.com`)
+
 ## Verification
 
 Test that the runner can execute basic commands:

--- a/scripts/docs/CI_WORKFLOWS.md
+++ b/scripts/docs/CI_WORKFLOWS.md
@@ -176,8 +176,18 @@ Both connected and disconnected jobs run automatically on every PR with E2E-rele
    - **run-connected**: Run connected mode (default: true)
    - **run-disconnected**: Run disconnected mode (default: true)
    - **storage-plugin**: lvms or odf (default: lvms)
+   - **cert-type**: TLS certificate type for ingress/API/Ironic certs; empty = self-signed,
+     `zerossl-ecdsa` = real certificate via ZeroSSL DNS-01 challenge (default: empty)
    - **skip-cleanup**: Leave infrastructure running (default: false)
    - **send-slack-notification**: Send Slack notification (default: false)
+
+**Note on real certificates** (`cert-type` set): The workflow calls `make generate-ironic-cert`
+before deployment to obtain a real Ironic TLS certificate via a DNS-01 challenge against
+Hetzner DNS. Ingress and API certificates are requested by `generate_enclave_vars.sh` during
+environment setup. Disconnected mode always enables Ironic HTTPS (`ENCLAVE_IRONIC_HTTPS=true`).
+Real-cert runs require the additional repository secrets listed in the Runner Setup guide:
+`HETZNER_API_TOKEN`, `ZEROSSL_EAB_KID`, `ZEROSSL_EAB_HMAC_KEY`, `ACME_EMAIL`, and
+`ENCLAVE_BASE_DOMAIN`.
 
 **Slash Commands**:
 - `/test e2e-connected` - Dispatch connected mode only

--- a/scripts/infrastructure/generate_enclave_vars.sh
+++ b/scripts/infrastructure/generate_enclave_vars.sh
@@ -27,6 +27,7 @@ ENCLAVE_CLUSTER_NAME="${ENCLAVE_CLUSTER_NAME:-enclave-test}"
 
 # Source dev-scripts configuration
 load_devscripts_config
+require_env_var "BASE_DOMAIN"
 
 # Configuration
 ensure_working_dir
@@ -70,9 +71,6 @@ LZ_BMC_IP=$(echo "$BMC_CIDR" | sed 's|/.*||' | awk -F. '{print $1"."$2"."$3".2"}
 
 # Get master count
 MASTER_COUNT=$(jq -r '.vms.masters | length' "$ENVIRONMENT_JSON")
-
-# Get base domain from config or use default
-BASE_DOMAIN="${CLUSTER_DOMAIN:-${CLUSTER_NAME}.lab}"
 
 # Get first master IP as rendezvous IP (bootstrap) before generating config
 RENDEZVOUS_IP=$(jq -r '.vms.masters[0].networks.cluster.ip' "$ENVIRONMENT_JSON")
@@ -213,42 +211,57 @@ for i in $(seq 0 $((MASTER_COUNT - 1))); do
 EOF
 done
 
-# Generate self-signed SSL certificates for CI
+# Generate SSL certificates for CI
 CLUSTER_FQDN="${CLUSTER_NAME}.${BASE_DOMAIN}"
-CERT_DIR=$(mktemp -d)
-trap 'rm -rf "$CERT_DIR"' EXIT
 
-info "Generating self-signed SSL certificates for ${CLUSTER_FQDN}..."
+if [ -n "${ENCLAVE_CERT_TYPE:-}" ]; then
+    info "Requesting real TLS certificate (${ENCLAVE_CERT_TYPE}) via enclave-cert-gen..."
+    CERTS_VARS_TEMP=$(mktemp "$(dirname "$CERTS_VARS_OUTPUT")/certificates.XXXXXX")
+    trap 'rm -f "$CERTS_VARS_TEMP"' EXIT
+    uv run --group cert-gen enclave-cert-gen ingress-api \
+        --san "api.${CLUSTER_NAME}.${ENCLAVE_BASE_DOMAIN}" \
+        --san "*.apps.${CLUSTER_NAME}.${ENCLAVE_BASE_DOMAIN}" \
+        --type "${ENCLAVE_CERT_TYPE}" \
+        > "${CERTS_VARS_TEMP}"
+    chmod 600 "${CERTS_VARS_TEMP}"
+    mv "${CERTS_VARS_TEMP}" "${CERTS_VARS_OUTPUT}"
+    trap - EXIT
+    info "✓ Real CA certificates written for api.${CLUSTER_FQDN} and *.apps.${CLUSTER_FQDN}"
+else
+    CERT_DIR=$(mktemp -d)
+    trap 'rm -rf "$CERT_DIR"' EXIT
 
-# Generate CA
-openssl req -x509 -newkey rsa:2048 -keyout "${CERT_DIR}/ca.key" -out "${CERT_DIR}/ca.crt" \
-    -days 365 -nodes -subj "/CN=${CLUSTER_FQDN} CA" 2>/dev/null
+    info "Generating self-signed SSL certificates for ${CLUSTER_FQDN}..."
 
-# Generate API certificate (api.<cluster>.<domain>)
-openssl req -newkey rsa:2048 -keyout "${CERT_DIR}/api.key" -out "${CERT_DIR}/api.csr" \
-    -nodes -subj "/CN=api.${CLUSTER_FQDN}" \
-    -addext "subjectAltName=DNS:api.${CLUSTER_FQDN}" 2>/dev/null
-openssl x509 -req -in "${CERT_DIR}/api.csr" -CA "${CERT_DIR}/ca.crt" -CAkey "${CERT_DIR}/ca.key" \
-    -CAcreateserial -out "${CERT_DIR}/api.crt" -days 365 \
-    -copy_extensions copyall 2>/dev/null
+    # Generate CA
+    openssl req -x509 -newkey rsa:2048 -keyout "${CERT_DIR}/ca.key" -out "${CERT_DIR}/ca.crt" \
+        -days 365 -nodes -subj "/CN=${CLUSTER_FQDN} CA" 2>/dev/null
 
-# Generate Ingress certificate (*.apps.<cluster>.<domain>)
-openssl req -newkey rsa:2048 -keyout "${CERT_DIR}/ingress.key" -out "${CERT_DIR}/ingress.csr" \
-    -nodes -subj "/CN=*.apps.${CLUSTER_FQDN}" \
-    -addext "subjectAltName=DNS:*.apps.${CLUSTER_FQDN}" 2>/dev/null
-openssl x509 -req -in "${CERT_DIR}/ingress.csr" -CA "${CERT_DIR}/ca.crt" -CAkey "${CERT_DIR}/ca.key" \
-    -CAcreateserial -out "${CERT_DIR}/ingress.crt" -days 365 \
-    -copy_extensions copyall 2>/dev/null
+    # Generate API certificate (api.<cluster>.<domain>)
+    openssl req -newkey rsa:2048 -keyout "${CERT_DIR}/api.key" -out "${CERT_DIR}/api.csr" \
+        -nodes -subj "/CN=api.${CLUSTER_FQDN}" \
+        -addext "subjectAltName=DNS:api.${CLUSTER_FQDN}" 2>/dev/null
+    openssl x509 -req -in "${CERT_DIR}/api.csr" -CA "${CERT_DIR}/ca.crt" -CAkey "${CERT_DIR}/ca.key" \
+        -CAcreateserial -out "${CERT_DIR}/api.crt" -days 365 \
+        -copy_extensions copyall 2>/dev/null
 
-# Read cert contents for YAML embedding
-API_KEY=$(cat "${CERT_DIR}/api.key")
-API_CERT=$(cat "${CERT_DIR}/api.crt")
-INGRESS_KEY=$(cat "${CERT_DIR}/ingress.key")
-INGRESS_CERT=$(cat "${CERT_DIR}/ingress.crt")
-CA_CERT=$(cat "${CERT_DIR}/ca.crt")
+    # Generate Ingress certificate (*.apps.<cluster>.<domain>)
+    openssl req -newkey rsa:2048 -keyout "${CERT_DIR}/ingress.key" -out "${CERT_DIR}/ingress.csr" \
+        -nodes -subj "/CN=*.apps.${CLUSTER_FQDN}" \
+        -addext "subjectAltName=DNS:*.apps.${CLUSTER_FQDN}" 2>/dev/null
+    openssl x509 -req -in "${CERT_DIR}/ingress.csr" -CA "${CERT_DIR}/ca.crt" -CAkey "${CERT_DIR}/ca.key" \
+        -CAcreateserial -out "${CERT_DIR}/ingress.crt" -days 365 \
+        -copy_extensions copyall 2>/dev/null
 
-# Generate config/certificates.yaml file
-cat > "$CERTS_VARS_OUTPUT" <<EOF
+    # Read cert contents for YAML embedding
+    API_KEY=$(cat "${CERT_DIR}/api.key")
+    API_CERT=$(cat "${CERT_DIR}/api.crt")
+    INGRESS_KEY=$(cat "${CERT_DIR}/ingress.key")
+    INGRESS_CERT=$(cat "${CERT_DIR}/ingress.crt")
+    CA_CERT=$(cat "${CERT_DIR}/ca.crt")
+
+    # Generate config/certificates.yaml file
+    cat > "$CERTS_VARS_OUTPUT" <<EOF
 ---
 # SSL Certificates Configuration
 # Auto-generated self-signed certificates for CI/testing
@@ -276,7 +289,8 @@ sslCACertificate: |
 $(echo "$CA_CERT" | sed 's/^/  /')
 EOF
 
-info "✓ Self-signed certificates generated for api.${CLUSTER_FQDN} and *.apps.${CLUSTER_FQDN}"
+    info "✓ Self-signed certificates generated for api.${CLUSTER_FQDN} and *.apps.${CLUSTER_FQDN}"
+fi
 
 # Generate config/cloud_infra.yaml file
 cat > "$CLOUD_INFRA_VARS_OUTPUT" <<EOF
@@ -327,7 +341,11 @@ info "  - Worker IPs: ${WORKER_IP_START}-${WORKER_IP_END} (will be assigned duri
 info "  - Storage: ${ACTIVE_STORAGE} with /dev/vda root disk"
 info "  - Registry: ${ACTIVE_REGISTRY}"
 info "  - Pull secret: Embedded in config/global.yaml (written to pullSecretPath at runtime)"
-info "  - SSL certificates: Self-signed (generated for CI/testing)"
+if [ -n "${ENCLAVE_CERT_TYPE:-}" ]; then
+    info "  - SSL certificates: Real CA (${ENCLAVE_CERT_TYPE}) via enclave-cert-gen"
+else
+    info "  - SSL certificates: Self-signed (generated for CI/testing)"
+fi
 echo ""
 info "Review config/global.yaml, config/certificates.yaml and config/cloud_infra.yaml"
 info "and adjust if needed before running Enclave Lab"

--- a/scripts/setup/configure_devscripts.sh
+++ b/scripts/setup/configure_devscripts.sh
@@ -111,6 +111,19 @@ MASTER_MEMORY_VAL=${MASTER_MEMORY_VAL:-$MASTER_MEMORY_VAL_DEFAULT}
 MASTER_VCPU_VAL=${MASTER_VCPU_VAL:-$MASTER_VCPU_VAL_DEFAULT}
 LANDINGZONE_DISK_VAL=${LANDINGZONE_DISK_VAL:-$LANDINGZONE_DISK_VAL_DEFAULT}
 
+# Resolve base domain: when using real certs the DNS names issued in the cert
+# must match the baseDomain written into dev-scripts config so that libvirt
+# dnsmasq creates records for mirror.<baseDomain>, api.<cluster>.<baseDomain>,
+# etc. that downstream validation and installation steps resolve.
+if [ -n "${ENCLAVE_CERT_TYPE:-}" ]; then
+    require_env_var "ENCLAVE_BASE_DOMAIN"
+    DEVSCRIPTS_BASE_DOMAIN="${ENCLAVE_BASE_DOMAIN}"
+    DEVSCRIPTS_CLUSTER_DOMAIN="${ENCLAVE_CLUSTER_NAME}.${ENCLAVE_BASE_DOMAIN}"
+else
+    DEVSCRIPTS_BASE_DOMAIN="${ENCLAVE_CLUSTER_NAME}.lab"
+    DEVSCRIPTS_CLUSTER_DOMAIN="${ENCLAVE_CLUSTER_NAME}.lab"
+fi
+
 # Create configuration file
 cat > "$CONFIG_FILE" <<EOF
 #!/bin/bash
@@ -196,11 +209,10 @@ export MANAGE_INT_BRIDGE="n"
 # Cluster name (used for VM naming prefix)
 export CLUSTER_NAME="${ENCLAVE_CLUSTER_NAME}"
 
-# Cluster domain (for DNS)
-export CLUSTER_DOMAIN="${ENCLAVE_CLUSTER_NAME}.lab"
-
-# Base domain (so dev-scripts uses .lab not test.metalkube.org for CLUSTER_DOMAIN)
-export BASE_DOMAIN="lab"
+# Base domain: .lab for self-signed cert runs; ENCLAVE_BASE_DOMAIN for real-cert runs
+# so libvirt dnsmasq creates records matching the cert SANs and baseDomain in global.yaml.
+export CLUSTER_DOMAIN="${DEVSCRIPTS_CLUSTER_DOMAIN}"
+export BASE_DOMAIN="${DEVSCRIPTS_BASE_DOMAIN}"
 
 # Working directory (where VMs and configs are stored)
 # Cluster-specific path for parallel execution isolation

--- a/src/enclave/cert_gen/__init__.py
+++ b/src/enclave/cert_gen/__init__.py
@@ -1,0 +1,1 @@
+"""Real-CA certificate generation for enclave deployments."""

--- a/src/enclave/cert_gen/main.py
+++ b/src/enclave/cert_gen/main.py
@@ -1,0 +1,450 @@
+"""Real-CA certificate generation for enclave deployments.
+
+Issues TLS certificates from public CAs via certbot + Hetzner DNS-01 and prints
+YAML suitable for use as certificates.yaml (ingress-api) or to populate
+ironicHTTPSCertificate/ironicHTTPSKey (ironic).
+
+Required environment variables:
+  HETZNER_API_TOKEN      Hetzner Cloud API token (used by certbot-dns-hetzner)
+  ACME_EMAIL             ACME account registration email
+
+ZeroSSL cert types also require:
+  ZEROSSL_EAB_KID        ZeroSSL EAB key ID
+  ZEROSSL_EAB_HMAC_KEY   ZeroSSL EAB HMAC key
+"""
+
+import os
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+import click
+import requests
+import yaml
+from cryptography import x509
+from cryptography.hazmat.primitives.serialization import Encoding
+from cryptography.x509 import UniformResourceIdentifier
+from cryptography.x509.oid import AuthorityInformationAccessOID
+
+
+class CertIssuanceError(Exception):
+    """Raised when certbot fails to issue or renew a certificate."""
+
+
+class RootCaExtractionError(Exception):
+    """Raised when the root CA cannot be located in the certificate chain."""
+
+
+LE_SERVER = "https://acme-v02.api.letsencrypt.org/directory"
+ZS_SERVER = "https://acme.zerossl.com/v2/DV90"
+
+# Each entry drives one certbot invocation.  Fields:
+#   server          — ACME directory URL
+#   key_type        — certbot --key-type value ("rsa" or "ecdsa")
+#   key_param       — --rsa-key-size (RSA) or --elliptic-curve (ECDSA)
+#   preferred_chain — certbot --preferred-chain; empty string = CA default
+CERT_TYPES: dict[str, dict[str, str]] = {
+    # Let's Encrypt — RSA 2048
+    # Key:   RSA 2048-bit
+    # Chain: leaf → R10/R11 intermediate (RSA, signed by ISRG Root X1)
+    # Root:  ISRG Root X1 (RSA 4096); trusted by virtually all TLS clients,
+    #        including Android < 7.1 and other legacy devices.
+    # Notes: broadest compatibility; largest handshake of the five types.
+    "le-rsa": {
+        "server": LE_SERVER,
+        "key_type": "rsa",
+        "key_param": "2048",
+        "preferred_chain": "",
+    },
+    # Let's Encrypt — ECDSA P-384, long chain (cross-signed to RSA root)
+    # Key:   ECDSA P-384 (secp384r1)
+    # Chain: leaf → E5/E6 intermediate (ECDSA, cross-signed by ISRG Root X1)
+    # Root:  ISRG Root X1 (RSA 4096)
+    # Notes: smaller leaf+intermediate than le-rsa but the RSA root keeps the
+    #        chain compatible with clients that do not yet trust ISRG Root X2.
+    #        "Long" refers to the cross-signature adding an extra cert vs the
+    #        short ECDSA chain; preferred_chain="" lets certbot pick this default.
+    "le-ecdsa-long": {
+        "server": LE_SERVER,
+        "key_type": "ecdsa",
+        "key_param": "secp384r1",
+        "preferred_chain": "",
+    },
+    # Let's Encrypt — ECDSA P-384, short chain (native ECDSA root)
+    # Key:   ECDSA P-384 (secp384r1)
+    # Chain: leaf → E5/E6 intermediate (ECDSA, signed directly by ISRG Root X2)
+    # Root:  ISRG Root X2 (ECDSA P-384); present in major trust stores since ~2021
+    #        (Chrome, Firefox, Safari, Android 8+, iOS 14+, RHEL 9+).
+    # Notes: shortest and fastest handshake of the LE options; requires a modern
+    #        trust store.  preferred_chain="ISRG Root X2" instructs certbot to
+    #        select this chain instead of the cross-signed default.
+    "le-ecdsa-short": {
+        "server": LE_SERVER,
+        "key_type": "ecdsa",
+        "key_param": "secp384r1",
+        "preferred_chain": "ISRG Root X2",
+    },
+    # ZeroSSL — RSA 2048
+    # Key:   RSA 2048-bit
+    # Chain: leaf → ZeroSSL RSA Domain Secure Site CA → USERTrust RSA CA
+    # Root:  USERTrust RSA Certification Authority (RSA 4096, Sectigo/COMODO);
+    #        trusted by all major browsers and OS trust stores.
+    # Notes: second CA vendor; diversifies CA dependency vs Let's Encrypt.
+    #        Requires EAB credentials (ZEROSSL_EAB_KID + ZEROSSL_EAB_HMAC_KEY).
+    "zerossl-rsa": {
+        "server": ZS_SERVER,
+        "key_type": "rsa",
+        "key_param": "2048",
+        "preferred_chain": "",
+    },
+    # ZeroSSL — ECDSA P-384
+    # Key:   ECDSA P-384 (secp384r1)
+    # Chain: leaf → ZeroSSL ECC Domain Secure Site CA → USERTrust ECC CA
+    # Root:  USERTrust ECC Certification Authority (ECDSA P-384, Sectigo/COMODO);
+    #        trusted by major browsers and OS trust stores (Android 7+, iOS 10+).
+    # Notes: smallest ZeroSSL chain; same EAB credential requirement as zerossl-rsa.
+    "zerossl-ecdsa": {
+        "server": ZS_SERVER,
+        "key_type": "ecdsa",
+        "key_param": "secp384r1",
+        "preferred_chain": "",
+    },
+}
+
+
+def write_hetzner_ini(work_dir: Path, token: str) -> Path:
+    """Write a 0600 certbot-dns-hetzner credentials file and return its path."""
+    ini_path = work_dir / "hetzner.ini"
+    ini_path.write_text(f"dns_hetzner_api_token = {token}\n", encoding="utf-8")
+    ini_path.chmod(0o600)
+    return ini_path
+
+
+def issue_cert(
+    config_dir: Path,
+    server: str,
+    key_type: str,
+    key_param: str,
+    preferred_chain: str,
+    domains: list[str],
+    *,
+    email: str,
+    hetzner_ini: Path,
+    eab_kid: str,
+    eab_hmac_key: str,
+) -> None:
+    """Run certbot to obtain a certificate via DNS-01 and store it under config_dir."""
+    args = [
+        "certbot",
+        "certonly",
+        "--non-interactive",
+        "--agree-tos",
+        "--email",
+        email,
+        "--no-eff-email",
+        "--authenticator",
+        "dns-hetzner",
+        "--dns-hetzner-credentials",
+        str(hetzner_ini),
+        "--server",
+        server,
+        "--config-dir",
+        str(config_dir),
+        "--work-dir",
+        str(config_dir / "work"),
+        "--logs-dir",
+        str(config_dir / "logs"),
+        "--key-type",
+        key_type,
+        "--force-renewal",
+    ]
+    if key_type == "rsa":
+        args += ["--rsa-key-size", key_param]
+    else:
+        args += ["--elliptic-curve", key_param]
+    if preferred_chain:
+        args += ["--preferred-chain", preferred_chain]
+    if eab_kid and eab_hmac_key:
+        # Write EAB credentials to a 0600 file and pass --config so they never
+        # appear in the process argument list (readable via /proc/<pid>/cmdline).
+        eab_ini = config_dir / "eab.ini"
+        eab_ini.write_text(
+            f"eab-kid = {eab_kid}\neab-hmac-key = {eab_hmac_key}\n", encoding="utf-8"
+        )
+        eab_ini.chmod(0o600)
+        args += ["--config", str(eab_ini)]
+    for domain in domains:
+        args += ["-d", domain]
+
+    result = subprocess.run(args, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        output = result.stdout + result.stderr
+        for secret in (eab_kid, eab_hmac_key):
+            if secret:
+                output = output.replace(secret, "***REDACTED***")
+        match = re.search(r"retry after \S+", output, re.IGNORECASE)
+        if match:
+            raise CertIssuanceError(f"CA rate limit reached — {match.group()}")
+        raise CertIssuanceError(f"Certificate issuance failed:\n{output}")
+
+
+def _aia_issuer_url(cert: x509.Certificate) -> str:
+    """Return the CA Issuers URL from a certificate's AIA extension."""
+    try:
+        aia = cert.extensions.get_extension_for_class(x509.AuthorityInformationAccess)
+    except x509.ExtensionNotFound as exc:
+        raise RootCaExtractionError(
+            f"Cert has no AIA extension: {cert.subject}"
+        ) from exc
+    for desc in aia.value:
+        if (
+            desc.access_method == AuthorityInformationAccessOID.CA_ISSUERS
+            and isinstance(desc.access_location, UniformResourceIdentifier)
+        ):
+            return desc.access_location.value
+    raise RootCaExtractionError(f"No CA Issuers URI in AIA of cert: {cert.subject}")
+
+
+def _fetch_cert(url: str) -> x509.Certificate:
+    """Download a DER or PEM certificate from url and return it parsed."""
+    if not url.startswith(("http://", "https://")):
+        raise RootCaExtractionError(f"Unsupported AIA issuer URL scheme: {url}")
+    try:
+        with requests.get(url, timeout=15, stream=True) as resp:
+            resp.raise_for_status()
+            data = resp.raw.read(65536, decode_content=True)
+    except requests.RequestException as exc:
+        raise RootCaExtractionError(f"Failed to fetch AIA issuer {url}: {exc}") from exc
+    try:
+        return x509.load_der_x509_certificate(data)
+    except ValueError:
+        try:
+            return x509.load_pem_x509_certificate(data)
+        except ValueError as exc:
+            raise RootCaExtractionError(f"Cannot parse cert from {url}") from exc
+
+
+def extract_root_ca(chain_pem_path: Path) -> str:
+    """Return the root CA PEM by scanning the chain file or walking AIA issuer URLs."""
+    pem_text = chain_pem_path.read_text(encoding="utf-8")
+    pem_blocks = re.findall(
+        r"-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----",
+        pem_text,
+        re.DOTALL,
+    )
+    if not pem_blocks:
+        raise RootCaExtractionError(f"No certificates found in {chain_pem_path}")
+
+    for pem in reversed(pem_blocks):
+        cert = x509.load_pem_x509_certificate(pem.encode())
+        if cert.subject == cert.issuer:
+            return pem
+
+    current = x509.load_pem_x509_certificate(pem_blocks[-1].encode())
+    for _ in range(5):
+        try:
+            url = _aia_issuer_url(current)
+        except RootCaExtractionError as exc:
+            raise RootCaExtractionError(
+                f"Chain in {chain_pem_path} contains no root CA and {exc}"
+            ) from exc
+        fetched = _fetch_cert(url)
+        if fetched.subject == fetched.issuer:
+            return fetched.public_bytes(Encoding.PEM).decode()
+        current = fetched
+
+    raise RootCaExtractionError(
+        f"Could not find root CA after 5 AIA hops from {chain_pem_path}"
+    )
+
+
+class _BlockLiteralDumper(yaml.Dumper):
+    pass
+
+
+def _literal_str(dumper: yaml.Dumper, data: str) -> yaml.ScalarNode:
+    r"""PyYAML representer that renders multiline strings as YAML literal block scalars.
+
+    PyYAML calls registered representers once per Python value being serialized,
+    including both mapping keys and values.  This function is registered for the
+    ``str`` type on ``_BlockLiteralDumper`` via ``add_representer``.
+
+    When ``data`` contains a newline the YAML ``|`` (literal block) style is
+    requested, which preserves every embedded newline exactly — the reader gets
+    back the string character-for-character.  PEM blobs always contain newlines,
+    so they reliably take this path and appear as indented blocks in the output:
+
+        sslAPICertificateKey: |
+          <base64 key data>
+          ...
+
+    When ``data`` has no newline (e.g. YAML mapping key names such as
+    ``sslAPICertificateKey``) ``style=None`` lets PyYAML choose the default plain
+    scalar style, which keeps key names on the same line as their ``:``.
+
+    PyYAML automatically selects the chomp indicator based on whether ``data``
+    ends with ``\\n``: ``|`` (clip — keep one trailing newline) when it does,
+    ``|-`` (strip — drop it) when it does not.  Real PEM files always end with
+    ``\\n``, so the output consistently uses ``|`` rather than ``|-``.
+    """
+    style = "|" if "\n" in data else None
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data, style=style)
+
+
+_BlockLiteralDumper.add_representer(str, _literal_str)
+
+
+def render_ingress_api_yaml(
+    fullchain: str, key: str, root_ca: str | None = None
+) -> str:
+    """Render the sslAPI*/sslIngress* (and optionally sslCACertificate) YAML block."""
+    data: dict[str, str] = {
+        "sslAPICertificateKey": key,
+        "sslAPICertificateFullChain": fullchain,
+        "sslIngressCertificateKey": key,
+        "sslIngressCertificateFullChain": fullchain,
+    }
+    if root_ca is not None:
+        data["sslCACertificate"] = root_ca
+    return yaml.dump(data, Dumper=_BlockLiteralDumper, sort_keys=False)
+
+
+def render_ironic_yaml(cert: str, key: str) -> str:
+    """Render the ironicHTTPSCertificate and ironicHTTPSKey YAML block."""
+    return yaml.dump(
+        {"ironicHTTPSCertificate": cert, "ironicHTTPSKey": key},
+        Dumper=_BlockLiteralDumper,
+        sort_keys=False,
+    )
+
+
+def _get_env(name: str) -> str:
+    """Return the value of environment variable name, raising UsageError if unset."""
+    val = os.environ.get(name, "")
+    if not val:
+        raise click.UsageError(f"Missing required environment variable: {name}")
+    return val
+
+
+def _load_credentials(cert_type: str) -> tuple[str, str, str, str]:
+    """Return (token, email, eab_kid, eab_hmac_key) for the given cert type."""
+    token = _get_env("HETZNER_API_TOKEN")
+    email = _get_env("ACME_EMAIL")
+    eab_kid = os.environ.get("ZEROSSL_EAB_KID", "")
+    eab_hmac_key = os.environ.get("ZEROSSL_EAB_HMAC_KEY", "")
+    if cert_type.startswith("zerossl") and not (eab_kid and eab_hmac_key):
+        raise click.UsageError(
+            "ZEROSSL_EAB_KID and ZEROSSL_EAB_HMAC_KEY are required "
+            "for zerossl cert types"
+        )
+    return token, email, eab_kid, eab_hmac_key
+
+
+@click.group()
+def cli() -> None:
+    """Issue real CA TLS certificates for enclave deployments."""
+
+
+@cli.command("ingress-api")
+@click.option(
+    "--san", "sans", multiple=True, required=True, help="Subject Alternative Name"
+)
+@click.option(
+    "--type",
+    "cert_type",
+    required=True,
+    type=click.Choice(list(CERT_TYPES)),
+    help="Certificate type",
+)
+@click.option(
+    "--root-ca", is_flag=True, default=False, help="Include root CA in output"
+)
+def cmd_ingress_api(sans: tuple[str, ...], cert_type: str, root_ca: bool) -> None:
+    """Issue a multi-SAN cert and print certificates.yaml fields to stdout."""
+    token, email, eab_kid, eab_hmac_key = _load_credentials(cert_type)
+
+    cfg = CERT_TYPES[cert_type]
+    primary_san = sans[0]
+
+    with tempfile.TemporaryDirectory() as tmp:
+        work_dir = Path(tmp)
+        hetzner_ini = write_hetzner_ini(work_dir, token)
+        config_dir = work_dir / "certbot"
+        config_dir.mkdir()
+        try:
+            issue_cert(
+                config_dir,
+                cfg["server"],
+                cfg["key_type"],
+                cfg["key_param"],
+                cfg["preferred_chain"],
+                list(sans),
+                email=email,
+                hetzner_ini=hetzner_ini,
+                eab_kid=eab_kid,
+                eab_hmac_key=eab_hmac_key,
+            )
+        except CertIssuanceError as exc:
+            raise click.ClickException(str(exc)) from exc
+
+        live_dir = config_dir / "live" / primary_san
+        fullchain = (live_dir / "fullchain.pem").read_text(encoding="utf-8")
+        privkey = (live_dir / "privkey.pem").read_text(encoding="utf-8")
+
+        extracted_root: str | None = None
+        if root_ca:
+            try:
+                extracted_root = extract_root_ca(live_dir / "chain.pem")
+            except RootCaExtractionError as exc:
+                raise click.ClickException(str(exc)) from exc
+
+        click.echo(
+            render_ingress_api_yaml(fullchain, privkey, extracted_root), nl=False
+        )
+
+
+@cli.command("ironic")
+@click.option(
+    "--san", "sans", multiple=True, required=True, help="Subject Alternative Name"
+)
+@click.option(
+    "--type",
+    "cert_type",
+    required=True,
+    type=click.Choice(list(CERT_TYPES)),
+    help="Certificate type",
+)
+def cmd_ironic(sans: tuple[str, ...], cert_type: str) -> None:
+    """Issue a cert and print ironicHTTPS* YAML fields to stdout."""
+    token, email, eab_kid, eab_hmac_key = _load_credentials(cert_type)
+
+    cfg = CERT_TYPES[cert_type]
+    primary_san = sans[0]
+
+    with tempfile.TemporaryDirectory() as tmp:
+        work_dir = Path(tmp)
+        hetzner_ini = write_hetzner_ini(work_dir, token)
+        config_dir = work_dir / "certbot"
+        config_dir.mkdir()
+        try:
+            issue_cert(
+                config_dir,
+                cfg["server"],
+                cfg["key_type"],
+                cfg["key_param"],
+                cfg["preferred_chain"],
+                list(sans),
+                email=email,
+                hetzner_ini=hetzner_ini,
+                eab_kid=eab_kid,
+                eab_hmac_key=eab_hmac_key,
+            )
+        except CertIssuanceError as exc:
+            raise click.ClickException(str(exc)) from exc
+
+        live_dir = config_dir / "live" / primary_san
+        fullchain = (live_dir / "fullchain.pem").read_text(encoding="utf-8")
+        privkey = (live_dir / "privkey.pem").read_text(encoding="utf-8")
+
+        click.echo(render_ironic_yaml(fullchain, privkey), nl=False)

--- a/src/tests/test_cert_gen.py
+++ b/src/tests/test_cert_gen.py
@@ -1,0 +1,584 @@
+"""Unit tests for enclave.cert_gen.main."""
+
+import subprocess
+from pathlib import Path
+from subprocess import CompletedProcess
+from unittest.mock import MagicMock, patch
+
+import click
+import pytest
+import requests
+from click.testing import CliRunner
+from cryptography import x509
+from cryptography.hazmat.primitives.serialization import Encoding
+
+from enclave.cert_gen.main import (
+    CertIssuanceError,
+    RootCaExtractionError,
+    _fetch_cert,
+    _load_credentials,
+    cli,
+    extract_root_ca,
+    issue_cert,
+    render_ingress_api_yaml,
+    render_ironic_yaml,
+    write_hetzner_ini,
+)
+from tests.cert_helpers import (
+    generate_ca,
+    generate_intermediate_ca,
+    generate_signed_leaf,
+)
+
+
+def _generate_intermediate_with_aia(
+    tmp_path: Path, parent_cert_path: Path, parent_key_path: Path, aia_url: str
+) -> str:
+    key = tmp_path / "inter_aia.key"
+    csr = tmp_path / "inter_aia.csr"
+    cert = tmp_path / "inter_aia.crt"
+    ext = tmp_path / "inter_aia.ext"
+    subprocess.run(
+        [
+            "openssl",
+            "genpkey",
+            "-algorithm",
+            "EC",
+            "-pkeyopt",
+            "ec_paramgen_curve:P-256",
+            "-out",
+            str(key),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        [
+            "openssl",
+            "req",
+            "-new",
+            "-key",
+            str(key),
+            "-out",
+            str(csr),
+            "-subj",
+            "/CN=Inter with AIA",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    ext.write_text(
+        "[ext]\nbasicConstraints=CA:TRUE,pathlen:0\nkeyUsage=keyCertSign,cRLSign\n"
+        f"authorityInfoAccess=caIssuers;URI:{aia_url}\n",
+        encoding="utf-8",
+    )
+    subprocess.run(
+        [
+            "openssl",
+            "x509",
+            "-req",
+            "-in",
+            str(csr),
+            "-CA",
+            str(parent_cert_path),
+            "-CAkey",
+            str(parent_key_path),
+            "-out",
+            str(cert),
+            "-days",
+            "1",
+            "-set_serial",
+            "20",
+            "-extfile",
+            str(ext),
+            "-extensions",
+            "ext",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return cert.read_text(encoding="utf-8").strip()
+
+
+def _make_result(
+    returncode: int = 0, stdout: str = "", stderr: str = ""
+) -> CompletedProcess[str]:
+    r: CompletedProcess[str] = CompletedProcess(args=[], returncode=returncode)
+    r.stdout = stdout
+    r.stderr = stderr
+    return r
+
+
+class TestWriteHetznerIni:
+    def test_writes_token(self, tmp_path: Path) -> None:
+        ini = write_hetzner_ini(tmp_path, "mytoken")
+        assert ini.read_text(encoding="utf-8") == "dns_hetzner_api_token = mytoken\n"
+
+    def test_permissions(self, tmp_path: Path) -> None:
+        ini = write_hetzner_ini(tmp_path, "tok")
+        assert oct(ini.stat().st_mode)[-3:] == "600"
+
+
+class TestExtractRootCa:
+    def test_finds_root_in_chain(self, tmp_path: Path) -> None:
+        root_pem, root_cert, root_key = generate_ca(tmp_path, "Root CA")
+        inter_pem, inter_cert, inter_key = generate_intermediate_ca(
+            tmp_path, "Intermediate CA", root_cert, root_key
+        )
+        leaf_pem = generate_signed_leaf(tmp_path, inter_cert, inter_key, "Leaf")
+
+        chain_path = tmp_path / "chain.pem"
+        chain_path.write_text(
+            f"{leaf_pem}\n{inter_pem}\n{root_pem}\n", encoding="utf-8"
+        )
+        result = extract_root_ca(chain_path)
+        assert "BEGIN CERTIFICATE" in result
+        cert = x509.load_pem_x509_certificate(result.encode())
+        assert cert.subject == cert.issuer
+
+    def test_root_last_or_middle(self, tmp_path: Path) -> None:
+        root_pem, root_cert, root_key = generate_ca(tmp_path, "Root CA")
+        inter_pem, _, _ = generate_intermediate_ca(
+            tmp_path, "Intermediate CA", root_cert, root_key
+        )
+        chain_path = tmp_path / "chain.pem"
+        chain_path.write_text(
+            f"{inter_pem}\n{root_pem}\n{inter_pem}\n", encoding="utf-8"
+        )
+        result = extract_root_ca(chain_path)
+        cert = x509.load_pem_x509_certificate(result.encode())
+        assert cert.subject == cert.issuer
+
+    def test_raises_when_no_root_and_no_aia(self, tmp_path: Path) -> None:
+        _, root_cert, root_key = generate_ca(tmp_path, "Root CA")
+        inter_pem, inter_cert, inter_key = generate_intermediate_ca(
+            tmp_path, "Intermediate CA", root_cert, root_key
+        )
+        leaf_pem = generate_signed_leaf(tmp_path, inter_cert, inter_key, "Leaf")
+
+        chain_path = tmp_path / "chain.pem"
+        chain_path.write_text(f"{leaf_pem}\n{inter_pem}\n", encoding="utf-8")
+        with pytest.raises(RootCaExtractionError, match="no AIA extension"):
+            extract_root_ca(chain_path)
+
+    def test_aia_walk_finds_root(self, tmp_path: Path) -> None:
+        root_pem, root_cert_path, root_key_path = generate_ca(tmp_path, "Root CA")
+
+        aia_url = "http://test.example.com/root.crt"
+        inter_pem = _generate_intermediate_with_aia(
+            tmp_path, root_cert_path, root_key_path, aia_url
+        )
+
+        chain_path = tmp_path / "chain.pem"
+        chain_path.write_text(inter_pem + "\n", encoding="utf-8")
+
+        root_cert_obj = x509.load_pem_x509_certificate(root_pem.encode())
+        root_der = root_cert_obj.public_bytes(Encoding.DER)
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_resp.raw.read.return_value = root_der
+
+        with patch("enclave.cert_gen.main.requests.get", return_value=mock_resp):
+            result = extract_root_ca(chain_path)
+
+        cert = x509.load_pem_x509_certificate(result.encode())
+        assert cert.subject == cert.issuer
+
+    def test_aia_walk_exhausted_after_five_hops(self, tmp_path: Path) -> None:
+        _, root_cert_path, root_key_path = generate_ca(tmp_path, "Root CA")
+        aia_url = "http://test.example.com/inter.crt"
+        inter_pem = _generate_intermediate_with_aia(
+            tmp_path, root_cert_path, root_key_path, aia_url
+        )
+        chain_path = tmp_path / "chain.pem"
+        chain_path.write_text(inter_pem + "\n", encoding="utf-8")
+
+        # Every fetch returns the same non-self-signed intermediate, so the loop
+        # never converges and must raise after exactly 5 hops.
+        inter_der = x509.load_pem_x509_certificate(inter_pem.encode()).public_bytes(
+            Encoding.DER
+        )
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_resp.raw.read.return_value = inter_der
+
+        with (
+            patch("enclave.cert_gen.main.requests.get", return_value=mock_resp),
+            pytest.raises(RootCaExtractionError, match="after 5 AIA hops"),
+        ):
+            extract_root_ca(chain_path)
+
+
+class TestFetchCert:
+    def test_invalid_scheme_raises(self) -> None:
+        with pytest.raises(
+            RootCaExtractionError, match="Unsupported AIA issuer URL scheme"
+        ):
+            _fetch_cert("ftp://example.com/cert.crt")
+
+    def test_request_exception_raises(self) -> None:
+        with (
+            patch(
+                "enclave.cert_gen.main.requests.get",
+                side_effect=requests.RequestException("timeout"),
+            ),
+            pytest.raises(RootCaExtractionError, match="Failed to fetch AIA issuer"),
+        ):
+            _fetch_cert("http://example.com/cert.crt")
+
+    def test_unparsable_body_raises(self) -> None:
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_resp.raw.read.return_value = b"not a cert"
+        with (
+            patch("enclave.cert_gen.main.requests.get", return_value=mock_resp),
+            pytest.raises(RootCaExtractionError, match="Cannot parse cert"),
+        ):
+            _fetch_cert("http://example.com/cert.crt")
+
+
+class TestLoadCredentials:
+    def test_missing_token_raises(self) -> None:
+        with (
+            patch.dict(
+                "os.environ", {"HETZNER_API_TOKEN": "", "ACME_EMAIL": "a@b.com"}
+            ),
+            pytest.raises(click.UsageError, match="HETZNER_API_TOKEN"),
+        ):
+            _load_credentials("le-rsa")
+
+    def test_zerossl_missing_eab_raises(self) -> None:
+        env = {
+            "HETZNER_API_TOKEN": "tok",
+            "ACME_EMAIL": "a@b.com",
+            "ZEROSSL_EAB_KID": "",
+            "ZEROSSL_EAB_HMAC_KEY": "",
+        }
+        with (
+            patch.dict("os.environ", env),
+            pytest.raises(click.UsageError, match="ZEROSSL_EAB_KID"),
+        ):
+            _load_credentials("zerossl-rsa")
+
+    def test_le_returns_empty_eab(self) -> None:
+        env = {"HETZNER_API_TOKEN": "tok", "ACME_EMAIL": "a@b.com"}
+        with patch.dict("os.environ", env, clear=True):
+            result = _load_credentials("le-rsa")
+        assert result == ("tok", "a@b.com", "", "")
+
+
+PEM_CHAIN = "CHAIN\n"
+PEM_KEY = "KEY\n"
+PEM_ROOT = "ROOT\n"
+
+
+class TestRenderIngressApiYaml:
+    def test_all_four_ssl_keys_present(self) -> None:
+        out = render_ingress_api_yaml(PEM_CHAIN, PEM_KEY)
+        assert "sslAPICertificateKey: |" in out
+        assert "sslAPICertificateFullChain: |" in out
+        assert "sslIngressCertificateKey: |" in out
+        assert "sslIngressCertificateFullChain: |" in out
+        assert "sslCACertificate" not in out
+
+    def test_with_root_ca(self) -> None:
+        out = render_ingress_api_yaml(PEM_CHAIN, PEM_KEY, root_ca=PEM_ROOT)
+        assert "sslCACertificate: |" in out
+        assert "  ROOT" in out
+
+    def test_values_indented(self) -> None:
+        out = render_ingress_api_yaml("line1\nline2\n", PEM_KEY)
+        assert "  line1\n  line2" in out
+
+    def test_api_and_ingress_share_cert(self) -> None:
+        out = render_ingress_api_yaml(PEM_CHAIN, PEM_KEY)
+        assert out.count("CHAIN") == 2
+        assert out.count("KEY") == 2
+
+
+class TestRenderIronicYaml:
+    def test_ironic_keys_present(self) -> None:
+        out = render_ironic_yaml(PEM_CHAIN, PEM_KEY)
+        assert "ironicHTTPSCertificate: |" in out
+        assert "ironicHTTPSKey: |" in out
+
+    def test_values_indented(self) -> None:
+        out = render_ironic_yaml("line1\nline2\n", PEM_KEY)
+        assert "  line1\n  line2" in out
+
+
+class TestIssueCert:
+    def test_success(self, tmp_path: Path) -> None:
+        ini = tmp_path / "h.ini"
+        ini.write_text("", encoding="utf-8")
+        with patch("subprocess.run", return_value=_make_result(0)):
+            issue_cert(
+                tmp_path,
+                "https://acme.example.com",
+                "rsa",
+                "2048",
+                "",
+                ["example.com"],
+                email="test@example.com",
+                hetzner_ini=ini,
+                eab_kid="",
+                eab_hmac_key="",
+            )
+
+    def test_ecdsa_uses_elliptic_curve_flag(self, tmp_path: Path) -> None:
+        ini = tmp_path / "h.ini"
+        ini.write_text("", encoding="utf-8")
+        with patch("subprocess.run", return_value=_make_result(0)) as mock_run:
+            issue_cert(
+                tmp_path,
+                "https://acme.example.com",
+                "ecdsa",
+                "secp384r1",
+                "",
+                ["example.com"],
+                email="test@example.com",
+                hetzner_ini=ini,
+                eab_kid="",
+                eab_hmac_key="",
+            )
+        args = mock_run.call_args[0][0]
+        assert "--elliptic-curve" in args
+        assert "secp384r1" in args
+        assert "--rsa-key-size" not in args
+
+    def test_preferred_chain_included(self, tmp_path: Path) -> None:
+        ini = tmp_path / "h.ini"
+        ini.write_text("", encoding="utf-8")
+        with patch("subprocess.run", return_value=_make_result(0)) as mock_run:
+            issue_cert(
+                tmp_path,
+                "https://acme.example.com",
+                "ecdsa",
+                "secp384r1",
+                "ISRG Root X2",
+                ["example.com"],
+                email="test@example.com",
+                hetzner_ini=ini,
+                eab_kid="",
+                eab_hmac_key="",
+            )
+        args = mock_run.call_args[0][0]
+        assert "--preferred-chain" in args
+        assert "ISRG Root X2" in args
+
+    def test_eab_credentials_included(self, tmp_path: Path) -> None:
+        ini = tmp_path / "h.ini"
+        ini.write_text("", encoding="utf-8")
+        with patch("subprocess.run", return_value=_make_result(0)) as mock_run:
+            issue_cert(
+                tmp_path,
+                "https://acme.zerossl.com/v2/DV90",
+                "rsa",
+                "2048",
+                "",
+                ["example.com"],
+                email="test@example.com",
+                hetzner_ini=ini,
+                eab_kid="kid123",
+                eab_hmac_key="hmac456",
+            )
+        args = mock_run.call_args[0][0]
+        # EAB creds must not appear in argv (readable via /proc/<pid>/cmdline).
+        assert "--eab-kid" not in args
+        assert "kid123" not in args
+        assert "--eab-hmac-key" not in args
+        assert "hmac456" not in args
+        # Instead they are written to a 0600 config file passed via --config.
+        eab_ini = tmp_path / "eab.ini"
+        assert eab_ini.exists()
+        content = eab_ini.read_text(encoding="utf-8")
+        assert "eab-kid = kid123" in content
+        assert "eab-hmac-key = hmac456" in content
+        assert "--config" in args
+        assert oct(eab_ini.stat().st_mode)[-3:] == "600"
+
+    def test_rate_limit_error(self, tmp_path: Path) -> None:
+        ini = tmp_path / "h.ini"
+        ini.write_text("", encoding="utf-8")
+        with (
+            patch(
+                "subprocess.run",
+                return_value=_make_result(
+                    1, stderr="Error: retry after 2026-08-01T06:00:00Z"
+                ),
+            ),
+            pytest.raises(CertIssuanceError, match="CA rate limit reached"),
+        ):
+            issue_cert(
+                tmp_path,
+                "https://acme-v02.api.letsencrypt.org/directory",
+                "rsa",
+                "2048",
+                "",
+                ["example.com"],
+                email="test@example.com",
+                hetzner_ini=ini,
+                eab_kid="",
+                eab_hmac_key="",
+            )
+
+    def test_generic_error(self, tmp_path: Path) -> None:
+        ini = tmp_path / "h.ini"
+        ini.write_text("", encoding="utf-8")
+        with (
+            patch(
+                "subprocess.run",
+                return_value=_make_result(1, stderr="ACME server rejected the request"),
+            ),
+            pytest.raises(CertIssuanceError, match="Certificate issuance failed"),
+        ):
+            issue_cert(
+                tmp_path,
+                "https://acme-v02.api.letsencrypt.org/directory",
+                "rsa",
+                "2048",
+                "",
+                ["example.com"],
+                email="test@example.com",
+                hetzner_ini=ini,
+                eab_kid="",
+                eab_hmac_key="",
+            )
+
+
+DUMMY_PEM = "-----BEGIN CERTIFICATE-----\nDUMMY\n-----END CERTIFICATE-----\n"
+
+
+def _make_issue_cert_side_effect(san: str) -> object:
+    """Return an issue_cert side_effect that creates a fake certbot live dir."""
+
+    def side_effect(config_dir: Path, *_args: object, **_kwargs: object) -> None:
+        live_dir = config_dir / "live" / san
+        live_dir.mkdir(parents=True, exist_ok=True)
+        for fname in ("fullchain.pem", "privkey.pem", "chain.pem"):
+            (live_dir / fname).write_text(DUMMY_PEM, encoding="utf-8")
+
+    return side_effect
+
+
+class TestCliIngressApi:
+    def _env(self) -> dict[str, str]:
+        return {
+            "HETZNER_API_TOKEN": "tok",
+            "ACME_EMAIL": "a@b.com",
+        }
+
+    def test_missing_hetzner_token(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["ingress-api", "--san", "api.x.nodns.in", "--type", "le-rsa"],
+            env={"ACME_EMAIL": "a@b.com", "HETZNER_API_TOKEN": None},
+            catch_exceptions=False,
+        )
+        assert result.exit_code != 0
+        assert "HETZNER_API_TOKEN" in result.output
+
+    def test_missing_acme_email(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["ingress-api", "--san", "api.x.nodns.in", "--type", "le-rsa"],
+            env={"HETZNER_API_TOKEN": "tok", "ACME_EMAIL": None},
+            catch_exceptions=False,
+        )
+        assert result.exit_code != 0
+        assert "ACME_EMAIL" in result.output
+
+    def test_zerossl_missing_eab(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["ingress-api", "--san", "api.x.nodns.in", "--type", "zerossl-rsa"],
+            env={**self._env(), "ZEROSSL_EAB_KID": None, "ZEROSSL_EAB_HMAC_KEY": None},
+            catch_exceptions=False,
+        )
+        assert result.exit_code != 0
+        assert "ZEROSSL_EAB_KID" in result.output
+
+    def test_success_le_rsa(self) -> None:
+        runner = CliRunner()
+        san = "api.smoke.nodns.in"
+        with patch(
+            "enclave.cert_gen.main.issue_cert",
+            side_effect=_make_issue_cert_side_effect(san),
+        ):
+            result = runner.invoke(
+                cli,
+                ["ingress-api", "--san", san, "--type", "le-rsa"],
+                env=self._env(),
+                catch_exceptions=False,
+            )
+        assert result.exit_code == 0
+        assert "sslAPICertificateKey: |" in result.output
+        assert "sslIngressCertificateFullChain: |" in result.output
+
+    def test_issue_cert_failure(self) -> None:
+        runner = CliRunner()
+        with patch(
+            "enclave.cert_gen.main.issue_cert",
+            side_effect=CertIssuanceError("cert failed"),
+        ):
+            result = runner.invoke(
+                cli,
+                ["ingress-api", "--san", "api.x.nodns.in", "--type", "le-rsa"],
+                env=self._env(),
+                catch_exceptions=False,
+            )
+        assert result.exit_code != 0
+        assert "cert failed" in result.output
+
+
+class TestCliIronic:
+    def _env(self) -> dict[str, str]:
+        return {
+            "HETZNER_API_TOKEN": "tok",
+            "ACME_EMAIL": "a@b.com",
+        }
+
+    def test_missing_hetzner_token(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["ironic", "--san", "ironic.x.nodns.in", "--type", "le-rsa"],
+            env={"ACME_EMAIL": "a@b.com", "HETZNER_API_TOKEN": None},
+            catch_exceptions=False,
+        )
+        assert result.exit_code != 0
+        assert "HETZNER_API_TOKEN" in result.output
+
+    def test_zerossl_missing_eab(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["ironic", "--san", "ironic.x.nodns.in", "--type", "zerossl-rsa"],
+            env={**self._env(), "ZEROSSL_EAB_KID": None, "ZEROSSL_EAB_HMAC_KEY": None},
+            catch_exceptions=False,
+        )
+        assert result.exit_code != 0
+        assert "ZEROSSL_EAB_KID" in result.output
+
+    def test_success_le_rsa(self) -> None:
+        runner = CliRunner()
+        san = "ironic.smoke.nodns.in"
+        with patch(
+            "enclave.cert_gen.main.issue_cert",
+            side_effect=_make_issue_cert_side_effect(san),
+        ):
+            result = runner.invoke(
+                cli,
+                ["ironic", "--san", san, "--type", "le-rsa"],
+                env=self._env(),
+                catch_exceptions=False,
+            )
+        assert result.exit_code == 0
+        assert "ironicHTTPSCertificate: |" in result.output
+        assert "ironicHTTPSKey: |" in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,22 @@ requires-python = "==3.12.*"
 constraints = [{ name = "google-auth", specifier = ">=2.56.2" }]
 
 [[package]]
+name = "acme"
+version = "5.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "josepy" },
+    { name = "pyopenssl" },
+    { name = "pyrfc3339" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/53/2e79e7d1c5384414d4670f02729601cf23e61fe13b7b99471d02c620ddbe/acme-5.7.0.tar.gz", hash = "sha256:4be4fe6cf3809c3988d75fa1213ce8e784d9d5d8380cac63c2dca555e105653d", size = 90640, upload-time = "2026-07-15T17:40:26.01Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/af/b5f590040cd2efae675ff5c9da533abcf3011c6d0b7b67e118aa86c14ceb/acme-5.7.0-py3-none-any.whl", hash = "sha256:a736f88e975f0ebe8c6fcabd3db164d1071b4f9e1a56d1319a9f6997e0a64a0a", size = 95023, upload-time = "2026-07-15T17:40:07.404Z" },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -241,6 +257,40 @@ wheels = [
 ]
 
 [[package]]
+name = "certbot"
+version = "5.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "acme" },
+    { name = "configargparse" },
+    { name = "configobj" },
+    { name = "cryptography" },
+    { name = "distro" },
+    { name = "josepy" },
+    { name = "parsedatetime" },
+    { name = "pyrfc3339" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/1a/eb1d1ff8682fbfcf7089f5e0cad80c259646f44cc85ce9d3533af901b3e6/certbot-5.7.0.tar.gz", hash = "sha256:c896a0aa3fe1fa1e344002d4a24a5934889a88b8759f41a22b4dcfe5a8e27b94", size = 704446, upload-time = "2026-07-15T17:40:27.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/70/b874a4aacc016f9136bd63d3ef6d23d0066759bfb4cbae4d7559c4f2b1a0/certbot-5.7.0-py3-none-any.whl", hash = "sha256:7e5e8f023c5eb4753f4b74f97c26ddd57e43493e82b76eeefb741c120a7d49b6", size = 780839, upload-time = "2026-07-15T17:40:08.913Z" },
+]
+
+[[package]]
+name = "certbot-dns-hetzner"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certbot" },
+    { name = "hcloud" },
+    { name = "tldextract" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/f1/f32ae191b57bb98d5ed7e497c56e4ad815a4766923e96da467c9721501bc/certbot_dns_hetzner-4.0.0.tar.gz", hash = "sha256:cc122c13b19e96bac8f9d7f7715887f6e0313b56be253de71e8877a8eacb6e3a", size = 8438, upload-time = "2026-04-20T12:58:16.473Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/c5/f32e10fe3bdf95360ef7f5a79f27a86be102fbeed5dce1dc8930ed40baef/certbot_dns_hetzner-4.0.0-py2.py3-none-any.whl", hash = "sha256:1dd5d43467bb624996d36a416ceeffb4068be7b315a774a6e7fc2b562140743f", size = 9378, upload-time = "2026-04-20T12:58:15.454Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.7.22"
 source = { registry = "https://pypi.org/simple" }
@@ -332,6 +382,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "configargparse"
+version = "1.7.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/0b/30328302903c55218ffc5199646d0e9d28348ff26c02ba77b2ffc58d294a/configargparse-1.7.5.tar.gz", hash = "sha256:e3f9a7bb6be34d66b2e3c4a2f58e3045f8dfae47b0dc039f87bcfaa0f193fb0f", size = 53548, upload-time = "2026-03-11T02:19:38.144Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/19/3ba5e1b0bcc7b91aeab6c258afd70e4907d220fed3972febe38feb40db30/configargparse-1.7.5-py3-none-any.whl", hash = "sha256:1e63fdffedf94da9cd435fc13a1cd24777e76879dd2343912c1f871d4ac8c592", size = 27692, upload-time = "2026-03-11T02:19:36.442Z" },
 ]
 
 [[package]]
@@ -446,6 +505,10 @@ dependencies = [
 ]
 
 [package.dev-dependencies]
+cert-gen = [
+    { name = "certbot" },
+    { name = "certbot-dns-hetzner" },
+]
 dev = [
     { name = "ansible-lint" },
     { name = "anymarkup" },
@@ -478,6 +541,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
+cert-gen = [
+    { name = "certbot", specifier = "==5.7.0" },
+    { name = "certbot-dns-hetzner", specifier = "==4.0.0" },
+]
 dev = [
     { name = "ansible-lint", specifier = "==26.8.0" },
     { name = "anymarkup", specifier = "==0.8.1" },
@@ -524,6 +591,19 @@ wheels = [
 ]
 
 [[package]]
+name = "hcloud"
+version = "2.23.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/b0/f3a2e44ad8c295df58275585aecb979fb0829f0ac7d36d41db958dd85c65/hcloud-2.23.0.tar.gz", hash = "sha256:c12dce3f14404ea342d79236292a15fbc4ceeb7861724a09dd3fe60cef513e0b", size = 154918, upload-time = "2026-07-21T12:32:35.679Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/ae/bb107bd26049627c63da41868616533c004da69113cb2747e6a4e4eda949/hcloud-2.23.0-py3-none-any.whl", hash = "sha256:5a3fa1bbd1f87bfc5f0c726caebe041b9e1119b4361aafabc12fad284a2c445a", size = 111603, upload-time = "2026-07-21T12:32:34.025Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.19"
 source = { registry = "https://pypi.org/simple" }
@@ -551,6 +631,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "josepy"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/ad/6f520aee9cc9618d33430380741e9ef859b2c560b1e7915e755c084f6bc0/josepy-2.2.0.tar.gz", hash = "sha256:74c033151337c854f83efe5305a291686cef723b4b970c43cfe7270cf4a677a9", size = 56500, upload-time = "2025-10-14T14:54:42.108Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/b2/b5caed897fbb1cc286c62c01feca977e08d99a17230ff3055b9a98eccf1d/josepy-2.2.0-py3-none-any.whl", hash = "sha256:63e9dd116d4078778c25ca88f880cc5d95f1cab0099bebe3a34c2e299f65d10b", size = 29211, upload-time = "2025-10-14T14:54:41.144Z" },
 ]
 
 [[package]]
@@ -729,6 +821,15 @@ wheels = [
 ]
 
 [[package]]
+name = "parsedatetime"
+version = "2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/20/cb587f6672dbe585d101f590c3871d16e7aec5a576a1694997a3777312ac/parsedatetime-2.6.tar.gz", hash = "sha256:4cb368fbb18a0b7231f4d76119165451c8d2e35951455dfee97c62a87b04d455", size = 60114, upload-time = "2020-05-31T23:50:57.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/a4/3dd804926a42537bf69fb3ebb9fd72a50ba84f807d95df5ae016606c976c/parsedatetime-2.6-py3-none-any.whl", hash = "sha256:cb96edd7016872f58479e35879294258c71437195760746faffedb692aef000b", size = 42548, upload-time = "2020-05-31T23:50:56.315Z" },
+]
+
+[[package]]
 name = "pathspec"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -821,6 +922,28 @@ wheels = [
 ]
 
 [[package]]
+name = "pyopenssl"
+version = "26.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/e8/7325d258199b159eb2c03fe32107533e2832e70e63f4fb88a6aa00023201/pyopenssl-26.4.0.tar.gz", hash = "sha256:28dfcce0162b9211413e26dfbfdf1d24317fbeba18fc93c12400a1856b2a0bc7", size = 182046, upload-time = "2026-08-01T19:50:50.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/ad/2cf6d3fa2fae5c79e1ed9960c0d42badd0f94d81dd12b50604cdc839e648/pyopenssl-26.4.0-py3-none-any.whl", hash = "sha256:f0eb0cb2d581d3ad2b9c489468485e7f2ab6727d08401bcf9d824c3caddf3c1c", size = 56026, upload-time = "2026-08-01T19:50:48.94Z" },
+]
+
+[[package]]
+name = "pyrfc3339"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/7f/3c194647ecb80ada6937c38a162ab3edba85a8b6a58fa2919405f4de2509/pyrfc3339-2.1.0.tar.gz", hash = "sha256:c569a9714faf115cdb20b51e830e798c1f4de8dabb07f6ff25d221b5d09d8d7f", size = 12589, upload-time = "2025-08-23T16:40:31.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/90/0200184d2124484f918054751ef997ed6409cb05b7e8dcbf5a22da4c4748/pyrfc3339-2.1.0-py3-none-any.whl", hash = "sha256:560f3f972e339f579513fe1396974352fd575ef27caff160a38b312252fcddf3", size = 6758, upload-time = "2025-08-23T16:40:30.49Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -889,6 +1012,16 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -933,6 +1066,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "requests-file"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3c/f8/5dc70102e4d337063452c82e1f0d95e39abfe67aa222ed8a5ddeb9df8de8/requests_file-3.0.1.tar.gz", hash = "sha256:f14243d7796c588f3521bd423c5dea2ee4cc730e54a3cac9574d78aca1272576", size = 6967, upload-time = "2025-10-20T18:56:42.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/d5/de8f089119205a09da657ed4784c584ede8381a0ce6821212a6d4ca47054/requests_file-3.0.1-py2.py3-none-any.whl", hash = "sha256:d0f5eb94353986d998f80ac63c7f146a307728be051d4d1cd390dbdb59c10fa2", size = 4514, upload-time = "2025-10-20T18:56:41.184Z" },
 ]
 
 [[package]]
@@ -1060,6 +1205,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/22/991efbf35bc811dfe7edcd749253f0931d2d4838cf55176132633e1c82a7/subprocess_tee-0.4.2.tar.gz", hash = "sha256:91b2b4da3aae9a7088d84acaf2ea0abee3f4fd9c0d2eae69a9b9122a71476590", size = 14951, upload-time = "2024-06-17T19:51:51.249Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/ab/e3a3be062cd544b2803760ff707dee38f0b1cb5685b2446de0ec19be28d9/subprocess_tee-0.4.2-py3-none-any.whl", hash = "sha256:21942e976715af4a19a526918adb03a8a27a8edab959f2d075b777e3d78f532d", size = 5249, upload-time = "2024-06-17T19:51:15.949Z" },
+]
+
+[[package]]
+name = "tldextract"
+version = "5.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "idna" },
+    { name = "requests" },
+    { name = "requests-file" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/a9/ed5d3be29bfaf90c00b7159d3884b311f3880b55833d1c7be764164dc288/tldextract-5.3.2.tar.gz", hash = "sha256:c017431bc0800f2d3d1b57cce36e06668f0930f60a6d8c4615d4e2b8da298fa9", size = 191971, upload-time = "2026-08-08T20:53:13.732Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/3b/930310b274dfe3b9a4fe64ef8b24e5faf376c9a6f94bba6fc6e438058598/tldextract-5.3.2-py3-none-any.whl", hash = "sha256:6c90d2a259f5c89f4fcf01f97af15708416a59ffedddff006d67222ab30d0fb0", size = 106415, upload-time = "2026-08-08T20:53:12.675Z" },
 ]
 
 [[package]]

--- a/validations.sh
+++ b/validations.sh
@@ -71,8 +71,9 @@ checkDNS(){
         validation fail $check_name "Failed to resolve $name"
     fi
 
-    if [[ $result != $value ]]; then
-        validation fail $check_name "$name points to $result. It does not match with $value"
+    if ! echo "$result" | grep -Fqx -- "$value"; then
+        validation fail $check_name "$name does not resolve to $value" "Resolved addresses:
+$result"
     fi
     validation pass $check_name "$name points to $value"
 }


### PR DESCRIPTION
Third and final PR in the series addressing gori-project/GoRI#943, which identified that all test certificates used a custom test CA and scenario 1 (well-known / system CA) was never exercised in CI. PR #609 added cert helpers and multi-hop chain / expiry test coverage; PR #613 moved all cert validation into the Python CLI and removed the bash cert functions. This PR closes the remaining gap by issuing real certificates from public CAs and using them in the disconnected e2e.

Introduces enclave-cert-gen, a Click CLI tool that issues certificates via certbot with Hetzner DNS-01 validation against Let's Encrypt and ZeroSSL, rotating through five CA types by day of week on the nightly schedule. The logic is embedded directly in the existing generate_enclave_vars.sh and generate_ironic_cert.sh scripts: when ENCLAVE_CERT_TYPE is set they call the tool; otherwise the self-signed path runs unchanged.

Real certs are also available on demand: a cert-type input on both workflow_dispatch and workflow_call accepts a specific type or "auto" (day-of-week rotation), defaulting to self-signed when omitted. The cert resolution step is unconditional and writes both ENCLAVE_CERT_TYPE and ENCLAVE_BASE_DOMAIN so they always agree, regardless of trigger. The dead /test check-real-certs slash command, which pointed at a workflow removed in PR #613, is also cleaned up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated certificate generation for enclave deployments.
  * Added Let’s Encrypt and ZeroSSL support with RSA and ECDSA options.
  * Added configurable certificate types for deployment workflows.
  * Added custom base domain support, defaulting to `lab`.
  * Added certificate output for ingress API and Ironic services.

* **Bug Fixes**
  * Improved certificate handling, deployment diagnostics, and DNS validation messages.
  * Improved deployment setup reliability by ensuring required tooling is available.
  * Improved Clair validation retries and failure diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->