### PR TITLE
OSAC-4561: Add Metal3 backend configuration for bare metal fulfillment

### DIFF
--- a/config/plugins/osac.example.yaml
+++ b/config/plugins/osac.example.yaml
@@ -106,3 +106,15 @@
 #   -----END CERTIFICATE-----
 # osacBcmInsecureSkipVerify: false
 # osacBcmHostClass: "bcm"
+
+# --- Metal3 Inventory Backend ---
+# Enable Metal3 (BareMetalHost) integration for bare metal fulfillment.
+# Uses locally-managed BareMetalHost CRs via the metal3.io API.
+# NOTE: BCM and Metal3 are mutually exclusive — only one can be enabled.
+# osacMetal3Enabled: true
+
+# Required when osacMetal3Enabled is true:
+# osacMetal3Namespace: "openshift-machine-api"
+
+# Optional Metal3 config:
+# osacMetal3HostClass: "metal3"

--- a/plugins/osac/defaults.yaml
+++ b/plugins/osac/defaults.yaml
@@ -19,6 +19,9 @@ osacNetrisEnabled: false
 # BCM inventory backend
 osacBcmEnabled: false
 
+# Metal3 inventory backend
+osacMetal3Enabled: false
+
 # AAP settings (chart manages the instance, these configure it)
 osac_aap_name: osac-aap
 osac_aap_operator_ns: ansible-aap

--- a/plugins/osac/schemas/config.yaml
+++ b/plugins/osac/schemas/config.yaml
@@ -170,6 +170,17 @@ properties:
     type: string
     minLength: 1
     description: "Namespace where BareMetalHost CRs are created for Metal3 power management"
+  osacMetal3Enabled:
+    type: boolean
+    description: "Enable Metal3 inventory backend for bare metal fulfillment"
+  osacMetal3Namespace:
+    type: string
+    minLength: 1
+    description: "Namespace where BareMetalHost CRs are located"
+  osacMetal3HostClass:
+    type: string
+    minLength: 1
+    description: "Host class identifier for Metal3 inventory (default: metal3)"
 required:
   - osacAapLicenseFile
 dependencies:
@@ -204,3 +215,18 @@ allOf:
         - osacBcmCert
         - osacBcmKey
         - osacBcmBmhNamespace
+      properties:
+        osacMetal3Enabled:
+          const: false
+  - if:
+      required:
+        - osacMetal3Enabled
+      properties:
+        osacMetal3Enabled:
+          const: true
+    then:
+      required:
+        - osacMetal3Namespace
+      properties:
+        osacBcmEnabled:
+          const: false

--- a/plugins/osac/schemas/defaults.yaml
+++ b/plugins/osac/schemas/defaults.yaml
@@ -103,6 +103,9 @@ properties:
   osacBcmEnabled:
     type: boolean
     description: Enable BCM inventory backend for bare metal fulfillment.
+  osacMetal3Enabled:
+    type: boolean
+    description: Enable Metal3 inventory backend for bare metal fulfillment.
   osacBYODatabase:
     type: boolean
     description: Use an external database instead of the built-in dev postgres.

--- a/plugins/osac/templates/values.yaml.j2
+++ b/plugins/osac/templates/values.yaml.j2
@@ -233,6 +233,12 @@ bmf:
     insecureSkipVerify: {{ osacBcmInsecureSkipVerify | default(false) | lower }}
     hostClass: "{{ osacBcmHostClass | default('bcm') }}"
     bmhNamespace: "{{ osacBcmBmhNamespace }}"
+{% elif osacMetal3Enabled | default(false) | bool %}
+  enabled: true
+  metal3:
+    enabled: true
+    namespace: "{{ osacMetal3Namespace }}"
+    hostClass: "{{ osacMetal3HostClass | default('metal3') }}"
 {% else %}
   enabled: false
 {% endif %}

--- a/plugins/osac/test-fixtures/schemas/config/invalid/bcm-metal3-both-enabled.yaml
+++ b/plugins/osac/test-fixtures/schemas/config/invalid/bcm-metal3-both-enabled.yaml
@@ -1,0 +1,11 @@
+---
+# Fixture: BCM and Metal3 both enabled (mutually exclusive)
+# Expected failure: osacMetal3Enabled must be false when osacBcmEnabled is true
+osacAapLicenseFile: "/home/cloud-user/aap-license.zip"
+osacBcmEnabled: true
+osacBcmUrl: "https://bcm-head:8081"
+osacBcmCert: "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----"
+osacBcmKey: "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----"
+osacBcmBmhNamespace: "openshift-machine-api"
+osacMetal3Enabled: true
+osacMetal3Namespace: "openshift-machine-api"

