### PR TITLE
Enable automerge for OLM operator patch updates in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -34,7 +34,9 @@
       },
       "major": {
         "enabled": false
-      }
+      },
+      "automerge": true,
+      "automergeType": "pr"
     },
     {
       "description": "Exclude metallb-operator (non-semver version)",


### PR DESCRIPTION
## Summary
- Added `automerge: true` and `automergeType: "pr"` to the Renovate package rule for OLM operators
- This enables automatic merging of patch (z-stream) updates for OLM operators tracked via the custom Red Hat operator catalog datasource

## Test plan
- [ ] Verify Renovate configuration is valid
- [ ] Wait for the next OLM operator patch update PR from Renovate
- [ ] Confirm automerge triggers after CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated maintenance automation to streamline handling of eligible package updates.
  * Major and minor updates remain excluded from automatic updates, while permitted updates can now be merged automatically after review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->