### PR TITLE
bump lvms plugin lvms-operator to version 4.20.1

### DIFF
--- a/plugins/lvms/plugin.yaml
+++ b/plugins/lvms/plugin.yaml
@@ -22,7 +22,7 @@ installOperatorsFleet: false
 
 operators:
   - name: lvms-operator
-    version: 4.20.0
+    version: 4.20.1
     channel: stable-4.20
     init_version: 4.20.0
     namespace: openshift-storage


### PR DESCRIPTION
this change is supported by another PR that handles the actual upgrade functionality. this PR is only the metadata changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the LVMS operator to version 4.20.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->