### PR TITLE
Reject manual OpenShift versions not in defaults/platforms.yaml

### DIFF
--- a/src/enclave/reconcile/cli.py
+++ b/src/enclave/reconcile/cli.py
@@ -39,7 +39,17 @@ def load_openshift_versions() -> list[dict[str, object]]:
     except yaml.YAMLError as exc:
         raise click.ClickException(f"Failed to parse {defaults_file}: {exc}") from exc
 
-    return platforms.get("openshift_versions", [])
+    if not isinstance(platforms, dict):
+        raise click.ClickException(
+            f"{defaults_file} must be a mapping with an 'openshift_versions' list"
+        )
+    openshift_versions = platforms.get("openshift_versions")
+    if not isinstance(openshift_versions, list) or not openshift_versions:
+        raise click.ClickException(
+            f"{defaults_file} must define a non-empty 'openshift_versions' list"
+        )
+
+    return openshift_versions
 
 
 @click.group(cls=KubeconfigGroup)

--- a/src/enclave/reconcile/cli.py
+++ b/src/enclave/reconcile/cli.py
@@ -26,6 +26,22 @@ def defaults_path(filename: str) -> Path:
     return path
 
 
+def load_openshift_versions() -> list[dict[str, object]]:
+    """Load the openshift_versions list from defaults/platforms.yaml."""
+    defaults_file = defaults_path("platforms.yaml")
+    try:
+        with defaults_file.open(encoding="utf-8") as fh:
+            platforms = yaml.safe_load(fh)
+    except FileNotFoundError as exc:
+        raise click.ClickException(
+            f"{defaults_file} not found; run from the repo root"
+        ) from exc
+    except yaml.YAMLError as exc:
+        raise click.ClickException(f"Failed to parse {defaults_file}: {exc}") from exc
+
+    return platforms.get("openshift_versions", [])
+
+
 @click.group(cls=KubeconfigGroup)
 @click.option(
     "--log-level",
@@ -138,23 +154,9 @@ def mgmt_cluster_version(
     if not use_defaults and not version:
         raise click.UsageError("Either --version or --use-defaults must be provided")
 
-    if use_defaults:
-        defaults_file = defaults_path("platforms.yaml")
-        try:
-            with defaults_file.open(encoding="utf-8") as fh:
-                platforms = yaml.safe_load(fh)
-        except FileNotFoundError as exc:
-            raise click.ClickException(
-                f"{defaults_file} not found; run from the repo root"
-            ) from exc
-        except yaml.YAMLError as exc:
-            raise click.ClickException(
-                f"Failed to parse {defaults_file}: {exc}"
-            ) from exc
+    openshift_versions = load_openshift_versions()
 
-        openshift_versions: list[dict[str, object]] = platforms.get(
-            "openshift_versions", []
-        )
+    if use_defaults:
         default_entry = next(
             (v for v in openshift_versions if v.get("default") is True), None
         )
@@ -166,6 +168,12 @@ def mgmt_cluster_version(
         resolved_version: str = str(default_entry["version"])
     else:
         resolved_version = cast("str", version)
+        allowed_versions = {str(v["version"]) for v in openshift_versions}
+        if resolved_version not in allowed_versions:
+            raise click.UsageError(
+                f"Version '{resolved_version}' is not in defaults/platforms.yaml. "
+                f"Allowed: {', '.join(sorted(allowed_versions))}"
+            )
 
     try:
         cluster_upgrade_reconcile(

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -165,7 +165,10 @@ def test_mgmt_cluster_version_unknown_version_rejected(mocker: MockerFixture) ->
         cli, ["mgmt-cluster-version", "--version", "4.99.0", "--dry-run"], env=_KC
     )
     assert result.exit_code != 0
+    assert "Version '4.99.0'" in result.output
     assert "not in defaults/platforms.yaml" in result.output
+    assert "4.20.21" in result.output
+    assert "4.20.32" in result.output
     mock_reconcile.assert_not_called()
 
 

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -159,6 +159,16 @@ def test_mgmt_cluster_version_with_version(mocker: MockerFixture) -> None:
     mock_reconcile.assert_called_once_with("4.20.21", dry_run, 180, 60)
 
 
+def test_mgmt_cluster_version_unknown_version_rejected(mocker: MockerFixture) -> None:
+    mock_reconcile = mocker.patch("enclave.reconcile.cli.cluster_upgrade_reconcile")
+    result = CliRunner().invoke(
+        cli, ["mgmt-cluster-version", "--version", "4.99.0", "--dry-run"], env=_KC
+    )
+    assert result.exit_code != 0
+    assert "not in defaults/platforms.yaml" in result.output
+    mock_reconcile.assert_not_called()
+
+
 def test_mgmt_cluster_version_use_defaults(mocker: MockerFixture) -> None:
     mock_reconcile = mocker.patch("enclave.reconcile.cli.cluster_upgrade_reconcile")
     dry_run = True


### PR DESCRIPTION
The mgmt-cluster-version command previously accepted any --version value verbatim. Now a manually-specified version must appear in defaults/platforms.yaml under openshift_versions, otherwise the command fails with a clear error listing the allowed versions.

OSAC-4740


Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added validation for explicitly requested OpenShift versions.
  - Unsupported versions now produce a clear error message listing the allowed versions.
  - Prevented cluster reconciliation from running when an invalid version is provided.
  - Improved handling of available OpenShift version data to provide more reliable command behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->