### PR TITLE
OSAC-4865: Add Renovate customManager for AWS CLI version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,15 @@
     },
     {
       "customType": "regex",
+      "description": "Update AWS CLI version in setup_env.sh",
+      "managerFilePatterns": ["setup_env.sh"],
+      "matchStrings": ["AWS_CLI_VERSION=(?<currentValue>[^\\s\"]+)"],
+      "depNameTemplate": "aws/aws-cli",
+      "datasourceTemplate": "github-tags",
+      "extractVersionTemplate": "^(?<version>.+)$"
+    },
+    {
+      "customType": "regex",
       "description": "Update OLM operator versions in operators.yaml",
       "managerFilePatterns": ["defaults/operators.yaml", "plugins/lvms/plugin.yaml"],
       "matchStrings": [
@@ -64,6 +73,11 @@
       "description": "Exclude metallb-operator (non-semver version)",
       "matchPackageNames": ["metallb-operator"],
       "enabled": false
+    },
+    {
+      "description": "AWS CLI: only allow v2 updates (installer URL is hardcoded to v2)",
+      "matchPackageNames": ["aws/aws-cli"],
+      "allowedVersions": "<3"
     },
     {
       "matchPackageNames": ["osac-project/charts/osac"],


### PR DESCRIPTION
## Summary

Adds a Renovate `customManager` to automatically track and update the AWS CLI v2 version pinned in `setup_env.sh` (`AWS_CLI_VERSION`), mirroring the existing pattern used for `uv`.

## Details

- **customManager**: regex manager on `setup_env.sh` capturing `AWS_CLI_VERSION`, using the `aws/aws-cli` GitHub tags datasource.
- **packageRule**: restricts updates to v2 (`allowedVersions: "<3"`) because the installer URL in `setup_env.sh` is hardcoded to the v2 linux x86_64 package.

## Jira

OSAC-4865 (epic: OSAC-1590 — Enclave upgrades)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated detection and tracking of AWS CLI version updates from GitHub tags.
  * Restricted automated AWS CLI updates to version 2 releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->