### PR TITLE
Automerge python lock file maintenance renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -84,5 +84,9 @@
       "ignoreUnstable": false,
       "respectLatest": false
     }
-  ]
+  ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true
+  }
 }


### PR DESCRIPTION
Once they've passed the builds, they're safe to be automerged without any further review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automated lock file maintenance.
  * Configured eligible lock file updates to merge automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->