### PR TITLE
fix(ci): remove ookla_speedtest-cli repo files blocking E2E runs

### DIFF
--- a/scripts/setup/configure_devscripts.sh
+++ b/scripts/setup/configure_devscripts.sh
@@ -14,6 +14,17 @@ ENCLAVE_DIR="$(cd -- "${SCRIPT_DIR}/../.." &>/dev/null && pwd)"
 source "${ENCLAVE_DIR}/scripts/lib/validation.sh"
 source "${ENCLAVE_DIR}/scripts/lib/common.sh"
 
+# Remove ookla speedtest-cli repo files if present: packagecloud.io now returns
+# HTTP 402 for all ookla repos (binary and source), which causes every subsequent
+# dnf invocation (including dev-scripts' make requirements) to fail when refreshing
+# metadata.
+for repo_file in /etc/yum.repos.d/ookla_speedtest-cli*.repo; do
+    [ -f "$repo_file" ] || continue
+    echo "Removing broken ookla repo: $repo_file (HTTP 402)..."
+    sudo rm -f "$repo_file"
+    echo "✓ Removed $repo_file"
+done
+
 # Validate required environment variables
 require_env_var "DEV_SCRIPTS_PATH"
 


### PR DESCRIPTION
packagecloud.io now returns HTTP 402 for both ookla_speedtest-cli and ookla_speedtest-cli-source repos. dev-scripts' 01_install_requirements.sh runs 'dnf info NetworkManager' which triggers a metadata refresh across all configured repos; the 402 fails the refresh, kills make requirements, and cascades into make infra_only failing before E2E can start.

configure_devscripts.sh now removes all ookla_speedtest-cli*.repo files before handing off to dev-scripts, unblocking existing runner hosts without requiring a re-run of the one-time runner setup script.