### PR TITLE
OSAC-4957: Make LVMS Quay app resources configurable; lower CI memory request

### DIFF
--- a/config/plugins/lvms.example.yaml
+++ b/config/plugins/lvms.example.yaml
@@ -11,3 +11,15 @@
 #       - /dev/disk/by-path/YOUR_DISK_PATH_1
 #       - /dev/disk/by-path/YOUR_DISK_PATH_2
 #       - /dev/disk/by-path/YOUR_DISK_PATH_3
+
+# Override Quay app container resources (LocalStorage backend). With a node-local
+# RWO PV the Quay app is pinned to one node, so a rolling update must briefly run a
+# second pod there; lower the memory request on constrained nodes so it can schedule.
+# Defaults live in plugins/lvms/defaults.yaml (lvmsQuayAppResources).
+# lvmsQuayAppResources:
+#   requests:
+#     cpu: "2"
+#     memory: "2Gi"
+#   limits:
+#     cpu: "4"
+#     memory: "12Gi"

--- a/config/plugins/lvms.example.yaml
+++ b/config/plugins/lvms.example.yaml
@@ -2,7 +2,8 @@
 ##############################################################################
 # LVMS PLUGIN CONFIGURATION TEMPLATE
 # Instructions: Copy this file to 'config/plugins/lvms.yaml' and set values.
-# Only needed to restrict which disks LVMS manages; omit to use all disks.
+# Only needed to override LVMS settings, such as managed disks or Quay app
+# resources; omit to use all defaults.
 ##############################################################################
 
 # lvmsConfig:

--- a/plugins/lvms/defaults.yaml
+++ b/plugins/lvms/defaults.yaml
@@ -9,3 +9,14 @@ lvmsDefaults:
     name: vg1-pool-1
     sizePercent: 90
     overprovisionRatio: 10
+# Resource requests/limits for the managed Quay app container (LocalStorage backend).
+# Override in config/plugins/lvms.yaml to fit constrained nodes: with a node-local
+# RWO PV the Quay app is pinned to a single node, so a rolling update must briefly
+# schedule a second pod there. Lowering the memory request lets that surge pod fit.
+lvmsQuayAppResources:
+  requests:
+    cpu: "{{ '2' if (disconnected | default(true)) else '1' }}"
+    memory: "{{ '6Gi' if (disconnected | default(true)) else '4Gi' }}"
+  limits:
+    cpu: "4"
+    memory: "12Gi"

--- a/plugins/lvms/schemas/config.yaml
+++ b/plugins/lvms/schemas/config.yaml
@@ -18,3 +18,28 @@ properties:
             minItems: 1
             items:
               type: string
+  lvmsQuayAppResources:
+    type: object
+    description: Override resource requests/limits for the managed Quay app container.
+    additionalProperties: false
+    properties:
+      requests:
+        type: object
+        additionalProperties: false
+        properties:
+          cpu:
+            "$ref": "#/definitions/k8sQuantity"
+            description: CPU request for the Quay app container.
+          memory:
+            "$ref": "#/definitions/k8sQuantity"
+            description: Memory request for the Quay app container.
+      limits:
+        type: object
+        additionalProperties: false
+        properties:
+          cpu:
+            "$ref": "#/definitions/k8sQuantity"
+            description: CPU limit for the Quay app container.
+          memory:
+            "$ref": "#/definitions/k8sQuantity"
+            description: Memory limit for the Quay app container.

--- a/plugins/lvms/schemas/config.yaml
+++ b/plugins/lvms/schemas/config.yaml
@@ -20,12 +20,22 @@ properties:
               type: string
   lvmsQuayAppResources:
     type: object
-    description: Override resource requests/limits for the managed Quay app container.
+    description: >-
+      Override resource requests/limits for the managed Quay app container.
+      This mapping replaces the default wholesale (Ansible hash_behaviour is
+      "replace"), so a complete requests/limits set is required to avoid
+      silently dropping default values.
     additionalProperties: false
+    required:
+      - requests
+      - limits
     properties:
       requests:
         type: object
         additionalProperties: false
