### PR TITLE
OSAC-4908: Move helm and mirror-registry binaries to mirror.openshift.com

### DIFF
--- a/defaults/control_binaries.yaml
+++ b/defaults/control_binaries.yaml
@@ -4,10 +4,10 @@ control_binaries:
     url: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.20.32/openshift-client-linux.tar.gz"
     checksum: "sha256:2deb2e225404047bdae2808036cf16e04612df57d2560a1152a01003f3f7a46d"
   helm:
-    url: "https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/helm/3.17.1/helm-linux-amd64"
+    url: "https://mirror.openshift.com/pub/openshift-v4/clients/helm/3.17.1/helm-linux-amd64"
     checksum: "sha256:ef6c04f6a748d0f1d624a94a56dc0db83f8d70a65e3dbb19e94107126efcc5fd"
   mirror_registry:
-    url: "https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/mirror-registry/1.3.11/mirror-registry.tar.gz"
+    url: "https://mirror.openshift.com/pub/openshift-v4/clients/mirror-registry/1.3.11/mirror-registry.tar.gz"
     checksum: "sha256:b2fbf8b13d794cdebb8baee48afbfa78d13c4d76a1c60fc99d52c3c9abd31cf1"
   oc_mirror:
     url: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.20.15/oc-mirror.tar.gz"


### PR DESCRIPTION
## Summary

`developers.redhat.com` content-gateway is misbehaving/unreliable when downloading control binaries. This moves the `helm` and `mirror_registry` URLs in `defaults/control_binaries.yaml` to `mirror.openshift.com`, aligning them with `openshift_client` and `oc_mirror`, which already use it.

Checksums are unchanged — both mirror URLs return HTTP 200 and resolve (via the same `access.cdn.redhat.com` backend) to files matching the existing SHA256 values, so the binaries are identical.

## Ticket

OSAC-4908

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the download locations for the Helm and mirror registry binaries.
  * Binary checksums remain unchanged, preserving existing integrity verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->