### PR TITLE
set openshift-ai plugin placement rule to label sovcloud.open-cluster-management.io/openshift-ai

### DIFF
--- a/plugins/openshift-ai/files/20-placementrule.yaml
+++ b/plugins/openshift-ai/files/20-placementrule.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   clusterSelector:
     matchExpressions:
-    - key: sovcloud.open-cluster-management.io/nvidia-gpu
+    - key: sovcloud.open-cluster-management.io/openshift-ai
       operator: In
       values:
       - "true"


### PR DESCRIPTION
in this PR we are creating a distinction between installing openshift-ai and installing nvidia-gpu plugin on spoke clusters.

to have both plugins installed, managed cluster would require both labels.