### PR TITLE
OSAC-5187: Align OSAC plugin Helm values with per-service enablement (#684)

### DIFF
--- a/config/plugins/osac.example.yaml
+++ b/config/plugins/osac.example.yaml
@@ -10,13 +10,25 @@
 # osacAapLicenseFile: "/path/to/aap-license.zip"
 
 # Optional: override OSAC Helm chart version (default from plugin defaults.yaml)
-# osacChartVersion: "0.0.6"
+# osacChartVersion: "0.0.9-nightly.20260911.6d92ac5.82.1"
 
-# Optional: enabled service profiles (default: [caas, vmaas])
+# Optional: enabled service profiles (default: [caas, bmaas])
 # See docs/OSAC_DEPLOYMENT.md for valid profiles and prerequisites.
+# The default pairs caas with bmaas (BMF scaled to zero, see note below) so it
+# works without OpenShift Virtualization. Add 'vmaas' (with the cnv plugin) for
+# VM-based compute.
+#
+# NOTE on 'bmaas' and bare-metal inventory backends (osacBcmEnabled /
+# osacMetal3Enabled):
+#   - A backend without 'bmaas' is rejected: BMF would not be deployed and the
+#     backend config would be silently ignored.
+#   - 'bmaas' without a backend IS allowed: BMF is scaled to zero replicas
+#     (mirrors upstream caas-ci). Use this to satisfy the chart's
+#     caas -> (vmaas|bmaas) requirement without real Metal3/BCM infrastructure.
+#   - 'bmaas' with a backend deploys a functional BMF against that backend.
 # osacProfilesList:
 #   - caas
-#   - vmaas
+#   - bmaas
 #   - ...
 
 # Optional: create test users for initial UI/CLI access (default: false)
@@ -85,6 +97,7 @@
 # --- BCM Inventory Backend ---
 # Enable BCM (NVIDIA Base Command Manager) integration for bare metal fulfillment.
 # Requires Metal3 for power management via BareMetalHost CRs.
+# Enabling a backend also requires 'bmaas' in osacProfilesList (see note above).
 # osacBcmEnabled: true
 
 # Required when osacBcmEnabled is true:
@@ -111,6 +124,7 @@
 # Enable Metal3 (BareMetalHost) integration for bare metal fulfillment.
 # Uses locally-managed BareMetalHost CRs via the metal3.io API.
 # NOTE: BCM and Metal3 are mutually exclusive — only one can be enabled.
+# Enabling a backend also requires 'bmaas' in osacProfilesList (see note above).
 # osacMetal3Enabled: true
 
 # Required when osacMetal3Enabled is true:

--- a/docs/OSAC_DEPLOYMENT.md
+++ b/docs/OSAC_DEPLOYMENT.md
@@ -63,10 +63,10 @@ Edit `config/plugins/osac.yaml`:
 # Required: path to AAP license file on the Landing Zone
 osacAapLicenseFile: "/home/<user>/aap-license.zip"
 
-# Optional: enabled service profiles (default: [caas, vmaas])
+# Optional: enabled service profiles (default: [caas, bmaas])
 # osacProfilesList:
 #   - caas
-#   - vmaas
+#   - bmaas
 
 # Optional: bring your own database
 # osacBYODatabase: true
@@ -78,8 +78,8 @@ osacAapLicenseFile: "/home/<user>/aap-license.zip"
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `osacAapLicenseFile` | string | Yes | — | Path to AAP license manifest.zip on the Landing Zone |
-| `osacChartVersion` | string | No | `0.0.6` | OSAC Helm chart version to deploy |
-| `osacProfilesList` | list | No | `[caas, vmaas]` | Enabled service profiles: `vmaas`, `caas`, `bmaas` |
+| `osacChartVersion` | string | No | `0.0.9-nightly.20260911.6d92ac5.82.1` | OSAC Helm chart version to deploy |
+| `osacProfilesList` | list | No | `[caas, bmaas]` | Enabled service profiles: `vmaas`, `caas`, `bmaas` |
 | `osacBYODatabase` | boolean | No | `false` | Use an external database instead of the built-in dev postgres |
 | `osacDatabaseUrl` | string | No | — | Connection URL for external database (requires `osacBYODatabase: true`) |
 
@@ -195,14 +195,26 @@ When BYO database is enabled:
 
 The `osacProfilesList` config value controls which OSAC operator controllers are enabled. Multiple profiles can be combined:
 
-| Profile | Controllers | Extra Prerequisites |
-|---------|------------|---------------------|
-| `vmaas` | computeInstance, tenant, networking | Dedicated CNV-enabled workload cluster |
-| `caas` | clusterOrder, tenant, networking | MCE |
-| `bmaas` | clusterOrder, tenant, networking | MCE |
+The tenant, networking and storage controllers are always enabled. The
+service-mapped controllers below are derived by the chart from
+`global.services.*` (set from `osacProfilesList`):
+
+| Profile | Service-mapped controller | Extra Prerequisites |
+|---------|---------------------------|---------------------|
+| `caas`  | clusterOrder | MCE; must be paired with `vmaas` or `bmaas` (chart requirement) |
+| `vmaas` | computeInstance | Dedicated CNV-enabled workload cluster (the `cnv` plugin) |
+| `bmaas` | bareMetalInstance | MCE; optionally a bare-metal inventory backend (BCM or Metal3) |
 
 - **MCE** (Multicluster Engine) is part of Enclave core infrastructure (ACM-based platform) and is always available.
+- **CaaS** cannot run alone: the chart requires it to be paired with a compute
+  service (`vmaas` or `bmaas`). The default `[caas, bmaas]` satisfies this
+  without OpenShift Virtualization.
 - **VMaaS** requires a separate OpenShift cluster with CNV (OpenShift Virtualization) — VM workloads run on dedicated clusters, not on the management cluster.
+- **BMaaS** enables the Bare Metal Fulfillment (BMF) subchart. When no inventory
+  backend (`osacBcmEnabled` or `osacMetal3Enabled`) is configured, BMF is scaled
+  to zero replicas — the service is registered for the caas pairing but does not
+  run against absent bare-metal infrastructure (mirrors upstream caas-ci).
+  Configure a backend to run a functional BMF.
 
 ## Post-Install Steps
 

--- a/plugins/osac/defaults.yaml
+++ b/plugins/osac/defaults.yaml
@@ -4,11 +4,17 @@
 # which is loaded into Ansible scope as-is. The defaults below use the same
 # camelCase convention to match. Ansible variables from defaults.yaml and
 # config/plugins/osac.yaml are merged into the same scope.
-osacChartVersion: "0.0.9-nightly.20260905.3a511a6.70.1"
+osacChartVersion: "0.0.9-nightly.20260911.6d92ac5.82.1"
 
+# Default profile pairs caas with bmaas (not vmaas): the chart requires caas to
+# be paired with a compute backend (vmaas or bmaas), and bmaas needs no cluster
+# add-on, whereas vmaas requires OpenShift Virtualization/KubeVirt. With no
+# bare-metal inventory backend configured, the values template scales BMF to
+# zero replicas (mirrors upstream osac-installer caas-ci). Enable vmaas
+# explicitly (with the cnv plugin) or a bmaas backend for functional compute.
 osacProfilesList:
   - caas
-  - vmaas
+  - bmaas
 
 # Test users (opt-in for dev/test environments)
 osacTestUsers: false

--- a/plugins/osac/schemas/config.yaml
+++ b/plugins/osac/schemas/config.yaml
@@ -230,3 +230,32 @@ allOf:
       properties:
         osacBcmEnabled:
           const: false
+  # A bare-metal inventory backend (BCM or Metal3) requires bmaas in
+  # osacProfilesList. This is an enclave-level constraint on enclave config vars
+  # only (no coupling to the upstream chart schema, which enforces neither):
+  #   - a backend without bmaas => BMF is not deployed and the backend config is
+  #     silently ignored.
+  # The reverse is NOT required: bmaas may be enabled without a backend. In that
+  # case the template scales BMF to zero replicas (mirroring upstream caas-ci),
+  # so it registers its API without crash-looping against absent BM infra. This
+  # lets caas be satisfied via the chart's caas -> (vmaas|bmaas) requirement
+  # without provisioning real Metal3/BCM infrastructure.
+  - if:
+      anyOf:
+        - required:
+            - osacBcmEnabled
+          properties:
+            osacBcmEnabled:
+              const: true
+        - required:
+            - osacMetal3Enabled
+          properties:
+            osacMetal3Enabled:
+              const: true
+    then:
+      required:
+        - osacProfilesList
+      properties:
+        osacProfilesList:
+          contains:
+            const: bmaas

--- a/plugins/osac/templates/values.yaml.j2
+++ b/plugins/osac/templates/values.yaml.j2
@@ -2,10 +2,8 @@
 # Chart-managed AAP architecture: the OSAC Helm chart deploys its own
 # AAP instance. deploy.yaml handles post-install AAP token creation
 # and operator patching.
-
-{% if osac_images is defined and osac_images.cli is defined %}
-cliImage: "{{ osac_images.cli }}"
-{% endif %}
+#
+# Section order mirrors the upstream chart values.yaml to keep diffs reviewable.
 
 global:
   services:
@@ -18,38 +16,38 @@ global:
     maas:
       enabled: false
 
+{% if osac_images is defined and osac_images.cli is defined %}
+cliImage: "{{ osac_images.cli }}"
+{% endif %}
+
+dbInit:
+  host: "{{ osac_db_name }}.osac.svc.cluster.local"
+
 operator:
   image:
-    pullPolicy: Always
 {% if osac_images is defined and osac_images.osac_operator is defined %}
     repository: "{{ osac_images.osac_operator.rsplit(':', 1)[0] }}"
     tag: "{{ osac_images.osac_operator.rsplit(':', 1)[1] }}"
 {% endif %}
+    pullPolicy: Always
   aap:
+    url: ""               # Set post-install by deploy.yaml
     insecureSkipVerify: "true"
     statusPollInterval: 30s
     templatePrefix: osac
-    url: ""               # Set post-install by deploy.yaml
-  controllers:
-{% if 'caas' in osacProfilesList or 'bmaas' in osacProfilesList %}
-    clusterOrder: true
-{% else %}
-    clusterOrder: false
-{% endif %}
-{% if 'vmaas' in osacProfilesList %}
-    computeInstance: true
-{% else %}
-    computeInstance: false
-{% endif %}
-    networking: true
-    tenant: true
-    bareMetalInstance: true
-    storage: true
   fulfillment:
     serverAddress: fulfillment-api:8000
     tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-  provisioning:
-    provider: aap
+  controllers:
+    # clusterOrder (caas), computeInstance (vmaas) and bareMetalInstance (bmaas)
+    # are intentionally omitted: the chart derives them from global.services.*
+    # (set above from osacProfilesList). Setting them here would override that
+    # gating -- e.g. bareMetalInstance would force the BM controller on even
+    # when bmaas is disabled. Only the controllers without a service mapping
+    # are set explicitly below.
+    tenant: true
+    networking: true
+    storage: true
   hubAccess:
     enabled: false
 
@@ -67,11 +65,11 @@ service:
 {% endif %}
 {% endif %}
   certs:
-    caBundle:
-      configMap: ca-bundle
     issuerRef:
       kind: ClusterIssuer
       name: default-ca
+    caBundle:
+      configMap: ca-bundle
   auth:
     issuerUrl: "https://{{ _osac_keycloak_hostname }}/realms/{{ osac_keycloak_realm }}"
     emergencyServiceAccounts:
@@ -124,18 +122,18 @@ aap:
       enabled: true
       name: "{{ osac_aap_name }}"
   bootstrap:
-    backoffLimit: 15
-    readinessConsecutiveSuccesses: 3
     enabled: true
 {% if osac_images is defined and osac_images.aap_bootstrap is defined %}
     image: "{{ osac_images.aap_bootstrap }}"
 {% endif %}
+    backoffLimit: 15
+    readinessConsecutiveSuccesses: 3
   configAsCode:
-    projectGitUri: "{{ osac_aap_project_git_uri }}"
-    projectGitBranch: "{{ osac_aap_project_git_branch }}"
 {% if osac_images is defined and osac_images.aap_bootstrap is defined %}
     eeImage: "{{ osac_images.aap_bootstrap }}"
 {% endif %}
+    projectGitUri: "{{ osac_aap_project_git_uri }}"
+    projectGitBranch: "{{ osac_aap_project_git_branch }}"
   instanceGroups:
 {% if osacNetrisEnabled | default(false) | bool %}
     clusterFulfillment:
@@ -227,9 +225,23 @@ aap:
         OSAC_TEMPLATE_COLLECTIONS: "osac.templates"
         OSAC_FULFILLMENT_SERVICE_URI: "https://fulfillment-internal-api:8001"
 
+# The BMF operator is gated by global.services.bmaas.enabled (chart Chart.yaml
+# condition); there is no top-level bmf.enabled anymore. The bcm/metal3 config
+# below only takes effect when bmaas is enabled via osacProfilesList.
+{% set _osac_bmaas_enabled = 'bmaas' in osacProfilesList %}
+{% set _osac_bm_backend = (osacBcmEnabled | default(false) | bool) or (osacMetal3Enabled | default(false) | bool) %}
 bmf:
+{% if _osac_bmaas_enabled and not _osac_bm_backend %}
+  # bmaas is enabled only to satisfy the chart's caas -> (vmaas|bmaas) schema
+  # requirement, but no bare-metal inventory backend (BCM or Metal3) is
+  # configured. Scale BMF to zero replicas so it registers its API without
+  # crash-looping against absent Metal3/BCM infrastructure. Mirrors upstream
+  # osac-installer caas-ci, which pairs caas with bmaas at replicaCount 0.
+  replicaCount: 0
+{% endif %}
+  env:
+    aapInsecureSkipVerify: "true"
 {% if osacBcmEnabled | default(false) | bool %}
-  enabled: true
   bcm:
     enabled: true
     url: "{{ osacBcmUrl }}"
@@ -245,31 +257,14 @@ bmf:
     hostClass: "{{ osacBcmHostClass | default('bcm') }}"
     bmhNamespace: "{{ osacBcmBmhNamespace }}"
 {% elif osacMetal3Enabled | default(false) | bool %}
-  enabled: true
   metal3:
     enabled: true
     namespace: "{{ osacMetal3Namespace }}"
     hostClass: "{{ osacMetal3HostClass | default('metal3') }}"
-{% else %}
-  enabled: false
 {% endif %}
-  env:
-    aapInsecureSkipVerify: "true"
-
-dbInit:
-  host: "{{ osac_db_name }}.osac.svc.cluster.local"
-
-dbMigrate:
-  enabled: false
 
 validation:
   enabled: true
 
 hubAccess:
   enabled: false
-
-bundledPostgres:
-  enabled: false
-  database:
-    name: service
-    user: service

--- a/scripts/deployment/deploy_plugin.sh
+++ b/scripts/deployment/deploy_plugin.sh
@@ -160,8 +160,6 @@ if [ -n "${AAP_LICENSE_FILE:-}" ] && { [ "$PLUGIN_NAME" = "aap" ] || [ "$PLUGIN_
 ---
 osacAapLicenseFile: "${LZ_AAP_LICENSE}"
 ${OSAC_CHART_VERSION:+osacChartVersion: "${OSAC_CHART_VERSION}"}
-osacProfilesList:
-  - caas
 osacTestUsers: true
 OSAC_EOF
     fi


### PR DESCRIPTION
## Summary

Adapts the Enclave `osac` plugin overlay to osac PR [#684](https://github.com/osac-project/osac/pull/684/), which moves service enablement to `global.services.{caas,vmaas,bmaas,maas}.enabled` and removes the old per-controller and top-level `bmf.enabled` knobs from the chart. Builds on #790 (which added the `global.services` block).

Jira: [OSAC-5187](https://redhat.atlassian.net/browse/OSAC-5187)

## Changes

**`plugins/osac/templates/values.yaml.j2`**
- Set `global.services.{caas,vmaas,bmaas}.enabled` from `osacProfilesList`.
- Drop `operator.controllers.{clusterOrder,computeInstance,bareMetalInstance}` so the chart derives them from `global.services.*`. Setting them here would override that gating — e.g. `bareMetalInstance` would force the bare-metal controller on even when `bmaas` is disabled. Keep `tenant`/`networking`/`storage`, which have no service mapping.
- Drop the top-level `bmf.enabled` key; BMF is now gated by the umbrella `Chart.yaml` condition `global.services.bmaas.enabled`. Keep `bmf.env` and the conditional `bmf.bcm`/`bmf.metal3` backend config.
- When `bmaas` is enabled **without** a bare-metal inventory backend, render `bmf.replicaCount: 0` so BMF registers its API without crash-looping against absent Metal3/BCM infrastructure. Mirrors upstream `osac-installer` caas-ci.
- Remove dead overlay keys absent from the upstream chart: `dbMigrate`, `bundledPostgres`, `operator.provisioning`.
- Reorder top-level sections and nested keys to mirror the upstream chart `values.yaml` for reviewable diffs (content-preserving).

**`plugins/osac/defaults.yaml`**
- Default `osacProfilesList` to `[caas, bmaas]`. The chart requires `caas` to be paired with a compute service (`vmaas` or `bmaas`); `bmaas` needs no cluster add-on, whereas `vmaas` requires OpenShift Virtualization (the `cnv` plugin). With no backend configured, BMF is scaled to zero (above), so the default deploys cleanly on a plain cluster. Mirrors upstream caas-ci.
- Bump `osacChartVersion` to `0.0.9-nightly.20260911.6d92ac5.82.1`, the first nightly containing #684 (the previous pin predates it).

**`plugins/osac/schemas/config.yaml`**
- Require `bmaas` when a backend (`osacBcmEnabled`/`osacMetal3Enabled`) is set: a backend without `bmaas` ⇒ BMF is not deployed and the config is ignored. The reverse is intentionally **not** required — `bmaas` without a backend is valid and renders BMF at zero replicas. Enclave-owned constraint on enclave config vars only; the upstream chart schema enforces neither direction.

**`scripts/deployment/deploy_plugin.sh`**
- Drop the hardcoded caas-only `osacProfilesList` from the config generated on the Landing Zone in CI so the plugin default (`[caas, bmaas]`) applies. Under #684 the chart requires `caas` to be paired with `vmaas` or `bmaas`, so a caas-only profile would now fail upstream values validation.

**`config/plugins/osac.example.yaml`, `docs/OSAC_DEPLOYMENT.md`**
- Document the relaxed `bmaas`/backend rule, the `[caas, bmaas]` default and the BMF zero-replicas behavior; fix the profile → controller mapping.

## Validation
- **Live deploy on `openshift-qe-002`** (caas+bmaas, no backend, chart `…20260911…`): `osac-operator` healthy with `OSAC_ENABLE_COMPUTE_INSTANCE_CONTROLLER=false` (no VirtualMachine dependency), `OSAC_ENABLE_CLUSTER_CONTROLLER=true` and `OSAC_ENABLE_BAREMETAL_INSTANCE_CONTROLLER=true`; `bmf-operator-controller-manager` at `0/0` replicas; no Metal3 pre-install validation gate.
- Schema guards unit-tested with `jsonschema` Draft7Validator across pass/fail cases (caas+bmaas no backend ✓; backend without bmaas ✗; metal3 without namespace ✗; bcm+metal3 mutually exclusive ✗).
- `yamllint` / YAML parse on changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - OSAC defaults now use the `caas` and `bmaas` profiles.
  - Bare-metal backend configurations now require the `bmaas` profile, while `bmaas` can operate without a backend.
  - Service controllers are selected from enabled services for more consistent deployment configuration.
  - Added database initialization and explicit operator URL configuration.

- **Bug Fixes**
  - Added validation to prevent BCM or Metal3 configurations without the required `bmaas` profile.

- **Documentation**
  - Updated deployment guidance, prerequisites, profile behavior, and chart version information.
  - Clarified `caas`, `bmaas`, and optional `vmaas` requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->