### PR TITLE
Add Renovate automation for Ansible collection version and sha256 updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -46,7 +46,7 @@
       "matchDatasources": ["galaxy-collection"],
       "postUpgradeTasks": {
         "commands": [
-          "./scripts/setup/update_ansible_collection_sha256.sh {{{depName}}} {{{newVersion}}}"
+          "./scripts/setup/update_ansible_collection_sha256.sh '{{{depName}}}' '{{{newVersion}}}'"
         ],
         "fileFilters": ["ansible_collections.sha256"],
         "executionMode": "update"

--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,9 @@
       "registryUrlTemplate": "https://catalog.redhat.com/api/containers/v1/operators/bundles?filter=package=={{packageName}};channel_name=={{packageChannel}};ocp_version==4.20"
     }
   ],
+  "ansible-galaxy": {
+    "managerFilePatterns": ["ansible_collections.txt"]
+  },
   "packageRules": [
     {
       "description": "OLM operators: only allow z-stream (patch) updates",
@@ -37,6 +40,17 @@
       "description": "Exclude metallb-operator (non-semver version)",
       "matchPackageNames": ["metallb-operator"],
       "enabled": false
+    },
+    {
+      "description": "Refresh ansible_collections.sha256 for the bumped collection",
+      "matchDatasources": ["galaxy-collection"],
+      "postUpgradeTasks": {
+        "commands": [
+          "./scripts/setup/update_ansible_collection_sha256.sh {{{depName}}} {{{newVersion}}}"
+        ],
+        "fileFilters": ["ansible_collections.sha256"],
+        "executionMode": "update"
+      }
     }
   ]
 }

--- a/scripts/setup/update_ansible_collection_sha256.sh
+++ b/scripts/setup/update_ansible_collection_sha256.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Refresh the checksum of one Ansible collection in ansible_collections.sha256
+#
+# Queries the Ansible Galaxy v3 API for the published sha256 of a specific
+# collection version and rewrites its line in ansible_collections.sha256.
+# Avoids downloading the collection tarball since Galaxy already publishes
+# its checksum as metadata.
+#
+# Usage:
+#   ./update_ansible_collection_sha256.sh <namespace.name> <version>
+#
+# Example:
+#   ./update_ansible_collection_sha256.sh community.crypto 3.2.2
+
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <namespace.name> <version>" >&2
+    exit 1
+fi
+
+FQCN="$1"
+NAMESPACE="${FQCN%%.*}"
+NAME="${FQCN#*.}"
+VERSION="$2"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+ENCLAVE_DIR="$(cd -- "${SCRIPT_DIR}/../.." &>/dev/null && pwd)"
+SHA256_FILE="${ENCLAVE_DIR}/ansible_collections.sha256"
+
+META_FILE="$(mktemp)"
+trap 'rm -f "$META_FILE"' EXIT
+
+curl -sf \
+    "https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/index/${NAMESPACE}/${NAME}/versions/${VERSION}/" \
+    -o "$META_FILE"
+
+python3 - "$NAMESPACE" "$NAME" "$META_FILE" "$SHA256_FILE" <<'PYEOF'
+import json
+import sys
+
+namespace, name, meta_file, sha256_file = sys.argv[1:5]
+
+with open(meta_file) as f:
+    artifact = json.load(f)["artifact"]
+
+try:
+    with open(sha256_file) as f:
+        lines = f.readlines()
+except FileNotFoundError:
+    lines = []
+
+prefix = f"*collections/{namespace}-{name}-"
+lines = [line for line in lines if prefix not in line]
+lines.append(f"{artifact['sha256']} *collections/{artifact['filename']}\n")
+
+with open(sha256_file, "w") as f:
+    f.writelines(lines)
+PYEOF
+
+echo "✅ Updated checksum for ${NAMESPACE}.${NAME} ${VERSION} in ${SHA256_FILE}"

--- a/scripts/setup/update_ansible_collection_sha256.sh
+++ b/scripts/setup/update_ansible_collection_sha256.sh
@@ -20,18 +20,35 @@ if [ "$#" -ne 2 ]; then
 fi
 
 FQCN="$1"
-NAMESPACE="${FQCN%%.*}"
-NAME="${FQCN#*.}"
 VERSION="$2"
 
-SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
-ENCLAVE_DIR="$(cd -- "${SCRIPT_DIR}/../.." &>/dev/null && pwd)"
+# Reject anything that isn't a plain Galaxy collection name / version before
+# it reaches the API URL, since both values are attacker-influenceable
+# (sourced from Renovate's depName/newVersion templates).
+if [[ ! "$FQCN" =~ ^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$ ]]; then
+    echo "ERROR: invalid collection name '${FQCN}' (expected namespace.name)" >&2
+    exit 1
+fi
+if [[ ! "$VERSION" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+    echo "ERROR: invalid version '${VERSION}'" >&2
+    exit 1
+fi
+
+NAMESPACE="${FQCN%%.*}"
+NAME="${FQCN#*.}"
+
+source "$(dirname -- "${BASH_SOURCE[0]}")/../lib/common.sh"
+detect_enclave_dir
 SHA256_FILE="${ENCLAVE_DIR}/ansible_collections.sha256"
 
 META_FILE="$(mktemp)"
 trap 'rm -f "$META_FILE"' EXIT
 
 curl -sf \
+    --connect-timeout 10 \
+    --max-time 30 \
+    --retry 3 \
+    --retry-max-time 60 \
     "https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/index/${NAMESPACE}/${NAME}/versions/${VERSION}/" \
     -o "$META_FILE"
 


### PR DESCRIPTION
## Summary
- Enable the built-in `ansible-galaxy` Renovate manager for `ansible_collections.txt` so collection versions are bumped automatically.
- Add a `postUpgradeTasks` rule (datasource `galaxy-collection`) that runs `scripts/setup/update_ansible_collection_sha256.sh` after each bump to refresh the matching line in `ansible_collections.sha256`.
- New script queries the Ansible Galaxy v3 API for the published `artifact.sha256`/`filename` of the bumped version — no tarball download needed — and rewrites just that collection's line in `ansible_collections.sha256`.

Note: whether `postUpgradeTasks` actually executes depends on the Renovate runner's `allowedCommands` allowlist, which is configured outside this repo.

## Test plan
- [x] `renovate.json` is valid JSON
- [x] Ran `scripts/setup/update_ansible_collection_sha256.sh community.crypto 3.2.2` against the real Galaxy API and confirmed the regenerated line matches the existing checksum in `ansible_collections.sha256`
- [ ] Confirm a live Renovate run against this config produces the expected version + checksum PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated tracking for Ansible Galaxy collection updates.
  * Added SHA-256 checksum retrieval and maintenance for updated collections.
  * Checksum records are automatically created or refreshed as collections change.
  * Update processing includes retry handling and validation to improve reliability.
  * Temporary update data is cleaned up automatically after processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->