+        required:
+          - cpu
+          - memory
         properties:
           cpu:
             "$ref": "#/definitions/k8sQuantity"
@@ -36,6 +46,9 @@ properties:
       limits:
         type: object
         additionalProperties: false
+        required:
+          - cpu
+          - memory
         properties:
           cpu:
             "$ref": "#/definitions/k8sQuantity"

--- a/plugins/lvms/schemas/defaults.yaml
+++ b/plugins/lvms/schemas/defaults.yaml
@@ -47,3 +47,28 @@ properties:
           - name
           - sizePercent
           - overprovisionRatio
+  lvmsQuayAppResources:
+    type: object
+    description: Resource requests/limits for the managed Quay app container.
+    additionalProperties: false
+    properties:
+      requests:
+        type: object
+        additionalProperties: false
+        properties:
+          cpu:
+            "$ref": "#/definitions/nonEmptyString"
+            description: CPU request for the Quay app container (may be templated).
+          memory:
+            "$ref": "#/definitions/nonEmptyString"
+            description: Memory request for the Quay app container (may be templated).
+      limits:
+        type: object
+        additionalProperties: false
+        properties:
+          cpu:
+            "$ref": "#/definitions/nonEmptyString"
+            description: CPU limit for the Quay app container (may be templated).
+          memory:
+            "$ref": "#/definitions/nonEmptyString"
+            description: Memory limit for the Quay app container (may be templated).

--- a/plugins/lvms/schemas/defaults.yaml
+++ b/plugins/lvms/schemas/defaults.yaml
@@ -51,10 +51,16 @@ properties:
     type: object
     description: Resource requests/limits for the managed Quay app container.
     additionalProperties: false
+    required:
+      - requests
+      - limits
     properties:
       requests:
         type: object
         additionalProperties: false
+        required:
+          - cpu
+          - memory
         properties:
           cpu:
             "$ref": "#/definitions/nonEmptyString"
@@ -65,6 +71,9 @@ properties:
       limits:
         type: object
         additionalProperties: false
+        required:
+          - cpu
+          - memory
         properties:
           cpu:
             "$ref": "#/definitions/nonEmptyString"

--- a/plugins/lvms/tasks/quay.yaml
+++ b/plugins/lvms/tasks/quay.yaml
@@ -22,13 +22,7 @@
           managed: true
           overrides:
             replicas: null
-            resources:
-              limits:
-                cpu: "4"
-                memory: 12Gi
-              requests:
-                cpu: "{{ '2' if (disconnected | default(true)) else '1' }}"
-                memory: "{{ '6Gi' if (disconnected | default(true)) else '4Gi' }}"
+            resources: "{{ lvmsQuayAppResources }}"
         - kind: postgres
           managed: true
           overrides:

--- a/plugins/lvms/test-fixtures/schemas/config/invalid/partial-quay-resources.yaml
+++ b/plugins/lvms/test-fixtures/schemas/config/invalid/partial-quay-resources.yaml
@@ -1,8 +1,10 @@
 ---
 # Fixture: lvmsQuayAppResources must be a complete mapping
-# Expected failure: partial override (missing limits) would silently drop the
-# default limits under replace semantics, so the schema requires both
-# requests and limits with cpu and memory.
+# Expected failure: limits is missing. requests is complete (cpu + memory) so
+# this fixture isolates the missing-limits case: under replace semantics a
+# partial override would silently drop the default limits, so the schema
+# requires both requests and limits.
 lvmsQuayAppResources:
   requests:
+    cpu: "2"
     memory: "2Gi"

--- a/plugins/lvms/test-fixtures/schemas/config/invalid/partial-quay-resources.yaml
+++ b/plugins/lvms/test-fixtures/schemas/config/invalid/partial-quay-resources.yaml
@@ -1,0 +1,8 @@
+---
+# Fixture: lvmsQuayAppResources must be a complete mapping
+# Expected failure: partial override (missing limits) would silently drop the
+# default limits under replace semantics, so the schema requires both
+# requests and limits with cpu and memory.
+lvmsQuayAppResources:
+  requests:
+    memory: "2Gi"

