### PR TITLE
OSAC-4023: Add Metal3 component upgrade support (Ironic and Baremetal Operator)

### DIFF
--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -43,16 +43,20 @@ Each Enclave tarball release includes:
 4. **Restore configurations** - Copy your `config/*.yaml` files back (or merge if needed)
 5. **Validate configuration** - Ensure your configs are compatible with new release
 6. **Sync content** - Run sync process to mirror new versions (disconnected mode)
+
     ```sh
     ./sync.sh
     ```
+
 7. **Execute upgrade script** - Run the upgrade automation to apply configuration migrations, upgrade Landing Zone components (Metal3 stack), then upgrade the management cluster and operators to the versions pinned in the tarball. This executes the `playbooks/upgrade.yaml` playbook, which runs migrations, Metal3 component upgrades, followed by `enclave reconcile mgmt-cluster-version --use-defaults` and `enclave reconcile operator-versions --use-defaults`:
+
     ```sh
     ./upgrade.sh
     ```
 
     **Metal3 Upgrade Phase**: Upgrades Ironic and Baremetal Operator in persistent mode (`metal3_persistent: true`) to match the management cluster OpenShift version. For intermediate version requirements, use the migration system.
 8. **(Optional) Run cluster/operator upgrades separately** - By default `upgrade.yaml` performs both the management cluster and operator upgrades. To skip either step (e.g. to control upgrade timing independently) pass `upgrade_mgmt_cluster=false` and/or `upgrade_operators=false`, then run the corresponding command manually when ready:
