### PR TITLE
Set oadp-subscription-spec annotation on MCH for disconnected installs

### DIFF
--- a/operators/advanced-cluster-management/configure_mch.yaml
+++ b/operators/advanced-cluster-management/configure_mch.yaml
@@ -1,6 +1,6 @@
 ---
-# Configure MultiClusterHub with MCE subscription spec annotation.
-# This ensures ACM respects Manual installPlanApproval for MCE subscription.
+# Configure MultiClusterHub with MCE and OADP subscription specs annotation.
+# This ensures ACM respects Manual installPlanApproval for MCE and OADP subscriptions.
 # Can be used for both initial creation and patching existing MCH during upgrades.
 
 - name: Set MCE subscription spec for disconnected
@@ -19,7 +19,23 @@
     mce_subscription_spec:
       installPlanApproval: "{{ 'Automatic' if (_mce_use_automatic | bool) else 'Manual' }}"
 
-- name: Ensure RHACM MultiClusterHub is present with MCE subscription spec
+- name: Set OADP subscription spec for disconnected
+  when: disconnected | default(true) | bool
+  ansible.builtin.set_fact:
+    oadp_subscription_spec:
+      installPlanApproval: Manual
+      source: cs-redhat-operator-index-v4-20
+
+- name: Set OADP subscription spec for connected
+  when: not (disconnected | default(true) | bool)
+  vars:
+    _oadp_operator: "{{ (operators | selectattr('name', 'equalto', 'redhat-oadp-operator') | list)[0] | default({}) }}"
+    _oadp_use_automatic: "{{ _oadp_operator.connected_auto | default(false) | bool }}"
+  ansible.builtin.set_fact:
+    oadp_subscription_spec:
+      installPlanApproval: "{{ 'Automatic' if (_oadp_use_automatic | bool) else 'Manual' }}"
+
+- name: Ensure RHACM MultiClusterHub is present with MCE and OADP subscription specs
   kubernetes.core.k8s:
     state: present
     definition:
@@ -30,6 +46,7 @@
         namespace: open-cluster-management
         annotations:
           installer.open-cluster-management.io/mce-subscription-spec: "{{ mce_subscription_spec | to_json }}"
+          installer.open-cluster-management.io/oadp-subscription-spec: "{{ oadp_subscription_spec | to_json }}"
       spec: {}
   retries: 60
   delay: 10


### PR DESCRIPTION
Without this, the cluster-backup component's OADP subscription defaults to source: redhat-operators, which doesn't exist in air-gapped clusters and leaves MultiClusterHub stuck in Pending.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added OADP subscription configuration alongside MCE when setting up Advanced Cluster Management.
  - OADP installation now supports disconnected environments and selects the appropriate subscription mode in connected environments.
  - MultiClusterHub setup now applies the OADP subscription configuration automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->