### PR TITLE
Collect all enclave config and rendered plugin Helm values in CI artifacts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,9 @@ The bundle captures cluster state at failure time: `cluster/events.txt`
 (`FailedScheduling`, `Insufficient memory`, …), `cluster/pods.txt` (Pending/Failed
 pods), per-pod describe and logs (including `--previous`), and
 `cluster/quay-diagnostics-*/` (QuayRegistry `.status.conditions`, deployment/PVC
-overview, health probes). See
+overview, health probes). It also captures the redacted enclave config and rendered
+plugin Helm values under `landing-zone/config/` and `landing-zone/helm-values/` — check
+these when a plugin deploys with unexpected values. See
 [scripts/docs/CI_TROUBLESHOOTING.md](scripts/docs/CI_TROUBLESHOOTING.md) for the full
 artifact map and step-by-step recipes.
 

--- a/scripts/docs/CI_TROUBLESHOOTING.md
+++ b/scripts/docs/CI_TROUBLESHOOTING.md
@@ -62,7 +62,7 @@ on e2e jobs; lighter jobs use `basic`/`infra`.
 | --- | --- |
 | `basic` | System info and process list of the runner. |
 | `infra` | Runner performance/logs, libvirt VMs/networks/storage, host network, BMC. |
-| `deployment` | Landing Zone: system info, DNS, cloud-init, deployment + pipeline logs, services, mirror registry. |
+| `deployment` | Landing Zone: system info, DNS, cloud-init, deployment + pipeline logs, services, mirror registry, redacted enclave config files, redacted rendered plugin Helm values. |
 | `full` | Cluster diagnostics via the kubeconfig (see the map below). Runs on failure. |
 
 ## 4. Artifact map
@@ -77,6 +77,8 @@ artifacts/
 │   ├── .openshift_install.log            OpenShift/agent installer log
 │   ├── openshift_install_agent.log
 │   ├── serial-console.log / qemu-domain.log   (SSH-less fallback only)
