### PR TITLE
Renovate osac helm chart regex versioning with named capture groups

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -40,7 +40,7 @@
       "depNameTemplate": "osac-project/charts/osac",
       "datasourceTemplate": "docker",
       "registryUrlTemplate": "https://ghcr.io",
-      "versioningTemplate": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(-nightly\\.(?<build>\\d+)\\.[a-f0-9]+\\.(?<revision>\\d+)\\.\\d+)?$"
+      "versioningTemplate": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(-nightly\\.(?<build>\\d+)\\.[a-f0-9]+\\.(?<revision>\\d+)\\.(?<prerelease>\\d+))?$"
     }
   ],
   "ansible-galaxy": {

--- a/renovate.json
+++ b/renovate.json
@@ -39,7 +39,8 @@
       ],
       "depNameTemplate": "osac-project/charts/osac",
       "datasourceTemplate": "docker",
-      "registryUrlTemplate": "https://ghcr.io"
+      "registryUrlTemplate": "https://ghcr.io",
+      "versioningTemplate": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(-nightly\\.(?<build>\\d+)\\.[a-f0-9]+\\.(?<revision>\\d+)\\.\\d+)?$"
     }
   ],
   "ansible-galaxy": {


### PR DESCRIPTION
related to https://redhat.atlassian.net/browse/OSAC-4051

according to instructions in https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1788180694421639?thread_ts=1788179873.691429&cid=C04PZ7H0VA8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart version detection to recognize standard semantic versions and optional nightly build variants.
  * Ensured version updates are evaluated using the correct versioning format.
  * Improved handling of nightly releases that include build, hash, and revision details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->