### PR TITLE
OSAC-3867: Validate glued PEM boundaries and safe-concat at use sites

### DIFF
--- a/playbooks/tasks/configure_certificates.yaml
+++ b/playbooks/tasks/configure_certificates.yaml
@@ -100,4 +100,11 @@
   ansible.builtin.replace:
     path: "{{ workingDir }}/ocp-cluster/auth/kubeconfig"
     regexp: "^( +certificate-authority-data):.*"
-    replace: "    certificate-authority-data: {{ (sslAPICertificateFullChain + sslCACertificate | default('')) |  ansible.builtin.b64encode }}"
+    replace: "    certificate-authority-data: {{ api_ca_bundle | b64encode }}"
+  vars:
+    api_ca_bundle: >-
+      {{ sslAPICertificateFullChain
+         ~ ('\n' if sslAPICertificateFullChain | length > 0
+                    and sslCACertificate | default('') | length > 0
+                    and sslAPICertificateFullChain[-1:] != '\n' else '')
+         ~ (sslCACertificate | default('')) }}

--- a/playbooks/tasks/deploy_ironic.yaml
+++ b/playbooks/tasks/deploy_ironic.yaml
@@ -90,9 +90,16 @@
   become: "{{ metal3_persistent | default(false) | bool }}"
   containers.podman.podman_secret:
     name: metal3-ca-bundle
-    data: "{{ sslIngressCertificateFullChain + sslCACertificate | default('') }}"
+    data: "{{ ironic_ca_bundle }}"
     state: present
     force: false
+  vars:
+    ironic_ca_bundle: >-
+      {{ sslIngressCertificateFullChain
+         ~ ('\n' if sslIngressCertificateFullChain | length > 0
+                    and sslCACertificate | default('') | length > 0
+                    and sslIngressCertificateFullChain[-1:] != '\n' else '')
+         ~ (sslCACertificate | default('')) }}
   no_log: true
 
 

--- a/src/enclave/tools/cert_utils.py
+++ b/src/enclave/tools/cert_utils.py
@@ -14,6 +14,8 @@ PEM_BLOCK_RE = re.compile(
     r"-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----",
     re.DOTALL,
 )
+# END line immediately followed by another PEM block without a newline between them.
+PEM_GLUED_BOUNDARY_RE = re.compile(r"-----END [A-Z0-9 ]+-----(?!\r?\n|$)")
 
 # OpenSSL always outputs English month abbreviations in notBefore/notAfter regardless
 # of the system locale. Python's %b in strptime follows LC_TIME, so it would reject
@@ -87,6 +89,18 @@ def openssl_verify(ca_pem: str, cert_pem: str) -> bool:
 def pem_blocks(pem_text: str) -> list[str]:
     """Return all PEM certificate blocks found in pem_text, in order."""
     return PEM_BLOCK_RE.findall(pem_text or "")
+
+
+def pem_glued_boundary_issue(field: str, pem: str) -> str | None:
+    """Return an issue string when PEM blocks in pem are glued without a newline."""
+    if not pem:
+        return None
+    if PEM_GLUED_BOUNDARY_RE.search(pem):
+        return (
+            f"{field}: PEM blocks must be separated by a newline "
+            f"(found -----END...----- immediately followed by -----BEGIN...-----)"
+        )
+    return None
 
 
 def is_self_signed(cert_pem: str) -> bool:

--- a/src/enclave/tools/cert_utils.py
+++ b/src/enclave/tools/cert_utils.py
@@ -14,8 +14,10 @@ PEM_BLOCK_RE = re.compile(
     r"-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----",
     re.DOTALL,
 )
-# END line immediately followed by another PEM block without a newline between them.
-PEM_GLUED_BOUNDARY_RE = re.compile(r"-----END [A-Z0-9 ]+-----(?!\r?\n|$)")
+# END line immediately followed by -----BEGIN without a newline between them.
+PEM_GLUED_BOUNDARY_RE = re.compile(
+    r"-----END [A-Z0-9 ]+-----(?=-----BEGIN [A-Z0-9 ]+-----)"
+)
 
 # OpenSSL always outputs English month abbreviations in notBefore/notAfter regardless
 # of the system locale. Python's %b in strptime follows LC_TIME, so it would reject