+
     ```sh
     ansible-playbook playbooks/upgrade.yaml -e workingDir=<your global.yaml workingDir variable> -e upgrade_mgmt_cluster=false -e upgrade_operators=false
 

--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -17,7 +17,7 @@ Upgrading to a new Enclave release follows this sequence:
 
 1. **Deploy new Enclave tarball** - Extract new release to Landing Zone, preserving your `config/*.yaml` customizations
 2. **Sync/Mirror new content** - Run sync process to download and mirror new OpenShift and operator images to local registry (disconnected mode)
-3. **Upgrade Landing Zone components** - Update components to the versions specified in the new tarball
+3. **Upgrade Landing Zone components** - Update components to the versions specified in the new tarball (includes Metal3 stack)
 4. **Upgrade the management cluster** - Update OpenShift to the version specified in the new tarball
 5. **Upgrade operators** - Update operators to the versions specified in the new tarball
 
@@ -46,10 +46,12 @@ Each Enclave tarball release includes:
     ```sh
     ./sync.sh
     ```
-7. **Execute upgrade script** - Run the upgrade automation to apply configuration migrations, then upgrade the management cluster and operators to the versions pinned in the tarball. This executes the `playbooks/upgrade.yaml` playbook, which runs migrations followed by `enclave reconcile mgmt-cluster-version --use-defaults` and `enclave reconcile operator-versions --use-defaults`:
+7. **Execute upgrade script** - Run the upgrade automation to apply configuration migrations, upgrade Landing Zone components (Metal3 stack), then upgrade the management cluster and operators to the versions pinned in the tarball. This executes the `playbooks/upgrade.yaml` playbook, which runs migrations, Metal3 component upgrades, followed by `enclave reconcile mgmt-cluster-version --use-defaults` and `enclave reconcile operator-versions --use-defaults`:
     ```sh
     ./upgrade.sh
     ```
+
+    **Metal3 Upgrade Phase**: Upgrades Ironic and Baremetal Operator in persistent mode (`metal3_persistent: true`) to match the management cluster OpenShift version. For intermediate version requirements, use the migration system.
 8. **(Optional) Run cluster/operator upgrades separately** - By default `upgrade.yaml` performs both the management cluster and operator upgrades. To skip either step (e.g. to control upgrade timing independently) pass `upgrade_mgmt_cluster=false` and/or `upgrade_operators=false`, then run the corresponding command manually when ready:
     ```sh
     ansible-playbook playbooks/upgrade.yaml -e workingDir=<your global.yaml workingDir variable> -e upgrade_mgmt_cluster=false -e upgrade_operators=false

--- a/playbooks/tasks/deploy_ironic.yaml
+++ b/playbooks/tasks/deploy_ironic.yaml
@@ -12,18 +12,48 @@
   ansible.builtin.set_fact:
     metal3_ironic_image: "{{ r_ironic_image.stdout }}"
 
-- name: Generate htpasswd hash for Ironic credentials  # noqa: command-instead-of-shell
+- name: Check if metal3-ironic-htpasswd secret exists (ephemeral)
+  when: not (metal3_persistent | default(false) | bool)
+  ansible.builtin.command: podman secret inspect --showsecret metal3-ironic-htpasswd --format "{{ '{{' }}.SecretData{{ '}}' }}"
+  register: r_htpasswd_secret_check_ephemeral
+  failed_when: r_htpasswd_secret_check_ephemeral.rc != 0 and r_htpasswd_secret_check_ephemeral.rc != 125
+  changed_when: false
+  no_log: true
+
+- name: Check if metal3-ironic-htpasswd secret exists (persistent)
+  when: metal3_persistent | default(false) | bool
+  become: yes
+  ansible.builtin.command: podman secret inspect --showsecret metal3-ironic-htpasswd --format "{{ '{{' }}.SecretData{{ '}}' }}"
+  register: r_htpasswd_secret_check_persistent
+  failed_when: r_htpasswd_secret_check_persistent.rc != 0 and r_htpasswd_secret_check_persistent.rc != 125
+  changed_when: false
+  no_log: true
+
+- name: Set active secret check result
+  ansible.builtin.set_fact:
+    r_htpasswd_secret_check: "{{ r_htpasswd_secret_check_ephemeral if not (metal3_persistent | default(false) | bool) else r_htpasswd_secret_check_persistent }}"
+  no_log: true
+
+- name: Generate htpasswd hash for Ironic credentials if secret doesn't exist  # noqa: command-instead-of-shell
   # shell module required: quote filter produces shell-quoted strings that need shell parsing
   ansible.builtin.shell:
     cmd: /usr/bin/htpasswd -nbB {{ metal3_ironic_username | quote }} {{ metal3_ironic_password | quote }}
   register: r_htpasswd
   changed_when: false
   no_log: true
+  when: r_htpasswd_secret_check.rc != 0
 
-- name: Set htpasswd variable
+- name: Set htpasswd variable from new generation
   ansible.builtin.set_fact:
     metal3_ironic_htpasswd: "{{ r_htpasswd.stdout }}"
   no_log: true
+  when: r_htpasswd_secret_check.rc != 0
+
+- name: Set htpasswd variable from existing secret
+  ansible.builtin.set_fact:
+    metal3_ironic_htpasswd: "{{ r_htpasswd_secret_check.stdout }}"
+  no_log: true
+  when: r_htpasswd_secret_check.rc == 0
 
 - name: Create podman secret for ironic htpasswd
   become: "{{ metal3_persistent | default(false) | bool }}"
@@ -31,7 +61,7 @@
     name: metal3-ironic-htpasswd
     data: "{{ metal3_ironic_htpasswd }}"
     state: present
-    force: true
+    force: false
   no_log: true
 
 - name: Check if SSL certificates are configured

--- a/playbooks/tasks/upgrade/metal3-components.yaml
+++ b/playbooks/tasks/upgrade/metal3-components.yaml
@@ -1,0 +1,32 @@
+---
+# Upgrade Metal3 components (Ironic + BMO) to new versions
+
+- name: Load common variables (without version override)
+  ansible.builtin.include_tasks: common/load-vars.yaml
+
+- name: Override OpenShift version if manually specified
+  ansible.builtin.set_fact:
+    mgmt_openshift_version: "{{ metal3_openshift_version | default(mgmt_openshift_version) }}"
+
+- name: Enable persistent deployment for upgrades
+  ansible.builtin.set_fact:
+    metal3_persistent: true
+
+- name: Display upgrade plan
+  ansible.builtin.debug:
+    msg: |
+      Upgrading Metal3 components to OpenShift version {{ mgmt_openshift_version }}
+
+- name: Deploy Metal3 common resources
+  ansible.builtin.include_tasks: ../../tasks/deploy_metal3_common.yaml
+
+- name: Upgrade Ironic
+  ansible.builtin.include_tasks: ../../tasks/deploy_ironic.yaml
+
+- name: Upgrade Baremetal Operator
+  ansible.builtin.include_tasks: ../../tasks/deploy_bmo.yaml
+
+- name: Display upgrade completion
+  ansible.builtin.debug:
+    msg: |
+      Metal3 components upgrade completed successfully to OpenShift version {{ mgmt_openshift_version }}

--- a/playbooks/upgrade-metal3-components.yaml
+++ b/playbooks/upgrade-metal3-components.yaml
@@ -1,0 +1,19 @@
+---
+# Upgrade Metal3 components (Ironic + BMO) to new versions
+# This playbook can be used as a migration to trigger Bare Metal Operator and Ironic upgrades
+
+- name: Upgrade Metal3 components
+  hosts: localhost
+  gather_facts: false
+
+  # Specific version can be forced by either:
+  # - Passing "-e metal3_openshift_version=4.20.4" via command line
+  # - Hardcoding the variable in the following vars section
+
+  # Uncomment to use hardcoded version
+  # vars:
+  #   metal3_openshift_version: "4.20.5"
+
+  tasks:
+    - name: Run metal3 upgrade tasks
+      ansible.builtin.include_tasks: tasks/upgrade/metal3-components.yaml

--- a/playbooks/upgrade.yaml
+++ b/playbooks/upgrade.yaml
@@ -22,6 +22,9 @@
       ansible.builtin.include_tasks:
         file: tasks/migrations.yaml
 
+    - name: Run metal3 upgrade tasks
+      ansible.builtin.include_tasks: tasks/upgrade/metal3-components.yaml
+
     - name: Upgrade management cluster OpenShift version
       ansible.builtin.command:
         argv:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an upgrade workflow for Metal3 components, including Ironic and the Baremetal Operator.
  * Added optional OpenShift version overrides and persistent deployment support.
  * Added progress and completion reporting for Metal3 upgrades.
  * Integrated Metal3 upgrades into the standard upgrade process and added a standalone upgrade option.

* **Bug Fixes**
  * Improved Ironic credential handling by reusing existing secrets and avoiding unnecessary replacement.
  * Suppressed sensitive credential output during upgrades.

* **Documentation**
  * Updated upgrade guidance to describe the Metal3 upgrade phase and sequence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->