### PR TITLE
remove openshift version 4.20.8

### DIFF
--- a/defaults/platforms.yaml
+++ b/defaults/platforms.yaml
@@ -1,6 +1,5 @@
 ---
 openshift_versions:
-- version: 4.20.8
 - version: 4.20.21
 - version: 4.20.29
   default: true


### PR DESCRIPTION
remove first version, with 2 versions already present.

this removes the option to upgrade from 4.20.8 clusters.