### PR TITLE
Revert "ACM MultiClusterHub disable update ClusterImageSets"

### DIFF
--- a/operators/advanced-cluster-management/configure_mch.yaml
+++ b/operators/advanced-cluster-management/configure_mch.yaml
@@ -30,8 +30,7 @@
         namespace: open-cluster-management
         annotations:
           installer.open-cluster-management.io/mce-subscription-spec: "{{ mce_subscription_spec | to_json }}"
-      spec:
-        disableUpdateClusterImageSets: true
+      spec: {}
   retries: 60
   delay: 10
   register: r_mch


### PR DESCRIPTION
Reverts rh-ecosystem-edge/enclave#351

this PR is likely not required following #723