### PR TITLE
OSAC-3867: Normalize PEM trailing newlines before secret apply

### DIFF
--- a/playbooks/common/load-vars.yaml
+++ b/playbooks/common/load-vars.yaml
@@ -36,6 +36,9 @@
         sslCACertificate: "{{ r_root_ca.stdout | trim }}"
       when: r_root_ca.rc == 0 and r_root_ca.stdout | trim | length > 0
 
+- name: Normalize PEM certificate fields
+  ansible.builtin.include_tasks: normalize-pem-vars.yaml
+
 - name: Write SSH public key to file if content provided
   when: sshPubKey is defined and sshPubKey | length > 0
   block:

--- a/playbooks/common/normalize-pem-vars.yaml
+++ b/playbooks/common/normalize-pem-vars.yaml
@@ -1,0 +1,16 @@
+---
+# Ensure PEM blobs end with exactly one trailing newline before secret writes
+# and PEM concatenation (tls.crt + tls.key, fullchain + CA).
+
+- name: Normalize PEM trailing newlines
+  ansible.builtin.set_fact:
+    "{{ item }}": "{{ lookup('ansible.builtin.vars', item).rstrip('\n') + '\n' }}"
+  when: lookup('ansible.builtin.vars', item, default='') | length > 0
+  loop:
+    - sslAPICertificateFullChain
+    - sslAPICertificateKey
+    - sslIngressCertificateFullChain
+    - sslIngressCertificateKey
+    - sslCACertificate
+    - ironicHTTPSCertificate
+    - ironicHTTPSKey

--- a/src/enclave/tools/cert_utils.py
+++ b/src/enclave/tools/cert_utils.py
@@ -89,6 +89,17 @@ def pem_blocks(pem_text: str) -> list[str]:
     return PEM_BLOCK_RE.findall(pem_text or "")
 
 
+def ensure_pem_trailing_newline(pem: str) -> str:
+    """Return pem with exactly one trailing newline.
+
+    Empty input stays empty. Extra trailing newlines are collapsed to one so
+    concatenated PEM blobs do not glue END/BEGIN headers.
+    """
+    if not pem:
+        return pem
+    return pem.rstrip("\n") + "\n"
+
+
 def is_self_signed(cert_pem: str) -> bool:
     """Return True if cert_pem is self-signed.
 

--- a/src/tests/test_cert_utils.py
+++ b/src/tests/test_cert_utils.py
@@ -15,6 +15,7 @@ from enclave.tools.cert_utils import (
     cert_covers_hostname,
     cert_key_pair_matches,
     cert_validity_window_ok,
+    ensure_pem_trailing_newline,
     is_self_signed,
     openssl_verify,
     pem_blocks,
@@ -198,3 +199,29 @@ def test_cert_covers_hostname_mismatch(tmp_path: Path) -> None:
         tmp_path, ca_cert_path, ca_key_path, "Leaf", sans=["bar.example.com"]
     )
     assert cert_covers_hostname(leaf_pem, "foo.example.com") is False
+
+
+def test_ensure_pem_trailing_newline_empty() -> None:
+    assert ensure_pem_trailing_newline("") == ""
+
+
+def test_ensure_pem_trailing_newline_adds_missing() -> None:
+    pem = "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----"
+    assert ensure_pem_trailing_newline(pem) == pem + "\n"
+
+
+def test_ensure_pem_trailing_newline_preserves_single() -> None:
+    pem = "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n"
+    assert ensure_pem_trailing_newline(pem) == pem
+
+
+def test_ensure_pem_trailing_newline_strips_extra() -> None:
+    pem = "-----END CERTIFICATE-----\n\n"
+    assert ensure_pem_trailing_newline(pem) == "-----END CERTIFICATE-----\n"
+
+
+def test_ensure_pem_trailing_newline_concat_does_not_glue_cert_and_key() -> None:
+    fullchain = "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----"
+    key = "-----BEGIN PRIVATE KEY-----\nMIIE\n-----END PRIVATE KEY-----"
+    joined = ensure_pem_trailing_newline(fullchain) + ensure_pem_trailing_newline(key)
+    assert "-----END CERTIFICATE----------BEGIN" not in joined


### PR DESCRIPTION
## Summary

- Add `ensure_pem_trailing_newline()` in `cert_utils.py` and normalize all PEM certificate fields in `load-vars` before Phase 4 secret writes and PEM concatenation.
- Prevents glued `-----END CERTIFICATE----------BEGIN PRIVATE KEY-----` boundaries that CrashLoop `oauth-openshift` when ingress fullchain lacks a terminator newline.

## Merge order

**Merge this PR first.** The enclave-wizard PR (OSAC-3867) is belt-and-suspenders for `certificates.yaml` on disk; apply-time normalization here is required for wizard, CLI, and hand-edited config paths.

## Test plan

- [x] `uv run pytest src/tests/test_cert_utils.py -k ensure_pem`
- [x] `make python-unit-test` (273 passed)
- [x] `make python-linter-test python-types-test`
- [x] `ansible-lint` on changed playbooks


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PEM certificate and key handling by ensuring values contain exactly one trailing newline.
  * Prevented concatenated PEM blocks from running together, improving certificate and key processing reliability.

* **Tests**
  * Added coverage for empty values, missing or extra newlines, and certificate/key concatenation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->