### PR TITLE
OSAC-4559: Add BCM backend configuration for bare metal fulfillment

### DIFF
--- a/config/plugins/osac.example.yaml
+++ b/config/plugins/osac.example.yaml
@@ -81,3 +81,28 @@
 #   -----BEGIN OPENSSH PRIVATE KEY-----
 #   ...
 #   -----END OPENSSH PRIVATE KEY-----
+
+# --- BCM Inventory Backend ---
+# Enable BCM (NVIDIA Base Command Manager) integration for bare metal fulfillment.
+# Requires Metal3 for power management via BareMetalHost CRs.
+# osacBcmEnabled: true
+
+# Required when osacBcmEnabled is true:
+# osacBcmUrl: "https://bcm-head:8081"
+# osacBcmCert: |
+#   -----BEGIN CERTIFICATE-----
+#   ...
+#   -----END CERTIFICATE-----
+# osacBcmKey: |
+#   -----BEGIN PRIVATE KEY-----
+#   ...
+#   -----END PRIVATE KEY-----
+# osacBcmBmhNamespace: "openshift-machine-api"
+
+# Optional BCM config:
+# osacBcmCaCert: |
+#   -----BEGIN CERTIFICATE-----
+#   ...
+#   -----END CERTIFICATE-----
+# osacBcmInsecureSkipVerify: false
+# osacBcmHostClass: "bcm"

--- a/plugins/osac/defaults.yaml
+++ b/plugins/osac/defaults.yaml
@@ -16,6 +16,9 @@ osacTestUsers: false
 # Netris network backend
 osacNetrisEnabled: false
 
+# BCM inventory backend
+osacBcmEnabled: false
+
 # AAP settings (chart manages the instance, these configure it)
 osac_aap_name: osac-aap
 osac_aap_operator_ns: ansible-aap

--- a/plugins/osac/schemas/config.yaml
+++ b/plugins/osac/schemas/config.yaml
@@ -144,24 +144,31 @@ properties:
     description: "Enable BCM inventory backend for bare metal fulfillment"
   osacBcmUrl:
     type: string
+    pattern: "^https://"
+    minLength: 1
     description: "BCM head node API endpoint (e.g. https://bcm-head:8081)"
   osacBcmCert:
     type: string
+    minLength: 1
     description: "PEM-encoded client certificate for BCM mTLS authentication"
   osacBcmKey:
     type: string
+    minLength: 1
     description: "PEM-encoded client private key for BCM mTLS authentication"
   osacBcmCaCert:
     type: string
+    minLength: 1
     description: "PEM-encoded CA certificate for verifying BCM server cert (optional)"
   osacBcmInsecureSkipVerify:
     type: boolean
     description: "Skip TLS verification of BCM server certificate (test environments only)"
   osacBcmHostClass:
     type: string
+    minLength: 1
     description: "Host class identifier for BCM inventory (default: bcm)"
   osacBcmBmhNamespace:
     type: string
+    minLength: 1
     description: "Namespace where BareMetalHost CRs are created for Metal3 power management"
 required:
   - osacAapLicenseFile

--- a/plugins/osac/schemas/config.yaml
+++ b/plugins/osac/schemas/config.yaml
@@ -139,6 +139,30 @@ properties:
   osacNetrisSshBastionKey:
     type: string
     description: "SSH private key for bastion host access"
+  osacBcmEnabled:
+    type: boolean
+    description: "Enable BCM inventory backend for bare metal fulfillment"
+  osacBcmUrl:
+    type: string
+    description: "BCM head node API endpoint (e.g. https://bcm-head:8081)"
+  osacBcmCert:
+    type: string
+    description: "PEM-encoded client certificate for BCM mTLS authentication"
+  osacBcmKey:
+    type: string
+    description: "PEM-encoded client private key for BCM mTLS authentication"
+  osacBcmCaCert:
+    type: string
+    description: "PEM-encoded CA certificate for verifying BCM server cert (optional)"
+  osacBcmInsecureSkipVerify:
+    type: boolean
+    description: "Skip TLS verification of BCM server certificate (test environments only)"
+  osacBcmHostClass:
+    type: string
+    description: "Host class identifier for BCM inventory (default: bcm)"
+  osacBcmBmhNamespace:
+    type: string
+    description: "Namespace where BareMetalHost CRs are created for Metal3 power management"
 required:
   - osacAapLicenseFile
 dependencies:
