### PR TITLE
reduce renvate configuration for ansible galaxy collections to basic

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -40,17 +40,6 @@
       "description": "Exclude metallb-operator (non-semver version)",
       "matchPackageNames": ["metallb-operator"],
       "enabled": false
-    },
-    {
-      "description": "Refresh ansible_collections.sha256 for the bumped collection",
-      "matchDatasources": ["galaxy-collection"],
-      "postUpgradeTasks": {
-        "commands": [
-          "./scripts/setup/update_ansible_collection_sha256.sh '{{{depName}}}' '{{{newVersion}}}'"
-        ],
-        "fileFilters": ["ansible_collections.sha256"],
-        "executionMode": "update"
-      }
     }
   ]
 }


### PR DESCRIPTION
trying to make it work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the automatic refresh of Ansible collection checksums after Galaxy collection updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->