### PR TITLE
Revert "reduce renvate configuration for ansible galaxy collections to basic"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -40,6 +40,17 @@
       "description": "Exclude metallb-operator (non-semver version)",
       "matchPackageNames": ["metallb-operator"],
       "enabled": false
+    },
+    {
+      "description": "Refresh ansible_collections.sha256 for the bumped collection",
+      "matchDatasources": ["galaxy-collection"],
+      "postUpgradeTasks": {
+        "commands": [
+          "./scripts/setup/update_ansible_collection_sha256.sh '{{{depName}}}' '{{{newVersion}}}'"
+        ],
+        "fileFilters": ["ansible_collections.sha256"],
+        "executionMode": "update"
+      }
     }
   ]
 }


### PR DESCRIPTION
Reverts rh-ecosystem-edge/enclave#711

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated Galaxy collection updates now refresh the associated collection checksum file after upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->