--- a/plugins/lvms/test-fixtures/schemas/config/valid/base.yaml
+++ b/plugins/lvms/test-fixtures/schemas/config/valid/base.yaml
@@ -1,7 +1,14 @@
 ---
-# Fixture: valid lvmsConfig with device selector
+# Fixture: valid lvmsConfig with device selector and Quay app resource override
 lvmsConfig:
   deviceSelector:
     optionalPaths:
       - /dev/disk/by-path/pci-0000:00:11.4-ata-1.0
       - /dev/disk/by-path/pci-0000:00:11.4-ata-2.0
+lvmsQuayAppResources:
+  requests:
+    cpu: "2"
+    memory: "2Gi"
+  limits:
+    cpu: "4"
+    memory: "12Gi"

--- a/plugins/lvms/test-fixtures/schemas/defaults/valid/base.yaml
+++ b/plugins/lvms/test-fixtures/schemas/defaults/valid/base.yaml
@@ -10,3 +10,10 @@ lvmsDefaults:
     name: vg1-pool-1
     sizePercent: 90
     overprovisionRatio: 10
+lvmsQuayAppResources:
+  requests:
+    cpu: "2"
+    memory: "6Gi"
+  limits:
+    cpu: "4"
+    memory: "12Gi"

--- a/scripts/infrastructure/generate_enclave_vars.sh
+++ b/scripts/infrastructure/generate_enclave_vars.sh
@@ -314,15 +314,22 @@ if [ "${STORAGE_PLUGIN:-lvms}" = "odf" ]; then
     info "Storage plugin overridden to ODF with RadosGWStorage backend"
 fi
 
-# Tune Quay app resources for the LVMS backend in CI (OSAC-4957). The node-local
-# RWO PV pins the Quay app to a single node, so a rolling update must briefly run a
-# second pod there; on constrained CI masters the default 6Gi request leaves the
-# surge pod unschedulable. Lower the memory request so the rollout can complete.
-if [ "${STORAGE_PLUGIN:-lvms}" = "lvms" ]; then
+# Tune Quay app resources for the LVMS backend in CI only (OSAC-4957). The
+# node-local RWO PV pins the Quay app to a single node, so a rolling update must
+# briefly run a second pod there; on constrained CI masters the default 6Gi
+# request leaves the surge pod unschedulable. Lower the memory request so the
+# rollout can complete. Gated on OPENSHIFT_CI so documented local deployments
+# (make install-enclave) keep the production defaults.
+if [ "${OPENSHIFT_CI:-}" = "true" ] && [ "${STORAGE_PLUGIN:-lvms}" = "lvms" ]; then
     LVMS_PLUGIN_CONFIG="$(dirname "$GLOBAL_VARS_OUTPUT")/plugins/lvms.yaml"
     mkdir -p "$(dirname "$LVMS_PLUGIN_CONFIG")"
-    cat > "$LVMS_PLUGIN_CONFIG" <<EOF
----
+    if [ -f "$LVMS_PLUGIN_CONFIG" ] && grep -q '^lvmsQuayAppResources:' "$LVMS_PLUGIN_CONFIG"; then
+        info "LVMS plugin config already defines lvmsQuayAppResources; leaving it unchanged: $LVMS_PLUGIN_CONFIG"
+    else
+        # Append as a new top-level key so any existing lvmsConfig (e.g.
+        # deviceSelector.optionalPaths) is preserved rather than overwritten.
+        [ -f "$LVMS_PLUGIN_CONFIG" ] || printf -- '---\n' > "$LVMS_PLUGIN_CONFIG"
+        cat >> "$LVMS_PLUGIN_CONFIG" <<EOF
 # Auto-generated CI override (OSAC-4957): lower the Quay app memory request so the
 # rolling-update surge pod fits on the node-pinned LVMS RWO PV.
 lvmsQuayAppResources:
@@ -333,7 +340,8 @@ lvmsQuayAppResources:
     cpu: "4"
     memory: "12Gi"
 EOF
-    info "Generated LVMS plugin config with tuned Quay app resources: $LVMS_PLUGIN_CONFIG"
+        info "Added tuned Quay app resources to LVMS plugin config: $LVMS_PLUGIN_CONFIG"
+    fi
 fi
 
 info "✓ Configuration files generated: $GLOBAL_VARS_OUTPUT, $CERTS_VARS_OUTPUT and $CLOUD_INFRA_VARS_OUTPUT"

