### PR TITLE
set ocp 4.20.32 as default

### DIFF
--- a/defaults/platforms.yaml
+++ b/defaults/platforms.yaml
@@ -1,5 +1,5 @@
 ---
 openshift_versions:
 - version: 4.20.21
-  default: true
 - version: 4.20.32
+  default: true

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -179,7 +179,7 @@ def test_mgmt_cluster_version_use_defaults(mocker: MockerFixture) -> None:
         cli, ["mgmt-cluster-version", "--use-defaults", "--dry-run"], env=_KC
     )
     assert result.exit_code == 0, result.output
-    mock_reconcile.assert_called_once_with("4.20.21", dry_run, 180, 60)
+    mock_reconcile.assert_called_once_with("4.20.32", dry_run, 180, 60)
 
 
 def test_mgmt_cluster_version_use_defaults_mutual_exclusive_version() -> None:


### PR DESCRIPTION
align with stable instead of going back to 4.20.21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the default OpenShift platform version from 4.20.21 to 4.20.32.
  * Management-cluster version reconciliation now expects OpenShift 4.20.32.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->