@@ -146,17 +170,30 @@ dependencies:
     - osacNetrisAwsSecretAccessKey
   osacNetrisAwsSecretAccessKey:
     - osacNetrisAwsAccessKeyId
-if:
-  required:
-    - osacNetrisEnabled
-  properties:
-    osacNetrisEnabled:
-      const: true
-then:
-  required:
-    - osacNetrisControllerUrl
-    - osacNetrisUsername
-    - osacNetrisPassword
-    - osacNetrisSiteId
-    - osacNetrisTenantId
-    - osacNetrisTenantName
+allOf:
+  - if:
+      required:
+        - osacNetrisEnabled
+      properties:
+        osacNetrisEnabled:
+          const: true
+    then:
+      required:
+        - osacNetrisControllerUrl
+        - osacNetrisUsername
+        - osacNetrisPassword
+        - osacNetrisSiteId
+        - osacNetrisTenantId
+        - osacNetrisTenantName
+  - if:
+      required:
+        - osacBcmEnabled
+      properties:
+        osacBcmEnabled:
+          const: true
+    then:
+      required:
+        - osacBcmUrl
+        - osacBcmCert
+        - osacBcmKey
+        - osacBcmBmhNamespace

--- a/plugins/osac/schemas/defaults.yaml
+++ b/plugins/osac/schemas/defaults.yaml
@@ -100,6 +100,9 @@ properties:
   osacNetrisEnabled:
     type: boolean
     description: Enable Netris network backend for cluster/network fulfillment.
+  osacBcmEnabled:
+    type: boolean
+    description: Enable BCM inventory backend for bare metal fulfillment.
   osacBYODatabase:
     type: boolean
     description: Use an external database instead of the built-in dev postgres.

--- a/plugins/osac/templates/values.yaml.j2
+++ b/plugins/osac/templates/values.yaml.j2
@@ -217,7 +217,22 @@ aap:
         OSAC_FULFILLMENT_SERVICE_URI: "https://fulfillment-internal-api:8001"
 
 bmf:
+{% if osacBcmEnabled | default(false) | bool %}
+  enabled: true
+  bcm:
+    enabled: true
+    url: "{{ osacBcmUrl }}"
+    cert: "{{ osacBcmCert }}"
+    key: "{{ osacBcmKey }}"
+{% if osacBcmCaCert is defined %}
+    caCert: "{{ osacBcmCaCert }}"
+{% endif %}
+    insecureSkipVerify: {{ osacBcmInsecureSkipVerify | default(false) | lower }}
+    hostClass: "{{ osacBcmHostClass | default('bcm') }}"
+    bmhNamespace: "{{ osacBcmBmhNamespace }}"
+{% else %}
   enabled: false
+{% endif %}
   env:
     aapInsecureSkipVerify: "true"
 

--- a/plugins/osac/templates/values.yaml.j2
+++ b/plugins/osac/templates/values.yaml.j2
@@ -222,10 +222,13 @@ bmf:
   bcm:
     enabled: true
     url: "{{ osacBcmUrl }}"
-    cert: "{{ osacBcmCert }}"
-    key: "{{ osacBcmKey }}"
+    cert: |
+{{ osacBcmCert | indent(6, first=true) }}
+    key: |
+{{ osacBcmKey | indent(6, first=true) }}
 {% if osacBcmCaCert is defined %}
-    caCert: "{{ osacBcmCaCert }}"
+    caCert: |
+{{ osacBcmCaCert | indent(6, first=true) }}
 {% endif %}
     insecureSkipVerify: {{ osacBcmInsecureSkipVerify | default(false) | lower }}
     hostClass: "{{ osacBcmHostClass | default('bcm') }}"

--- a/plugins/osac/test-fixtures/schemas/config/invalid/bcm-enabled-missing-required.yaml
+++ b/plugins/osac/test-fixtures/schemas/config/invalid/bcm-enabled-missing-required.yaml
@@ -1,0 +1,5 @@
+---
+# Fixture: BCM enabled but missing required fields
+# Expected failure: osacBcmUrl, osacBcmCert, osacBcmKey, osacBcmBmhNamespace required
+osacAapLicenseFile: "/home/cloud-user/aap-license.zip"
+osacBcmEnabled: true

