### PR TITLE
feat: Add optional DNS configuration for OSAC cluster fulfillment

### DIFF
--- a/config/plugins/osac.example.yaml
+++ b/config/plugins/osac.example.yaml
@@ -47,6 +47,10 @@
 # osacNetrisTenantId: "1"
 # osacNetrisTenantName: "Admin"
 
+# Optional: DNS configuration
+# osacDnsClass: "dns.route53.dns"
+# osacDnsZone: "example.com"
+
 # Optional Netris config:
 # osacNetrisStepsCollection: "netris.steps"
 # osacNetrisMgmtVpcId: "4"

--- a/plugins/osac/schemas/config.yaml
+++ b/plugins/osac/schemas/config.yaml
@@ -52,6 +52,13 @@ properties:
   osacTestUsers:
     type: boolean
     description: "Create test users in the Keycloak osac realm for initial UI/CLI access"
+  osacDnsClass:
+    type: string
+    description: "Fully-qualified Ansible role name of the DNS driver"
+    enum: ["dns.route53.dns"]
+  osacDnsZone:
+    type: string
+    description: "DNS zone to operate in (defaults to EXTERNAL_ACCESS_BASE_DOMAIN)"
   osacNetrisEnabled:
     type: boolean
     description: "Enable Netris network backend for cluster/network fulfillment"

--- a/plugins/osac/templates/values.yaml.j2
+++ b/plugins/osac/templates/values.yaml.j2
@@ -130,6 +130,12 @@ aap:
     clusterFulfillment:
       enabled: true
       config:
+{% if osacDnsClass is defined %}
+        DNS_CLASS: "{{ osacDnsClass }}"
+{% endif %}
+{% if osacDnsZone is defined %}
+        DNS_ZONE: "{{ osacDnsZone }}"
+{% endif %}
         NETWORK_CLASS: "netris"
         NETWORK_STEPS_COLLECTION: "{{ osacNetrisStepsCollection | default('netris.steps') }}"
         NETRIS_CONTROLLER_URL: "{{ osacNetrisControllerUrl }}"


### PR DESCRIPTION
Introduce osacDnsClass and osacDnsZone config options in the OSAC
plugin schema, example config, and cluster fulfillment template to
support configuring a DNS driver (Route53) and zone.

Addresses:
- https://redhat.atlassian.net/browse/OSAC-1626

Signed-off-by: Jonathan Kilzi <jkilzi@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional DNS configuration for OSAC deployments.
  * Added support for specifying a DNS driver and DNS zone.
  * DNS zones default to the configured external access base domain when not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->