### PR TITLE
bump OSAC plugin helm chart version from 0.0.6 to 0.0.9-nightly.20260813.72aefaa.11.1

### DIFF
--- a/plugins/osac/defaults.yaml
+++ b/plugins/osac/defaults.yaml
@@ -4,7 +4,7 @@
 # which is loaded into Ansible scope as-is. The defaults below use the same
 # camelCase convention to match. Ansible variables from defaults.yaml and
 # config/plugins/osac.yaml are merged into the same scope.
-osacChartVersion: "0.0.6"
+osacChartVersion: "0.0.9-nightly.20260813.72aefaa.11.1"
 
 osacProfilesList:
   - caas

--- a/plugins/osac/templates/values.yaml.j2
+++ b/plugins/osac/templates/values.yaml.j2
@@ -3,6 +3,10 @@
 # AAP instance. deploy.yaml handles post-install AAP token creation
 # and operator patching.
 
+{% if osac_images is defined and osac_images.cli is defined %}
+cliImage: "{{ osac_images.cli }}"
+{% endif %}
+
 operator:
   image:
     pullPolicy: Always
@@ -28,11 +32,15 @@ operator:
 {% endif %}
     networking: true
     tenant: true
+    bareMetalInstance: true
+    storage: true
   fulfillment:
     serverAddress: fulfillment-api:8000
     tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
   provisioning:
     provider: aap
+  hubAccess:
+    enabled: false
 
 service:
   variant: openshift
@@ -106,23 +114,106 @@ aap:
       name: "{{ osac_aap_name }}"
   bootstrap:
     backoffLimit: 15
-{% if osac_images is defined and osac_images.cli is defined %}
-    cliImage: "{{ osac_images.cli }}"
-{% endif %}
+    readinessConsecutiveSuccesses: 3
     enabled: true
 {% if osac_images is defined and osac_images.aap_bootstrap is defined %}
     image: "{{ osac_images.aap_bootstrap }}"
 {% endif %}
-
-configAsCode:
-  projectGitUri: "{{ osac_aap_project_git_uri }}"
-  projectGitBranch: "{{ osac_aap_project_git_branch }}"
+  configAsCode:
+    projectGitUri: "{{ osac_aap_project_git_uri }}"
+    projectGitBranch: "{{ osac_aap_project_git_branch }}"
 {% if osac_images is defined and osac_images.aap_bootstrap is defined %}
-  eeImage: "{{ osac_images.aap_bootstrap }}"
+    eeImage: "{{ osac_images.aap_bootstrap }}"
 {% endif %}
