### PR TITLE
Enhance Helm installation logging and failure diagnostics

### DIFF
--- a/playbooks/tasks/helm_deploy.yaml
+++ b/playbooks/tasks/helm_deploy.yaml
@@ -115,32 +115,96 @@
   ansible.builtin.set_fact:
     _helm_log: "{{ workingDir }}/logs/helm-{{ plugin_name }}-{{ helm_chart.release }}.{{ lookup('pipe', 'date +%s') }}.log"
 
-- name: "Helm | Install {{ helm_chart.release }}{{ ' ' ~ helm_chart.version if helm_chart.version is defined else '' }}"
-  ansible.builtin.shell: |
-    set -o pipefail
-    {{ workingDir }}/bin/helm upgrade --install \
-      {{ helm_chart.release }} \
-      {{ _helm_chart_ref }} \
-      --namespace {{ helm_chart.namespace }} \
-      {{ '--create-namespace' if (helm_chart.createNamespace | default(true) | bool) else '' }} \
-      {{ '--wait' if (helm_chart.wait | default(true) | bool) else '' }} \
-      --timeout {{ helm_chart.timeout | default('15m') }} \
-      {{ '--version ' ~ helm_chart.version if helm_chart.version is defined else '' }} \
-      {{ _helm_values_arg }} \
-      2>&1 | tee {{ _helm_log }}
-  args:
-    executable: /bin/bash
-  register: r_helm_install
-  retries: 2
-  delay: 30
-  until: r_helm_install is success
-
-- name: "Helm | Verify release status"
-  ansible.builtin.command:
-    cmd: "{{ workingDir }}/bin/helm status {{ helm_chart.release }} --namespace {{ helm_chart.namespace }}"
-  register: r_helm_status
-  changed_when: false
-
-- name: "Helm | Show status"
+- name: "Helm | Log file location"
   ansible.builtin.debug:
-    msg: "{{ r_helm_status.stdout_lines | default([]) }}"
+    msg: "Helm install logs: {{ _helm_log }}"
+
+- name: "Helm | Install {{ helm_chart.release }}{{ ' ' ~ helm_chart.version if helm_chart.version is defined else '' }}"
+  block:
+    - name: "Helm | Run upgrade/install"
+      ansible.builtin.shell: |
+        set -o pipefail
+        {{ workingDir }}/bin/helm upgrade --install \
+          {{ helm_chart.release }} \
+          {{ _helm_chart_ref }} \
+          --namespace {{ helm_chart.namespace }} \
+          {{ '--create-namespace' if (helm_chart.createNamespace | default(true) | bool) else '' }} \
+          {{ '--wait' if (helm_chart.wait | default(true) | bool) else '' }} \
+          --timeout {{ helm_chart.timeout | default('15m') }} \
+          {{ '--version ' ~ helm_chart.version if helm_chart.version is defined else '' }} \
+          {{ _helm_values_arg }} \
+          --debug \
+          2>&1 | tee {{ _helm_log }}
+      args:
+        executable: /bin/bash
+      register: r_helm_install
+      retries: 2
+      delay: 30
+      until: r_helm_install is success
+
+    - name: "Helm | Verify release status"
+      ansible.builtin.command:
+        cmd: "{{ workingDir }}/bin/helm status {{ helm_chart.release }} --namespace {{ helm_chart.namespace }}"
+      register: r_helm_status
+      changed_when: false
+
+    - name: "Helm | Show status"
+      ansible.builtin.debug:
+        msg: "{{ r_helm_status.stdout_lines | default([]) }}"
+
+  rescue:
+    - name: "Helm | Read log file on failure"
+      ansible.builtin.slurp:
+        src: "{{ _helm_log }}"
+      register: _r_helm_log_content
+      ignore_errors: true
+
+    - name: "Helm | Display failure logs"
+      ansible.builtin.debug:
+        msg: |
+          Helm installation failed for {{ helm_chart.release }}
+
+          Log file: {{ _helm_log }}
+
+          --- Last 100 lines of output ---
+          {{ (_r_helm_log_content.content | b64decode).split('\n')[-100:] | join('\n') if _r_helm_log_content is success else 'Log file could not be read' }}
+
+          --- End of logs ---
+
+    - name: "Helm | Get failed release info"
+      ansible.builtin.command:
+        cmd: "{{ workingDir }}/bin/helm list --namespace {{ helm_chart.namespace }} --filter {{ helm_chart.release }}"
+      register: r_helm_list
+      ignore_errors: true
+      changed_when: false
+
+    - name: "Helm | Show release list"
+      ansible.builtin.debug:
+        msg: "{{ r_helm_list.stdout_lines | default([]) }}"
+      when: r_helm_list is success
+
+    - name: "Helm | Get pods status for debugging"
+      ansible.builtin.command:
+        cmd: "{{ workingDir }}/bin/oc get pods -n {{ helm_chart.namespace }}"
+      register: r_pods_status
+      ignore_errors: true
+      changed_when: false
+
+    - name: "Helm | Show pods status"
+      ansible.builtin.debug:
+        msg: "{{ r_pods_status.stdout_lines | default([]) }}"
+      when: r_pods_status is success
+
+    - name: "Helm | Fail with context"
+      ansible.builtin.fail:
+        msg: |
+          Helm installation failed for {{ helm_chart.release }}
+
+          Full logs available at: {{ _helm_log }}
+
+          Review the logs above for details.
+          Common issues:
+          - Image pull errors
+          - Resource conflicts
+          - Timeout waiting for pods
+          - Invalid values configuration


### PR DESCRIPTION
## Summary

Improves Helm chart installation debugging by adding comprehensive logging and automatic failure diagnostics to `playbooks/tasks/helm_deploy.yaml`.

## Changes

- **Pre-installation logging**: Display log file path before installation starts
- **Verbose output**: Added `--debug` flag to Helm upgrade/install command
- **Automatic failure diagnostics**: On installation failure, automatically:
  - Display last 100 lines of Helm output
  - Show Helm release status
  - Show pod status in the namespace
  - Provide full log file path and common troubleshooting tips
- **Structured error handling**: Use Ansible block/rescue pattern for consistent error capture

## Benefits

- No more hunting for log files when installations fail
- Immediate visibility into failure reasons (image pull errors, timeouts, resource conflicts, etc.)
- Pod status included for faster root cause analysis
- Log file location always visible for deeper investigation

## Test plan

- [ ] Test successful Helm installation (verify logs are created and path is displayed)
- [ ] Test failed Helm installation (verify failure diagnostics are displayed)
- [ ] Verify log files contain debug output
- [ ] Confirm pod status is shown on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Helm deployment failure handling with clearer diagnostics.
  * Added recent log output, failed release details, and pod status information when installation fails.
  * Enabled Helm debug output to support troubleshooting.
  * Deployment retries and existing installation options remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->