### PR TITLE
add renovate configuration to update quay-operator

### DIFF
--- a/.github/workflows/build-push-tarball.yml
+++ b/.github/workflows/build-push-tarball.yml
@@ -144,6 +144,7 @@ jobs:
           EXCLUDED_PATHS=(
             ".git/"
             ".github/"
+            ".renovate.json"
             "Makefile.ci"
           )
 

--- a/.github/workflows/build-push-tarball.yml
+++ b/.github/workflows/build-push-tarball.yml
@@ -80,6 +80,7 @@ jobs:
               --exclude='.gitignore' \
               --exclude='.github' \
               --exclude='.tekton' \
+              --exclude='.renovate.json' \
               --exclude='scripts' \
               --exclude='Makefile.ci' \
               --exclude='.coderabbit.yaml' \

--- a/.renovate.json
+++ b/.renovate.json
@@ -4,7 +4,7 @@
     {
       "customType": "regex",
       "description": "quay-operator",
-      "managerFilePatterns": ["(^|/)defaults/operators\\.yaml$"],
+      "managerFilePatterns": ["defaults/operators.yaml"],
       "matchStrings": ["- name: quay-operator\\n\\s+version: (?<currentValue>\\S+)"],
       "datasourceTemplate": "docker",
       "depNameTemplate": "registry.redhat.io/quay/quay-operator-bundle"

--- a/.renovate.json
+++ b/.renovate.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "quay-operator",
+      "managerFilePatterns": ["(^|/)defaults/operators\\.yaml$"],
+      "matchStrings": ["- name: quay-operator\\n\\s+version: (?<currentValue>\\S+)"],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "registry.redhat.io/quay/quay-operator-bundle"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "OLM operators: only allow z-stream (patch) updates",
+      "matchManagers": ["custom.regex"],
+      "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
follow up on #642 where we introduced konflux and renovate, this is a custom configuration to keep operator versions up to date.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated dependency tracking for operator image versions has been configured.
  * Operator updates are limited to patch-level changes.
  * Generated release archives no longer include internal dependency-management configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->