### PR TITLE
renovate: restrict PR creation to weekends only

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "schedule": ["* * * * 0,6"],
+  "updateNotScheduled": false,
   "customDatasources": {
     "redhat-operator-catalog": {
       "format": "json",


### PR DESCRIPTION
Avoid interference with weekday CI by scheduling Renovate to open and rebase PRs only on weekends, when e2e test load is lower.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Scheduled dependency updates to run only on weekends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->