--- a/scripts/infrastructure/generate_enclave_vars.sh
+++ b/scripts/infrastructure/generate_enclave_vars.sh
@@ -323,8 +323,9 @@ fi
 if [ "${OPENSHIFT_CI:-}" = "true" ] && [ "${STORAGE_PLUGIN:-lvms}" = "lvms" ]; then
     LVMS_PLUGIN_CONFIG="$(dirname "$GLOBAL_VARS_OUTPUT")/plugins/lvms.yaml"
     mkdir -p "$(dirname "$LVMS_PLUGIN_CONFIG")"
-    # Tolerate quoted keys and whitespace before the colon (all valid YAML forms).
-    if [ -f "$LVMS_PLUGIN_CONFIG" ] && grep -qE '^[[:space:]]*"?lvmsQuayAppResources"?[[:space:]]*:' "$LVMS_PLUGIN_CONFIG"; then
+    # Tolerate unquoted, double-quoted and single-quoted keys (matching
+    # delimiters) plus whitespace before the colon (all valid YAML forms).
+    if [ -f "$LVMS_PLUGIN_CONFIG" ] && grep -qE '^[[:space:]]*("lvmsQuayAppResources"|'\''lvmsQuayAppResources'\''|lvmsQuayAppResources)[[:space:]]*:' "$LVMS_PLUGIN_CONFIG"; then
         info "LVMS plugin config already defines lvmsQuayAppResources; leaving it unchanged: $LVMS_PLUGIN_CONFIG"
     else
         # Append as a new top-level key so any existing lvmsConfig (e.g.

--- a/scripts/infrastructure/generate_enclave_vars.sh
+++ b/scripts/infrastructure/generate_enclave_vars.sh
@@ -314,6 +314,28 @@ if [ "${STORAGE_PLUGIN:-lvms}" = "odf" ]; then
     info "Storage plugin overridden to ODF with RadosGWStorage backend"
 fi
 
+# Tune Quay app resources for the LVMS backend in CI (OSAC-4957). The node-local
+# RWO PV pins the Quay app to a single node, so a rolling update must briefly run a
+# second pod there; on constrained CI masters the default 6Gi request leaves the
+# surge pod unschedulable. Lower the memory request so the rollout can complete.
+if [ "${STORAGE_PLUGIN:-lvms}" = "lvms" ]; then
+    LVMS_PLUGIN_CONFIG="$(dirname "$GLOBAL_VARS_OUTPUT")/plugins/lvms.yaml"
+    mkdir -p "$(dirname "$LVMS_PLUGIN_CONFIG")"
+    cat > "$LVMS_PLUGIN_CONFIG" <<EOF
+---
+# Auto-generated CI override (OSAC-4957): lower the Quay app memory request so the
+# rolling-update surge pod fits on the node-pinned LVMS RWO PV.
+lvmsQuayAppResources:
+  requests:
+    cpu: "2"
+    memory: "2Gi"
+  limits:
+    cpu: "4"
+    memory: "12Gi"
+EOF
+    info "Generated LVMS plugin config with tuned Quay app resources: $LVMS_PLUGIN_CONFIG"
+fi
+
 info "✓ Configuration files generated: $GLOBAL_VARS_OUTPUT, $CERTS_VARS_OUTPUT and $CLOUD_INFRA_VARS_OUTPUT"
 echo ""
 info "Configuration summary:"

--- a/scripts/infrastructure/generate_enclave_vars.sh
+++ b/scripts/infrastructure/generate_enclave_vars.sh
@@ -323,12 +323,18 @@ fi
 if [ "${OPENSHIFT_CI:-}" = "true" ] && [ "${STORAGE_PLUGIN:-lvms}" = "lvms" ]; then
     LVMS_PLUGIN_CONFIG="$(dirname "$GLOBAL_VARS_OUTPUT")/plugins/lvms.yaml"
     mkdir -p "$(dirname "$LVMS_PLUGIN_CONFIG")"