--- a/plugins/osac/test-fixtures/schemas/config/invalid/bcm-http-url.yaml
+++ b/plugins/osac/test-fixtures/schemas/config/invalid/bcm-http-url.yaml
@@ -1,0 +1,9 @@
+---
+# Fixture: BCM enabled with HTTP URL (must be HTTPS)
+# Expected failure: osacBcmUrl pattern requires https://
+osacAapLicenseFile: "/home/cloud-user/aap-license.zip"
+osacBcmEnabled: true
+osacBcmUrl: "http://bcm-head:8081"
+osacBcmCert: "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----"
+osacBcmKey: "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----"
+osacBcmBmhNamespace: "openshift-machine-api"

--- a/plugins/osac/test-fixtures/schemas/config/invalid/bcm-http-url.yaml
+++ b/plugins/osac/test-fixtures/schemas/config/invalid/bcm-http-url.yaml
@@ -4,6 +4,6 @@
 osacAapLicenseFile: "/home/cloud-user/aap-license.zip"
 osacBcmEnabled: true
 osacBcmUrl: "http://bcm-head:8081"
-osacBcmCert: "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----"
-osacBcmKey: "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----"
+osacBcmCert: "placeholder-cert-data"
+osacBcmKey: "placeholder-key-data"
 osacBcmBmhNamespace: "openshift-machine-api"

--- a/plugins/osac/test-fixtures/schemas/defaults/valid/base.yaml
+++ b/plugins/osac/test-fixtures/schemas/defaults/valid/base.yaml
@@ -21,6 +21,7 @@ osac_keycloak_validate_certs: true
 
 osacTestUsers: false
 osacNetrisEnabled: false
+osacBcmEnabled: false
 
 osacBYODatabase: false
 osac_db_name: postgres


### PR DESCRIPTION
## Summary

- Wire BCM (NVIDIA Base Command Manager) inventory backend configuration through the OSAC plugin
- Follow the existing Netris backend pattern: config schema with conditional required fields, defaults, Jinja2 values template, and example config
- BCM uses mTLS authentication (`cert`/`key`/`caCert`) rather than username/password, and requires Metal3 for power management via BareMetalHost CRs

### Changes

| File | What |
|------|------|
| `plugins/osac/schemas/config.yaml` | Add 8 BCM properties + `allOf` conditional requiring `url`, `cert`, `key`, `bmhNamespace` when enabled |
| `plugins/osac/schemas/defaults.yaml` | Add `osacBcmEnabled` boolean property |
| `plugins/osac/defaults.yaml` | Default `osacBcmEnabled: false` |
| `plugins/osac/templates/values.yaml.j2` | Conditionally populate `bmf.bcm.*` Helm values when BCM is enabled |
| `config/plugins/osac.example.yaml` | Add commented-out BCM configuration section |
| `test-fixtures/schemas/defaults/valid/base.yaml` | Add `osacBcmEnabled: false` |
| `test-fixtures/schemas/config/invalid/bcm-enabled-missing-required.yaml` | New fixture: BCM enabled without required fields |

### Upstream

Depends on [osac-project/osac#391](https://github.com/osac-project/osac/pull/391) for the `bmf.bcm.*` Helm chart values.

## Test plan

- [x] `make -f Makefile.ci validate-json-schema` passes (valid + invalid fixtures)
- [x] `make -f Makefile.ci validate-plugins` passes
- [ ] Deploy with `osacBcmEnabled: false` (default) — no behavioral change
- [ ] Deploy with `osacBcmEnabled: true` + required fields — verify rendered values include `bmf.bcm.*` block

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional NVIDIA Base Command Manager integration for bare-metal fulfillment.
  * Added configuration for BCM connectivity, certificates, TLS verification, host class, and BareMetalHost namespace.
  * BCM integration is disabled by default and requires the necessary connection settings when enabled.
  * Added a commented configuration example to help set up the integration.

* **Bug Fixes**
  * Added validation to prevent incomplete or insecure BCM configurations from being accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->