### PR TITLE
Use quayUser variable for Quay SUPER_USERS configuration

### DIFF
--- a/operators/quay-operator/templates/quay-config-secret.yaml.j2
+++ b/operators/quay-operator/templates/quay-config-secret.yaml.j2
@@ -11,7 +11,7 @@ stringData:
     DEFAULT_TAG_EXPIRATION: 2w
     FEATURE_USER_INITIALIZE: true
     SUPER_USERS:
-      - quayadmin
+      - {{ quayUser }}
     BROWSER_API_CALLS_XHR_ONLY: false
     FEATURE_USER_CREATION: false
     CREATE_NAMESPACE_ON_PUSH: true

--- a/operators/quay-operator/templates/quay-config-secret.yaml.j2
+++ b/operators/quay-operator/templates/quay-config-secret.yaml.j2
@@ -11,7 +11,7 @@ stringData:
     DEFAULT_TAG_EXPIRATION: 2w
     FEATURE_USER_INITIALIZE: true
     SUPER_USERS:
-      - {{ quayUser }}
+      - {{ quayUser | to_json }}
     BROWSER_API_CALLS_XHR_ONLY: false
     FEATURE_USER_CREATION: false
     CREATE_NAMESPACE_ON_PUSH: true


### PR DESCRIPTION
## Summary
Fixes the Quay SUPER_USERS configuration to use the configurable `quayUser` variable instead of the hardcoded `quayadmin` value.

## Problem
The Quay username can be configured in `global.yaml` via the `quayUser` property, but the `SUPER_USERS` setting in the Quay configuration template had `quayadmin` hardcoded. This meant that users who configured a different username in `global.yaml` would not receive superuser privileges.

## Solution
Replace the hardcoded `quayadmin` value with the `{{ quayUser }}` variable in the template, ensuring the configured user receives superuser privileges.

## Changes
- `operators/quay-operator/templates/quay-config-secret.yaml.j2`: Updated SUPER_USERS to use `{{ quayUser }}` instead of hardcoded `quayadmin`

## Testing
- The `quayUser` variable is already validated in the schema and is used throughout the operator tasks
- No schema changes required as `quayUser` is already a required field

Fixes: gori-project/GoRI#956

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configured Quay super-user access to use the selected administrator account instead of a fixed default account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->