### PR TITLE
OSAC-4380: configure Renovate to update uv in setup_ansible.sh

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,15 @@
   "customManagers": [
     {
       "customType": "regex",
+      "description": "Update uv version in setup_ansible.sh",
+      "managerFilePatterns": ["setup_ansible.sh"],
+      "matchStrings": ["UV_VERSION=\"(?<currentValue>[^\"]+)\""],
+      "depNameTemplate": "astral-sh/uv",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^(?<version>.+)$"
+    },
+    {
+      "customType": "regex",
       "description": "Update OLM operator versions in operators.yaml",
       "managerFilePatterns": ["defaults/operators.yaml", "plugins/lvms/plugin.yaml"],
       "matchStrings": [


### PR DESCRIPTION
## Summary

- Adds a regex custom manager to `renovate.json` so Renovate tracks `UV_VERSION` in `setup_ansible.sh`
- Keeps the shell script in sync with the uv version already managed via the Docker manager in `Dockerfile.ci`
- Closes the gap exposed by #726, which had to be done manually because Renovate only updated the Dockerfile

## Test plan

- [ ] Verify `renovate.json` is valid JSON and passes schema validation
- [ ] Confirm Renovate picks up `UV_VERSION` in `setup_ansible.sh` on next run (check Renovate dashboard or dry-run)

Jira: https://redhat.atlassian.net/browse/OSAC-4380

🤖 Generated with [Claude Code](https://claude.ai/claude-code)