### PR TITLE
OSAC-3984: Remove ironic persistent storage volumes (conf/data)

### DIFF
--- a/playbooks/tasks/configure_hardware_ironic_cleanup.yaml
+++ b/playbooks/tasks/configure_hardware_ironic_cleanup.yaml
@@ -10,8 +10,6 @@
     name: "{{ item }}"
     state: absent
   loop:
-    - metal3-ironic-conf
-    - metal3-ironic-data
     - metal3-ironic-shared
   when: metal3_cleanup_volumes | default(false) | bool
 

--- a/playbooks/tasks/deploy_ironic.yaml
+++ b/playbooks/tasks/deploy_ironic.yaml
@@ -125,18 +125,6 @@
   no_log: true
   register: vmedia_key_secret
 
-- name: Create ironic-conf volume
-  become: "{{ metal3_persistent | default(false) | bool }}"
-  containers.podman.podman_volume:
-    name: metal3-ironic-conf
-    state: present
-
-- name: Create ironic-data volume
-  become: "{{ metal3_persistent | default(false) | bool }}"
-  containers.podman.podman_volume:
-    name: metal3-ironic-data
-    state: present
-
 - name: Create ironic-shared volume
   become: "{{ metal3_persistent | default(false) | bool }}"
   containers.podman.podman_volume:

--- a/playbooks/tasks/deploy_ironic_containers.yaml
+++ b/playbooks/tasks/deploy_ironic_containers.yaml
@@ -101,8 +101,6 @@
     cap_drop:
       - ALL
     volume:
-      - metal3-ironic-conf:/conf
-      - metal3-ironic-data:/data
       - metal3-ironic-shared:/shared
       - "{{ workingDir }}/ocp-cluster/abi-iso:/iso:ro"
     secrets: "{{ ironic_secrets }}"

--- a/playbooks/tasks/migrations/20260813130547_remove_ironic_storage_volumes.yaml
+++ b/playbooks/tasks/migrations/20260813130547_remove_ironic_storage_volumes.yaml
@@ -1,0 +1,26 @@
+---
+# Remove Ironic Persistent Storage Volumes Migration
+#
+# First upgrades Metal3 components (Ironic + BMO) so containers are redeployed
+# without the removed volume mounts, then removes the legacy persistent storage
+# volumes (metal3-ironic-conf, metal3-ironic-data) from both user and root podman.
+
+- name: Upgrade Metal3 components before removing volumes
+  ansible.builtin.include_tasks: ../upgrade/metal3-components.yaml
+
+- name: Remove ironic persistent storage volumes (user)
+  containers.podman.podman_volume:
+    name: "{{ item }}"
+    state: absent
+  loop:
+    - metal3-ironic-conf
+    - metal3-ironic-data
+
+- name: Remove ironic persistent storage volumes (root)
+  become: yes
+  containers.podman.podman_volume:
+    name: "{{ item }}"
+    state: absent
+  loop:
+    - metal3-ironic-conf
+    - metal3-ironic-data

--- a/playbooks/templates/quadlets/metal3-ironic-api.container.j2
+++ b/playbooks/templates/quadlets/metal3-ironic-api.container.j2
@@ -8,8 +8,6 @@ Pull=never
 Pod=metal3-ironic.pod
 User=1002:1003
 DropCapability=ALL
-Volume=metal3-ironic-conf:/conf
-Volume=metal3-ironic-data:/data
 Volume=metal3-ironic-shared:/shared
 Volume={{ workingDir }}/ocp-cluster/abi-iso:/iso:ro
 Secret=metal3-ironic-htpasswd,type=env,target=IRONIC_HTPASSWD

--- a/scripts/cleanup/cleanup_bootstrap_leftovers.sh
+++ b/scripts/cleanup/cleanup_bootstrap_leftovers.sh
@@ -35,7 +35,7 @@ info "Quadlet files removed"
 info "Removing root podman resources..."
 sudo podman pod rm -f metal3-ironic
 sudo podman rm -f ironic httpd baremetal-operator
-sudo podman volume rm -f metal3-ironic-conf metal3-ironic-data metal3-ironic-shared
+sudo podman volume rm -f metal3-ironic-shared
 sudo podman secret rm -i metal3-ironic-htpasswd metal3-ironic-password metal3-kubeconfig metal3-ironic-username metal3-ca-bundle
 info "Root podman resources removed"
 
@@ -43,7 +43,7 @@ info "Root podman resources removed"
 info "Removing user podman resources..."
 podman pod rm -f metal3-ironic
 podman rm -f baremetal-operator
-podman volume rm -f metal3-ironic-conf metal3-ironic-data metal3-ironic-shared quay-storage
+podman volume rm -f metal3-ironic-shared quay-storage
 podman secret rm --ignore metal3-ironic-htpasswd metal3-ironic-username metal3-ca-bundle metal3-ironic-password
 info "User podman resources removed"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Ironic services now use shared storage and no longer rely on separate persistent configuration and data volumes.
  - Existing installations are migrated automatically, with legacy storage removed safely where applicable.
  - Cleanup procedures now remove only obsolete shared resources, reducing leftover storage after teardown.
  - Ironic API container storage mounts have been simplified while retaining required shared and ISO access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->