### PR TITLE
OSAC-4507: Override dbInit.host for Enclave-managed postgres

### DIFF
--- a/plugins/osac/templates/values.yaml.j2
+++ b/plugins/osac/templates/values.yaml.j2
@@ -221,6 +221,9 @@ bmf:
   env:
     aapInsecureSkipVerify: "true"
 
+dbInit:
+  host: "{{ osac_db_name }}.osac.svc.cluster.local"
+
 dbMigrate:
   enabled: false
 


### PR DESCRIPTION
## Summary

- The OSAC Helm chart (`0.0.9-nightly`) introduced a `db-init` pre-install hook that defaults `PGHOST` to `postgres.osac-infra.svc.cluster.local`, matching the osac-installer's namespace layout where the `osac-infra` chart deploys postgres into a dedicated namespace
- Enclave deploys its own postgres into the `osac` namespace (via `post-operators.yaml`), so the db-init job fails with DNS resolution error: `could not translate host name "postgres.osac-infra.svc.cluster.local" to address: Name or service not known`
- Override `dbInit.host` in the values template to point at Enclave's postgres service

## Test plan

- [ ] Deploy OSAC plugin and verify `osac-db-init` job completes successfully
- [ ] Verify fulfillment service connects to postgres after db-init

Fixes: [OSAC-4507](https://redhat.atlassian.net/browse/OSAC-4507)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added database initialization configuration using the OSAC PostgreSQL service hostname.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->