### PR TITLE
fix(runners): restrict Podman socket to runners group 

### DIFF
--- a/scripts/runners/README-runners.md
+++ b/scripts/runners/README-runners.md
@@ -158,8 +158,24 @@ Jobs run in parallel across available runners using podman for container isolati
 
 - **System podman socket:** `/run/podman/podman.sock` (enabled via systemd)
 - **Docker compatibility:** `/var/run/docker.sock` → symlink to podman socket
-- **Permissions:** Socket is world-accessible (666) for GitHub Actions
 - **No Docker:** Pure podman setup, Docker removed if present
+
+#### Socket permissions
+
+Access to the rootful Podman socket is restricted to the `runners` system group:
+
+| Path | Owner | Mode | Notes |
+|---|---|---|---|
+| `/run/podman/` | `root:runners` | `0750` | Persisted via `/etc/tmpfiles.d/podman-socket.conf` |
+| `/run/podman/podman.sock` | `root:runners` | `0660` | Set via systemd socket override |
+
+Any account that needs to reach the Podman API must belong to `runners` as a
+**supplementary** group member. Accounts whose **primary GID** is `runners` are
+also validated during setup and must appear in the approved-account list.
+
+The setup script maintains an allowlist (`APPROVED_RUNNER_ACCOUNTS`). It aborts
+if any unapproved account — supplementary or primary-GID — is found in the group
+before assigning `SocketGroup=runners`.
 
 ### Runner Services
 
@@ -226,8 +242,8 @@ sudo -u github-runner podman ps
 
 Socket should be:
 ```
-srw-rw-rw-. 1 root root 0 /run/podman/podman.sock
-lrwxrwxrwx. 1 root root 23 /var/run/docker.sock -> /run/podman/podman.sock
+srw-rw----. 1 root runners 0 /run/podman/podman.sock
+lrwxrwxrwx. 1 root root    23 /var/run/docker.sock -> /run/podman/podman.sock
 ```
 
 ### Remove specific runner

--- a/scripts/runners/README-runners.md
+++ b/scripts/runners/README-runners.md
@@ -169,9 +169,9 @@ Access to the rootful Podman socket is restricted to the `runners` system group:
 | `/run/podman/` | `root:runners` | `0750` | Persisted via `/etc/tmpfiles.d/podman-socket.conf` |
 | `/run/podman/podman.sock` | `root:runners` | `0660` | Set via systemd socket override |
 
-Any account that needs to reach the Podman API must belong to `runners` as a
-**supplementary** group member. Accounts whose **primary GID** is `runners` are
-also validated during setup and must appear in the approved-account list.
+Any account that needs to reach the Podman API must use `runners` as either a
+supplementary group or its primary group. Both cases are validated during setup
+and must appear in the approved-account list.
 
 The setup script maintains an allowlist (`APPROVED_RUNNER_ACCOUNTS`). It aborts
 if any unapproved account — supplementary or primary-GID — is found in the group

--- a/scripts/runners/setup_github_runners_podman.sh
+++ b/scripts/runners/setup_github_runners_podman.sh
@@ -88,22 +88,56 @@ fi
 # Step 4: Configure socket permissions
 heading "Step 4: Configuring Socket Permissions"
 
+info "Creating runners group for socket access..."
+APPROVED_RUNNER_ACCOUNTS=("github-runner")
+if getent group runners > /dev/null 2>&1; then
+    info "Group 'runners' already exists — validating members..."
+    RUNNERS_GID=$(getent group runners | cut -d: -f3)
+
+    # Check supplementary members (getent group field 4)
+    CURRENT_MEMBERS=$(getent group runners | cut -d: -f4)
+    IFS=',' read -ra MEMBERS <<< "$CURRENT_MEMBERS"
+
+    # Also check accounts whose primary GID is the runners GID — those
+    # processes match the socket group permission even though they are not
+    # listed in the group's member field.
+    while IFS=: read -r acct _ _ pgid _; do
+        [[ "$pgid" == "$RUNNERS_GID" ]] && MEMBERS+=("$acct")
+    done < /etc/passwd
+
+    for member in "${MEMBERS[@]}"; do
+        [[ -z "$member" ]] && continue
+        approved=0
+        for approved_account in "${APPROVED_RUNNER_ACCOUNTS[@]}"; do
+            [[ "$member" == "$approved_account" ]] && approved=1 && break
+        done
+        if [[ $approved -eq 0 ]]; then
+            error "Unapproved account '$member' found in 'runners' group — aborting"
+            exit 1
+        fi
+    done
+    success "All 'runners' group members are approved"
+else
+    groupadd --system runners
+fi
+
 info "Creating systemd override for socket permissions..."
 mkdir -p /etc/systemd/system/podman.socket.d
 
 cat > /etc/systemd/system/podman.socket.d/override.conf <<'EOF'
 [Socket]
-# Make socket world-accessible for GitHub Actions
-SocketMode=0666
+SocketMode=0660
+SocketGroup=runners
 EOF
 
 info "Setting directory permissions..."
-chmod 755 /run/podman
+chown root:runners /run/podman
+chmod 750 /run/podman
 
 # Persist directory permissions across reboots and socket restarts.
 # Without this, systemd recreates /run/podman with 0700 (root-only),
-# blocking non-root users from accessing the socket even if SocketMode=0666.
-echo 'd /run/podman 0755 root root -' > /etc/tmpfiles.d/podman-socket.conf
+# blocking members of the runners group from accessing the socket.
+echo 'd /run/podman 0750 root runners -' > /etc/tmpfiles.d/podman-socket.conf
 
 info "Restarting podman.socket with new permissions..."
 systemctl daemon-reload
@@ -111,7 +145,6 @@ systemctl restart podman.socket
 sleep 2
 
 info "Verifying permissions..."
-chmod 666 /run/podman/podman.sock
 ls -la /run/podman/podman.sock
 
 success "Socket permissions configured"
@@ -167,7 +200,8 @@ if id github-runner &>/dev/null; then
     info "Enabling linger for github-runner..."
     loginctl enable-linger github-runner 2>/dev/null || true
 
-    info "Adding github-runner to libvirt and qemu groups..."
+    info "Adding github-runner to runners, libvirt, and qemu groups..."
+    usermod -aG runners github-runner
     usermod -aG libvirt github-runner 2>/dev/null || true
     usermod -aG qemu github-runner 2>/dev/null || true
 


### PR DESCRIPTION
Replace world-writable socket mode 0666 with 0660 restricted to a dedicated `runners` system group. Add github-runner to that group so CI jobs retain access while preventing any other local account from reaching the rootful socket.

This addresses ENCLAVE-002 in https://gitlab.cee.redhat.com/proguski/gpt-5.5-cyber-scans/-/blob/main/ecoengg-scan-5/results/enclave/README.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Restricted Podman socket access to authorized members of the `runners` group.
  * Removed world-accessible socket permissions.
  * Added validation to block unauthorized group members during setup.
  * Persisted secure ownership and permissions for the Podman socket directory.

* **Documentation**
  * Updated runner setup and troubleshooting guidance to reflect the new access controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->