@@ -92,7 +94,12 @@ def pem_blocks(pem_text: str) -> list[str]:
 
 
 def pem_glued_boundary_issue(field: str, pem: str) -> str | None:
-    """Return an issue string when PEM blocks in pem are glued without a newline."""
+    """Return an issue when PEM blocks in pem are glued without a newline.
+
+    Detects ``-----END ...-----`` immediately followed by ``-----BEGIN ...-----``
+    with no line break between them. Trailing whitespace or other non-PEM text
+    after the final END marker is allowed.
+    """
     if not pem:
         return None
     if PEM_GLUED_BOUNDARY_RE.search(pem):

--- a/src/enclave/tools/check_certificate_chains.py
+++ b/src/enclave/tools/check_certificate_chains.py
@@ -13,6 +13,7 @@ from enclave.tools.cert_utils import (
     is_self_signed,
     openssl_verify,
     pem_blocks,
+    pem_glued_boundary_issue,
 )
 from enclave.tools.system_ca import find_system_ca_for_chain
 
@@ -35,6 +36,21 @@ CERT_TYPE_TO_KEY_FIELD: dict[str, str] = {
 # Types that carry a full chain and require completeness + CA consistency checks.
 # "ironic" is excluded: ironicHTTPSCertificate is a single cert with no CA counterpart.
 CHAIN_CERT_TYPES: frozenset[str] = frozenset({"api", "ingress"})
+
+# PEM fields checked for glued block boundaries when non-empty (raw YAML values).
+PEM_FIELDS_BY_CERT_TYPE: dict[str, list[str]] = {
+    "api": [
+        "sslAPICertificateFullChain",
+        "sslAPICertificateKey",
+        "sslCACertificate",
+    ],
+    "ingress": [
+        "sslIngressCertificateFullChain",
+        "sslIngressCertificateKey",
+        "sslCACertificate",
+    ],
+    "ironic": ["ironicHTTPSCertificate", "ironicHTTPSKey"],
+}
 
 
 class CertificateValidationError(Exception):
@@ -115,6 +131,23 @@ def _check_chain(field: str, chain_pem: str, ca_pem: str) -> str | None:
     )
 
 
