### PR TITLE
OSAC-4929: Track uv as a single Renovate dependency

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,12 +13,12 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Update uv version in setup_ansible.sh",
+      "description": "Update uv version in setup_ansible.sh and install_enclave.sh (kept in sync with ghcr.io/astral-sh/uv in Dockerfile.ci via a shared datasource)",
       "managerFilePatterns": ["setup_ansible.sh", "scripts/deployment/install_enclave.sh"],
       "matchStrings": ["UV_VERSION=\"(?<currentValue>[^\"]+)\""],
-      "depNameTemplate": "astral-sh/uv",
-      "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^(?<version>.+)$"
+      "depNameTemplate": "ghcr.io/astral-sh/uv",
+      "datasourceTemplate": "docker",
+      "registryUrlTemplate": "https://ghcr.io"
     },
     {
       "customType": "regex",


### PR DESCRIPTION
## Problem

Renovate was tracking the `uv` tool as **two separate dependencies**, producing two conflicting update PRs that bumped `uv` to different versions:

- `astral-sh/uv` via the `github-releases` datasource (custom manager for `setup_ansible.sh` and `scripts/deployment/install_enclave.sh`) → e.g. `0.12.9` (#773)
- `ghcr.io/astral-sh/uv` via the `docker` datasource (built-in Dockerfile manager for `.github/workflows/Dockerfile.ci`) → e.g. `0.12.10` (#777)

## Fix

Point the `uv` custom manager at the **same datasource and depName as the Docker image** (`ghcr.io/astral-sh/uv` via `docker`, registry `https://ghcr.io`). Renovate now treats all three files as one dependency and produces a single PR bumping to a single version.

The `uv` tag scheme is identical on ghcr.io and GitHub releases (`0.12.x`, no `v` prefix), so `extractVersionTemplate` is no longer needed and was dropped.

## Follow-up

Existing PRs #773 and #777 become stale once this lands and should be closed so Renovate regenerates a single unified PR.

Jira: https://redhat.atlassian.net/browse/OSAC-4929

🤖 Generated with [Claude Code](https://claude.com/claude-code)