### PR TITLE
create cluster-image-set-git-repo configmap to prevent reconciliation

### DIFF
--- a/operators/multicluster-engine/tasks.yaml
+++ b/operators/multicluster-engine/tasks.yaml
@@ -313,10 +313,9 @@
       data:
         description: "block acccess to uptream clusterimagesets"
         channel: stable
-        gitRepoBranch: release-2.8
+        gitRepoBranch: backplane-2.8
         gitRepoPath: clusterImageSets
-        gitRepoUrl: 'https://localhost/prevent-cis-reconcile.git'
-        insecureSkipVerify: 'true'
+        gitRepoUrl: https://localhost/bad-acm-hive-openshift-releases.git
 
 - name: Create AgentServiceConfig for disconnected environment
   when: disconnected | default(true) | bool

--- a/operators/multicluster-engine/tasks.yaml
+++ b/operators/multicluster-engine/tasks.yaml
@@ -300,6 +300,24 @@
   delay: "{{ k8s_delay }}"
   until: r_configmap_assisted_service is success
 
+- name: Create cluster-image-set-git-repo ConfigMap for disconnected to prevent the recreation of clusterimagesets
+  when: disconnected | default(true) | bool
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      kind: ConfigMap
+      apiVersion: v1
+      metadata:
+        name: cluster-image-set-git-repo
+        namespace: multicluster-engine
+      data:
+        description: "block acccess to uptream clusterimagesets"
+        channel: stable
+        gitRepoBranch: release-2.8
+        gitRepoPath: clusterImageSets
+        gitRepoUrl: 'https://localhost/prevent-cis-reconcile.git'
+        insecureSkipVerify: 'true'
+
 - name: Create AgentServiceConfig for disconnected environment
   when: disconnected | default(true) | bool
   vars:

--- a/operators/multicluster-engine/tasks.yaml
+++ b/operators/multicluster-engine/tasks.yaml
@@ -316,6 +316,10 @@
         gitRepoBranch: backplane-2.8
         gitRepoPath: clusterImageSets
         gitRepoUrl: https://localhost/bad-acm-hive-openshift-releases.git
+  register: r_configmap_cis_git_repo
+  retries: "{{ k8s_retries }}"
+  delay: "{{ k8s_delay }}"
+  until: r_configmap_cis_git_repo is success
 
 - name: Create AgentServiceConfig for disconnected environment
   when: disconnected | default(true) | bool

--- a/operators/multicluster-engine/tasks.yaml
+++ b/operators/multicluster-engine/tasks.yaml
@@ -311,7 +311,7 @@
         name: cluster-image-set-git-repo
         namespace: multicluster-engine
       data:
-        description: "block acccess to uptream clusterimagesets"
+        description: "block access to upstream clusterimagesets"
         channel: stable
         gitRepoBranch: backplane-2.8
         gitRepoPath: clusterImageSets


### PR DESCRIPTION
part of https://redhat.atlassian.net/browse/OSAC-4355

create configmap that points the clusterimageset reconciliation to a non-existent git repo instead of the upstream one.

this prevents reconciliation and also prevents outbound calls to github.

follow up on #351 which didn't do what was expected.

docs: https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.8/pdf/clusters/red_hat_advanced_cluster_management_for_kubernetes-2.8-clusters-en-us.pdf?utm_source=openai (search for "pause")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added disconnected-environment configuration for stable cluster image set metadata.
  * Uses the `backplane-2.8` branch and configured repository path for image sets.
  * Prevents automatic recreation of upstream cluster image sets in disconnected installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->