+│   ├── config/                 Redacted enclave config: every *.yaml/*.yml under config/ (recurses into config/plugins/), examples excluded
+│   ├── helm-values/            Redacted rendered plugin Helm values (helm-values-<plugin>-<release>.yaml)
 │   └── pipeline-logs/          oc-mirror progress, helm logs, mirroring_errors_*
 └── cluster/                    Only present when the cluster came up (level: full)
     ├── cluster-status.txt      clusterversion, nodes, ClusterOperators, MCPs, degraded COs
@@ -93,7 +95,10 @@ artifacts/
 ```
 
 Security note: `vars.yaml` (pull secrets, Quay admin password) is intentionally **not**
-collected. Secrets appear by name only. Do not add raw secret dumps to the bundle.
+collected. Secrets appear by name only. The `config/` and `helm-values/` files are passed
+through a redactor before upload — values under secret-like keys (password, secret, key,
+token, credential, auth, cert) are replaced with `REDACTED`, and credentials embedded in
+URLs are stripped — but treat them as best-effort: do not add raw secret dumps to the bundle.
 
 ## 5. Reading the bundle by failure signature
 
@@ -105,6 +110,7 @@ collected. Secrets appear by name only. Do not add raw secret dumps to the bundl
 | PVC unbound / storage | `cluster/quay-diagnostics-*/overview.txt` (PVCs), `cluster/events.txt`, `libvirt/` storage |
 | Mirroring / disconnected image pull | `landing-zone/pipeline-logs/` (`oc-mirror*`, `mirroring_errors_*`) |
 | Install never reaches a cluster (no `cluster/` dir) | `landing-zone/.openshift_install.log`, `landing-zone/pipeline-logs/`, `landing-zone/serial-console.log` |
+| Plugin deploys wrong values / misconfiguration (e.g. a service enabled/disabled unexpectedly, bad hostname) | `landing-zone/config/` (input config, incl. `config/plugins/<plugin>.yaml`), `landing-zone/helm-values/` (what was actually rendered and applied) |
 
 Worked example: an LVMS Quay rollout hang (OSAC-4957) showed only
 `ProgressDeadlineExceeded` in the step log. `cluster/events.txt` had

--- a/scripts/verification/collect_ci_artifacts.sh
+++ b/scripts/verification/collect_ci_artifacts.sh
@@ -363,10 +363,12 @@ LZ_SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o Conn
 # ssh_lz <lz_ip> <remote-command...>
 # Override the default per-call deadline with LZ_CMD_TIMEOUT (seconds), e.g.
 #   LZ_CMD_TIMEOUT=600 ssh_lz "$lz_ip" "..."
+# ssh -n keeps calls from consuming the caller's stdin (e.g. a loop reading a
+# file list), which would otherwise stop the loop after the first iteration.
 ssh_lz() {
     local lz_ip="$1"
     shift
-    timeout -k 10 "${LZ_CMD_TIMEOUT:-120}" ssh "${LZ_SSH_OPTS[@]}" cloud-user@"$lz_ip" "$@"
+    timeout -k 10 "${LZ_CMD_TIMEOUT:-120}" ssh -n "${LZ_SSH_OPTS[@]}" cloud-user@"$lz_ip" "$@"
 }
 
 # scp_lz <scp-args...> -- callers pass cloud-user@<ip>:<remote> and a local dest.
@@ -557,18 +559,17 @@ collect_lz_config_files() {
     scp_lz cloud-user@"$lz_ip":/home/cloud-user/.openshift_install.log "${OUTPUT_DIR}/landing-zone/openshift_install_agent.log" 2>/dev/null || true
 }
 
-collect_lz_enclave_config() {
-    local lz_ip="$1"
-    local config_dir="${OUTPUT_DIR}/landing-zone/config"
-
-    mkdir -p "$config_dir"
-    info "Collecting enclave configuration files from Landing Zone..."
-
-    # Redact any key matching /password|secret|key|cert/i at all nesting levels before collecting.
-    # String values that are valid JSON are parsed and redacted recursively (e.g. odfExternalConfig).
-    local redact_py='
+# Redact sensitive data before collecting, at all nesting levels:
+#   - any key matching /password|secret|key|cert|token|credential|auth/i
+#   - credentials embedded in URL userinfo (scheme://user:pass@host), which
+#     catches connection strings whose key does not match, e.g. osacDatabaseUrl
+# String values that are valid JSON are parsed and redacted recursively
+# (e.g. odfExternalConfig). Shared by enclave-config and rendered Helm-values
+# collection.
+REDACT_PY='
 import yaml, sys, re, json
-PATTERN = re.compile(r"password|secret|key|cert", re.IGNORECASE)
+PATTERN = re.compile(r"password|secret|key|cert|token|credential|auth", re.IGNORECASE)
+URL_CRED = re.compile(r"://[^/@\s]+@")
 def redact(obj):
     if isinstance(obj, dict):
         return {k: "REDACTED" if PATTERN.search(k) else redact(v) for k, v in obj.items()}
@@ -579,20 +580,88 @@ def redact(obj):
             return json.dumps(redact(json.loads(obj)))
         except (json.JSONDecodeError, ValueError):
             pass
+        return URL_CRED.sub("://REDACTED@", obj)
     return obj
 data = yaml.safe_load(open(sys.argv[1]))
 print(yaml.dump(redact(data), default_flow_style=False))
 '
 
-    for cfg in global.yaml certificates.yaml cloud_infra.yaml; do
-        local remote_path="/home/cloud-user/enclave/config/${cfg}"
-        local out
-        out=$(ssh_lz "$lz_ip" \
-            "[ -f ${remote_path} ] && python3 -c '${redact_py}' ${remote_path}" 2>/dev/null) \
+collect_lz_enclave_config() {
+    local lz_ip="$1"
+    local config_dir="${OUTPUT_DIR}/landing-zone/config"
+    local remote_config_dir="/home/cloud-user/enclave/config"
+
+    mkdir -p "$config_dir"
+    info "Collecting enclave configuration files from Landing Zone..."
+
+    # Discover every real YAML config on the LZ, recursing into config/plugins/
+    # so any enabled plugin's config (osac, lvms, odf, ...) is picked up without
+    # enumerating them here. Example templates ship with the repo and hold no
+    # deployment state, so they are skipped.
+    local remote_files
+    if ! remote_files=$(ssh_lz "$lz_ip" \
+        "find ${remote_config_dir} -type f \( -name '*.yaml' -o -name '*.yml' \) ! -name '*.example.*' 2>/dev/null"); then
+        warn "Could not list enclave config files on Landing Zone"
+        return
+    fi
+
+    if [ -z "$remote_files" ]; then
+        info "No enclave config files found on Landing Zone"
+        return
+    fi
+
+    local remote_path remote_path_q cfg out
+    while IFS= read -r remote_path; do
+        [ -n "$remote_path" ] || continue
+        # Path relative to config/ so config/plugins/osac.yaml keeps its subdir.
+        cfg="${remote_path#"$remote_config_dir"/}"
+        # Shell-quote the discovered path so a filename with metacharacters
+        # cannot inject commands into the remote shell.
+        remote_path_q=$(printf '%q' "$remote_path")
+        out=$(ssh_lz "$lz_ip" "python3 -c '${REDACT_PY}' ${remote_path_q}" 2>/dev/null) \
             && [ -n "$out" ] \
+            && mkdir -p "$(dirname "${config_dir}/${cfg}")" \
             && echo "$out" > "${config_dir}/${cfg}" \
             || warn "Could not collect ${cfg}"
-    done
+    done <<< "$remote_files"
+}
+
+collect_lz_helm_values() {
+    local lz_ip="$1"
+    local values_dir="${OUTPUT_DIR}/landing-zone/helm-values"
+    # Rendered plugin values are written to workingDir as helm-values-<plugin>-<release>.yaml
+    # (e.g. helm-values-osac-osac.yaml). In CI workingDir is sessions/1.
+    local remote_working_dir="/home/cloud-user/sessions/1"
+
+    info "Collecting rendered Helm values from Landing Zone..."
+
+    # Discover every rendered plugin values file so any enabled plugin (osac,
+    # lvms, odf, ...) is captured without enumerating releases here.
+    local remote_files
+    if ! remote_files=$(ssh_lz "$lz_ip" \
+        "find ${remote_working_dir} -maxdepth 1 -type f -name 'helm-values-*.yaml' 2>/dev/null"); then
+        warn "Could not list rendered Helm values on Landing Zone"
+        return
+    fi
+
+    if [ -z "$remote_files" ]; then
+        info "No rendered Helm values found on Landing Zone"
+        return
+    fi
+
+    mkdir -p "$values_dir"
+    local remote_path remote_path_q name out
+    while IFS= read -r remote_path; do
+        [ -n "$remote_path" ] || continue
+        name=$(basename "$remote_path")
+        # Shell-quote the discovered path so a filename with metacharacters
+        # cannot inject commands into the remote shell.
+        remote_path_q=$(printf '%q' "$remote_path")
+        out=$(ssh_lz "$lz_ip" "python3 -c '${REDACT_PY}' ${remote_path_q}" 2>/dev/null) \
+            && [ -n "$out" ] \
+            && echo "$out" > "${values_dir}/${name}" \
+            || warn "Could not collect ${name}"
+    done <<< "$remote_files"
 }
 
 collect_lz_services() {
@@ -1016,6 +1085,7 @@ collect_deployment() {
     collect_lz_pipeline_logs "$lz_ip"
     collect_lz_config_files "$lz_ip"
     collect_lz_enclave_config "$lz_ip"
+    collect_lz_helm_values "$lz_ip"
     collect_lz_services "$lz_ip"
     collect_lz_registry "$lz_ip"
 


### PR DESCRIPTION
## Summary

Expands CI artifact collection (`scripts/verification/collect_ci_artifacts.sh`) so debugging failed E2E runs has the full picture of what was configured and what was actually rendered to Helm.

- **Collect all enclave config files** — `collect_lz_enclave_config` now discovers every real `*.yaml`/`*.yml` under `config/` on the Landing Zone (recursing into `config/plugins/`) instead of an enumerated core-only list. Any enabled plugin's config (osac, lvms, odf, rhbk, vast-csi, …) is captured automatically. Example templates (`*.example.*`) are skipped and subdirectory structure is preserved.
- **Collect rendered plugin Helm values** — new `collect_lz_helm_values` gathers the rendered `helm-values-*.yaml` files from the working dir (`sessions/1`), capturing the osac plugin values (`helm-values-osac-osac.yaml`) and any other plugin's rendered values.
- The `password|secret|key|cert` recursive redaction is hoisted to a shared `REDACT_PY` constant and applied to every collected file.

## Artifact layout

```
landing-zone/
├── config/
│   ├── global.yaml
│   ├── certificates.yaml
│   ├── cloud_infra.yaml
│   └── plugins/
│       └── osac.yaml
└── helm-values/
    └── helm-values-osac-osac.yaml
```

## Notes

- Discovery-based collection only iterates files that exist, so absent plugin configs/values never produce spurious warnings; missing rendered values log at `info` (not `warn`).
- Redaction keeps debugging-relevant fields visible (e.g. `global.services.*`, `operator.controllers.*`, `bmf.*.enabled`, profile lists) while masking certs/keys/passwords.

## Test plan

- [x] `bash -n` syntax check passes
- [ ] `make -f Makefile.ci validate-shell` (shellcheck)
- [x] Verify artifacts on a CI E2E run include `landing-zone/config/plugins/osac.yaml` and `landing-zone/helm-values/helm-values-osac-osac.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI artifact collection now includes applicable Landing Zone YAML configuration files, including nested plugin configurations.
  * Rendered Helm values files are included in collected deployment artifacts.
  * Collected configuration files retain their directory structure and are redacted before storage.
  * Sensitive credentials are more comprehensively removed, including credentials embedded in URLs.
  * Example configuration files are excluded from collection.
* **Bug Fixes**
  * Deployment artifact collection now handles cases where no configuration files are found.
  * SSH-based collection no longer consumes input from the calling process.
* **Documentation**
  * Troubleshooting guidance now documents the additional configuration and Helm values artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->