### PR TITLE
renovate osac helm chart version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,6 +30,16 @@
       "datasourceTemplate": "custom.redhat-operator-catalog",
       "versioningTemplate": "semver",
       "registryUrlTemplate": "https://catalog.redhat.com/api/containers/v1/operators/bundles?filter=package=={{packageName}};channel_name=={{packageChannel}};ocp_version==4.20"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["plugins/osac/defaults.yaml"],
+      "matchStrings": [
+        "osacChartVersion: \"(?<currentValue>[^\"]+)\""
+      ],
+      "depNameTemplate": "osac-project/charts/osac",
+      "datasourceTemplate": "docker",
+      "registryUrlTemplate": "https://ghcr.io"
     }
   ],
   "ansible-galaxy": {
@@ -53,6 +63,11 @@
       "description": "Exclude metallb-operator (non-semver version)",
       "matchPackageNames": ["metallb-operator"],
       "enabled": false
+    },
+    {
+      "matchPackageNames": ["osac-project/charts/osac"],
+      "ignoreUnstable": false,
+      "respectLatest": false
     }
   ]
 }


### PR DESCRIPTION
related to https://redhat.atlassian.net/browse/OSAC-4051

adding renovate configuration to keep OSAC helm chart version up to date: https://github.com/rh-ecosystem-edge/enclave/blob/cc9320aa0dfd44ea29a32f8f91287c6477f214ef/plugins/osac/defaults.yaml#L7

according to https://github.com/osac-project/osac-installer/pkgs/container/charts%2Fosac/versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated version tracking for OSAC chart releases.
  * Included support for detecting unstable versions from the OSAC container image repository.
  * Adjusted update rules to prevent latest-version constraints from blocking eligible updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->