### PR TITLE
OSAC-4108: Validate machineNetwork CIDR has zero host bits

### DIFF
--- a/validations.sh
+++ b/validations.sh
@@ -173,6 +173,13 @@ fi
 ## IP Validations
 validation_section "ip_address"
 
+actual_network=$(ipcalc --no-decorate --network "$machine_network")
+given_address="${machine_network%%/*}"
+if [[ "$actual_network" != "$given_address" ]]; then
+    validation fail machineNetwork "machineNetwork $machine_network has non-zero host bits (expected ${actual_network}/${machine_network##*/})"
+fi
+validation pass machineNetwork "machineNetwork $machine_network is a valid network address"
+
 if [[ "$api_vip" == "$ingress_vip" ]]; then
     validation fail api_ingress "API VIP ($api_vip) and Ingress VIP ($ingress_vip) are the same"
 fi


### PR DESCRIPTION
## Summary
- Adds validation in `validations.sh` that `machineNetwork` is a proper network address (host bits zeroed)
- A value like `192.168.1.5/24` now fails early with a clear message suggesting the correct address (`192.168.1.0/24`)
- Previously, invalid CIDRs passed both JSON schema validation (regex only checks syntax) and runtime `checkIP` validation (`ipcalc` normalizes internally), then were written verbatim into `install-config.yaml`

## Test plan
- [ ] `validations.sh` passes with a valid machineNetwork (e.g. `192.168.2.0/24`)
- [ ] `validations.sh` fails with a clear error for invalid machineNetwork (e.g. `192.168.2.5/24`)
- [ ] `make -f Makefile.ci validate-shell` passes (shellcheck)

Fixes: [OSAC-4108](https://redhat.atlassian.net/browse/OSAC-4108)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to ensure `machineNetwork` is a canonical network address without host bits.
  * Reports an error when host bits are present and confirms valid network addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->