### PR TITLE
OSAC-4866: Add --latest flag to enclave reconcile mgmt-cluster-version

### DIFF
--- a/src/enclave/reconcile/cli.py
+++ b/src/enclave/reconcile/cli.py
@@ -13,6 +13,7 @@ from enclave.utils import (
     LOG_LEVELS,
     KubeconfigGroup,
     configure_logging,
+    semver_key,
 )
 
 
@@ -136,7 +137,14 @@ def operator_versions(
     "--use-defaults",
     is_flag=True,
     default=False,
-    help="Load the default version from defaults/platforms.yaml (mutually exclusive with --version)",
+    help="Load the default version from defaults/platforms.yaml (mutually exclusive with --version, --latest)",
+)
+@click.option(
+    "--latest",
+    "use_latest",
+    is_flag=True,
+    default=False,
+    help="Upgrade to the highest semver version in defaults/platforms.yaml (mutually exclusive with --version, --use-defaults)",
 )
 @click.option("--dry-run/--no-dry-run", default=False)
 @click.option(
@@ -154,15 +162,20 @@ def operator_versions(
 def mgmt_cluster_version(
     version: str | None,
     use_defaults: bool,
+    use_latest: bool,
     dry_run: bool,
     timeout_minutes: int,
     sleep_interval: int,
 ) -> None:
-    if use_defaults and version:
-        raise click.UsageError("--use-defaults is mutually exclusive with --version")
+    if sum([version is not None, use_defaults, use_latest]) > 1:
+        raise click.UsageError(
+            "--version, --use-defaults, and --latest are mutually exclusive"
+        )
 
-    if not use_defaults and not version:
-        raise click.UsageError("Either --version or --use-defaults must be provided")
+    if not use_defaults and not use_latest and not version:
+        raise click.UsageError(
+            "One of --version, --use-defaults, or --latest must be provided"
+        )
 
     openshift_versions = load_openshift_versions()
 
@@ -176,6 +189,12 @@ def mgmt_cluster_version(
                 "set 'default: true' on one entry"
             )
         resolved_version: str = str(default_entry["version"])
+    elif use_latest:
+        resolved_version = str(
+            max(openshift_versions, key=lambda v: semver_key(str(v["version"])))[
+                "version"
+            ]
+        )
     else:
         resolved_version = cast("str", version)
         allowed_versions = {str(v["version"]) for v in openshift_versions}

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -190,6 +190,32 @@ def test_mgmt_cluster_version_use_defaults_mutual_exclusive_version() -> None:
     assert "mutually exclusive" in result.output
 
 
+def test_mgmt_cluster_version_latest(mocker: MockerFixture) -> None:
+    mock_reconcile = mocker.patch("enclave.reconcile.cli.cluster_upgrade_reconcile")
+    dry_run = True
+    result = CliRunner().invoke(
+        cli, ["mgmt-cluster-version", "--latest", "--dry-run"], env=_KC
+    )
+    assert result.exit_code == 0, result.output
+    mock_reconcile.assert_called_once_with("4.20.32", dry_run, 180, 60)
+
+
+def test_mgmt_cluster_version_latest_mutual_exclusive_version() -> None:
+    result = CliRunner().invoke(
+        cli, ["mgmt-cluster-version", "--latest", "--version", "4.20.21"], env=_KC
+    )
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output
+
+
+def test_mgmt_cluster_version_latest_mutual_exclusive_use_defaults() -> None:
+    result = CliRunner().invoke(
+        cli, ["mgmt-cluster-version", "--latest", "--use-defaults"], env=_KC
+    )
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output
+
+
 def test_mgmt_cluster_version_no_args_shows_help() -> None:
     result = CliRunner().invoke(cli, ["mgmt-cluster-version"])
     assert result.exit_code == 2


### PR DESCRIPTION
## Summary

- Adds `--latest` flag to `enclave reconcile mgmt-cluster-version`
- Resolves to the highest semver version in `defaults/platforms.yaml`
- Mutually exclusive with `--version` and `--use-defaults`

## Test plan

- [ ] `enclave reconcile mgmt-cluster-version --latest --dry-run` resolves to the highest version in `defaults/platforms.yaml`
- [ ] `enclave reconcile mgmt-cluster-version --latest --version 4.20.21` exits with usage error
- [ ] `enclave reconcile mgmt-cluster-version --latest --use-defaults` exits with usage error
- [ ] `make python-unit-test python-linter-test python-types-test` all pass

Jira: https://redhat.atlassian.net/browse/OSAC-4866

🤖 Generated with [Claude Code](https://claude.com/claude-code)