### PR TITLE
update renovate to use a custom http datasource to redhat catalog pyxis api

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,22 +1,35 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "customDatasources": {
+    "redhat-operator-catalog": {
+      "defaultRegistryUrlTemplate": "https://catalog.redhat.com/api/containers/v1/operators/bundles?filter=package=={{packageName}};channel_name=={{packageChannel}};ocp_version==4.20",
+      "format": "json",
+      "transformTemplates": [
+        "{ \"releases\": data.[{ \"version\": version, \"releaseTimestamp\": creation_date }] }"
+      ]
+    }
+  },
   "customManagers": [
     {
       "customType": "regex",
-      "description": "quay-operator",
+      "description": "Update OLM operator versions in operators.yaml",
       "managerFilePatterns": ["defaults/operators.yaml"],
-      "matchStrings": ["- name: quay-operator\\n\\s+version: (?<currentValue>\\S+)"],
-      "datasourceTemplate": "docker",
-      "depNameTemplate": "registry.redhat.io/quay/quay-operator-bundle",
-      "extractVersionTemplate": "^v?(?<version>\\d+\\.\\d+\\.\\d+)",
-      "versioningTemplate": "semver"
+      "matchStrings": [
+        "- name: (?<packageName>[a-zA-Z0-9-]+)\\n\\s+version: (?<currentValue>[^\\s]+)\\n\\s+channel: (?<packageChannel>[a-zA-Z0-9.-]+)"
+      ],
+      "datasourceTemplate": "custom.redhat-operator-catalog"
     }
   ],
   "packageRules": [
     {
       "description": "OLM operators: only allow z-stream (patch) updates",
-      "matchManagers": ["custom.regex"],
+      "matchDatasources": ["custom.redhat-operator-catalog"],
       "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
+    },
+    {
+      "description": "Exclude metallb-operator (non-semver version)",
+      "matchPackageNames": ["metallb-operator"],
       "enabled": false
     }
   ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependency Updates**
  * Improved automated update detection for OpenShift operators using Red Hat’s operator catalog.
  * Added filtering by release channel and OpenShift version.
  * Expanded support for operators defined in the project’s default configuration.
  * Limited automated updates to patch versions and excluded MetalLB Operator updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->