### PR TITLE
docs: document Landing Zone firewall/port requirements

### DIFF
--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -127,6 +127,63 @@ The following dependencies are automatically installed by the setup scripts (`se
 - **Provisioning Network**: For ISO boot and cluster installation
 - **VIPs**: Virtual IPs for API and Ingress (must be in the same subnet)
 
+#### Firewall / Port Requirements
+
+The Landing Zone (deployment host) runs several services that bare metal
+nodes, BMCs, and the cluster itself must be able to reach. If `firewalld`
+(or another host firewall) is enabled on the Landing Zone, open the
+following ports:
+
+| Service | Port | Protocol | Direction | Notes |
+|---------|------|----------|-----------|-------|
+| SSH | 22 | TCP | Inbound to LZ | Administrative access |
+| DNS (`dnsmasq`) | 53 | TCP/UDP | Inbound to LZ from cluster nodes and BMCs | Resolves `api.*`/`apps.*`/mirror hostnames; matches `defaultDNS` |
+| DHCP (`dnsmasq`) | 67, 68 | UDP | Inbound to LZ from the provisioning network | Only if `dnsmasq` provides DHCP on that network |
+| Ironic API | 6385 | TCP | Inbound to LZ from cluster nodes / BMO controller | BareMetalHost provisioning and inspection |
+| Ironic HTTP (ISO/vmedia) | 6180 | TCP | Inbound to LZ from BMCs | Serves the boot ISO for virtual media |
+| Ironic vmedia (TLS) | 6183 | TCP | Inbound to LZ from BMCs | Only when `ironicHTTPSCertificate`/`ironicHTTPSKey` are configured |
+| Redfish | 443 (or as configured) | TCP | Outbound from LZ to each BMC | Port comes from the `redfish` field (`ip` or `ip:port`) per host in `config/cloud_infra.yaml` |
+| Mirror registry (Quay) | 8443 | TCP | Inbound to LZ from cluster nodes | Image pulls/pushes against `quayHostname:8443` |
+| OCP API | 6443 | TCP | Outbound from LZ to the cluster `apiVIP` | Used by the Ansible controller (`oc`/`KUBECONFIG`) and by the BMO/Ironic controllers reconciling `BareMetalHost` objects after install |
+| NTP | 123 | UDP | Inbound to LZ from cluster nodes | Only if `defaultNtpServers` points at the Landing Zone |
+
+**Example `firewalld` configuration**:
+
+```bash
+sudo firewall-cmd --permanent --add-port=22/tcp
+sudo firewall-cmd --permanent --add-port=53/tcp --add-port=53/udp
+sudo firewall-cmd --permanent --add-port=67/udp --add-port=68/udp
+sudo firewall-cmd --permanent --add-port=6385/tcp
+sudo firewall-cmd --permanent --add-port=6180/tcp
+sudo firewall-cmd --permanent --add-port=6183/tcp
+sudo firewall-cmd --permanent --add-port=8443/tcp
+sudo firewall-cmd --reload
+```
+
+Where possible, restrict access to the management/provisioning CIDRs
+instead of opening ports to all sources, for example:
+
+```bash
+sudo firewall-cmd --permanent --zone=internal \
+  --add-rich-rule='rule family=ipv4 source address=100.64.0.0/16 port port=6385 protocol=tcp accept'
+```
+
+**Validating connectivity** after configuring the firewall:
+
+```bash
+# From the Landing Zone: review active firewalld rules
+sudo firewall-cmd --list-all-zones
+
+# From a cluster node: confirm DNS resolution against the Landing Zone
+dig api.<clusterName>.<baseDomain> @<defaultDNS>
+
+# From a cluster node: confirm the mirror registry is reachable
+curl -sk https://<quayHostname>:8443/v2/ -o /dev/null -w '%{http_code}\n'
+
+# From the BMC network: confirm Ironic vmedia is reachable
+curl -sk https://<lzBmcIP>:6183/ -o /dev/null -w '%{http_code}\n'
+```
+
 ## Configuration
 
 Configuration is split across multiple files for better organization:

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -149,28 +149,37 @@ following ports:
 
 **Example `firewalld` configuration**:
 
+Do not add these ports to the default zone — that opens them on every
+interface, including any uplink/external network. Scope them to the zone
+bound to the provisioning-network interface instead:
+
 ```bash
-sudo firewall-cmd --permanent --add-port=22/tcp
-sudo firewall-cmd --permanent --add-port=53/tcp --add-port=53/udp
-sudo firewall-cmd --permanent --add-port=67/udp --add-port=68/udp
-sudo firewall-cmd --permanent --add-port=6385/tcp
-sudo firewall-cmd --permanent --add-port=6180/tcp
-sudo firewall-cmd --permanent --add-port=8443/tcp
+# Identify the zone already bound to the provisioning-network interface
+# (adjust the interface name for your environment)
+PROVISIONING_ZONE=$(sudo firewall-cmd --get-zone-of-interface=<provisioning-interface>)
+
+sudo firewall-cmd --permanent --zone="${PROVISIONING_ZONE}" --add-port=22/tcp
+sudo firewall-cmd --permanent --zone="${PROVISIONING_ZONE}" --add-port=53/tcp --add-port=53/udp
+sudo firewall-cmd --permanent --zone="${PROVISIONING_ZONE}" --add-port=67/udp --add-port=68/udp
+sudo firewall-cmd --permanent --zone="${PROVISIONING_ZONE}" --add-port=6385/tcp
+sudo firewall-cmd --permanent --zone="${PROVISIONING_ZONE}" --add-port=6180/tcp
+sudo firewall-cmd --permanent --zone="${PROVISIONING_ZONE}" --add-port=8443/tcp
 
 # Only if ironicHTTPSCertificate/ironicHTTPSKey are configured:
-sudo firewall-cmd --permanent --add-port=6183/tcp
+sudo firewall-cmd --permanent --zone="${PROVISIONING_ZONE}" --add-port=6183/tcp
 
 # Only if defaultNtpServers points cluster nodes at the Landing Zone:
-sudo firewall-cmd --permanent --add-port=123/udp
+sudo firewall-cmd --permanent --zone="${PROVISIONING_ZONE}" --add-port=123/udp
 
 sudo firewall-cmd --reload
 ```
 
-Where possible, restrict access to the management/provisioning CIDRs
-instead of opening ports to all sources, for example:
+For tighter scoping than a zone-wide port, restrict by source CIDR with a
+rich rule instead — this is the preferred approach where the provisioning
+and management networks share a zone:
 
 ```bash
-sudo firewall-cmd --permanent --zone=internal \
+sudo firewall-cmd --permanent --zone="${PROVISIONING_ZONE}" \
   --add-rich-rule='rule family=ipv4 source address=100.64.0.0/16 port port=6385 protocol=tcp accept'
 ```
 

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -155,8 +155,14 @@ sudo firewall-cmd --permanent --add-port=53/tcp --add-port=53/udp
 sudo firewall-cmd --permanent --add-port=67/udp --add-port=68/udp
 sudo firewall-cmd --permanent --add-port=6385/tcp
 sudo firewall-cmd --permanent --add-port=6180/tcp
-sudo firewall-cmd --permanent --add-port=6183/tcp
 sudo firewall-cmd --permanent --add-port=8443/tcp
+
+# Only if ironicHTTPSCertificate/ironicHTTPSKey are configured:
+sudo firewall-cmd --permanent --add-port=6183/tcp
+
+# Only if defaultNtpServers points cluster nodes at the Landing Zone:
+sudo firewall-cmd --permanent --add-port=123/udp
+
 sudo firewall-cmd --reload
 ```
 


### PR DESCRIPTION
## Summary
- Expands the existing "Network Requirements" section in `docs/DEPLOYMENT_GUIDE.md` with a firewall port/protocol matrix for the services the Landing Zone exposes (SSH, DNS/DHCP via `dnsmasq`, Ironic API/HTTP/vmedia-TLS, Redfish, mirror registry, OCP API, NTP)
- Adds example `firewalld` configuration (including a CIDR-scoped rich-rule example)
- Adds validation steps (`firewall-cmd --list-all-zones`, `dig`/`curl` checks) for confirming connectivity after configuring the firewall

Ports/services are grounded in existing playbook tasks (`deploy_ironic_containers.yaml`, `mirror_registry.yaml`) and `CONFIGURATION_REFERENCE.md`, not guessed.

Related: gori-project/GoRI#952 (Landing Zone services should have documented firewall requirements instead of disabling `firewalld` entirely).

## Test plan
- [x] Docs-only change; no code/schema impact
- [ ] Review by someone who owns a physical Landing Zone deployment to confirm the port list and defaults (especially Redfish port, which varies by BMC vendor)

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added firewall and port requirements for Landing Zone services.
  * Documented traffic directions, example firewall commands, CIDR restrictions, and connectivity validation steps for DNS, the mirror registry, and Ironic virtual media.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->