### PR TITLE
OSAC-4797: Fix ODF e2e Quay crashloop (Ceph/LZ capacity)

### DIFF
--- a/scripts/docs/ODF_CEPH_CI.md
+++ b/scripts/docs/ODF_CEPH_CI.md
@@ -13,7 +13,7 @@ CI Runner Machine (runs: [self-hosted, enclave-large])
 │   │   ├── Ceph cluster (cephadm, podman containers)
 │   │   │   ├── MON  – port 3300/6789
 │   │   │   ├── MGR  – prometheus metrics port 9283
-│   │   │   ├── OSDs – 3x loopback files (/var/lib/ceph-loops/osd-{0,1,2}.img)
+│   │   │   ├── OSDs – 3x 300GB loopback files (/var/lib/ceph-loops/osd-{0,1,2}.img)
 │   │   │   └── RGW  – S3-compatible, port 7480
 │   │   ├── Enclave Lab (Ansible playbooks)
 │   │   └── ~/ceph-config/  (generated config files)
@@ -33,15 +33,18 @@ CI Runner Machine (runs: [self-hosted, enclave-large])
 Cephadm filters out raw loop devices, so each OSD uses an LVM stack:
 
 ```text
-Sparse file (20GB)          Loop device          LVM
+Sparse file (300GB)         Loop device          LVM
 osd-0.img  ──────────>  /dev/loop0  ──────>  ceph-vg0/ceph-lv0  ──> OSD.0
 osd-1.img  ──────────>  /dev/loop1  ──────>  ceph-vg1/ceph-lv1  ──> OSD.1
 osd-2.img  ──────────>  /dev/loop2  ──────>  ceph-vg2/ceph-lv2  ──> OSD.2
 ```
 
-- Files are **sparse** (`truncate -s 20G`) -- only consume disk as data is written
+- Files are **sparse** (`truncate -s 300G`) -- only consume disk as data is written
 - LZ is ephemeral (destroyed after each CI run), so no systemd loopback service is needed
 - Single-node replication: `osd_pool_default_size=1` (no redundancy, CI-only)
