### PR TITLE
OSAC-5067: Fix CA bundle concat corrupted by folded YAML scalar (#757 regression)

### DIFF
--- a/playbooks/tasks/configure_certificates.yaml
+++ b/playbooks/tasks/configure_certificates.yaml
@@ -102,9 +102,13 @@
     regexp: "^( +certificate-authority-data):.*"
     replace: "    certificate-authority-data: {{ api_ca_bundle | b64encode }}"
   vars:
-    api_ca_bundle: >-
-      {{ sslAPICertificateFullChain
-         ~ ('\n' if sslAPICertificateFullChain | length > 0
-                    and sslCACertificate | default('') | length > 0
-                    and sslAPICertificateFullChain[-1:] != '\n' else '')
-         ~ (sslCACertificate | default('')) }}
+    # Must be a double-quoted scalar, not a folded (>-) block scalar: YAML only
+    # processes the \n escape inside double-quoted scalars, so the '\n'
+    # separator (and the [-1:] != '\n' guard) resolve to a real newline. In a
+    # folded scalar '\n' stays a literal backslash-n, which glues a corrupt
+    # boundary before sslCACertificate and drops the root from the trust bundle.
+    api_ca_bundle: "{{ sslAPICertificateFullChain
+      ~ ('\n' if sslAPICertificateFullChain | length > 0
+                 and sslCACertificate | default('') | length > 0
+                 and sslAPICertificateFullChain[-1:] != '\n' else '')
+      ~ (sslCACertificate | default('')) }}"

--- a/playbooks/tasks/deploy_ironic.yaml
+++ b/playbooks/tasks/deploy_ironic.yaml
@@ -94,12 +94,16 @@
     state: present
     force: false
   vars:
-    ironic_ca_bundle: >-
-      {{ sslIngressCertificateFullChain
-         ~ ('\n' if sslIngressCertificateFullChain | length > 0
-                    and sslCACertificate | default('') | length > 0
-                    and sslIngressCertificateFullChain[-1:] != '\n' else '')
-         ~ (sslCACertificate | default('')) }}
+    # Must be a double-quoted scalar, not a folded (>-) block scalar: YAML only
+    # processes the \n escape inside double-quoted scalars, so the '\n'
+    # separator (and the [-1:] != '\n' guard) resolve to a real newline. In a
+    # folded scalar '\n' stays a literal backslash-n, which glues a corrupt
+    # boundary before sslCACertificate and drops the root from the bundle.
+    ironic_ca_bundle: "{{ sslIngressCertificateFullChain
+      ~ ('\n' if sslIngressCertificateFullChain | length > 0
+                 and sslCACertificate | default('') | length > 0
+                 and sslIngressCertificateFullChain[-1:] != '\n' else '')
+      ~ (sslCACertificate | default('')) }}"
   no_log: true
 
 


### PR DESCRIPTION
## Summary

Fixes a regression that broke every real-cert (Let's Encrypt / ZeroSSL) **e2e disconnected scheduled** run starting 2026-09-06. Runs failed at the Ansible task "Trust custom Root CA certificate" → "Read current Proxy/cluster configuration" with:

```
SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED]
certificate verify failed: unable to get issuer certificate'))
```

Jira: [OSAC-5067](https://redhat.atlassian.net/browse/OSAC-5067)

## Root cause

PR #757 ([OSAC-3867](https://redhat.atlassian.net/browse/OSAC-3867), merged 2026-09-04) rewrote the CA-bundle concatenation in `configure_certificates.yaml` (`api_ca_bundle`) and `deploy_ironic.yaml` (`ironic_ca_bundle`) using a **folded (`>-`) YAML block scalar** containing a `~ ('\n' if ...) ~` safe-join expression.

YAML only processes the `\n` escape inside **double-quoted** scalars. In a folded/plain scalar, `'\n'` reaches Jinja as a literal backslash-n. So:

- The newline guard `sslAPICertificateFullChain[-1:] != '\n'` compares a real newline against the literal string `\n` → **always true** → a separator is always inserted.
- The inserted separator is itself a literal backslash-n.

The resulting kubeconfig trust bundle contains `-----END CERTIFICATE-----\n\n-----BEGIN CERTIFICATE-----` where the second `\n` is literal. This corrupts the `-----BEGIN` line of the appended self-signed root (ISRG Root X1), so no PEM parser loads it. The top loadable cert becomes the cross-signed ISRG Root X2 (issuer ≠ subject), and OpenSSL fails with *unable to get issuer certificate*.

The root-CA auto-resolution in `playbooks/common/load-vars.yaml` was correct all along — #757 corrupted the bundle only at the concat step. That's why 2026-09-03 (pre-#757) passed and 2026-09-06 onward fail, across **all** real cert types.

## Fix

Switch `api_ca_bundle` and `ironic_ca_bundle` from folded (`>-`) to **double-quoted** scalars so YAML converts `\n` to a real newline. Both the guard and the separator then behave correctly whether or not the fullchain already ends in a newline. Inline comments document the requirement to prevent regression.

## Test plan

- [x] Reproduced the exact CI error from the failing run's real certs with the original (folded) bundle: `error 2 ... ISRG Root X2 ... unable to get issuer certificate`.
- [x] Fixed (double-quoted) bundle passes `openssl verify` → `OK`.
- [x] Verified both guard branches (fullchain with/without trailing newline) render a real newline separator in Ansible 2.21.
- [x] `yamllint` + `ansible-lint` (production profile) pass on both files.
- [x] Manual `workflow_dispatch` e2e disconnected run with a real cert (zerossl): [run 34344425586](https://github.com/rh-ecosystem-edge/enclave/actions/runs/34344425586) **passed**. Standard e2e (self-signed) also green.

## Related

- Original PR that introduced the regression: #757
- Original ticket: [OSAC-3867](https://redhat.atlassian.net/browse/OSAC-3867)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