+def _check_pem_boundaries(raw: dict[str, Any], fields: list[str]) -> list[str]:
+    """Return issue strings for PEM fields with glued block boundaries."""
+    issues: list[str] = []
+    for field in fields:
+        value = raw.get(field)
+        if not value:
+            continue
+        if not isinstance(value, str):
+            raise CertificateValidationError(
+                f"{field}: expected a string value, got {type(value).__name__}"
+            )
+        issue = pem_glued_boundary_issue(field, value)
+        if issue:
+            issues.append(issue)
+    return issues
+
+
 def _check_leaf(
     field: str,
     leaf_pem: str,
@@ -177,6 +210,10 @@ def check_certificate_chains(
     if not hostnames:
         msg = f"{cert_type}: at least one hostname is required"
         raise CertificateValidationError(msg)
+
+    pem_boundary_issues = _check_pem_boundaries(raw, PEM_FIELDS_BY_CERT_TYPE[cert_type])
+    if pem_boundary_issues:
+        raise CertificateValidationError("\n".join(pem_boundary_issues))
 
     key_pem: str = _get_config_str(raw, key_field)
     if not key_pem:

--- a/src/tests/test_cert_utils.py
+++ b/src/tests/test_cert_utils.py
@@ -202,15 +202,24 @@ def test_cert_covers_hostname_mismatch(tmp_path: Path) -> None:
 
 
 def test_pem_glued_boundary_issue_empty() -> None:
+    """Empty PEM input is valid and returns no issue."""
     assert pem_glued_boundary_issue("sslAPICertificateFullChain", "") is None
 
 
 def test_pem_glued_boundary_issue_allows_missing_eof_newline() -> None:
+    """Missing EOF newline alone is not treated as glued blocks."""
     pem = "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----"
     assert pem_glued_boundary_issue("sslAPICertificateFullChain", pem) is None
 
 
+def test_pem_glued_boundary_issue_allows_trailing_whitespace() -> None:
+    """Trailing non-PEM text after END must not be reported as glued blocks."""
+    pem = "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE----- "
+    assert pem_glued_boundary_issue("sslAPICertificateFullChain", pem) is None
+
+
 def test_pem_glued_boundary_issue_allows_properly_separated_blocks() -> None:
+    """Newline-separated PEM blocks in one field are accepted."""
     pem = (
         "-----BEGIN CERTIFICATE-----\nleaf\n-----END CERTIFICATE-----\n"
         "-----BEGIN CERTIFICATE-----\ninter\n-----END CERTIFICATE-----"
@@ -219,6 +228,7 @@ def test_pem_glued_boundary_issue_allows_properly_separated_blocks() -> None:
 
 
 def test_pem_glued_boundary_issue_detects_internal_glue() -> None:
+    """Adjacent certificate blocks without a separator are rejected."""
     pem = (
         "-----BEGIN CERTIFICATE-----\nleaf\n-----END CERTIFICATE-----"
         "-----BEGIN CERTIFICATE-----\ninter\n-----END CERTIFICATE-----\n"
@@ -229,6 +239,7 @@ def test_pem_glued_boundary_issue_detects_internal_glue() -> None:
 
 
 def test_pem_glued_boundary_issue_detects_cert_to_key_glue() -> None:
+    """Certificate immediately followed by private key block is rejected."""
     pem = (
         "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----"
         "-----BEGIN PRIVATE KEY-----\nMIIE\n-----END PRIVATE KEY-----\n"

--- a/src/tests/test_cert_utils.py
+++ b/src/tests/test_cert_utils.py
@@ -18,6 +18,7 @@ from enclave.tools.cert_utils import (
     is_self_signed,
     openssl_verify,
     pem_blocks,
+    pem_glued_boundary_issue,
 )
 from tests.cert_helpers import (
     generate_ca,
@@ -198,3 +199,39 @@ def test_cert_covers_hostname_mismatch(tmp_path: Path) -> None:
         tmp_path, ca_cert_path, ca_key_path, "Leaf", sans=["bar.example.com"]
     )
     assert cert_covers_hostname(leaf_pem, "foo.example.com") is False
+
+
+def test_pem_glued_boundary_issue_empty() -> None:
+    assert pem_glued_boundary_issue("sslAPICertificateFullChain", "") is None
+
+
+def test_pem_glued_boundary_issue_allows_missing_eof_newline() -> None:
+    pem = "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----"
+    assert pem_glued_boundary_issue("sslAPICertificateFullChain", pem) is None
+
+
+def test_pem_glued_boundary_issue_allows_properly_separated_blocks() -> None:
+    pem = (
+        "-----BEGIN CERTIFICATE-----\nleaf\n-----END CERTIFICATE-----\n"
+        "-----BEGIN CERTIFICATE-----\ninter\n-----END CERTIFICATE-----"
+    )
+    assert pem_glued_boundary_issue("sslAPICertificateFullChain", pem) is None
+
+
+def test_pem_glued_boundary_issue_detects_internal_glue() -> None:
+    pem = (
+        "-----BEGIN CERTIFICATE-----\nleaf\n-----END CERTIFICATE-----"
+        "-----BEGIN CERTIFICATE-----\ninter\n-----END CERTIFICATE-----\n"
+    )
+    issue = pem_glued_boundary_issue("sslAPICertificateFullChain", pem)
+    assert issue is not None
+    assert "PEM blocks must be separated by a newline" in issue
+
+
+def test_pem_glued_boundary_issue_detects_cert_to_key_glue() -> None:
+    pem = (
+        "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----"
+        "-----BEGIN PRIVATE KEY-----\nMIIE\n-----END PRIVATE KEY-----\n"
+    )
+    issue = pem_glued_boundary_issue("sslIngressCertificateFullChain", pem)
+    assert issue is not None

--- a/src/tests/test_check_certificate_chains.py
+++ b/src/tests/test_check_certificate_chains.py
@@ -321,6 +321,24 @@ def test_check_raises_when_chain_has_content_but_no_pem_blocks(
         check_certificate_chains(str(path), "api", ["api.cluster.example.com"])
 
 
+def test_check_raises_when_pem_blocks_are_glued(tmp_path: Path) -> None:
+    """Raise before chain checks when PEM blocks lack a separating newline."""
+    glued_chain = (
+        "-----BEGIN CERTIFICATE-----\nleaf\n-----END CERTIFICATE-----"
+        "-----BEGIN CERTIFICATE-----\ninter\n-----END CERTIFICATE-----\n"
+    )
+    path = _write_certs(
+        tmp_path,
+        sslAPICertificateFullChain=glued_chain,
+        sslAPICertificateKey="fake-key\n",
+    )
+    with pytest.raises(
+        CertificateValidationError,
+        match="sslAPICertificateFullChain: PEM blocks must be separated by a newline",
+    ):
+        check_certificate_chains(str(path), "api", ["api.cluster.example.com"])
+
+
 def test_check_raises_on_missing_file() -> None:
     """Raise when the config file does not exist."""
     with pytest.raises(CertificateValidationError, match="cannot read"):

--- a/src/tests/test_check_certificate_chains.py
+++ b/src/tests/test_check_certificate_chains.py
@@ -20,6 +20,7 @@ from tests.cert_helpers import (
 
 
 def _write_certs(tmp_path: Path, **kwargs: str) -> str:
+    """Write a minimal certificates.yaml for chain-validation tests."""
     content = "\n".join(
         f"{k}: |\n  " + v.replace("\n", "\n  ") for k, v in kwargs.items()
     )


### PR DESCRIPTION
## Summary

Prevents glued PEM boundaries (`-----END …----------BEGIN …-----`) that can break TLS material (e.g. `oauth-openshift` CrashLoop) when certificate fields are concatenated or contain multiple blocks without separating newlines.

**Approach (no config mutation at `load-vars`):**

1. **`check-certificate-chains`** — fail early when a PEM field contains glued blocks (END immediately followed by BEGIN without a newline). Does **not** require a trailing EOF newline.
2. **Playbook concat sites** — `configure_certificates.yaml` and `deploy_ironic.yaml` (previously naive `+` concat) follow the same safe-join pattern as `trust_custom_ca.yaml`: insert `\n` only when joining two non-empty blobs and the left operand lacks a trailing newline. Config vars on disk stay untouched.
3. **Wizard** — [enclave-wizard#20](https://github.com/rh-ecosystem-edge/enclave-wizard/pull/20) (merged) still normalizes PEM on write to `certificates.yaml`.

## Changes

| Area | What |
|------|------|
| `cert_utils.py` | `pem_glued_boundary_issue()` — detect glued PEM block boundaries |
| `check_certificate_chains.py` | Validate raw YAML PEM fields before chain/leaf checks |
| `configure_certificates.yaml` | Safe join for kubeconfig `certificate-authority-data` |
| `deploy_ironic.yaml` | Safe join for metal3 CA bundle secret |
| Removed | `normalize-pem-vars.yaml` / `load-vars` runtime normalization |

## Test plan

- [x] `uv run pytest src/tests/test_cert_utils.py -k pem_glued`
- [x] `uv run pytest src/tests/test_check_certificate_chains.py -k glued`
- [x] `make python-unit-test` (pending devcontainer / CI — local macOS openssl/trust-store failures)
- [x] `make python-linter-test python-types-test`
- [x] `ansible-lint` on changed playbooks

## Related work

- https://github.com/rh-ecosystem-edge/enclave-wizard/pull/20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Certificate bundles now preserve required newline separators when combining certificate and CA data.
  - Certificate validation detects and reports PEM blocks that are concatenated without a separating newline.
  - Valid PEM content remains accepted, including files without a trailing newline.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->