### PR TITLE
bump default ocp version to 4.20.32

### DIFF
--- a/defaults/control_binaries.yaml
+++ b/defaults/control_binaries.yaml
@@ -1,8 +1,8 @@
 ---
 control_binaries:
   openshift_client:
-    url: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.20.29/openshift-client-linux.tar.gz"
-    checksum: "sha256:a8cb9187c000b4744cf87546045dbab8bf35eb4f4950b5238f7a94f2f4b63460"
+    url: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.20.32/openshift-client-linux.tar.gz"
+    checksum: "sha256:2deb2e225404047bdae2808036cf16e04612df57d2560a1152a01003f3f7a46d"
   helm:
     url: "https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/helm/3.17.1/helm-linux-amd64"
     checksum: "sha256:ef6c04f6a748d0f1d624a94a56dc0db83f8d70a65e3dbb19e94107126efcc5fd"

--- a/defaults/platforms.yaml
+++ b/defaults/platforms.yaml
@@ -1,5 +1,5 @@
 ---
 openshift_versions:
 - version: 4.20.21
-- version: 4.20.29
+- version: 4.20.32
   default: true

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -166,7 +166,7 @@ def test_mgmt_cluster_version_use_defaults(mocker: MockerFixture) -> None:
         cli, ["mgmt-cluster-version", "--use-defaults", "--dry-run"], env=_KC
     )
     assert result.exit_code == 0, result.output
-    mock_reconcile.assert_called_once_with("4.20.29", dry_run, 180, 60)
+    mock_reconcile.assert_called_once_with("4.20.32", dry_run, 180, 60)
 
 
 def test_mgmt_cluster_version_use_defaults_mutual_exclusive_version() -> None:


### PR DESCRIPTION
4.20.29 was removed from the update graph in https://github.com/openshift/cincinnati-graph-data/commit/d4c2fb6074f284b95527138dd3e75beda7e0c128#diff-0f802d15b810c91d42111774052fb6c462eee56183d69ce50b687ade694961aa.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated the default OpenShift version to 4.20.32.
  * Updated the included OpenShift client to version 4.20.32.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->