### PR TITLE
Add OSAC global.services values

### DIFF
--- a/plugins/osac/templates/values.yaml.j2
+++ b/plugins/osac/templates/values.yaml.j2
@@ -7,6 +7,17 @@
 cliImage: "{{ osac_images.cli }}"
 {% endif %}
 
+global:
+  services:
+    caas:
+      enabled: {{ ('caas' in osacProfilesList) | lower }}
+    vmaas:
+      enabled: {{ ('vmaas' in osacProfilesList) | lower }}
+    bmaas:
+      enabled: {{ ('bmaas' in osacProfilesList) | lower }}
+    maas:
+      enabled: false
+
 operator:
   image:
     pullPolicy: Always


### PR DESCRIPTION
# Summary
- add `global.services` entries to the rendered OSAC chart values
- derive the enabled flags from `osacProfilesList`
- keep the existing values structure intact for backward compatibility

follow up on https://github.com/osac-project/osac/pull/684

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added global service configuration for CaaS, VMAAS, and BMAAS, enabled according to selected OSAC profiles.
* **Configuration**
  * Explicitly disabled the MAAS service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->