--- a/plugins/osac/test-fixtures/schemas/config/invalid/bcm-metal3-both-enabled.yaml
+++ b/plugins/osac/test-fixtures/schemas/config/invalid/bcm-metal3-both-enabled.yaml
@@ -4,8 +4,8 @@
 osacAapLicenseFile: "/home/cloud-user/aap-license.zip"
 osacBcmEnabled: true
 osacBcmUrl: "https://bcm-head:8081"
-osacBcmCert: "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----"
-osacBcmKey: "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----"
+osacBcmCert: "placeholder-cert-data"
+osacBcmKey: "placeholder-key-data"
 osacBcmBmhNamespace: "openshift-machine-api"
 osacMetal3Enabled: true
 osacMetal3Namespace: "openshift-machine-api"

--- a/plugins/osac/test-fixtures/schemas/config/invalid/metal3-enabled-missing-required.yaml
+++ b/plugins/osac/test-fixtures/schemas/config/invalid/metal3-enabled-missing-required.yaml
@@ -1,0 +1,5 @@
+---
+# Fixture: Metal3 enabled but missing required namespace
+# Expected failure: osacMetal3Namespace required when osacMetal3Enabled is true
+osacAapLicenseFile: "/home/cloud-user/aap-license.zip"
+osacMetal3Enabled: true

--- a/plugins/osac/test-fixtures/schemas/defaults/valid/base.yaml
+++ b/plugins/osac/test-fixtures/schemas/defaults/valid/base.yaml
@@ -22,6 +22,7 @@ osac_keycloak_validate_certs: true
 osacTestUsers: false
 osacNetrisEnabled: false
 osacBcmEnabled: false
+osacMetal3Enabled: false
 
 osacBYODatabase: false
 osac_db_name: postgres


### PR DESCRIPTION
## Summary

- Wire Metal3 (BareMetalHost) inventory backend configuration through the OSAC plugin
- Metal3 uses locally-managed BareMetalHost CRs via the metal3.io API — simpler than BCM (no mTLS, just namespace and host class)
- Add mutual exclusivity constraint: BCM and Metal3 cannot both be enabled (enforced at schema level)
- Stacked on #737 (OSAC-4559: BCM backend config)

### Changes

| File | What |
|------|------|
| `plugins/osac/schemas/config.yaml` | Add 3 Metal3 properties + conditional required + mutual exclusivity via `allOf` |
| `plugins/osac/schemas/defaults.yaml` | Add `osacMetal3Enabled` boolean property |
| `plugins/osac/defaults.yaml` | Default `osacMetal3Enabled: false` |
| `plugins/osac/templates/values.yaml.j2` | Add `elif` branch populating `bmf.metal3.*` when Metal3 is enabled |
| `config/plugins/osac.example.yaml` | Add commented-out Metal3 section with mutual exclusivity note |
| `test-fixtures/.../metal3-enabled-missing-required.yaml` | Invalid: Metal3 enabled without namespace |
| `test-fixtures/.../bcm-metal3-both-enabled.yaml` | Invalid: both backends enabled simultaneously |

### Upstream

Depends on [osac-project/osac#387](https://github.com/osac-project/osac/pull/387) (merged) for the `bmf.metal3.*` Helm chart values.

## Test plan

- [x] `make -f Makefile.ci validate-json-schema` passes (all valid + invalid fixtures)
- [x] `make -f Makefile.ci validate-plugins` passes
- [ ] Deploy with both backends disabled (default) — no behavioral change
- [ ] Deploy with `osacMetal3Enabled: true` + `osacMetal3Namespace` — verify rendered values
- [ ] Verify schema rejects both `osacBcmEnabled` and `osacMetal3Enabled` set to true

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional Metal3 inventory backend support for bare metal fulfillment.
  - Added configuration for enabling Metal3, selecting its namespace, and specifying a host class.
  - Existing BCM behavior remains available when Metal3 is disabled.

- **Bug Fixes**
  - Added validation to prevent Metal3 and BCM from being enabled simultaneously.
  - Metal3 configurations now require a namespace when enabled.

- **Tests**
  - Added coverage for invalid backend combinations and missing required Metal3 settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->