+  instanceGroups:
+{% if osacNetrisEnabled | default(false) | bool %}
+    clusterFulfillment:
+      enabled: true
+      config:
+        NETWORK_CLASS: "netris"
+        NETWORK_STEPS_COLLECTION: "{{ osacNetrisStepsCollection | default('netris.steps') }}"
+        NETRIS_CONTROLLER_URL: "{{ osacNetrisControllerUrl }}"
+        NETRIS_USERNAME: "{{ osacNetrisUsername }}"
+        NETRIS_SITE_ID: "{{ osacNetrisSiteId }}"
+        NETRIS_TENANT_ID: "{{ osacNetrisTenantId }}"
+        NETRIS_TENANT_NAME: "{{ osacNetrisTenantName }}"
+{% if osacNetrisMgmtVpcId is defined %}
+        NETRIS_MGMT_VPC_ID: "{{ osacNetrisMgmtVpcId }}"
+{% endif %}
+{% if osacNetrisMgmtVpcName is defined %}
+        NETRIS_MGMT_VPC_NAME: "{{ osacNetrisMgmtVpcName }}"
+{% endif %}
+{% if osacNetrisResourceClassMap is defined %}
+        NETRIS_RESOURCE_CLASS_MAP: '{{ osacNetrisResourceClassMap }}'
+{% endif %}
+{% if osacNetrisSshBastionHost is defined %}
+        SERVER_SSH_BASTION_HOST: "{{ osacNetrisSshBastionHost }}"
+{% endif %}
+{% if osacNetrisSshBastionUser is defined %}
+        SERVER_SSH_BASTION_USER: "{{ osacNetrisSshBastionUser }}"
+{% endif %}
+{% if osacNetrisSshUser is defined %}
+        SERVER_SSH_USER: "{{ osacNetrisSshUser }}"
+{% endif %}
+{% if osacNetrisMgmtRouteDestination is defined %}
+        SERVER_MGMT_ROUTE_DESTINATION: "{{ osacNetrisMgmtRouteDestination }}"
+{% endif %}
+{% if osacNetrisMgmtRouteGateway is defined %}
+        SERVER_MGMT_ROUTE_GATEWAY: "{{ osacNetrisMgmtRouteGateway }}"
+{% endif %}
+{% if osacNetrisExternalAccessBaseDomain is defined %}
+        EXTERNAL_ACCESS_BASE_DOMAIN: "{{ osacNetrisExternalAccessBaseDomain }}"
+{% endif %}
+{% if osacNetrisExternalAccessSupportedBaseDomains is defined %}
+        EXTERNAL_ACCESS_SUPPORTED_BASE_DOMAINS: "{{ osacNetrisExternalAccessSupportedBaseDomains }}"
+{% endif %}
+{% if osacNetrisExternalAccessApiInternalNetwork is defined %}
+        EXTERNAL_ACCESS_API_INTERNAL_NETWORK: "{{ osacNetrisExternalAccessApiInternalNetwork }}"
+{% endif %}
+{% if osacNetrisHostedClusterBaseDomain is defined %}
+        HOSTED_CLUSTER_BASE_DOMAIN: "{{ osacNetrisHostedClusterBaseDomain }}"
+{% endif %}
+{% if osacNetrisHostedClusterControllerAvailabilityPolicy is defined %}
+        HOSTED_CLUSTER_CONTROLLER_AVAILABILITY_POLICY: "{{ osacNetrisHostedClusterControllerAvailabilityPolicy }}"
+{% endif %}
+{% if osacNetrisHostedClusterInfrastructureAvailabilityPolicy is defined %}
+        HOSTED_CLUSTER_INFRASTRUCTURE_AVAILABILITY_POLICY: "{{ osacNetrisHostedClusterInfrastructureAvailabilityPolicy }}"
+{% endif %}
+      secret:
+        NETRIS_PASSWORD: "{{ osacNetrisPassword }}"
+{% if osacNetrisAwsAccessKeyId is defined %}
+        AWS_ACCESS_KEY_ID: "{{ osacNetrisAwsAccessKeyId }}"
+{% endif %}
+{% if osacNetrisAwsSecretAccessKey is defined %}
+        AWS_SECRET_ACCESS_KEY: "{{ osacNetrisAwsSecretAccessKey }}"
+{% endif %}
+{% if osacNetrisSshKey is defined %}
+        SERVER_SSH_KEY: "{{ osacNetrisSshKey }}"
+{% endif %}
+{% if osacNetrisSshBastionKey is defined %}
+        SERVER_SSH_BASTION_KEY: "{{ osacNetrisSshBastionKey }}"
+{% endif %}
+    networkFulfillment:
+      enabled: true
+      config:
+        NETRIS_CONTROLLER_URL: "{{ osacNetrisControllerUrl }}"
+        NETRIS_USERNAME: "{{ osacNetrisUsername }}"
+        NETRIS_SITE_ID: "{{ osacNetrisSiteId }}"
+        NETRIS_TENANT_ID: "{{ osacNetrisTenantId }}"
+        NETRIS_TENANT_NAME: "{{ osacNetrisTenantName }}"
+      secret:
+        NETRIS_PASSWORD: "{{ osacNetrisPassword }}"
+{% endif %}
+    publishTemplates:
+      enabled: true
+      config:
+        OSAC_TEMPLATE_COLLECTIONS: "osac.templates"
+        OSAC_FULFILLMENT_SERVICE_URI: "https://fulfillment-internal-api:8001"
 
 bmf:
   enabled: false
+  env:
+    aapInsecureSkipVerify: "true"
 
 dbMigrate:
   enabled: false
@@ -130,82 +221,11 @@ dbMigrate:
 validation:
   enabled: true
 
