### PR TITLE
Add ClusterImageSet validation for disconnected mode

### DIFF
--- a/operators/advanced-cluster-management/acm_cis.yaml
+++ b/operators/advanced-cluster-management/acm_cis.yaml
@@ -9,6 +9,23 @@
     kind: ClusterImageSet
   register: r_cluster_image_set
 
+- name: Validate ClusterImageSet in disconnected mode
+  when: disconnected | default(false) | bool
+  block:
+    - name: Validate ClusterImageSet count
+      ansible.builtin.assert:
+        that:
+          - r_cluster_image_set.resources | length == 1
+        fail_msg: "Expected exactly 1 ClusterImageSet, found {{ r_cluster_image_set.resources | length }}"
+        success_msg: "Validated: exactly 1 ClusterImageSet exists"
+
+    - name: Validate ClusterImageSet name
+      ansible.builtin.assert:
+        that:
+          - r_cluster_image_set.resources[0].metadata.name == "local-cluster-image-set"
+        fail_msg: "Expected ClusterImageSet name 'local-cluster-image-set', found '{{ r_cluster_image_set.resources[0].metadata.name }}'"
+        success_msg: "Validated: ClusterImageSet name is 'local-cluster-image-set'"
+
 - name: Set desired ClusterImageSet names
   ansible.builtin.set_fact:
     r_desired_image_set: "{{ openshift_versions | map(attribute='version') | map('regex_replace', '^(.*)$', 'openshift-v\\1-disconnected') | list }}"


### PR DESCRIPTION
## Summary

Adds validation to ensure proper ClusterImageSet configuration in disconnected environments:
- Validates exactly 1 ClusterImageSet exists
- Validates the ClusterImageSet name is `local-cluster-image-set`

This validation runs only when `disconnected` mode is enabled and helps catch configuration issues early in the reconciliation process.

## Context

Follow-up to PR #733 (revert of #351) which restored ClusterImageSet updates. This validation ensures the expected state is maintained in disconnected environments following #723.

## Test plan

- [ ] Verify validation passes with correct configuration (1 ClusterImageSet named `local-cluster-image-set`)
- [ ] Verify validation fails appropriately with incorrect count
- [ ] Verify validation fails appropriately with incorrect name
- [ ] Verify validation is skipped in connected mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)