+- CI uses **300GB** OSDs (set by `setup_ceph_on_lz.sh`); the `setup_ceph.sh`
+  standalone default is 50GB. See [Capacity and sizing](#capacity-and-sizing)
+  for why 300GB.
 
 ### Ceph Services
 
@@ -56,14 +59,78 @@ osd-2.img  ──────────>  /dev/loop2  ──────>  cep
 
 | Pool | Purpose |
 |------|---------|
-| `ceph-rbd` | RBD block storage for ODF StorageCluster |
-| Default pools | Internal Ceph pools (`.mgr`, `.rgw.root`, etc.) |
+| `ceph-rbd` | RBD block storage for ODF StorageCluster (backs all cluster PVCs, incl. Quay/Clair Postgres) |
+| `default.rgw.buckets.data` | RGW object data -- holds the mirrored image blobs; **fills first** and drives OSD sizing |
+| Default pools | Internal Ceph pools (`.mgr`, `.rgw.root`, `default.rgw.*` metadata, etc.) |
 
 ### S3 / RGW
 
 - User: `quay-ci` (system user with full access)
 - Bucket: `quay-storage` (pre-created for Quay mirror registry)
 - Used as Quay's `RadosGWStorage` backend instead of `LocalStorage`
+
+## Capacity and sizing
+
+The single biggest operational failure mode of this setup is **Ceph running out
+of disk**. Sizing exists to keep the OSDs comfortably below the `full_ratio`
+wall throughout a disconnected mirror.
+
+### OSD sizing
+
+CI runs **3 x 300GB** loopback OSDs = 900GB raw, ~855GB usable at
+`osd_pool_default_size=1`. This is set in `setup_ceph_on_lz.sh`
+(`OSD_SIZE_GB=300`), overriding the `setup_ceph.sh` standalone default of 50GB.
+
+Why 300GB: a disconnected mirror pushes **~512GB** of image blobs into RadosGW's
+`default.rgw.buckets.data`. The earlier 200GB OSDs (600GB raw) overflowed --
+one OSD crossed `full_ratio` and froze the whole cluster (see below). 300GB
+keeps the hottest OSD near ~63% for the current imageset, leaving headroom for
+imageset growth.
+
+### The full-ratio failure mode (read this before touching sizing)
+
+Ceph enforces three usage thresholds:
+
+| Threshold | Default | Effect |
+|-----------|---------|--------|
+| `nearfull_ratio` | 0.85 | HEALTH_WARN, still writable |
+| `backfillfull_ratio` | 0.90 | blocks backfill/rebalance |
+| `full_ratio` | 0.95 | **blocks ALL writes cluster-wide** |
+
+When *any single* OSD crosses `full_ratio`, Ceph enters `HEALTH_ERR` and stops
+accepting writes across the **entire** cluster (all pools report full). Because
+every cluster PVC -- including Quay's and Clair's Postgres -- lives on
+`ceph-rbd`, their commits hang indefinitely.
+
+The observed symptom is misleading: Quay's `boot.py` runs synchronously before
+the web server starts, blocks on its first Postgres **commit** (an RBD write),
+never binds `:8080`, and is then killed by its startup/liveness probes -- a
+permanent crashloop that looks like a Quay/app bug. Reads still work
+(`select 1` returns in milliseconds); only **writes** freeze. If ODF Quay is
+crashlooping during the operators/mirror phase, check Ceph health first.
+
+### Landing Zone disk sizing
+
+The **running** LZ disk is sized by `provision_landing_zone.sh` (which recreates
+the LZ via `virt-install`), **not** by `vm_infra.py` (whose value only sizes the
+throwaway placeholder domain). For disconnected+odf it is **1500GB**.
+
+It must be that large because the mirror lands on the LZ **twice**:
+
+- oc-mirror's `~/.local` container cache (~315GB), and
+- the Ceph loopback OSD files under `/var/lib/ceph-loops` (~575GB actual for the
+  ~512GB of RadosGW data)
+
+plus the OS and per-run session data. See the `LANDINGZONE_DISK` row in
+[`vm-infra.md`](vm-infra.md) for the connected / disconnected / disconnected+odf
+values.
+
+### Why grow rather than shrink the mirror
+
+ODF runs solo on its runner (~251 GiB RAM, nvme with multiple TiB free), so
+there is ample room to grow the OSDs and LZ disk. Trimming the imageset would
+also relieve pressure but cuts operator coverage (e.g. cnv/aap), so growing
+capacity is preferred while the host has headroom.
 
 ## Networking
 
@@ -149,7 +216,7 @@ The script is idempotent. Environment variables for customization:
 | `CEPH_HOST_IP` | auto-detected | Host IP for Ceph to bind to |
 | `CEPH_RELEASE` | `reef` | Ceph release to install |
 | `OSD_COUNT` | `3` | Number of loopback OSDs |
-| `OSD_SIZE_GB` | `50` | Size per OSD (sparse) |
+| `OSD_SIZE_GB` | `50` | Size per OSD (sparse). CI overrides this to **300** via `setup_ceph_on_lz.sh` -- see [Capacity and sizing](#capacity-and-sizing) |
 | `RGW_PORT` | `7480` | RadosGW port |
 | `LOOP_DIR` | `/var/lib/ceph-loops` | Directory for loopback image files |
 | `SKIP_LOOPBACK_SERVICE` | `false` | Skip systemd loopback service |
@@ -162,6 +229,11 @@ The script is idempotent. Environment variables for customization:
 # Cluster health
 sudo cephadm shell -- ceph health        # expect HEALTH_OK
 sudo cephadm shell -- ceph osd tree      # expect 3 OSDs up
+
+# Disk pressure (see "Capacity and sizing" -- a full OSD freezes all writes)
+sudo cephadm shell -- ceph -s            # watch for HEALTH_ERR / "full osd(s)" / "pool(s) full"
+sudo cephadm shell -- ceph df            # raw vs per-pool usage; watch default.rgw.buckets.data
+sudo cephadm shell -- ceph osd df        # per-OSD %USE vs the 0.95 full_ratio wall
 
 # RGW / S3
 curl http://localhost:7480/

--- a/scripts/docs/vm-infra.md
+++ b/scripts/docs/vm-infra.md
@@ -123,13 +123,13 @@ that references them.
 | `ENCLAVE_DEPLOYMENT_MODE` | no | `disconnected` | `connected` or `disconnected` |
 | `ENCLAVE_NUM_MASTERS` | no | `3` | Number of master VMs |
 | `STORAGE_PLUGIN` | no | `lvms` | `lvms` or `odf` — affects VM sizing defaults |
-| `MASTER_MEMORY` | no | 32768 / 49152 (odf) | Master RAM in MiB |
+| `MASTER_MEMORY` | no | 32768 / 49152 (odf) | Master RAM in MiB. ODF masters get 48 GB for the ODF/ACM/MCE control plane and Ceph consumers; more does not help (the operators-phase Quay CrashLoop is a Quay-backend health-probe issue, not master memory) |
 | `MASTER_VCPU` | no | 12 / 16 (odf) | Master vCPU count |
 | `MASTER_DISK` | no | 120 | Master primary disk in GiB |
 | `MASTER_EXTRA_DISK` | derived | 1200 (disconnected+lvms) / 60 | Master extra disk in GiB; not directly overridable — derived from `STORAGE_PLUGIN` and `ENCLAVE_DEPLOYMENT_MODE` |
-| `LANDINGZONE_MEMORY` | no | 8192 | Landing Zone RAM in MiB |
-| `LANDINGZONE_DISK` | no | 60 / 500 (odf) | Landing Zone disk in GiB |
-| `LANDINGZONE_VCPU` | no | 4 | Landing Zone vCPU count |
+| `LANDINGZONE_MEMORY` | no | 16384 / 24576 (odf) | Landing Zone RAM in MiB. The running LZ is sized by `provision_landing_zone.sh` (it destroys the placeholder domain vm_infra.py defines and recreates it via `virt-install`); the odf default gives Ceph-on-LZ headroom |
+| `LANDINGZONE_DISK` | no | 60 / 500 (odf) | Landing Zone disk in GiB for the vm_infra.py **placeholder only**. The running LZ disk is sized by `provision_landing_zone.sh` (which recreates the LZ): 600 (connected) / 1000 (disconnected) / 1500 (disconnected + odf, for the Ceph loopback OSD files) |
+| `LANDINGZONE_VCPU` | no | 16 | Landing Zone vCPU count. The running LZ is sized by `provision_landing_zone.sh` (`--vcpus "${LANDINGZONE_VCPU:-16}"`); the 4 vCPU in `vm_infra.py` only applies to the throwaway placeholder domain |
 
 ### XML templates
 

--- a/scripts/infrastructure/provision_landing_zone.sh
+++ b/scripts/infrastructure/provision_landing_zone.sh
@@ -300,14 +300,24 @@ sudo qemu-img convert -f qcow2 -O qcow2 \
     "${LZ_WORKING_DIR}/${CLOUD_IMAGE_NAME}" \
     "${POOL_PATH}/${LZ_VM_NAME}.qcow2"
 
-# Resize disk: 1000GB for disconnected deployment, 600GB otherwise
-if is_enclave_disconnected; then
+# Resize disk. Disconnected mirrors the full release + OLM catalogs locally, so
+# it needs far more than connected. ODF additionally keeps a SECOND copy of the
+# mirror on the LZ: oc-mirror's local container cache (~/.local) plus the Ceph
+# loopback OSD files under /var/lib/ceph-loops that back RadosGW/RBD. ODF needs
+# that Ceph headroom regardless of connectivity, so it is sized first (the CI
+# decision logic only ever pairs odf with disconnected, but keep this correct
+# by construction for manual/standalone connected+odf runs).
+if [ "${STORAGE_PLUGIN:-lvms}" = "odf" ]; then
+    LZ_DISK_SIZE="1500G"
+elif is_enclave_disconnected; then
     LZ_DISK_SIZE="1000G"
 else
     LZ_DISK_SIZE="600G"
 fi
 # 600GB: Quay ~130GB, oc-mirror ~7GB, ISO ~3GB, binaries ~3GB, OS and buffer
 # 1000GB: extra headroom for full release mirror and OLM catalogs in disconnected env
+# 1500GB (odf): ~900GB raw for the Ceph loopback OSD files (3x OSD_SIZE_GB) plus
+#               ~600GB for the mirror, OS, and buffer
 info "Resizing disk to ${LZ_DISK_SIZE}..."
 sudo qemu-img resize "${POOL_PATH}/${LZ_VM_NAME}.qcow2" "$LZ_DISK_SIZE"
 
@@ -364,10 +374,21 @@ if [ "${ENCLAVE_DEPLOYMENT_MODE:-}" = "disconnected" ]; then
     info "Disconnected mode: adding uplink NIC on ${UPLINK_NETWORK}"
 fi
 
+# ODF stands up a single-node Ceph cluster (MON + MGR + OSDs) on the LZ alongside
+# Quay and oc-mirror; 16 GB is not enough and the guest OOM-kills Quay during the
+# operators phase, so give ODF runs extra headroom. This is where the LZ VM is
+# actually sized: vm_infra.py only defines a placeholder domain that the teardown
+# above destroys and this virt-install recreates.
+if [ "${STORAGE_PLUGIN:-}" = "odf" ]; then
+    LZ_MEM_DEFAULT=24576
+else
+    LZ_MEM_DEFAULT=16384
+fi
+
 # shellcheck disable=SC2086
 sudo virt-install \
     --name "$LZ_VM_NAME" \
-    --memory "${LANDINGZONE_MEMORY:-16384}" \
+    --memory "${LANDINGZONE_MEMORY:-${LZ_MEM_DEFAULT}}" \
     --vcpus "${LANDINGZONE_VCPU:-16}" \
     --disk vol=${POOL_NAME}/${LZ_VM_NAME}.qcow2,bus=virtio \
     --disk "${LZ_WORKING_DIR}/cloud-init.iso,device=cdrom,bus=sata" \

--- a/scripts/infrastructure/setup_ceph_on_lz.sh
+++ b/scripts/infrastructure/setup_ceph_on_lz.sh
@@ -51,7 +51,12 @@ fi
 # Setup SSH configuration
 setup_ssh_config "$CLUSTER_IP"
 
-OSD_SIZE_GB="${OSD_SIZE_GB:-200}"
+# 3 loopback OSDs of this size back the LZ Ceph (RadosGW object store + RBD).
+# 200GB (600GB raw) overflowed: the disconnected mirror pushes ~512GB of blobs
+# into RadosGW, one OSD crossed the 0.95 full_ratio, Ceph froze all writes and
+# Quay's boot.py hung on its Postgres RBD commit. 300GB (900GB raw, ~855 usable)
+# keeps the hottest OSD near 63% for the current imageset.
+OSD_SIZE_GB="${OSD_SIZE_GB:-300}"
 
 info "========================================="
 info "Ceph Setup on Landing Zone"

--- a/scripts/infrastructure/vm_infra.py
+++ b/scripts/infrastructure/vm_infra.py
@@ -109,15 +109,29 @@ class Config:
             sys.exit(f"ERROR: STORAGE_PLUGIN must be 'lvms' or 'odf', got {storage_plugin!r}")
 
         if storage_plugin == "odf":
+            # ODF runs solo per host. Masters need more than the lvms 32 GB for
+            # the ODF/ACM/MCE control plane and Ceph consumers, but the Quay
+            # CrashLoop during the operators phase is NOT a master-memory
+            # problem: at 64 GB the masters showed no OOM/eviction and every
+            # cluster operator stayed healthy, yet Quay still failed identically.
+            # The real cause is Quay's health probe timing out on its external
+            # RadosGW/Postgres backend, so keep masters at 48 GB.
             default_master_mem = 49152
             default_master_vcpu = 16
             default_master_extra = 60
             default_lz_disk = 500
+            # ODF stands up a single-node Ceph cluster (MON + MGR + OSDs) on the
+            # LZ alongside Quay and oc-mirror; 8 GB (and even 16 GB) is not enough
+            # and the guest OOM-kills Quay during the operators phase, so give ODF
+            # runs extra headroom.
+            default_lz_mem = 24576
         else:
             default_master_mem = 32768
             default_master_vcpu = 12
             default_master_extra = 1200 if deployment_mode == "disconnected" else 60
             default_lz_disk = 60
+            # No Ceph on the LZ for non-ODF; the LZ still runs Quay + oc-mirror.
+            default_lz_mem = 16384
 
         cluster_name = validate(
             "ENCLAVE_CLUSTER_NAME",
@@ -142,7 +156,7 @@ class Config:
                 extra_disk_gb=default_master_extra,
             ),
             lz=VMSpec(
-                memory_mb=optint("LANDINGZONE_MEMORY", 8192),
+                memory_mb=optint("LANDINGZONE_MEMORY", default_lz_mem),
                 vcpu=optint("LANDINGZONE_VCPU", 4),
                 disk_gb=optint("LANDINGZONE_DISK", default_lz_disk),
                 extra_disk_gb=0,

--- a/scripts/verification/collect_ci_artifacts.sh
+++ b/scripts/verification/collect_ci_artifacts.sh
@@ -771,6 +771,99 @@ collect_cluster_problem_pod_logs() {
     fi
 }
 
+collect_cluster_quay_diagnostics() {
+    local lz_ip="$1"
+    local ssh_opts="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -q"
+
+    # The generic problem-pod capture only grabs non-Running pods at tail=500,
+    # so it misses Quay's Postgres/Redis (Running), the QuayRegistry CR status,
+    # the config-bundle secret rotation, and the /health/instance body that
+    # names the failing subsystem (database vs storage vs redis). This captures
+    # the full quay-enterprise picture in one shot. Runs for both lvms and odf.
+    local kube_env="export KUBECONFIG=/home/cloud-user/sessions/1/ocp-cluster/auth/kubeconfig; export PATH=/home/cloud-user/sessions/1/bin:\$PATH"
+
+    # Only a confirmed NotFound means "nothing to collect" -- skip cleanly then.
+    # SSH/API/auth/RBAC failures must NOT masquerade as an absent namespace (that
+    # would drop Quay diagnostics exactly when they are most needed), so warn and
+    # attempt collection anyway; the per-command `|| true` below captures the errors.
+    local ns_check
+    if ns_check=$(ssh $ssh_opts cloud-user@"$lz_ip" "$kube_env; oc get namespace quay-enterprise" 2>&1); then
+        : # namespace exists, proceed with collection
+    elif printf '%s' "$ns_check" | grep -q 'NotFound'; then
+        info "quay-enterprise namespace not present; skipping Quay diagnostics"
+        return
+    else
+        warn "Quay namespace check failed (not a clean NotFound), collecting anyway"
+    fi
+
+    info "Collecting Quay diagnostics..."
+    ssh $ssh_opts cloud-user@"$lz_ip" "
+        $kube_env
+        ns=quay-enterprise
+        out=/tmp/quay-diagnostics-${TIMESTAMP}
+        mkdir -p \$out
+
+        # QuayRegistry CR - .status.conditions is the operator's own view of why
+        # the registry is not healthy. Spec holds only secret references, not values.
+        oc get quayregistry -n \$ns -o yaml > \$out/quayregistry.yaml 2>&1 || true
+
+        {
+            echo '=== Pods ==='
+            oc get pods -n \$ns -o wide
+            echo ''
+            echo '=== Deployments ==='
+            oc get deployments -n \$ns -o wide
+            echo ''
+            echo '=== HPA (replica count / scaling) ==='
+            oc get hpa -n \$ns -o wide
+            echo ''
+            echo '=== Events (by time) ==='
+            oc get events -n \$ns --sort-by=.lastTimestamp
+            echo ''
+            echo '=== PVCs (registry/db backend binding) ==='
+            oc get pvc -n \$ns
+            echo ''
+            # Names/types only - never dump secret VALUES. The config-bundle
+            # rotation churn (registry-quay-config-secret-*) is visible here.
+            echo '=== Secrets (names only) ==='
+            oc get secrets -n \$ns
+        } > \$out/overview.txt 2>&1 || true
+
+        # Per-pod: describe + current and previous logs, all containers. Larger
+        # tail than the generic capture - Quay /health failures and DB errors
+        # scroll fast and got truncated to startup noise last time.
+        for pod in \$(oc get pods -n \$ns --no-headers -o custom-columns=:.metadata.name 2>/dev/null); do
+            oc describe pod -n \$ns \$pod > \$out/\${pod}_describe.txt 2>&1 || true
+            oc logs -n \$ns \$pod --all-containers --prefix --tail=2000 > \$out/\${pod}.log 2>&1 || true
+            oc logs -n \$ns \$pod --all-containers --prefix --tail=2000 --previous > \$out/\${pod}_previous.log 2>&1 || true
+        done
+
+        # /health/instance body names the failing subsystem. Best-effort: works
+        # only while a quay-app pod is briefly up between crashloop restarts.
+        {
+            echo '=== /health/instance ==='
+            oc exec -n \$ns deploy/registry-quay-app -c quay-app -- \
+                curl -sS -m 10 http://localhost:8080/health/instance 2>&1 \
+                || echo '(quay-app not execable - likely crashlooping)'
+        } > \$out/health-instance.txt 2>&1 || true
+
+        cd /tmp && tar czf quay-diagnostics-${TIMESTAMP}.tar.gz quay-diagnostics-${TIMESTAMP}/ 2>/dev/null
+    " 2>&1 || warn "Could not collect Quay diagnostics"
+
+    if scp $ssh_opts cloud-user@"$lz_ip":/tmp/quay-diagnostics-${TIMESTAMP}.tar.gz "${OUTPUT_DIR}/cluster/" 2>/dev/null; then
+        # Only remove the remote copies once the transfer succeeded. Cleanup
+        # normally destroys the LZ, but skip-cleanup (or a failed cleanup) leaves
+        # it running, where repeated full collections would otherwise accumulate
+        # the timestamped dir and archive under /tmp.
+        ssh $ssh_opts cloud-user@"$lz_ip" \
+            "rm -rf /tmp/quay-diagnostics-${TIMESTAMP} /tmp/quay-diagnostics-${TIMESTAMP}.tar.gz" 2>/dev/null || true
+        (cd "${OUTPUT_DIR}/cluster" && tar xzf quay-diagnostics-${TIMESTAMP}.tar.gz && rm quay-diagnostics-${TIMESTAMP}.tar.gz) \
+            || warn "Could not extract Quay diagnostics archive"
+    else
+        warn "Could not transfer Quay diagnostics archive from LZ"
+    fi
+}
+
 collect_cluster_plugin_diagnostics() {
     local lz_ip="$1"
     local ssh_opts="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -q"
@@ -942,6 +1035,7 @@ collect_full() {
     collect_cluster_events "$lz_ip"
     collect_cluster_pods "$lz_ip"
     collect_cluster_problem_pod_logs "$lz_ip"
+    collect_cluster_quay_diagnostics "$lz_ip"
     collect_cluster_plugin_diagnostics "$lz_ip"
 
     info "✓ Full collection complete"


### PR DESCRIPTION
## What

Fix the daily `E2E Disconnected (odf)` failure where the in-cluster Quay Enterprise app crashlooped during the operators/mirror phase.

**Root cause (found via live cluster inspection):** the Landing Zone Ceph ran out of disk. The disconnected mirror pushes ~512GB of image blobs into RadosGW's `default.rgw.buckets.data`; one of the three 200GB loopback OSDs crossed the `full_ratio` (0.95), and Ceph froze **all** writes cluster-wide (HEALTH_ERR). Quay's Postgres PVC lives on Ceph-RBD, so `boot.py` hung on its first commit, never bound `:8080`, and was killed by its startup/liveness probes — a permanent crashloop. Earlier memory/HPA/probe theories were all downstream symptoms.

## Changes

- **Ceph/LZ/VM sizing** — OSD 200→300GB (900GB raw), LZ disk 1500G for disconnected+odf (the mirror lands on the LZ twice: oc-mirror cache + Ceph loop files), ODF master/LZ memory per storage plugin.
- **Quay diagnostics** — new `collect_cluster_quay_diagnostics` captures the full quay-enterprise picture on failure (CR status, per-pod logs, HPA, events, PVCs, /health/instance body); skips only on confirmed NotFound.
- **Docs** — `ODF_CEPH_CI.md` capacity + full-ratio failure-mode section; `vm-infra.md` sizing rows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * ODF Landing Zones now use larger disk and memory defaults to support storage workloads.
  * Ceph CI environments now provide increased OSD capacity and clearer sizing guidance.
  * Verification documentation includes commands for checking cluster and disk pressure.

* **Diagnostics**
  * CI artifact collection now includes comprehensive Quay health, workload, storage, event, and log diagnostics when Quay is deployed.

* **Documentation**
  * Updated infrastructure guidance clarifies Landing Zone sizing, runtime configuration, capacity limits, and storage pool behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->