-{% if osacNetrisEnabled | default(false) | bool %}
-clusterFulfillment:
-  enabled: true
-  config:
-    NETWORK_CLASS: "netris"
-    NETWORK_STEPS_COLLECTION: "{{ osacNetrisStepsCollection | default('netris.steps') }}"
-    NETRIS_CONTROLLER_URL: "{{ osacNetrisControllerUrl }}"
-    NETRIS_USERNAME: "{{ osacNetrisUsername }}"
-    NETRIS_SITE_ID: "{{ osacNetrisSiteId }}"
-    NETRIS_TENANT_ID: "{{ osacNetrisTenantId }}"
-    NETRIS_TENANT_NAME: "{{ osacNetrisTenantName }}"
-{% if osacNetrisMgmtVpcId is defined %}
-    NETRIS_MGMT_VPC_ID: "{{ osacNetrisMgmtVpcId }}"
-{% endif %}
-{% if osacNetrisMgmtVpcName is defined %}
-    NETRIS_MGMT_VPC_NAME: "{{ osacNetrisMgmtVpcName }}"
-{% endif %}
-{% if osacNetrisResourceClassMap is defined %}
-    NETRIS_RESOURCE_CLASS_MAP: '{{ osacNetrisResourceClassMap }}'
-{% endif %}
-{% if osacNetrisSshBastionHost is defined %}
-    SERVER_SSH_BASTION_HOST: "{{ osacNetrisSshBastionHost }}"
-{% endif %}
-{% if osacNetrisSshBastionUser is defined %}
-    SERVER_SSH_BASTION_USER: "{{ osacNetrisSshBastionUser }}"
-{% endif %}
-{% if osacNetrisSshUser is defined %}
-    SERVER_SSH_USER: "{{ osacNetrisSshUser }}"
-{% endif %}
-{% if osacNetrisMgmtRouteDestination is defined %}
-    SERVER_MGMT_ROUTE_DESTINATION: "{{ osacNetrisMgmtRouteDestination }}"
-{% endif %}
-{% if osacNetrisMgmtRouteGateway is defined %}
-    SERVER_MGMT_ROUTE_GATEWAY: "{{ osacNetrisMgmtRouteGateway }}"
-{% endif %}
-{% if osacNetrisExternalAccessBaseDomain is defined %}
-    EXTERNAL_ACCESS_BASE_DOMAIN: "{{ osacNetrisExternalAccessBaseDomain }}"
-{% endif %}
-{% if osacNetrisExternalAccessSupportedBaseDomains is defined %}
-    EXTERNAL_ACCESS_SUPPORTED_BASE_DOMAINS: "{{ osacNetrisExternalAccessSupportedBaseDomains }}"
-{% endif %}
-{% if osacNetrisExternalAccessApiInternalNetwork is defined %}
-    EXTERNAL_ACCESS_API_INTERNAL_NETWORK: "{{ osacNetrisExternalAccessApiInternalNetwork }}"
-{% endif %}
-{% if osacNetrisHostedClusterBaseDomain is defined %}
-    HOSTED_CLUSTER_BASE_DOMAIN: "{{ osacNetrisHostedClusterBaseDomain }}"
-{% endif %}
-{% if osacNetrisHostedClusterControllerAvailabilityPolicy is defined %}
-    HOSTED_CLUSTER_CONTROLLER_AVAILABILITY_POLICY: "{{ osacNetrisHostedClusterControllerAvailabilityPolicy }}"
-{% endif %}
-{% if osacNetrisHostedClusterInfrastructureAvailabilityPolicy is defined %}
-    HOSTED_CLUSTER_INFRASTRUCTURE_AVAILABILITY_POLICY: "{{ osacNetrisHostedClusterInfrastructureAvailabilityPolicy }}"
-{% endif %}
-  secret:
-    NETRIS_PASSWORD: "{{ osacNetrisPassword }}"
-{% if osacNetrisAwsAccessKeyId is defined %}
-    AWS_ACCESS_KEY_ID: "{{ osacNetrisAwsAccessKeyId }}"
-{% endif %}
-{% if osacNetrisAwsSecretAccessKey is defined %}
-    AWS_SECRET_ACCESS_KEY: "{{ osacNetrisAwsSecretAccessKey }}"
-{% endif %}
-{% if osacNetrisSshKey is defined %}
-    SERVER_SSH_KEY: "{{ osacNetrisSshKey }}"
-{% endif %}
-{% if osacNetrisSshBastionKey is defined %}
-    SERVER_SSH_BASTION_KEY: "{{ osacNetrisSshBastionKey }}"
-{% endif %}
+hubAccess:
+  enabled: false
 
-networkFulfillment:
-  enabled: true
-  config:
-    NETRIS_CONTROLLER_URL: "{{ osacNetrisControllerUrl }}"
-    NETRIS_USERNAME: "{{ osacNetrisUsername }}"
-    NETRIS_SITE_ID: "{{ osacNetrisSiteId }}"
-    NETRIS_TENANT_ID: "{{ osacNetrisTenantId }}"
-    NETRIS_TENANT_NAME: "{{ osacNetrisTenantName }}"
-  secret:
-    NETRIS_PASSWORD: "{{ osacNetrisPassword }}"
-{% endif %}
+bundledPostgres:
+  enabled: false
+  database:
+    name: service
+    user: service


### PR DESCRIPTION
slack: https://redhat-internal.slack.com/archives/C0B7CM99EH5/p1786615568707029

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the OSAC chart to the latest nightly version.
  * Enabled bare-metal and storage controller support.
  * Added configuration for cluster and network fulfillment, template publishing, validation, and collection access.
  * Added settings for hub access, bundled PostgreSQL, database migration, and bare-metal functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->