### PR TITLE
set ocp 4.20.21 as default version

### DIFF
--- a/defaults/platforms.yaml
+++ b/defaults/platforms.yaml
@@ -1,5 +1,5 @@
 ---
 openshift_versions:
 - version: 4.20.21
-- version: 4.20.32
   default: true
+- version: 4.20.32

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -179,7 +179,7 @@ def test_mgmt_cluster_version_use_defaults(mocker: MockerFixture) -> None:
         cli, ["mgmt-cluster-version", "--use-defaults", "--dry-run"], env=_KC
     )
     assert result.exit_code == 0, result.output
-    mock_reconcile.assert_called_once_with("4.20.32", dry_run, 180, 60)
+    mock_reconcile.assert_called_once_with("4.20.21", dry_run, 180, 60)
 
 
 def test_mgmt_cluster_version_use_defaults_mutual_exclusive_version() -> None:


### PR DESCRIPTION
with recent issues such as #750 we want to create a distinction between install version and available versions.

install version is more thoroughly tested for reliability since installation is a complex and sensitive workflow, and can be replaced by a more reasonable and current z-release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated the default OpenShift platform version to 4.20.21.
  * OpenShift version 4.20.32 remains available for selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->