### PR TITLE
bump multicluster-engine to 2.10.4

### DIFF
--- a/defaults/operators.yaml
+++ b/defaults/operators.yaml
@@ -8,7 +8,7 @@ operators:
     namespace: quay-enterprise
 
   - name: multicluster-engine
-    version: 2.10.3
+    version: 2.10.4
     channel: stable-2.10
     init_version: 2.10.0
     namespace: multicluster-engine


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the multicluster engine operator to version 2.10.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->