### PR TITLE
OSAC-4100: Allow plugins to opt out of Helm install retries

### DIFF
--- a/docs/PLUGIN_ARCHITECTURE.md
+++ b/docs/PLUGIN_ARCHITECTURE.md
@@ -78,7 +78,7 @@ registries:
 | `additionalImages` | Extra images to include in the plugin's oc-mirror image set. |
 | `blockedImages` | Images to exclude from mirroring (by tag, digest, or pattern). |
 | `requires` | Declarative requirements validated at load time, before any deployment work begins. See [Load-Time Validation](#load-time-validation). |
-| `helm` | List of Helm charts to install after operators, before `tasks/deploy.yaml`. Supports local charts, OCI charts (`oci://`), and remote repos. Each entry specifies `release`, `namespace`, and optional `chart`, `repo`, `version`, values template, and `extractImages`. When `extractImages: true` is set on a chart (local or OCI), `helm template` is run before mirroring to discover container image references and merge them into `additionalImages` automatically. |
+| `helm` | List of Helm charts to install after operators, before `tasks/deploy.yaml`. Supports local charts, OCI charts (`oci://`), and remote repos. Each entry specifies `release`, `namespace`, and optional `chart`, `repo`, `version`, `timeout`, `retries`, `wait`, values template, and `extractImages`. When `extractImages: true` is set on a chart (local or OCI), `helm template` is run before mirroring to discover container image references and merge them into `additionalImages` automatically. `timeout` defaults to `15m`, `retries` defaults to `2`, and `wait` defaults to `true`. Set `retries: 0` for charts with long timeouts where failures are structural rather than transient. |
 
 The plugin descriptor is validated by JSON Schema (`schemas/plugin.yaml`) during `make validate`. The validator (`make validate-plugins`) also checks directory structure.
 

--- a/playbooks/tasks/helm_deploy.yaml
+++ b/playbooks/tasks/helm_deploy.yaml
@@ -131,7 +131,7 @@
   args:
     executable: /bin/bash
   register: r_helm_install
-  retries: 2
+  retries: "{{ helm_chart.retries | default(2) }}"
   delay: 30
   until: r_helm_install is success
 

--- a/plugins/osac/plugin.yaml
+++ b/plugins/osac/plugin.yaml
@@ -16,6 +16,7 @@ helm:
     valuesTemplate: templates/values.yaml.j2
     createNamespace: true
     timeout: "45m"
+    retries: 0
     wait: false    # AAP takes 30+ minutes; deploy.yaml handles post-install waits
 
 additionalImages:

--- a/schemas/plugin.yaml
+++ b/schemas/plugin.yaml
@@ -206,6 +206,10 @@ definitions:
       timeout:
         type: string
         description: "Helm timeout (e.g. '15m'). Default: '15m'."
+      retries:
+        type: integer
+        minimum: 0
+        description: "Number of Helm install retries on failure. Default: 2."
       wait:
         type: boolean
         description: "Pass --wait. Default: true."


### PR DESCRIPTION
## Summary
- Makes Helm install retry count configurable per plugin via `retries` field in `plugin.yaml`, defaulting to `2` for backward compatibility
- Sets OSAC plugin to `retries: 0` — its 45-minute timeout means failures are structural (e.g. AAP bootstrap crash-looping), not transient. Retrying wastes up to 2h 15m of CI budget and causes the job to be cancelled with no useful error
- Adds `retries` property to the plugin schema

## Test plan
- [ ] Existing plugins without `retries` field still retry 2 times (backward compatible)
- [ ] OSAC plugin Helm install fails fast without retrying
- [ ] `make -f Makefile.ci validate-plugins` passes

Fixes: [OSAC-4100](https://redhat.atlassian.net/browse/OSAC-4100)

🤖 Generated with [Claude Code](https://claude.com/claude-code)