-    if [ -f "$LVMS_PLUGIN_CONFIG" ] && grep -q '^lvmsQuayAppResources:' "$LVMS_PLUGIN_CONFIG"; then
+    # Tolerate quoted keys and whitespace before the colon (all valid YAML forms).
+    if [ -f "$LVMS_PLUGIN_CONFIG" ] && grep -qE '^[[:space:]]*"?lvmsQuayAppResources"?[[:space:]]*:' "$LVMS_PLUGIN_CONFIG"; then
         info "LVMS plugin config already defines lvmsQuayAppResources; leaving it unchanged: $LVMS_PLUGIN_CONFIG"
     else
         # Append as a new top-level key so any existing lvmsConfig (e.g.
         # deviceSelector.optionalPaths) is preserved rather than overwritten.
-        [ -f "$LVMS_PLUGIN_CONFIG" ] || printf -- '---\n' > "$LVMS_PLUGIN_CONFIG"
+        if [ ! -f "$LVMS_PLUGIN_CONFIG" ]; then
+            printf -- '---\n' > "$LVMS_PLUGIN_CONFIG"
+        elif [ -s "$LVMS_PLUGIN_CONFIG" ]; then
+            # Ensure a terminal newline so the appended key starts on its own line.
+            printf '\n' >> "$LVMS_PLUGIN_CONFIG"
+        fi
         cat >> "$LVMS_PLUGIN_CONFIG" <<EOF
 # Auto-generated CI override (OSAC-4957): lower the Quay app memory request so the
 # rolling-update surge pod fits on the node-pinned LVMS RWO PV.


### PR DESCRIPTION
## Problem

The `registry-quay-app` rollout intermittently fails CI with `ProgressDeadlineExceeded` (Phase 5, `operators/quay-operator/oauth_setup.yaml:130`).

With the LVMS `LocalStorage` backend, the Quay app uses a node-local RWO PV (`WaitForFirstConsumer`) whose hard node affinity pins the pod to a single node. Updating the `quay-config` secret with the OAuth client-ID whitelist triggers a `RollingUpdate`; `maxSurge: 25%` (rounds up to 1) starts a surge pod before terminating the old one. Both pods can only land on the PV's node, and each requests 6Gi — so the surge pod fails scheduling with `Insufficient memory`, stays `Pending` until `progressDeadlineSeconds` elapses, and the wait task never passes.

This is structurally deterministic for the LVMS backend, not a flake, and is a latent production risk.

## Fix

Expose the Quay app resources via the plugin config layer instead of hardcoding them, and lower the memory request **in CI only**:

- `plugins/lvms/tasks/quay.yaml` — reference `lvmsQuayAppResources` instead of an inline `resources` block.
- `plugins/lvms/defaults.yaml` — add `lvmsQuayAppResources` default **identical to the previous inline values** (incl. the disconnected conditional), so existing behavior is unchanged.
- `plugins/lvms/schemas/{defaults,config}.yaml` — schema for the new variable. Config uses the shared `k8sQuantity` definition for strict validation; defaults use `nonEmptyString` since the values may be templated (Jinja).
- `config/plugins/lvms.example.yaml` — document the override.
- test-fixtures — exercise the new field in the valid defaults/config fixtures.
- `scripts/infrastructure/generate_enclave_vars.sh` — write `config/plugins/lvms.yaml` with a 2Gi memory request when `STORAGE_PLUGIN=lvms` (CI only).

Default behavior is unchanged for all existing deployments; only CI lowers the request so the rolling-update surge pod fits.

## Validation

- `validate-plugins`, `validate-shell`, `validate-json-schema`, `validate-yaml` (my files), `ansible-lint` (quay.yaml), `git diff --check` — all pass.

Refs: OSAC-4957

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable CPU and memory requests and limits for the managed Quay application.
  * Provides different default resource requests for connected and disconnected deployments.
  * OpenShift CI environments using LVMS now receive automatic Quay resource configuration.

* **Documentation**
  * Added configuration examples and guidance for complete resource overrides.

* **Tests**
  * Added validation coverage for valid configurations and incomplete resource overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->