### PR TITLE
OSAC-4099: Update AAP project git URI to point to monorepo

### DIFF
--- a/plugins/osac/defaults.yaml
+++ b/plugins/osac/defaults.yaml
@@ -109,5 +109,5 @@ osac_db_user: service
 osac_db_database: service
 
 # AAP bootstrap
-osac_aap_project_git_uri: "https://github.com/osac-project/osac-aap"
+osac_aap_project_git_uri: "https://github.com/osac-project/osac"
 osac_aap_project_git_branch: main

--- a/plugins/osac/test-fixtures/schemas/defaults/valid/base.yaml
+++ b/plugins/osac/test-fixtures/schemas/defaults/valid/base.yaml
@@ -29,5 +29,5 @@ osac_db_size: 5Gi
 osac_db_user: service
 osac_db_database: service
 
-osac_aap_project_git_uri: "https://github.com/osac-project/osac-aap"
+osac_aap_project_git_uri: "https://github.com/osac-project/osac"
 osac_aap_project_git_branch: main


### PR DESCRIPTION
## Summary
- Updates `osac_aap_project_git_uri` default from the archived `osac-project/osac-aap` to the monorepo `osac-project/osac`
- The standalone repo was archived on Aug 15, 2026; the code was migrated to the monorepo in [osac-project/osac#72](https://github.com/osac-project/osac/pull/72)
- The AAP bootstrap container image expects monorepo-layout playbook paths (with `osac-aap/` prefix), but the old URI causes the AAP project to clone from the standalone repo where playbooks are at the root, causing all job template creation to fail

## Test plan
- [x] Deploy osac plugin and verify AAP bootstrap completes successfully
- [x] Verify AAP project clones from monorepo and playbook cache is populated with `osac-aap/` prefixed paths
- [x] Verify job templates (e.g. `osac-create-hosted-cluster`) are created successfully

Fixes: [OSAC-4099](https://redhat.atlassian.net/browse/OSAC-4099)

🤖 Generated with [Claude Code](https://claude.com/claude-code)