### PR TITLE
OSAC-3982: Support existing management cluster deployments with automatic detection

### DIFF
--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -256,6 +256,43 @@ Phase 7: Discovery (07-configure-discovery.yaml)
   Configure hardware discovery for additional nodes
 ```
 
+### Existing Management Cluster Mode
+
+The deployment automatically detects when a management cluster already exists and skips provisioning steps:
+
+**Detection**: If `workingDir/ocp-cluster/auth/kubeconfig` exists, the deployment enters "existing management cluster" mode.
+
+**Modified workflow**:
+```text
+Phase 1: Prepare (01-prepare.yaml)
+  Download binaries and RHCOS content
+         ↓
+Phase 2: Mirror (02-mirror.yaml)          ← disconnected only
+  Deploy mirror registry, mirror images
+         ↓
+Validate: Validate existing cluster
+  Verify kubeconfig, check cluster version
+         ↓
+Phase 3: SKIPPED - management cluster already exists
+         ↓
+Phase 4: SKIPPED - cluster already configured
+         ↓
+Phase 5: Operators (05-operators.yaml)
+  Install and configure cluster operators
+         ↓
+Phase 6: Day-2 (06-day2.yaml)
+  Clair, ACM policies, model config, plugin deployment
+         ↓
+Phase 7: Discovery (07-configure-discovery.yaml)
+  Configure hardware discovery for additional nodes
+```
+
+**Use case**: This mode is ideal for focusing on Enclave's mirroring flow (quay.io → mirror-registry → quay-enterprise) when you already have a management cluster provisioned.
+
+**Setup**: Place your existing cluster's kubeconfig at `workingDir/ocp-cluster/auth/kubeconfig` before running the deployment.
+
+**Validation**: The cluster version must match `openshift_version_default` in your configuration.
+
 ### Bootstrap
 
 Before running the deployment phases, run `bootstrap.sh` to:

--- a/docs/EXISTING_CLUSTER_MODE.md
+++ b/docs/EXISTING_CLUSTER_MODE.md
@@ -1,0 +1,178 @@
+# Existing Management Cluster Mode
+
+## Overview
+
+Enclave supports deploying to a pre-existing management cluster, automatically skipping cluster provisioning phases and focusing on the mirroring flow and operator installation.
+
+This mode is ideal when:
+- You already have a management cluster deployed
+- You want to focus on Enclave's mirroring flow (quay.io → mirror-registry → quay-enterprise)
+- You need to re-run operator installation or configuration without reprovisioning
+
+## How It Works
+
+The deployment **automatically detects** an existing management cluster by checking for:
+```
+workingDir/ocp-cluster/auth/kubeconfig
+```
+
+If this file exists, the deployment:
+1. ✅ Runs Phase 1 (Prepare) - downloads binaries
+2. ✅ Runs Phase 2 (Mirror) - sets up mirror-registry and mirrors images
+3. ✅ Validates existing cluster - connectivity and version checks
+4. ⏭️  Skips Phase 3 (Deploy) - cluster already exists
+5. ⏭️  Skips Phase 4 (Post-Install) - cluster already configured
+6. ✅ Runs Phase 5 (Operators) - installs operators
+7. ✅ Runs Phase 6 (Day2) - day-2 operations
+8. ✅ Runs Phase 7 (Discovery) - hardware discovery (optional)
+
+## Setup
+
+### 1. Prepare Your Kubeconfig
+
+Place your existing cluster's kubeconfig at the expected location:
+
+```bash
+mkdir -p /home/enclave/ocp-cluster/auth
+cp /path/to/your/kubeconfig /home/enclave/ocp-cluster/auth/kubeconfig
+
+# Verify connectivity
+export KUBECONFIG=/home/enclave/ocp-cluster/auth/kubeconfig
+oc whoami
+oc get clusterversion
+```
+
+### 2. Configure Your Deployment
+
+Update `config/global.yaml` to match your existing cluster:
+
+```yaml
+workingDir: /home/enclave
+clusterName: mgmt  # Must match existing cluster
+baseDomain: example.com  # Must match existing cluster
+
+# Network settings (for reference, not used for provisioning)
+apiVIP: 192.168.2.201
+ingressVIP: 192.168.2.202
+machineNetwork: 192.168.2.0/24
+
+# Agent hosts (still required for documentation)
+agent_hosts:
+  - hostname: node1
+    # ... (not provisioned, but kept for reference)
+```
+
+### 3. Run Deployment
+
+```bash
+# Full deployment with existing cluster
+ansible-playbook playbooks/main.yaml -e workingDir=/home/enclave
+
+# Or run specific phases
+ansible-playbook playbooks/02-mirror.yaml -e workingDir=/home/enclave
+ansible-playbook playbooks/05-operators.yaml -e workingDir=/home/enclave
+```
+
+## Validation
+
+The `validate-existing-cluster.yaml` playbook automatically runs when an existing cluster is detected. It checks:
+
+1. **Kubeconfig accessibility** - can read and parse the kubeconfig
+2. **Cluster connectivity** - `oc whoami` succeeds
+3. **Version match** - cluster version matches `openshift_version_default` in configuration
+
+If validation fails:
+- Update your `config/global.yaml` to match the cluster version, OR
+- Use a different cluster that matches the expected version
+
+## Example Workflow
+
+```bash
+# 1. You already have a management cluster
+oc get nodes
+# NAME    STATUS   ROLES           AGE   VERSION
+# node1   Ready    control-plane   5d    v1.30.0
+# node2   Ready    control-plane   5d    v1.30.0
+# node3   Ready    control-plane   5d    v1.30.0
+
+# 2. Place kubeconfig
+mkdir -p /home/enclave/ocp-cluster/auth
+cp ~/.kube/config /home/enclave/ocp-cluster/auth/kubeconfig
+
+# 3. Run deployment - automatically detects existing cluster
+ansible-playbook playbooks/main.yaml -e workingDir=/home/enclave
+
+# Output:
+# TASK [Display deployment mode]
+# ok: [localhost] => {
+#     "msg": "Management cluster exists - skipping provisioning, focusing on mirroring flow"
+# }
+#
+# PLAY [Validate existing management cluster]
+# ...
+# TASK [Validation successful]
+# ok: [localhost] => {
+#     "msg": "✓ Management cluster validation passed - proceeding with mirroring and operator installation"
+# }
+```
+
+## Switching Modes
+
+### From New Cluster → Existing Cluster
+
+After initial deployment, the kubeconfig exists. Future runs automatically use existing cluster mode.
+
+### From Existing Cluster → New Cluster
+
+Remove the kubeconfig to force fresh provisioning:
+
+```bash
+rm -rf /home/enclave/ocp-cluster/auth/kubeconfig
+# Next deployment will provision a new cluster
+```
+
+## Configuration Reference
+
+The `agent_hosts` configuration is **still required** even in existing cluster mode:
+- Kept for documentation and reference
+- Not used for provisioning
+- Useful for understanding cluster topology
+
+## Troubleshooting
+
+### "Management cluster version mismatch" Error
+
+**Problem**: Your cluster version doesn't match the configuration.
+
+**Solution**:
+```yaml
+# Update config/global.yaml
+openshift_version_default: "4.17.8"  # Match your cluster
+```
+
+Or check available versions:
+```bash
+oc get clusterversion -o yaml
+```
+
+### Kubeconfig Permission Issues
+
+**Problem**: Cannot read kubeconfig file.
+
+**Solution**:
+```bash
+chmod 600 /home/enclave/ocp-cluster/auth/kubeconfig
+```
+
+### Want to Force Fresh Provisioning
+
+**Problem**: Kubeconfig exists but you want to deploy fresh.
+
+**Solution**:
+```bash
+# Backup existing kubeconfig
+mv /home/enclave/ocp-cluster/auth/kubeconfig{,.backup}
+
+# Run deployment - will provision new cluster
+ansible-playbook playbooks/main.yaml -e workingDir=/home/enclave
+```

--- a/playbooks/main.yaml
+++ b/playbooks/main.yaml
@@ -1,7 +1,7 @@
 ---
 # Red Hat Sovereign Enclave - Main Deployment Playbook
 #
-# Supports both connected and disconnected deployment modes:
+# Supports multiple deployment modes:
 #
 # DISCONNECTED MODE (default):
 #   Phase 1: Prepare - Download binaries and content
@@ -21,12 +21,26 @@
 #   Phase 6: Day2 - Optional advanced features
 #   Phase 7: Configure Discovery - Hardware discovery (optional)
 #
+# EXISTING MANAGEMENT CLUSTER MODE:
+#   Auto-detected when workingDir/ocp-cluster/auth/kubeconfig exists
+#   Phase 1: Prepare - Download binaries and content
+#   Phase 2: Mirror - Set up local registry and mirror images
+#   Validate: Validate existing management cluster
+#   Phase 3: SKIPPED - Use existing cluster
+#   Phase 4: SKIPPED - Cluster already configured
+#   Phase 5: Operators - Install and configure operators
+#   Phase 6: Day2 - Optional advanced features
+#   Phase 7: Configure Discovery - Hardware discovery (optional)
+#
 # Usage:
 #   # Full deployment (disconnected mode)
 #   ansible-playbook playbooks/main.yaml -e workingDir=/home/cloud-user
 #
 #   # Full deployment (connected mode)
 #   ansible-playbook playbooks/main.yaml -e workingDir=/home/cloud-user -e disconnected=false
+#
+#   # Use existing management cluster (place kubeconfig at workingDir/ocp-cluster/auth/kubeconfig)
+#   ansible-playbook playbooks/main.yaml -e workingDir=/home/cloud-user
 #
 #   # Run specific phases
 #   ansible-playbook playbooks/04-post-install.yaml -e workingDir=/home/cloud-user
@@ -39,11 +53,39 @@
   ansible.builtin.import_playbook: 02-mirror.yaml
   when: disconnected | default(true) | bool
 
+- name: Detect existing management cluster
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Load common variables for detection
+      ansible.builtin.include_tasks:
+        file: common/load-vars.yaml
+
+    - name: Check if management cluster kubeconfig already exists
+      ansible.builtin.stat:
+        path: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+      register: existing_kubeconfig
+
+    - name: Set flag based on kubeconfig presence
+      ansible.builtin.set_fact:
+        management_cluster_exists: "{{ existing_kubeconfig.stat.exists }}"
+        cacheable: yes
+
+    - name: Display deployment mode
+      ansible.builtin.debug:
+        msg: "{{ 'Management cluster exists - skipping provisioning, focusing on mirroring flow' if management_cluster_exists else 'Provisioning new management cluster' }}"
+
+- name: Validate existing management cluster
+  ansible.builtin.import_playbook: validate-existing-cluster.yaml
+  when: management_cluster_exists | default(false) | bool
+
 - name: Phase 3 - Deploy OpenShift cluster
   ansible.builtin.import_playbook: 03-deploy.yaml
+  when: not (management_cluster_exists | default(false) | bool)
 
 - name: Phase 4 - Post-installation configuration
   ansible.builtin.import_playbook: 04-post-install.yaml
+  when: not (management_cluster_exists | default(false) | bool)
 
 - name: Phase 5 - Operator installation
   ansible.builtin.import_playbook: 05-operators.yaml

--- a/playbooks/validate-existing-cluster.yaml
+++ b/playbooks/validate-existing-cluster.yaml
@@ -1,0 +1,73 @@
+---
+# Validate Existing Management Cluster
+# Auto-detected when workingDir/ocp-cluster/auth/kubeconfig exists
+#
+# Performs:
+# - Verify kubeconfig is accessible
+# - Check cluster connectivity
+# - Validate OpenShift version matches configuration
+#
+# Usage:
+#   ansible-playbook playbooks/validate-existing-cluster.yaml
+
+- name: Validate existing management cluster
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Load common variables
+      ansible.builtin.include_tasks:
+        file: common/load-vars.yaml
+        apply:
+          tags: always
+      tags: always
+
+    - name: Execute validation tasks
+      environment:
+        PATH: "{{ workingDir }}/bin:{{ lookup('env', 'HOME') }}/.local/bin:{{ lookup('env', 'PATH') }}"
+      block:
+        - name: Display validation message
+          ansible.builtin.debug:
+            msg: "Validating existing management cluster at {{ workingDir }}/ocp-cluster/auth/kubeconfig"
+
+        - name: Test cluster connectivity
+          environment:
+            KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+          ansible.builtin.command: "{{ workingDir }}/bin/oc whoami"
+          register: oc_whoami
+          changed_when: false
+          failed_when: oc_whoami.rc != 0
+
+        - name: Get cluster version
+          environment:
+            KUBECONFIG: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
+          kubernetes.core.k8s_info:
+            kind: ClusterVersion
+            name: version
+          register: cluster_version_info
+          failed_when: cluster_version_info.resources | length == 0
+
+        - name: Extract cluster version
+          ansible.builtin.set_fact:
+            actual_cluster_version: "{{ cluster_version_info.resources[0].status.desired.version }}"
+
+        - name: Display cluster information
+          ansible.builtin.debug:
+            msg: |
+              Management cluster version: {{ actual_cluster_version }}
+              Expected version: {{ openshift_version_default }}
+              Authenticated as: {{ oc_whoami.stdout }}
+
+        - name: Validate cluster version matches configuration
+          ansible.builtin.assert:
+            that:
+              - actual_cluster_version is version(openshift_version_default, '==')
+            fail_msg: |
+              Management cluster version mismatch:
+                Actual: {{ actual_cluster_version }}
+                Expected: {{ openshift_version_default }}
+              Update config/global.yaml or use a different cluster.
+            success_msg: "Management cluster version matches expected version {{ openshift_version_default }}"
+
+        - name: Validation successful
+          ansible.builtin.debug:
+            msg: "✓ Management cluster validation passed - proceeding with mirroring and operator installation"


### PR DESCRIPTION
## Summary

Adds support for deploying to pre-existing management clusters, enabling users to skip cluster provisioning phases and focus on Enclave's mirroring flow (quay.io → mirror-registry → quay-enterprise).

## Changes

### Automatic Detection
- Detects existing management cluster by checking for `workingDir/ocp-cluster/auth/kubeconfig`
- No configuration flags required - detection is fully automatic
- Conditionally skips Phase 3 (Deploy) and Phase 4 (Post-Install) when cluster exists

### Validation
- New playbook `playbooks/validate-existing-cluster.yaml` validates:
  - Kubeconfig accessibility
  - Cluster connectivity (`oc whoami`)
  - Cluster version matches `openshift_version_default` in configuration
- Clear error messages on version mismatch

### Modified Workflow

**Normal mode:**
```
Prepare → Mirror → Deploy → Post-Install → Operators → Day2 → Discovery
```

**Existing cluster mode (auto-detected):**
```
Prepare → Mirror → Validate → [Deploy skipped] → [Post-Install skipped] → Operators → Day2 → Discovery
```

## Files Changed

- **playbooks/main.yaml**: Detection logic and conditional phase execution
- **playbooks/validate-existing-cluster.yaml**: New validation playbook
- **docs/DEPLOYMENT_GUIDE.md**: Updated with existing cluster mode section
- **docs/EXISTING_CLUSTER_MODE.md**: New comprehensive usage guide

## Usage

Place your existing cluster's kubeconfig at the expected location:

```bash
mkdir -p /home/enclave/ocp-cluster/auth
cp /path/to/kubeconfig /home/enclave/ocp-cluster/auth/kubeconfig
ansible-playbook playbooks/main.yaml -e workingDir=/home/enclave
```

The deployment will automatically detect and validate the existing cluster.

## Use Cases

- Management cluster already provisioned
- Focus on mirroring flow and operator installation
- Re-running deployment without cluster reprovisioning

## Testing

1. Place a valid kubeconfig at `workingDir/ocp-cluster/auth/kubeconfig`
2. Run `ansible-playbook playbooks/main.yaml -e workingDir=/home/enclave`
3. Verify Phase 3 and 4 are skipped
4. Verify validation playbook runs and passes

## Related

Jira: https://redhat.atlassian.net/browse/OSAC-3982

✨ **Claude Code**: Implemented automatic detection mechanism and validation playbook in commit 3650c92

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for deploying against an existing management cluster using a detected kubeconfig.
  * Added validation for cluster connectivity, authentication, and expected platform version.
  * Existing clusters now skip provisioning and post-installation while continuing with operator, Day-2, and discovery steps.

* **Documentation**
  * Added deployment guidance, configuration references, example workflows, mode switching instructions, and troubleshooting information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->